### PR TITLE
fix(thread-store): publish live writers after registry persistence

### DIFF
--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -426,7 +426,7 @@ export class FileThreadStore implements ThreadStore {
       params.source === undefined
         ? undefined
         : canonicalizeThreadSource(params.source);
-    this.bindLiveRecorder(threadId, params.rolloutStore);
+    this.prepareLiveRecorder(params.rolloutStore);
 
     this.updateRegistry((registry) => {
       const now = new Date().toISOString();
@@ -471,6 +471,7 @@ export class FileThreadStore implements ThreadStore {
       };
       registry.set(threadId, entry);
     });
+    this.bindLiveRecorder(threadId, params.rolloutStore);
   }
 
   resumeThread(params: ResumeThreadParams): void {
@@ -492,7 +493,7 @@ export class FileThreadStore implements ThreadStore {
         );
       }
 
-      this.bindLiveRecorder(threadId, params.rolloutStore);
+      this.prepareLiveRecorder(params.rolloutStore);
 
       const now = new Date().toISOString();
       const entry: RegistryEntry = {
@@ -531,6 +532,7 @@ export class FileThreadStore implements ThreadStore {
       };
       registry.set(threadId, entry);
     });
+    this.bindLiveRecorder(threadId, params.rolloutStore);
   }
 
   appendItems(params: AppendThreadItemsParams): void {
@@ -1174,12 +1176,15 @@ export class FileThreadStore implements ThreadStore {
    * (`appendItems`, metadata patches, path lookups).
    */
   private bindLiveRecorder(threadId: ThreadId, rolloutStore: RolloutStore): void {
-    this.liveRecorders.set(threadId, rolloutStore);
     rolloutStore.setOnRolloutCommitted((rolloutPath) => {
       if (this.closed) return;
       if (this.liveRecorders.get(threadId) !== rolloutStore) return;
       this.indexRolloutFile(rolloutPath);
     });
+    this.liveRecorders.set(threadId, rolloutStore);
+  }
+
+  private prepareLiveRecorder(rolloutStore: RolloutStore): void {
     if (existsSync(rolloutStore.rolloutPath)) {
       this.indexRolloutFile(rolloutStore.rolloutPath);
     }

--- a/runtime/tests/thread-store/writer-registration-retry.test.ts
+++ b/runtime/tests/thread-store/writer-registration-retry.test.ts
@@ -1,0 +1,133 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
+import { StateThreadRepository } from "../../src/state/threads.js";
+import { FileThreadStore, ThreadNotFoundError } from "../../src/thread-store/store.js";
+
+interface Fixture {
+  readonly directory: string;
+  readonly store: FileThreadStore;
+  readonly rollout: RolloutStore;
+  readonly driver: StateSqliteDriver;
+}
+
+const fixtures: Fixture[] = [];
+
+function fixture(): Fixture {
+  const directory = mkdtempSync(join(tmpdir(), "agenc-writer-retry-"));
+  const cwd = join(directory, "project");
+  const agencHome = join(directory, "home");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  const store = new FileThreadStore({ cwd, agencHome });
+  store.listThreads({ pageSize: 10, archived: false });
+  const rollout = new RolloutStore({
+    cwd, agencHome, sessionId: "thread-retry", agencVersion: "0.17.0", sessionTempRoot: directory,
+  });
+  rollout.open({
+    sessionId: "thread-retry", timestamp: "2026-05-01T00:00:00.000Z", cwd,
+    originator: "writer-retry-test", agencVersion: "0.17.0", model: "fixture-model", modelProvider: "fixture",
+  });
+  rollout.flushDurable();
+  const driver = openStateDatabases({ cwd, agencHome });
+  const result = { directory, store, rollout, driver };
+  fixtures.push(result);
+  return result;
+}
+
+function register(current: Fixture, operation: "createThread" | "resumeThread"): void {
+  current.store[operation]({
+    threadId: "thread-retry", rolloutStore: current.rollout, model: "attempt-model",
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const current of fixtures.splice(0)) {
+    current.store.close();
+    current.rollout.close();
+    current.driver.close();
+    rmSync(current.directory, { recursive: true, force: true });
+  }
+});
+
+describe.each(["createThread", "resumeThread"] as const)("%s writer publication", (operation) => {
+  test("does not retain a live writer after a registry read failure", () => {
+    const current = fixture();
+    const read = vi.spyOn(StateThreadRepository.prototype, "listThreads")
+      .mockImplementationOnce(() => { throw new Error("registry read failed"); });
+    expect(() => register(current, operation)).toThrow("registry read failed");
+    expect(() => current.store.appendItems({ threadId: "thread-retry", items: [] }))
+      .toThrow(ThreadNotFoundError);
+    read.mockRestore();
+    expect(() => register(current, operation)).not.toThrow();
+    expect(current.store.readThread({ threadId: "thread-retry", includeHistory: false, includeArchived: false }).model)
+      .toBe("attempt-model");
+  });
+
+  test("can retry after the registry mutator reaches a failing SQLite upsert", () => {
+    const current = fixture();
+    current.driver.state.exec(`CREATE TRIGGER reject_registration BEFORE INSERT ON threads
+      WHEN NEW.model = 'attempt-model'
+      BEGIN SELECT RAISE(ABORT, 'registry upsert failed'); END`);
+    expect(() => register(current, operation)).toThrow("registry upsert failed");
+    expect(() => current.store.appendItems({ threadId: "thread-retry", items: [] }))
+      .toThrow(ThreadNotFoundError);
+    current.driver.state.exec("DROP TRIGGER reject_registration");
+    expect(() => register(current, operation)).not.toThrow();
+    expect(current.store.readThread({ threadId: "thread-retry", includeHistory: false, includeArchived: false }).model)
+      .toBe("attempt-model");
+  });
+
+  test("leaves no live writer when registry lock acquisition fails", () => {
+    const current = fixture();
+    const lockPath = `${current.store.registryFilePath}.lock`;
+    mkdirSync(lockPath);
+    writeFileSync(join(lockPath, "holder.pid"), String(process.pid));
+    let now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 31_000;
+      return now;
+    });
+    expect(() => register(current, operation)).toThrow("failed to acquire registry lock");
+    clock.mockRestore();
+    rmSync(lockPath, { recursive: true });
+    expect(() => current.store.appendItems({ threadId: "thread-retry", items: [] }))
+      .toThrow(ThreadNotFoundError);
+    expect(() => register(current, operation)).not.toThrow();
+  });
+
+  test("preserves a valid writer when a second registration is rejected", () => {
+    const current = fixture();
+    register(current, operation);
+    const callback = vi.spyOn(current.rollout, "setOnRolloutCommitted");
+    expect(() => register(current, operation)).toThrow("already has a live local writer");
+    expect(callback).not.toHaveBeenCalled();
+    expect(() => current.store.appendItems({ threadId: "thread-retry", items: [] })).not.toThrow();
+  });
+
+  test.each(["index", "registry"])("preserves the existing rollout callback after a %s failure", (failure) => {
+    const current = fixture();
+    const previous = vi.fn();
+    current.rollout.setOnRolloutCommitted(previous);
+    const callback = vi.spyOn(current.rollout, "setOnRolloutCommitted");
+    const fault = failure === "index"
+      ? vi.spyOn(StateThreadRepository.prototype, "getBackfillFile")
+        .mockImplementationOnce(() => { throw new Error("initial index failed"); })
+      : vi.spyOn(StateThreadRepository.prototype, "listThreads")
+        .mockImplementationOnce(() => { throw new Error("registry read failed"); });
+    expect(() => register(current, operation)).toThrow("failed");
+    expect(callback).not.toHaveBeenCalled();
+    expect(() => current.store.appendItems({ threadId: "thread-retry", items: [] }))
+      .toThrow(ThreadNotFoundError);
+    fault.mockRestore();
+    current.rollout.appendRollout({
+      type: "response_item", payload: { role: "user", content: "prior callback evidence", id: "prior" },
+    });
+    current.rollout.flushDurable();
+    expect(previous).toHaveBeenCalledWith(current.rollout.rolloutPath);
+    expect(() => register(current, operation)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Prepare the existing rollout index before installing a live writer. Publish the writer and its flush callback only after the registry update returns successfully.
- Apply the same order to create and resume, preserving their existing archive checks and metadata/index ordering.
- Leave existing callbacks and live writers unchanged when indexing, registry reads, locking, or SQLite upsert fails. The same thread ID can be retried after the fault is repaired.

## Validation

- Original source reproduces four failures with four passing controls across create and resume. The regressions check the public append path, not private map contents.
- Both runtime typechecks and 216 tests across seven files pass, including backfill, multi-project routing, daemon contracts, and bootstrap services. These include direct rollout-flush mirror coverage and callback ownership after failed indexing/registry reads.
- On 8e349b397ed2bc210ff435eb307ee56c36e54ea9, dedicated new-test typecheck, build, package entrypoints, generated SDK types, and real-PTY startup pass. The full local suite passes 24,212 runtime tests across 2,306 files, plus root and launcher checks. Linux native checks pass 92 tests across five files.
- Exact-head Cursor Bugbot completes without findings, Cursor explicitly approves that SHA, and Security succeeds. Sonar is OK with zero new issues, zero security hotspots, and zero duplication.
- GitNexus rates FileThreadStore HIGH with 16 direct callers and two indexed bootstrap flows; interface dispatch means this is a lower bound. The implementation changes only create/resume publication order and splits index preparation from callback registration. No measured FND input changed.

This change does not make the existing whole-registry upsert loop transactional or undo index rows already committed from a valid rollout. It prevents a failed registration from publishing a new in-memory writer or replacing the prior callback. No schema or public API changes are needed.

Hosted Actions remain disabled. No Actions dispatch, retry, or rerun is requested.

Closes #2088.
