### PR TITLE
fix(state): retain failed session snapshots for bounded retry

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -354,8 +354,10 @@ otherwise.
 Session snapshots stay dirty until persistence succeeds. Failed writes retain
 their serialized payload and timestamp. New events remain pending for the next
 snapshot. Timer retries start at 250 ms and double to a 30-second cap; explicit
-and periodic flushes can also retry. A retry verifies any existing database row
-instead of inserting a duplicate or replacing different content. New pending
+and periodic flushes can also retry. A failed session or project does not block
+the remaining periodic writes. A retry verifies any existing database row,
+accepting identical content instead of inserting a duplicate or replacing
+different content. New pending
 write files carry this verification flag through startup replay. Older pending
 files keep their existing replay behavior, and older runtimes do not enforce the
 new flag. Finish pending recovery before downgrading.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -351,6 +351,23 @@ otherwise.
 | `agent.retention.snapshot_max_bytes` | `67108864` |
 | `agent.retention.rollout_days` | `30` (0 keeps every session) |
 
+Session snapshots stay dirty until persistence succeeds. Failed writes retain
+their serialized payload and timestamp. New events remain pending for the next
+snapshot. Timer retries start at 250 ms and double to a 30-second cap; explicit
+and periodic flushes can also retry. A retry verifies any existing database row
+instead of inserting a duplicate or replacing different content. New pending
+write files carry this verification flag through startup replay. Older pending
+files keep their existing replay behavior, and older runtimes do not enforce the
+new flag. Finish pending recovery before downgrading.
+
+If a dirty session cannot be persisted during eviction, the policy refuses the
+new session rather than exceeding its tracking cap. A failed close retains the
+session and its database driver, stops timers, and reports a cleanup error. An
+in-process owner can repair storage and retry close. Daemon shutdown reports a
+nonzero exit status but does not wait indefinitely for storage repair. Memory
+cannot survive process exit; if storage failed before a recovery file became
+durable, shutdown or a forced kill can still lose that unpersisted state.
+
 `max_turns` is unset by default; an unset turn cap does not impose a
 synthetic stop. `stream_watchdog_timeout_ms` defaults to `600000` (ten
 minutes of provider silence): the runtime warns at half that time and aborts

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -4957,8 +4957,17 @@ class AgenCDaemonSnapshotPolicyRegistry {
   }
 
   flushPeriodic(): void {
+    const errors: unknown[] = [];
     for (const entry of this.#policies.values()) {
-      entry.policy.flushPeriodic();
+      try {
+        entry.policy.flushPeriodic();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      for (const error of errors) this.#onError(error);
+      throw new AggregateError(errors, "daemon periodic snapshot flush failed");
     }
   }
 

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -4978,21 +4978,28 @@ class AgenCDaemonSnapshotPolicyRegistry {
       clearInterval(this.#periodicTimer);
       this.#periodicTimer = undefined;
     }
-    for (const entry of this.#policies.values()) {
+    const errors: unknown[] = [];
+    for (const [key, entry] of this.#policies) {
       // Flush dirty sessions synchronously before the state DB goes away.
       try {
         entry.policy.close();
+        entry.driver.close();
+        this.#policies.delete(key);
       } catch (error) {
+        errors.push(error);
         this.#onError(error);
       }
-      entry.driver.close();
     }
     for (const store of this.#threadStores.values()) {
       store.close();
     }
-    this.#policies.clear();
-    this.#sessionPolicyKeys.clear();
+    for (const [sessionId, key] of this.#sessionPolicyKeys) {
+      if (!this.#policies.has(key)) this.#sessionPolicyKeys.delete(sessionId);
+    }
     this.#threadStores.clear();
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "daemon snapshot policies retained unpersisted sessions");
+    }
   }
 
   recordSessionEvent(sessionId: string, event: JsonObject): void {

--- a/runtime/src/state/atomic-snapshot-writes.ts
+++ b/runtime/src/state/atomic-snapshot-writes.ts
@@ -29,6 +29,7 @@ export interface SessionSnapshotWriteRecord {
 export interface SessionSnapshotAtomicWriteOptions {
   readonly updateRunLastSnapshotAt?: boolean;
   readonly replayOnStartup?: boolean;
+  readonly verifyExisting?: boolean;
 }
 
 export interface PendingSessionSnapshotWrite {
@@ -37,6 +38,7 @@ export interface PendingSessionSnapshotWrite {
   readonly record: SessionSnapshotWriteRecord;
   readonly updateRunLastSnapshotAt: boolean;
   readonly replayOnStartup: boolean;
+  readonly verifyExisting: boolean;
 }
 
 interface SessionSnapshotWriteFile {
@@ -44,6 +46,7 @@ interface SessionSnapshotWriteFile {
   readonly schemaVersion: typeof SNAPSHOT_WRITE_SCHEMA_VERSION;
   readonly replayOnStartup: boolean;
   readonly updateRunLastSnapshotAt: boolean;
+  readonly verifyExisting?: boolean;
   readonly record: SessionSnapshotWriteRecord;
 }
 
@@ -52,9 +55,14 @@ export function writeSessionSnapshotAtomically(
   record: SessionSnapshotWriteRecord,
   options: SessionSnapshotAtomicWriteOptions = {},
 ): void {
+  if (options.verifyExisting && driver.state.inTransaction) {
+    throw new Error("retryable snapshot writes require their own transaction");
+  }
   const pending = stageSessionSnapshotWrite(driver.projectDir, record, options);
   try {
-    commitPendingSessionSnapshotWrite(driver.state, pending, "strict");
+    commitPendingSessionSnapshotWrite(
+      driver.state, pending, options.verifyExisting ? "verify" : "strict",
+    );
   } catch (error) {
     if (!pending.replayOnStartup) removePendingSessionSnapshotWrite(pending);
     throw error;
@@ -81,7 +89,7 @@ export function replayAtomicSessionSnapshotWrites(
         removePendingSessionSnapshotWrite(pending);
         continue;
       }
-      commitPendingSessionSnapshotWrite(db, pending, "idempotent");
+      commitPendingSessionSnapshotWrite(db, pending, pending.verifyExisting ? "verify" : "idempotent");
       removePendingSessionSnapshotWrite(pending);
     } catch {
       // A torn or otherwise corrupt pending write (ENOSPC, power loss,
@@ -126,12 +134,14 @@ export function stageSessionSnapshotWrite(
     record,
     updateRunLastSnapshotAt: options.updateRunLastSnapshotAt === true,
     replayOnStartup: options.replayOnStartup === true,
+    verifyExisting: options.verifyExisting === true,
   };
   const payload: SessionSnapshotWriteFile = {
     format: SNAPSHOT_WRITE_FORMAT,
     schemaVersion: SNAPSHOT_WRITE_SCHEMA_VERSION,
     replayOnStartup: pending.replayOnStartup,
     updateRunLastSnapshotAt: pending.updateRunLastSnapshotAt,
+    ...(pending.verifyExisting ? { verifyExisting: true } : {}),
     record,
   };
   atomicWriteFile(pending.directory, pending.path, `${JSON.stringify(payload)}\n`);
@@ -141,7 +151,7 @@ export function stageSessionSnapshotWrite(
 function commitPendingSessionSnapshotWrite(
   db: SqliteDatabase,
   pending: PendingSessionSnapshotWrite,
-  mode: "strict" | "idempotent",
+  mode: "strict" | "idempotent" | "verify",
 ): void {
   const commit = (): void => {
     insertPendingSessionSnapshotWrite(db, pending, mode);
@@ -157,8 +167,28 @@ function commitPendingSessionSnapshotWrite(
 function insertPendingSessionSnapshotWrite(
   db: SqliteDatabase,
   pending: PendingSessionSnapshotWrite,
-  mode: "strict" | "idempotent",
+  mode: "strict" | "idempotent" | "verify",
 ): void {
+  if (mode === "verify") {
+    const existing = db.prepare<[string, string], {
+      conversation_json: string;
+      tool_state_json: string;
+      mcp_connection_state_json: string;
+    }>(
+      `SELECT conversation_json, tool_state_json, mcp_connection_state_json
+       FROM session_state_snapshots WHERE session_id = ? AND snapshot_at = ?`,
+    ).get(pending.record.sessionId, pending.record.snapshotAt);
+    if (existing !== undefined) {
+      if (
+        existing.conversation_json !== pending.record.conversationJson ||
+        existing.tool_state_json !== pending.record.toolStateJson ||
+        existing.mcp_connection_state_json !== pending.record.mcpConnectionStateJson
+      ) {
+        throw new Error("snapshot retry conflicts with the persisted payload");
+      }
+      return;
+    }
+  }
   const onConflict =
     mode === "idempotent"
       ? `ON CONFLICT(session_id, snapshot_at) DO UPDATE SET
@@ -225,6 +255,7 @@ function readPendingSessionSnapshotWrite(
     record: file.record,
     updateRunLastSnapshotAt: file.updateRunLastSnapshotAt,
     replayOnStartup: file.replayOnStartup,
+    verifyExisting: file.verifyExisting === true,
   };
 }
 
@@ -247,6 +278,8 @@ function expectSnapshotWriteFile(
       file.updateRunLastSnapshotAt,
       "updateRunLastSnapshotAt",
     ),
+    verifyExisting: file.verifyExisting === undefined
+      ? false : expectBoolean(file.verifyExisting, "verifyExisting"),
     record: expectSnapshotRecord(file.record, "record"),
   };
 }

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -1,7 +1,10 @@
 import type { JsonObject, JsonValue } from "../app-server/protocol/index.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
 import { updateAgentRunStatus } from "./agent-runs.js";
-import { writeSessionSnapshotAtomically } from "./atomic-snapshot-writes.js";
+import {
+  writeSessionSnapshotAtomically,
+  type SessionSnapshotWriteRecord,
+} from "./atomic-snapshot-writes.js";
 import {
   pruneRolloutSessions,
   pruneSessionSnapshotsForSession,
@@ -141,6 +144,14 @@ interface SessionSnapshotState {
   // ticks); a dirty one is flushed by the coalescing timer, the periodic
   // tick, flushSession, or close.
   dirty: boolean;
+  revision: number;
+  writing: boolean;
+  retryAttempt: number;
+  pendingWrite?: {
+    readonly record: SessionSnapshotWriteRecord;
+    readonly trigger: SnapshotPolicyTrigger;
+    readonly revision: number;
+  };
   pendingTrigger?: SnapshotPolicyTrigger;
   // Policy-clock time of the last durable write, for coalescing.
   lastWriteMs?: number;
@@ -222,6 +233,7 @@ export class AgenCSessionSnapshotPolicy {
   #periodicTimer: SnapshotPolicyTimer | undefined;
   #lastSnapshotMs = 0;
   #sessionTouchSeq = 0;
+  #closing = false;
 
   constructor(
     driver: StateSqliteDriver,
@@ -431,23 +443,37 @@ export class AgenCSessionSnapshotPolicy {
   }
 
   /**
-   * Stop timers, flush every dirty session synchronously, and forget all
-   * tracked sessions. Called by the daemon before the state DB is closed.
+   * Stop timers and flush dirty sessions synchronously. Failed sessions stay
+   * tracked and close throws so the owner can retain the DB and retry.
    */
   close(): void {
+    if (this.#closing) throw new Error("snapshot policy close is already running");
     this.stopPeriodic();
-    // Dropping the current entry while iterating a Map is well defined.
-    for (const state of this.#sessions.values()) {
-      try {
-        if (state.dirty) {
-          this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
+    this.#closing = true;
+    const errors: unknown[] = [];
+    try {
+      for (const state of this.#sessions.values()) {
+        if (state.coalesceTimer !== undefined) {
+          this.#clearTimeout(state.coalesceTimer);
+          state.coalesceTimer = undefined;
         }
-      } catch (error) {
-        this.#onError(error);
+        try {
+          if (state.dirty) {
+            this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
+          }
+          this.#dropSession(state);
+        } catch (error) {
+          errors.push(error);
+          this.#onError(error);
+        }
       }
-      this.#dropSession(state);
+      this.#reportPruning();
+    } finally {
+      this.#closing = false;
     }
-    this.#reportPruning();
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "snapshot policy close retained unpersisted sessions");
+    }
   }
 
   hydrateSession(hydration: SnapshotPolicySessionHydration): void {
@@ -467,6 +493,7 @@ export class AgenCSessionSnapshotPolicy {
     // dropped, the tail is re-capped); write that once on the next tick so
     // the newest row reflects what this daemon instance actually holds.
     state.dirty = true;
+    state.revision += 1;
     state.pendingTrigger = "periodic";
   }
 
@@ -561,6 +588,7 @@ export class AgenCSessionSnapshotPolicy {
       // periodic tick.
       if (appended) {
         state.dirty = true;
+        state.revision += 1;
         state.pendingTrigger ??= "message_exchange";
       }
       return undefined;
@@ -882,6 +910,9 @@ export class AgenCSessionSnapshotPolicy {
       sessionId,
       lastTouchedMs: this.#sessionTouchSeq++,
       dirty: false,
+      revision: 0,
+      writing: false,
+      retryAttempt: 0,
       conversation: [],
       seenConversationKeys: new Set(),
       toolState: {
@@ -896,13 +927,13 @@ export class AgenCSessionSnapshotPolicy {
         events: [],
       },
     };
-    this.#sessions.set(sessionId, created);
     this.#evictStaleSessions();
+    this.#sessions.set(sessionId, created);
     return created;
   }
 
   #evictStaleSessions(): void {
-    while (this.#sessions.size > this.#maxTrackedSessions) {
+    while (this.#sessions.size >= this.#maxTrackedSessions) {
       let oldest: SessionSnapshotState | undefined;
       for (const state of this.#sessions.values()) {
         if (oldest === undefined || state.lastTouchedMs < oldest.lastTouchedMs) {
@@ -917,6 +948,7 @@ export class AgenCSessionSnapshotPolicy {
         }
       } catch (error) {
         this.#onError(error);
+        throw error;
       }
       this.#dropSession(oldest);
     }
@@ -991,7 +1023,9 @@ export class AgenCSessionSnapshotPolicy {
     trigger: SnapshotPolicyTrigger,
   ): SnapshotPolicySnapshotRecord | undefined {
     state.dirty = true;
+    state.revision += 1;
     state.pendingTrigger = trigger;
+    if (state.writing) return undefined;
     const nowIso = this.#now();
     const nowMs = Date.parse(nowIso);
     const sinceLastWriteMs =
@@ -1017,16 +1051,7 @@ export class AgenCSessionSnapshotPolicy {
         this.#coalesceIntervalMs,
         Math.max(1, this.#coalesceIntervalMs - sinceLastWriteMs),
       );
-      state.coalesceTimer = this.#setTimeout(() => {
-        state.coalesceTimer = undefined;
-        if (!state.dirty) return;
-        try {
-          this.#writeSnapshot(state, state.pendingTrigger ?? trigger);
-        } catch (error) {
-          this.#onError(error);
-        }
-      }, delayMs);
-      state.coalesceTimer.unref?.();
+      this.#scheduleSnapshot(state, delayMs);
     }
     return undefined;
   }
@@ -1036,20 +1061,80 @@ export class AgenCSessionSnapshotPolicy {
     trigger: SnapshotPolicyTrigger,
     nowIso?: string,
   ): SnapshotPolicySnapshotRecord {
-    const snapshotAt = this.#nextSnapshotAt(nowIso);
+    if (state.writing) throw new Error("snapshot write is already running");
     if (state.coalesceTimer !== undefined) {
       this.#clearTimeout(state.coalesceTimer);
       state.coalesceTimer = undefined;
     }
-    state.dirty = false;
-    state.pendingTrigger = undefined;
-    state.lastWriteMs = Date.parse(snapshotAt);
-    state.toolState.lastTrigger = trigger;
-    const conversation = [...state.conversation];
+    state.writing = true;
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        state.pendingWrite ??= this.#captureSnapshot(
+          state, attempt === 0 ? trigger : state.pendingTrigger ?? trigger,
+          attempt === 0 ? nowIso : undefined,
+        );
+        const pending = state.pendingWrite;
+        timed("session_snapshot_write", () =>
+          writeSessionSnapshotAtomically(this.#driver, pending.record, {
+            updateRunLastSnapshotAt: true, replayOnStartup: true, verifyExisting: true,
+          }),
+        );
+        state.pendingWrite = undefined;
+        state.lastWriteMs = Date.parse(pending.record.snapshotAt);
+        state.toolState.lastTrigger = pending.trigger;
+        state.retryAttempt = 0;
+        state.dirty = state.revision !== pending.revision;
+        if (!state.dirty) state.pendingTrigger = undefined;
+        this.#prunePersistedSnapshot(state.sessionId, pending.record.snapshotAt);
+        if (!state.dirty) {
+          return {
+            sessionId: state.sessionId,
+            snapshotAt: pending.record.snapshotAt,
+            trigger: pending.trigger,
+            conversation: JSON.parse(pending.record.conversationJson) as JsonValue[],
+            toolState: JSON.parse(pending.record.toolStateJson) as JsonObject,
+            mcpConnectionState: JSON.parse(pending.record.mcpConnectionStateJson) as JsonObject,
+          };
+        }
+      }
+      throw new Error("snapshot changed repeatedly during persistence; retry required");
+    } catch (error) {
+      if (state.dirty && !this.#closing) {
+        const delayMs = Math.min(30_000, 250 * 2 ** state.retryAttempt);
+        state.retryAttempt = Math.min(7, state.retryAttempt + 1);
+        this.#scheduleSnapshot(state, delayMs);
+      }
+      throw error;
+    } finally {
+      state.writing = false;
+    }
+  }
+
+  #scheduleSnapshot(state: SessionSnapshotState, delayMs: number): void {
+    if (state.coalesceTimer !== undefined || this.#closing) return;
+    state.coalesceTimer = this.#setTimeout(() => {
+      state.coalesceTimer = undefined;
+      if (!state.dirty) return;
+      try {
+        this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
+      } catch (error) {
+        this.#onError(error);
+      }
+    }, delayMs);
+    state.coalesceTimer.unref?.();
+  }
+
+  #captureSnapshot(
+    state: SessionSnapshotState,
+    trigger: SnapshotPolicyTrigger,
+    nowIso?: string,
+  ): NonNullable<SessionSnapshotState["pendingWrite"]> {
+    const snapshotAt = this.#nextSnapshotAt(nowIso);
     const toolState = normalizeJsonObject({
       ...state.toolState.extras,
       ...state.toolState,
       extras: undefined,
+      lastTrigger: trigger,
       inFlight: { ...state.toolState.inFlight },
       completed: { ...state.toolState.completed },
       statusTransitions: [...state.toolState.statusTransitions],
@@ -1060,41 +1145,38 @@ export class AgenCSessionSnapshotPolicy {
       extras: undefined,
       events: [...state.mcpConnectionState.events],
     });
-    timed("session_snapshot_write", () =>
-      writeSessionSnapshotAtomically(
-        this.#driver,
-        {
-          sessionId: state.sessionId,
-          snapshotAt,
-          conversationJson: JSON.stringify(conversation),
-          toolStateJson: JSON.stringify(toolState),
-          mcpConnectionStateJson: JSON.stringify(mcpConnectionState),
-        },
-        { updateRunLastSnapshotAt: true, replayOnStartup: true },
-      ),
-    );
+    return {
+      revision: state.revision,
+      trigger,
+      record: {
+        sessionId: state.sessionId,
+        snapshotAt,
+        conversationJson: JSON.stringify(state.conversation),
+        toolStateJson: JSON.stringify(toolState),
+        mcpConnectionStateJson: JSON.stringify(mcpConnectionState),
+      },
+    };
+  }
+
+  #prunePersistedSnapshot(sessionId: string, snapshotAt: string): void {
     // Retention runs on every write. The per-session prune is a few indexed
     // statements over at most SESSION_SNAPSHOT_HARD_CAP rows, unlike the
     // table-wide LENGTH() scan it replaces, whose 60 s throttle let one
     // session grow to 5,607 rows / 1.16 GB without ever deleting a row.
     // Reports are aggregated and surfaced from the periodic tick.
-    const pruned = pruneSessionSnapshotsForSession(
-      this.#driver,
-      state.sessionId,
-      { ...(this.#snapshotRetention ?? {}), now: () => snapshotAt },
-    );
-    if (pruned.prunedSnapshots > 0) {
-      this.#prunedSinceReport += pruned.prunedSnapshots;
-      this.#prunedSessionsSinceReport.add(state.sessionId);
+    try {
+      const pruned = pruneSessionSnapshotsForSession(
+        this.#driver,
+        sessionId,
+        { ...(this.#snapshotRetention ?? {}), now: () => snapshotAt },
+      );
+      if (pruned.prunedSnapshots > 0) {
+        this.#prunedSinceReport += pruned.prunedSnapshots;
+        this.#prunedSessionsSinceReport.add(sessionId);
+      }
+    } catch (error) {
+      this.#onError(error);
     }
-    return {
-      sessionId: state.sessionId,
-      snapshotAt,
-      trigger,
-      conversation,
-      toolState,
-      mcpConnectionState,
-    };
   }
 
   #reportPruning(): void {

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -675,15 +675,24 @@ export class AgenCSessionSnapshotPolicy {
     // every 30 s forever: 21 identical snapshots per session in the ten idle
     // minutes after the measured runs ended.
     const records: SnapshotPolicySnapshotRecord[] = [];
+    const errors: unknown[] = [];
     for (const state of this.#sessions.values()) {
       if (!state.dirty) continue;
-      records.push(this.#writeSnapshot(state, "periodic"));
+      try {
+        records.push(this.#writeSnapshot(state, "periodic"));
+      } catch (error) {
+        errors.push(error);
+      }
     }
     // Piggy-back the disk-retention sweep on the same throttled tick so
     // rollout/session pruning runs on a bounded timer, not a tight loop.
     this.sweepRolloutRetention();
     this.#reclaimFreePages();
     this.#reportPruning();
+    if (errors.length > 0) {
+      for (const error of errors) this.#onError(error);
+      throw new AggregateError(errors, "periodic snapshot flush retained unpersisted sessions");
+    }
     return records;
   }
 

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -5,6 +5,7 @@ import {
   fstatSync,
   mkdirSync,
   readFileSync,
+  rmSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
@@ -26,6 +27,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import type { AgenCShutdownSignal } from "../lifecycle/signal-handlers.js";
 import { openStateDatabases } from "../state/sqlite-driver.js";
+import { AgenCSessionSnapshotPolicy } from "../../src/state/snapshot-policy.js";
+import { AgenCCleanupRegistry, type AgenCCleanupTask } from "../../src/lifecycle/cleanup-registry.js";
 import { StateRunDurabilityRepository } from "../state/run-durability.js";
 import { ROLLOUT_SCHEMA_VERSION } from "../session/event-log.js";
 import { RolloutStore } from "../session/rollout-store.js";
@@ -6865,6 +6868,55 @@ snapshot_max_bytes = 64
     expect(io.stderrText()).toContain("cleanup[daemon-snapshots] failed");
 
     await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("retains a failed snapshot policy and its driver for a later close retry", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+    const signalProcess = createSignalProcess();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    let retryCleanup: AgenCCleanupTask | undefined;
+    let retainedPolicy: AgenCSessionSnapshotPolicy | undefined;
+    let pending: string | undefined;
+    const register = AgenCCleanupRegistry.prototype.register;
+    vi.spyOn(AgenCCleanupRegistry.prototype, "register").mockImplementation(function (this: AgenCCleanupRegistry, name, task) {
+      if (name === "daemon-snapshot-policy") retryCleanup = task;
+      return register.call(this, name, task);
+    });
+    const close = AgenCSessionSnapshotPolicy.prototype.close;
+    vi.spyOn(AgenCSessionSnapshotPolicy.prototype, "close").mockImplementationOnce(function (this: AgenCSessionSnapshotPolicy) {
+      retainedPolicy = this;
+      this.hydrateSession({ sessionId: "shutdown-retry", conversation: [{ content: "shutdown evidence" }] });
+      close.call(this);
+    });
+    const running = runAgenCDaemonCli(
+      { kind: "command", action: "run" }, { host, io, signalProcess },
+    );
+    try {
+      await expect(waitForPid(pidPath)).resolves.toBe(4100);
+      const driver = openStateDatabases({ cwd: process.cwd(), agencHome });
+      pending = join(driver.projectDir, "session_state_snapshots.pending");
+      driver.close();
+      writeFileSync(pending, "staging obstruction");
+      signalProcess.emit("SIGTERM");
+      await expect(running).resolves.toBe(1);
+      expect(io.stderrText()).toContain("cleanup[daemon-snapshot-policy] failed");
+      expect(retainedPolicy?.trackedSessionIds()).toContain("shutdown-retry");
+      rmSync(pending);
+      expect(retainedPolicy?.flushSession("shutdown-retry")?.conversation)
+        .toEqual([{ content: "shutdown evidence" }]);
+      expect(retryCleanup).toBeDefined();
+      await retryCleanup!({ reason: "daemon_shutdown" });
+      expect(retainedPolicy?.trackedSessionIds()).toEqual([]);
+      expect(() => retainedPolicy?.loadLatest("shutdown-retry")).toThrow();
+    } finally {
+      signalProcess.emit("SIGTERM");
+      await running.catch(() => {});
+      if (pending !== undefined) rmSync(pending, { recursive: true, force: true });
+      await retryCleanup?.({ reason: "daemon_shutdown" });
+      await rm(agencHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -6918,6 +6918,43 @@ snapshot_max_bytes = 64
       await rm(agencHome, { recursive: true, force: true });
     }
   });
+
+  it("periodic snapshot failure in one project does not starve another project", async () => {
+    const agencHome = await tempAgencHome();
+    const otherCwd = await mkdtemp(join(tmpdir(), "agenc-periodic-other-"));
+    await mkdir(join(otherCwd, ".git"));
+    const host = createHost(agencHome);
+    const io = createIo();
+    const signalProcess = createSignalProcess();
+    seedRecoverableDaemonState(agencHome, {
+      cwd: otherCwd, runId: "run-periodic-good", sessionId: "session-periodic-good", status: "blocked",
+    });
+    const flushPeriodic = AgenCSessionSnapshotPolicy.prototype.flushPeriodic;
+    vi.spyOn(AgenCSessionSnapshotPolicy.prototype, "flushPeriodic").mockImplementation(function (this: AgenCSessionSnapshotPolicy) {
+      if (!this.trackedSessionIds().includes("session-periodic-good")) {
+        throw new Error("default project periodic failure");
+      }
+      return flushPeriodic.call(this);
+    });
+    const runner: AgenCBackgroundAgentRunner = {
+      startAgent: async () => { throw new Error("not used"); },
+      restoreAgent: async () => true,
+    };
+    const running = runAgenCDaemonCli(
+      { kind: "command", action: "run" },
+      { host, io, signalProcess, runner, snapshotPeriodicIntervalMs: 10 },
+    );
+    try {
+      await expect(waitForPid(resolveAgenCDaemonPidPath(host.env, host.userHome))).resolves.toBe(4100);
+      await waitForSnapshotAfter(agencHome, otherCwd, "session-periodic-good", SEEDED_RECOVERY_SNAPSHOT_AT);
+      expect(io.stderrText()).toContain("daemon snapshot policy failed");
+    } finally {
+      signalProcess.emit("SIGTERM");
+      await running;
+      await rm(otherCwd, { recursive: true, force: true });
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
 });
 
 /** snapshot_at of the recovered row seeded by seedRecoverableDaemonState. */

--- a/runtime/tests/state/snapshot-policy-retry.test.ts
+++ b/runtime/tests/state/snapshot-policy-retry.test.ts
@@ -1,0 +1,308 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AgenCSessionSnapshotPolicy, type SnapshotPolicyOptions } from "../../src/state/snapshot-policy.js";
+import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
+import { replayAtomicSessionSnapshotWrites, writeSessionSnapshotAtomically } from "../../src/state/atomic-snapshot-writes.js";
+import { pruneSessionSnapshotsForSession } from "../../src/state/pruning.js";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, unlinkSync: vi.fn(actual.unlinkSync) };
+});
+
+vi.mock("../../src/state/atomic-snapshot-writes.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/state/atomic-snapshot-writes.js")>();
+  return { ...actual, writeSessionSnapshotAtomically: vi.fn(actual.writeSessionSnapshotAtomically) };
+});
+
+vi.mock("../../src/state/pruning.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/state/pruning.js")>();
+  return { ...actual, pruneSessionSnapshotsForSession: vi.fn(actual.pruneSessionSnapshotsForSession) };
+});
+
+interface Fixture {
+  readonly directory: string;
+  readonly pending: string;
+  readonly driver: StateSqliteDriver;
+  readonly policy: AgenCSessionSnapshotPolicy;
+  readonly errors: unknown[];
+}
+
+const fixtures: Fixture[] = [];
+
+function fixture(options: SnapshotPolicyOptions = {}): Fixture {
+  const directory = mkdtempSync(join(tmpdir(), "agenc-snapshot-retry-"));
+  const cwd = join(directory, "project");
+  const home = join(directory, "home");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  const driver = openStateDatabases({ cwd, agencHome: home });
+  const errors: unknown[] = [];
+  const policy = new AgenCSessionSnapshotPolicy(driver, {
+    agencHome: home, coalesceIntervalMs: 0, onError: (error) => errors.push(error), ...options,
+  });
+  const result = { directory, pending: join(driver.projectDir, "session_state_snapshots.pending"), driver, policy, errors };
+  fixtures.push(result);
+  return result;
+}
+
+function message(policy: AgenCSessionSnapshotPolicy, content = "retained conversation"): void {
+  policy.recordMessageExchange({
+    sessionId: "session-1", agentId: "agent-1", content, messageId: content,
+    streamId: "stream-1", acceptedAt: "2026-05-01T00:00:00.000Z",
+  });
+}
+
+function stored(driver: StateSqliteDriver): readonly { conversation_json: string; snapshot_at: string }[] {
+  return driver.prepareState<[], { conversation_json: string; snapshot_at: string }>(
+    "SELECT conversation_json, snapshot_at FROM session_state_snapshots ORDER BY snapshot_at",
+  ).all();
+}
+
+afterEach(() => {
+  for (const current of fixtures.splice(0)) {
+    try { current.policy.close(); } catch {}
+    current.driver.close();
+    rmSync(current.directory, { recursive: true, force: true });
+  }
+  vi.mocked(unlinkSync).mockReset();
+  vi.mocked(writeSessionSnapshotAtomically).mockReset();
+  vi.mocked(pruneSessionSnapshotsForSession).mockReset();
+});
+
+describe("session snapshot persistence retry", () => {
+  test.each(["explicit", "periodic"])("retries a staging failure through %s flush", (kind) => {
+    const { pending, driver, policy } = fixture();
+    writeFileSync(pending, "staging obstruction");
+    expect(() => message(policy)).toThrow(/EEXIST|ENOTDIR/u);
+    expect(stored(driver)).toEqual([]);
+    rmSync(pending);
+    const result = kind === "explicit" ? policy.flushSession("session-1") : policy.flushPeriodic()[0];
+    expect(result).toBeDefined();
+    expect(stored(driver)).toHaveLength(1);
+    expect(stored(driver)[0]!.conversation_json).toContain("retained conversation");
+    expect(policy.flushSession("session-1")).toBeUndefined();
+    expect(policy.flushPeriodic()).toEqual([]);
+  });
+
+  test("retains dirty state after close fails", () => {
+    const { pending, policy } = fixture();
+    policy.hydrateSession({ sessionId: "session-1", conversation: [{ content: "close evidence" }] });
+    writeFileSync(pending, "staging obstruction");
+    try { policy.close(); } catch {}
+    expect(policy.trackedSessionIds()).toContain("session-1");
+    rmSync(pending);
+    expect(policy.flushSession("session-1")).toBeDefined();
+    policy.close();
+    expect(policy.trackedSessionIds()).toEqual([]);
+  });
+
+  test("keeps failed dirty state without admitting unbounded new sessions", () => {
+    const { pending, policy } = fixture({ maxTrackedSessions: 1 });
+    policy.hydrateSession({ sessionId: "session-1", conversation: [{ content: "eviction evidence" }] });
+    writeFileSync(pending, "staging obstruction");
+    try { policy.trackSession("session-2"); } catch {}
+    expect(policy.trackedSessionIds()).toEqual(["session-1"]);
+    rmSync(pending);
+    expect(policy.flushSession("session-1")).toBeDefined();
+  });
+
+  test("does not duplicate a successfully persisted snapshot", () => {
+    const { driver, policy } = fixture();
+    message(policy);
+    expect(policy.flushSession("session-1")).toBeUndefined();
+    expect(stored(driver)).toHaveLength(1);
+  });
+
+  test("retries the same staged bytes after a database failure and preserves newer events", () => {
+    const { pending, driver, policy } = fixture();
+    driver.state.exec(`CREATE TRIGGER reject_snapshot BEFORE INSERT ON session_state_snapshots
+      BEGIN SELECT RAISE(ABORT, 'snapshot commit rejected'); END`);
+    expect(() => message(policy)).toThrow("snapshot commit rejected");
+    const stagedPath = join(pending, readdirSync(pending)[0]!);
+    const staged = readFileSync(stagedPath, "utf8");
+    expect(() => message(policy, "newer conversation")).toThrow("snapshot commit rejected");
+    expect(readFileSync(stagedPath, "utf8")).toBe(staged);
+    expect(readdirSync(pending)).toHaveLength(1);
+    driver.state.exec("DROP TRIGGER reject_snapshot");
+    expect(policy.flushSession("session-1")).toBeDefined();
+    expect(stored(driver)).toHaveLength(2);
+    expect(stored(driver)[0]!.snapshot_at).toBe(JSON.parse(staged).record.snapshotAt);
+    expect(stored(driver)[0]!.conversation_json).not.toContain("newer conversation");
+    expect(stored(driver)[1]!.conversation_json).toContain("newer conversation");
+    expect(readdirSync(pending)).toEqual([]);
+    replayAtomicSessionSnapshotWrites(driver.state, driver.projectDir);
+    expect(stored(driver)).toHaveLength(2);
+    expect(policy.flushSession("session-1")).toBeUndefined();
+  });
+
+  test.each(["before", "after"])("retains an event delivered %s persistence during retry", (phase) => {
+    const { pending, driver, policy } = fixture();
+    writeFileSync(pending, "staging obstruction");
+    expect(() => message(policy)).toThrow();
+    rmSync(pending);
+    const persist = vi.mocked(writeSessionSnapshotAtomically).getMockImplementation()!;
+    vi.mocked(writeSessionSnapshotAtomically).mockImplementationOnce((...args) => {
+      if (phase === "before") message(policy, "reentrant conversation");
+      persist(...args);
+      if (phase === "after") message(policy, "reentrant conversation");
+    });
+    expect(policy.flushSession("session-1")!.conversation).toEqual(expect.arrayContaining([
+      expect.objectContaining({ content: "reentrant conversation" }),
+    ]));
+    expect(stored(driver)).toHaveLength(2);
+    expect(stored(driver)[0]!.conversation_json).not.toContain("reentrant conversation");
+    expect(stored(driver)[1]!.conversation_json).toContain("reentrant conversation");
+    expect(policy.flushSession("session-1")).toBeUndefined();
+  });
+
+  test("retains a newer event when the retry itself fails", () => {
+    const { pending, driver, policy } = fixture();
+    writeFileSync(pending, "staging obstruction");
+    expect(() => message(policy)).toThrow();
+    vi.mocked(writeSessionSnapshotAtomically).mockImplementationOnce(() => {
+      message(policy, "event during failed retry");
+      throw new Error("retry failed");
+    });
+    expect(() => policy.flushSession("session-1")).toThrow("retry failed");
+    rmSync(pending);
+    policy.flushSession("session-1");
+    expect(stored(driver)).toHaveLength(2);
+    expect(stored(driver)[1]!.conversation_json).toContain("event during failed retry");
+    expect(policy.flushSession("session-1")).toBeUndefined();
+  });
+
+  test("retries post-commit cleanup without duplicating the database row", () => {
+    const { pending, driver, policy } = fixture();
+    vi.mocked(unlinkSync).mockImplementationOnce(() => { throw new Error("cleanup failed"); });
+    expect(() => message(policy)).toThrow("cleanup failed");
+    const first = stored(driver);
+    expect(first).toHaveLength(1);
+    expect(readdirSync(pending)).toHaveLength(1);
+    policy.flushSession("session-1");
+    expect(stored(driver)).toEqual(first);
+    expect(readdirSync(pending)).toEqual([]);
+    expect(policy.flushSession("session-1")).toBeUndefined();
+  });
+
+  test("rejects a conflicting existing row without acknowledging or overwriting it", () => {
+    const { pending, driver, policy } = fixture();
+    vi.mocked(unlinkSync).mockImplementationOnce(() => { throw new Error("cleanup failed"); });
+    expect(() => message(policy)).toThrow("cleanup failed");
+    const original = stored(driver)[0]!;
+    driver.state.exec("UPDATE session_state_snapshots SET conversation_json = '[]'");
+    expect(() => policy.flushSession("session-1")).toThrow("conflicts");
+    expect(stored(driver)[0]!.conversation_json).toBe("[]");
+    expect(readdirSync(pending)).toHaveLength(1);
+    driver.prepareState<[string]>("UPDATE session_state_snapshots SET conversation_json = ?")
+      .run(original.conversation_json);
+    policy.flushSession("session-1");
+    expect(stored(driver)).toEqual([original]);
+  });
+
+  test.each([false, true])("startup replay verifies an existing row, conflicting=%s", (conflicting) => {
+    const { pending, driver, policy } = fixture();
+    vi.mocked(unlinkSync).mockImplementationOnce(() => { throw new Error("cleanup failed"); });
+    expect(() => message(policy)).toThrow("cleanup failed");
+    const original = stored(driver)[0]!;
+    if (conflicting) driver.state.exec("UPDATE session_state_snapshots SET conversation_json = '[]'");
+    const beforeReplay = stored(driver);
+    replayAtomicSessionSnapshotWrites(driver.state, driver.projectDir);
+    expect(stored(driver)).toEqual(beforeReplay);
+    if (conflicting) {
+      expect(readdirSync(pending)).toEqual([expect.stringMatching(/\.json\.corrupt$/u)]);
+      driver.prepareState<[string]>("UPDATE session_state_snapshots SET conversation_json = ?")
+        .run(original.conversation_json);
+    } else {
+      expect(readdirSync(pending)).toEqual([]);
+    }
+    policy.flushSession("session-1");
+    expect(stored(driver)).toEqual([original]);
+    expect(policy.flushSession("session-1")).toBeUndefined();
+  });
+
+  test("bounds synchronous draining when every attempt receives a newer event", () => {
+    const { driver, policy } = fixture();
+    const persist = vi.mocked(writeSessionSnapshotAtomically).getMockImplementation()!;
+    let attempts = 0;
+    vi.mocked(writeSessionSnapshotAtomically).mockImplementation((...args) => {
+      persist(...args);
+      attempts += 1;
+      message(policy, `new event ${attempts}`);
+    });
+    expect(() => message(policy)).toThrow("changed repeatedly");
+    expect(attempts).toBe(2);
+    expect(stored(driver)).toHaveLength(2);
+    vi.mocked(writeSessionSnapshotAtomically).mockReset();
+    policy.flushSession("session-1");
+    expect(stored(driver)).toHaveLength(3);
+    expect(stored(driver)[2]!.conversation_json).toContain("new event 2");
+    expect(policy.flushSession("session-1")).toBeUndefined();
+  });
+
+  test("does not acknowledge a snapshot inside a caller's uncommitted transaction", () => {
+    const { driver, policy } = fixture();
+    policy.hydrateSession({ sessionId: "session-1", conversation: [{ content: "transaction evidence" }] });
+    expect(() => driver.transaction(() => policy.flushSession("session-1")))
+      .toThrow("require their own transaction");
+    expect(stored(driver)).toEqual([]);
+    expect(policy.flushSession("session-1")).toBeDefined();
+    expect(stored(driver)).toHaveLength(1);
+  });
+
+  test("does not retry an already committed snapshot when retention fails", () => {
+    const { driver, policy, errors } = fixture();
+    vi.mocked(pruneSessionSnapshotsForSession).mockImplementationOnce(() => {
+      throw new Error("retention failed");
+    });
+    message(policy);
+    expect(errors).toEqual([expect.objectContaining({ message: "retention failed" })]);
+    expect(policy.flushSession("session-1")).toBeUndefined();
+    expect(stored(driver)).toHaveLength(1);
+  });
+
+  test("bounds retry timers and stops them on failed close", () => {
+    const timers = new Map<object, { callback: () => void; delayMs: number }>();
+    const { pending, policy, errors } = fixture({
+      setTimeout: (callback, delayMs) => {
+        const timer = {};
+        timers.set(timer, { callback, delayMs });
+        return timer;
+      },
+      clearTimeout: (timer) => { timers.delete(timer); },
+    });
+    writeFileSync(pending, "staging obstruction");
+    expect(() => message(policy)).toThrow();
+    let lastDelay = 0;
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      expect(timers.size).toBe(1);
+      const [timer, scheduled] = [...timers][0]!;
+      expect(scheduled.delayMs).toBeGreaterThanOrEqual(Math.max(250, lastDelay));
+      expect(scheduled.delayMs).toBeLessThanOrEqual(30_000);
+      lastDelay = scheduled.delayMs;
+      timers.delete(timer);
+      scheduled.callback();
+    }
+    expect(errors).toHaveLength(12);
+    expect(() => policy.close()).toThrow("retained unpersisted sessions");
+    expect(timers.size).toBe(0);
+    rmSync(pending);
+    expect(policy.flushSession("session-1")).toBeDefined();
+    expect(timers.size).toBe(0);
+  });
+
+  test("refuses repeated admissions while a dirty eviction cannot persist", () => {
+    const { pending, policy } = fixture({ maxTrackedSessions: 1 });
+    policy.hydrateSession({ sessionId: "session-1", conversation: [{ content: "bounded evidence" }] });
+    writeFileSync(pending, "staging obstruction");
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      expect(() => policy.trackSession(`new-${attempt}`)).toThrow();
+      expect(policy.trackedSessionIds()).toEqual(["session-1"]);
+    }
+    rmSync(pending);
+    policy.trackSession("new-success");
+    expect(policy.trackedSessionIds()).toEqual(["new-success"]);
+    expect(policy.loadLatest("session-1")!.conversation).toEqual([{ content: "bounded evidence" }]);
+  });
+});

--- a/runtime/tests/state/snapshot-policy-retry.test.ts
+++ b/runtime/tests/state/snapshot-policy-retry.test.ts
@@ -305,4 +305,26 @@ describe("session snapshot persistence retry", () => {
     expect(policy.trackedSessionIds()).toEqual(["new-success"]);
     expect(policy.loadLatest("session-1")!.conversation).toEqual([{ content: "bounded evidence" }]);
   });
+
+  test("periodic failure does not starve later dirty sessions without retry timers", () => {
+    const { driver, policy } = fixture();
+    driver.state.exec(`CREATE TRIGGER reject_one_snapshot BEFORE INSERT ON session_state_snapshots
+      WHEN NEW.session_id = 'bad-session'
+      BEGIN SELECT RAISE(ABORT, 'one session failed'); END`);
+    policy.hydrateSession({ sessionId: "bad-session", conversation: [{ content: "retry later" }] });
+    policy.hydrateSession({ sessionId: "good-session", conversation: [{ content: "persist now" }] });
+    expect(() => policy.flushPeriodic()).toThrow();
+    expect(policy.loadLatest("good-session")?.conversation).toEqual([{ content: "persist now" }]);
+    expect(policy.loadLatest("bad-session")).toBeUndefined();
+    policy.recordSessionEvent("good-session", {
+      method: "event.message_chunk", params: { delta: "next tick", eventId: "chunk-next" },
+    });
+    expect(() => policy.flushPeriodic()).toThrow();
+    expect(policy.loadLatest("good-session")?.conversation).toEqual(expect.arrayContaining([
+      expect.objectContaining({ delta: "next tick" }),
+    ]));
+    driver.state.exec("DROP TRIGGER reject_one_snapshot");
+    expect(policy.flushPeriodic()).toHaveLength(1);
+    expect(policy.flushPeriodic()).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- Keep immutable snapshot bytes and timestamps after staging, database, or cleanup failures. Clear dirty bookkeeping only after persistence succeeds.
- Preserve newer events during retry, bound synchronous draining to two writes, and retry timers with a 250 ms to 30 s backoff.
- Retain failed dirty sessions during close and eviction. Refuse new session admission at the cap when eviction cannot persist. Keep failed daemon policies and their drivers available for an in-process close retry, and report shutdown failure.
- Continue periodic flushing after a failed session or project, then report the collected errors. Timer-only and hydrated siblings cannot be starved by a repeatedly failing entry.
- Verify identical rows during retry and startup replay for newly flagged pending files. Do not overwrite conflicting database content. Existing unflagged replay and strict import behavior remain unchanged.

## Validation

- Original source reproduces four failures with one passing control for staging, explicit/periodic flush, close, and eviction.
- Both runtime typecheck configurations and 216 targeted tests across seven files pass, with zero skips.
- The new retry test file typechecks independently. The existing daemon contract file has 40 pre-existing standalone type diagnostics; compiler comparison against its baseline source reports no added or removed diagnostics. No runtime compiler options or test suppressions changed.
- Initial e62f33ff012dd006ba9034febe7cde00391d137d passes the full local suite, 24,198 runtime tests across 2,305 files, along with root and launcher checks.
- Final 940b2b033f25efbdfb02d2fe4880f87c3c397b6a passes build, package entrypoints, generated SDK types, real-PTY startup, and 92 Linux native tests across five files. Its full run reports 24,199 passes and one failure in the unchanged FND red-probe supervisor contract: an injected dependency exit=23 was classified as residual_process rather than expected-red failure. The unchanged test file passes all 79 tests on a focused rerun. Its runner, process supervisor, and test helpers are unchanged. The full run is not claimed clean.
- Initial Bugbot review found periodic starvation. Added two regressions that fail against that head: one failed test with 18 passing controls for sibling sessions, and one failed test with 139 passing controls for separate daemon projects. The follow-up isolates both loops.
- Final-head Bugbot completes with no issues, Cursor explicitly approves that SHA, and Security succeeds. Exact-head Sonar passes with zero new issues, zero security hotspots, and zero duplication.
- The FND benchmark artifact and its measured source inputs are unchanged.

## Recovery limits

No database migration is required. New pending files add an optional verification flag; older runtimes do not enforce it, so pending recovery should finish before downgrade. Failed close retains in-memory state only while its owner remains alive. Daemon shutdown reports a nonzero exit but does not wait indefinitely for storage repair. If no durable recovery file could be written, process exit can still lose that state.

Hosted GitHub Actions remain disabled. Validation runs locally; no Actions dispatch, rerun, or retry is requested.

Closes #2087.
