### PR TITLE
fix(startup): share readiness deadlines across launcher and SDK

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -40,8 +40,23 @@ Ready-wait timeout for clients that start the daemon
 
 | Client                                                         | Default      |
 | -------------------------------------------------------------- | ------------ |
-| Published launcher (`packages/agenc`)                          | **2000** ms  |
+| Published launcher (`packages/agenc`)                          | **45000** ms |
 | Runtime daemon autostart / `agenc daemon` / SDK socket connect | **45000** ms |
+
+The launcher and SDK use one deadline from the initial probe through readiness.
+The SDK includes its socket connection and initialize handshake. The launcher's
+old 2s default covered only polling after the starter finished; the 45s total
+budget now includes that starter. Both pass the remaining budget to the nested
+daemon-start command.
+
+Timeout or caller cancellation terminates the owned starter, with `SIGKILL`
+after 100 ms if needed. Waiting for `close` can add up to 1s. Cleanup failure is
+reported rather than treated as proof of termination. An existing or already
+detached daemon is not signalled by this cleanup. Custom launcher
+`spawnDaemonFn` callbacks must honor the supplied `signal` and register bounded
+child cleanup with `registerCleanup(promise)` if they manage their own child.
+An unresolved callback alone cannot expose a hidden child for termination.
+The launcher still continues to the requested command after autostart failure.
 
 ```bash
 AGENC_DAEMON_READY_TIMEOUT_MS=45000

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -226,7 +226,7 @@ still works. `amazon-bedrock` uses AWS SigV4 aliases and does not read
 | Var | Effect |
 | --- | --- |
 | `AGENC_DAEMON_AUTOSTART` | `0` disables autostart |
-| `AGENC_DAEMON_READY_TIMEOUT_MS` | Ready-wait. Launcher default 2000 ms; runtime/SDK default 45000 ms |
+| `AGENC_DAEMON_READY_TIMEOUT_MS` | Readiness budget. Launcher/runtime/SDK default 45000 ms; launcher and SDK include initial probe and starter time |
 | `AGENC_DAEMON_REQUEST_TIMEOUT_MS` | Per-request RPC timeout (SDK default 30000 ms) |
 | `AGENC_DAEMON_MAX_OLD_SPACE_MB` | Detached daemon V8 heap cap (default 4096) |
 | `AGENC_DAEMON_MAX_QUEUED_REQUESTS`, `AGENC_DAEMON_MAX_IN_FLIGHT_REQUESTS` | RPC overload bounds |

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -216,7 +216,12 @@ Windows.
 
 When the socket is not accepting connections and `autostart` is enabled
 (default), `connect()` runs `<agencCommand> daemon start` and polls the cookie
-and socket until ready (45s budget, or `AGENC_DAEMON_READY_TIMEOUT_MS`).
+and socket until ready. The 45s default budget, overridden by `readyTimeoutMs`
+or `AGENC_DAEMON_READY_TIMEOUT_MS`, covers the initial probe, starter, polling,
+final connection, and initialize handshake together. Pass `signal` for caller
+cancellation. Starter termination can add up to 1s for cleanup; an unclosed
+starter produces an explicit cleanup error. See the
+[SDK startup and custom-spawner contract](../packages/agenc-sdk/README.md#defaults).
 
 Deviation from the launcher: the runtime's internal autostart also handles
 build-skew respawn and orphan-daemon adoption. Those need runtime-internal

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -81,6 +81,25 @@ await client.close();
 
 ## Defaults
 
+`connect({ readyTimeoutMs, signal })` uses one monotonic deadline for the initial
+probe, CLI startup, readiness polling, socket connection, and initialize
+handshake. The default is 45,000 ms. Caller cancellation preserves
+`signal.reason`; cancellation after `connect()` returns does not close the client.
+Control RPCs keep their separate request timeout.
+
+The nested starter receives the remaining `AGENC_DAEMON_READY_TIMEOUT_MS`.
+On timeout or cancellation, the SDK sends its starter `SIGTERM`, escalates to
+`SIGKILL` after 100 ms, and waits for `close`. Cleanup can add up to 1,000 ms
+beyond the readiness deadline. Missing `close` produces an `AggregateError`
+with the original reason as its cause. The SDK does not signal an existing
+daemon or claim to terminate a daemon that the starter already detached.
+
+Custom `AgencSpawnFn` adapters must now provide `kill`, `on("error")`,
+`once("close")`, and `removeListener` for those events. A piped stderr stream
+also needs `removeListener("data")`. Update exit-only test fakes to emit `close`
+after exit and stdio closure. A Node `ChildProcess` satisfies the contract
+without an adapter. No protocol or stored-state migration is needed.
+
 - Local endpoint: `${AGENC_HOME:-~/.agenc}/daemon.sock` on Unix; a stable per-home named pipe on Windows
 - Cookie: `${AGENC_HOME:-~/.agenc}/daemon.cookie` (first message must be `initialize` with `authCookie`; `connect()` handles this)
 - Plugin storage: `createSession()` requires an exact absolute `pluginStorageRoot` of at most 4096 UTF-8 bytes, with no surrounding whitespace. `AgencClient` does not reread `AGENC_PLUGIN_CACHE_DIR`, derive a root from `AGENC_HOME`, or accept `agentId`; use `attachAgent()` for an existing agent.

--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -26,6 +26,9 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, win32 } from "node:path";
 import { createConnection, type Socket } from "node:net";
 import { spawn as nodeSpawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { StartupDeadline } from "./startup-deadline.js";
+import { waitForStartupChild, type StartupChild } from "./startup-child.js";
 import {
   AGENC_SDK_JSON_RPC_VERSION,
   isJsonObject,
@@ -157,6 +160,7 @@ interface PendingRequest {
 
 export interface AgencSocketTransportOptions {
   readonly socketPath: string;
+  readonly signal?: AbortSignal;
   readonly connectTimeoutMs?: number;
   readonly requestTimeoutMs?: number;
   readonly onNotification?: (message: JsonObject) => void;
@@ -226,22 +230,45 @@ export class AgencSocketTransport implements AgencTransport {
 
   static connect(options: AgencSocketTransportOptions): Promise<AgencSocketTransport> {
     return new Promise((resolve, reject) => {
+      const signal = options.signal;
+      if (signal?.aborted) {
+        reject(signal.reason);
+        return;
+      }
       const socket = createConnection(options.socketPath);
-      const timeout = setTimeout(() => {
+      let settled = false;
+      const cleanup = (): void => {
+        clearTimeout(timeout);
+        signal?.removeEventListener("abort", onAbort);
+        socket.removeListener("connect", onConnect);
+        socket.removeListener("error", onError);
+      };
+      const fail = (error: unknown): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
         socket.destroy();
-        reject(
-          new Error(`Timed out connecting to daemon at ${options.socketPath}`),
-        );
-      }, options.connectTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
-      socket.once("error", (error) => {
-        clearTimeout(timeout);
         reject(error);
-      });
-      socket.once("connect", () => {
-        clearTimeout(timeout);
-        socket.removeAllListeners("error");
+      };
+      const onAbort = (): void => fail(signal?.reason);
+      const onError = (error: Error): void => fail(error);
+      const onConnect = (): void => {
+        if (settled) return;
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        settled = true;
+        cleanup();
         resolve(new AgencSocketTransport(socket, options));
-      });
+      };
+      const timeout = setTimeout(() => {
+        fail(new Error(`Timed out connecting to daemon at ${options.socketPath}`));
+      }, options.connectTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+      socket.once("error", onError);
+      socket.once("connect", onConnect);
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) onAbort();
     });
   }
 
@@ -350,14 +377,7 @@ export type AgencSpawnFn = (
     /** stdin and stdout are discarded; stderr is piped so a failed start can say why. */
     readonly stdio: "ignore" | readonly ["ignore", "ignore", "pipe"];
   },
-) => {
-  once(event: "exit", listener: (code: number | null) => void): unknown;
-  once(event: "error", listener: (error: Error) => void): unknown;
-  /** Present when stderr is piped; absent or null spawners keep the bare exit message. */
-  readonly stderr?: {
-    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
-  } | null;
-};
+) => StartupChild;
 
 /** How much of the CLI's stderr a failed daemon start carries into its error. */
 const DAEMON_START_STDERR_TAIL_BYTES = 2_048;
@@ -391,6 +411,7 @@ export interface AgencConnectOptions {
   readonly agencCommand?: string | readonly string[];
   /** Total budget for autostart + readiness polling. Default 45s or `AGENC_DAEMON_READY_TIMEOUT_MS`. */
   readonly readyTimeoutMs?: number;
+  readonly signal?: AbortSignal;
   /**
    * Per-request timeout for bounded control RPCs. Default 30s or
    * `AGENC_DAEMON_REQUEST_TIMEOUT_MS`. Full-turn message RPCs are unbounded.
@@ -427,69 +448,61 @@ export async function connect(
     requestTimeoutMsFromEnv(env.AGENC_DAEMON_REQUEST_TIMEOUT_MS) ??
     DEFAULT_REQUEST_TIMEOUT_MS;
 
-  let authCookie = await readDaemonCookie(cookiePath);
-  let reachable = authCookie !== null && (await canConnect(socketPath));
-
-  if (!reachable) {
-    if (options.autostart === false) {
-      throw new Error(
-        `AgenC daemon is not running at ${socketPath} and autostart is disabled`,
-      );
-    }
-    await startDaemonViaCli(options.agencCommand ?? "agenc", env, options.spawn);
-    const deadline = Date.now() + readyTimeoutMs;
-    for (;;) {
-      authCookie = await readDaemonCookie(cookiePath);
-      if (authCookie !== null && (await canConnect(socketPath))) {
-        reachable = true;
-        break;
-      }
-      if (Date.now() >= deadline) {
+  const deadline = new StartupDeadline(
+    readyTimeoutMs,
+    `AgenC daemon did not become ready at ${socketPath} within ${readyTimeoutMs}ms`,
+    options.signal,
+  );
+  let transport: AgencSocketTransport | undefined;
+  try {
+    let authCookie = await deadline.run(() => readDaemonCookie(cookiePath, deadline.signal));
+    const reachable = authCookie !== null && await canConnect(socketPath, deadline);
+    if (!reachable) {
+      if (options.autostart === false) {
         throw new Error(
-          `AgenC daemon did not become ready at ${socketPath} within ${readyTimeoutMs}ms`,
+          `AgenC daemon is not running at ${socketPath} and autostart is disabled`,
         );
       }
-      await sleep(READY_POLL_MS);
+      deadline.assertActive();
+      await startDaemonViaCli(options.agencCommand ?? "agenc", env, options.spawn, deadline);
+      for (;;) {
+        authCookie = await deadline.run(() => readDaemonCookie(cookiePath, deadline.signal));
+        if (authCookie !== null && await canConnect(socketPath, deadline)) break;
+        await deadline.run(() => delay(Math.min(READY_POLL_MS, deadline.remainingMs()), undefined, { signal: deadline.signal }));
+      }
     }
-  }
-
-  if (authCookie === null) {
-    throw new Error(`daemon cookie is not available at ${cookiePath}`);
-  }
-
-  let client: AgencClient | null = null;
-  const transport = await AgencSocketTransport.connect({
-    socketPath,
-    requestTimeoutMs,
-    connectTimeoutMs: readyTimeoutMs,
-    onNotification: (message) => client?.dispatchNotification(message),
-    onClose: (error) => options.onDisconnect?.(error),
-  });
-  client = new AgencClient({
-    transport,
-    ...(options.clientId !== undefined ? { clientId: options.clientId } : {}),
-    ...(options.clientName !== undefined
-      ? { clientName: options.clientName }
-      : {}),
-    ...(options.onPermissionRequest !== undefined
-      ? { onPermissionRequest: options.onPermissionRequest }
-      : {}),
-    ...(options.onElicitationRequest !== undefined
-      ? { onElicitationRequest: options.onElicitationRequest }
-      : {}),
-  });
-  try {
-    await client.initialize({ authCookie });
+    if (authCookie === null) throw new Error(`daemon cookie is not available at ${cookiePath}`);
+    let client: AgencClient | null = null;
+    transport = await AgencSocketTransport.connect({
+      socketPath,
+      requestTimeoutMs,
+      signal: deadline.signal,
+      connectTimeoutMs: deadline.remainingMs(),
+      onNotification: (message) => client?.dispatchNotification(message),
+      onClose: (error) => options.onDisconnect?.(error),
+    });
+    deadline.assertActive();
+    client = new AgencClient({
+      transport,
+      ...(options.clientId !== undefined ? { clientId: options.clientId } : {}),
+      ...(options.clientName !== undefined ? { clientName: options.clientName } : {}),
+      ...(options.onPermissionRequest !== undefined ? { onPermissionRequest: options.onPermissionRequest } : {}),
+      ...(options.onElicitationRequest !== undefined ? { onElicitationRequest: options.onElicitationRequest } : {}),
+    });
+    const initializedClient = client;
+    await deadline.run(() => initializedClient.initialize({ authCookie }));
+    return client;
   } catch (error) {
-    await transport.close();
+    await transport?.close();
     throw error;
+  } finally {
+    deadline.dispose();
   }
-  return client;
 }
 
-async function readDaemonCookie(cookiePath: string): Promise<string | null> {
+async function readDaemonCookie(cookiePath: string, signal: AbortSignal): Promise<string | null> {
   try {
-    const cookie = (await readFile(cookiePath, "utf8")).trim();
+    const cookie = (await readFile(cookiePath, { encoding: "utf8", signal })).trim();
     return cookie.length > 0 ? cookie : null;
   } catch (error) {
     const code = (error as NodeJS.ErrnoException | undefined)?.code;
@@ -498,24 +511,25 @@ async function readDaemonCookie(cookiePath: string): Promise<string | null> {
   }
 }
 
-function canConnect(socketPath: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = createConnection(socketPath);
-    socket.once("connect", () => {
-      socket.destroy();
-      resolve(true);
+async function canConnect(socketPath: string, deadline: StartupDeadline): Promise<boolean> {
+  try {
+    const transport = await AgencSocketTransport.connect({
+      socketPath, signal: deadline.signal, connectTimeoutMs: deadline.remainingMs(),
     });
-    socket.once("error", () => {
-      socket.destroy();
-      resolve(false);
-    });
-  });
+    await transport.close();
+    deadline.assertActive();
+    return true;
+  } catch {
+    deadline.assertActive();
+    return false;
+  }
 }
 
-function startDaemonViaCli(
+async function startDaemonViaCli(
   command: string | readonly string[],
   env: NodeJS.ProcessEnv,
   spawnFn: AgencSpawnFn | undefined,
+  deadline: StartupDeadline,
 ): Promise<void> {
   const [executable, ...prefixArgs] =
     typeof command === "string" ? [command] : command;
@@ -531,43 +545,38 @@ function startDaemonViaCli(
         stdio:
           spawnOptions.stdio === "ignore" ? "ignore" : [...spawnOptions.stdio],
       }));
-  return new Promise((resolve, reject) => {
-    const child = spawner(executable, [...prefixArgs, "daemon", "start"], {
-      env,
-      stdio: ["ignore", "ignore", "pipe"],
-    });
-    const stderrChunks: string[] = [];
-    let stderrBytes = 0;
-    child.stderr?.on("data", (chunk) => {
-      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-      stderrChunks.push(text);
-      stderrBytes += text.length;
-      // Bound the buffer: drop whole leading chunks once the tail is covered.
-      while (
-        stderrChunks.length > 1 &&
-        stderrBytes - stderrChunks[0].length >= DAEMON_START_STDERR_TAIL_BYTES
-      ) {
-        stderrBytes -= stderrChunks.shift()!.length;
-      }
-    });
-    child.once("error", (error: Error) => {
-      reject(
-        new Error(`failed to start AgenC daemon via ${executable}: ${error.message}`),
-      );
-    });
-    child.once("exit", (code: number | null) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(
-        new Error(
-          `AgenC daemon start exited with code ${code ?? "null"} (command: ${executable})` +
-            describeDaemonStartStderr(stderrChunks),
-        ),
-      );
-    });
+  const child = spawner(executable, [...prefixArgs, "daemon", "start"], {
+    env: { ...env, AGENC_DAEMON_READY_TIMEOUT_MS: String(deadline.remainingMs()) },
+    stdio: ["ignore", "ignore", "pipe"],
   });
+  const stderrChunks: string[] = [];
+  let stderrBytes = 0;
+  const onData = (chunk: Buffer | string): void => {
+    const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    stderrChunks.push(text);
+    stderrBytes += text.length;
+    // Bound the buffer: drop whole leading chunks once the tail is covered.
+    while (
+      stderrChunks.length > 1 &&
+      stderrBytes - stderrChunks[0].length >= DAEMON_START_STDERR_TAIL_BYTES
+    ) {
+      stderrBytes -= stderrChunks.shift()!.length;
+    }
+  };
+  let code: number | null;
+  try {
+    code = await waitForStartupChild(child, deadline.signal, onData);
+  } catch (error) {
+    if (deadline.signal.aborted || error instanceof AggregateError) throw error;
+    throw new Error(`failed to start AgenC daemon via ${executable}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  deadline.assertActive();
+  if (code !== 0) {
+    throw new Error(
+      `AgenC daemon start exited with code ${code ?? "null"} (command: ${executable})` +
+        describeDaemonStartStderr(stderrChunks),
+    );
+  }
 }
 
 function positiveIntFromEnv(raw: string | undefined): number | null {
@@ -583,10 +592,4 @@ function requestTimeoutMsFromEnv(raw: string | undefined): number | null {
   if (!/^[1-9]\d*$/u.test(trimmed)) return null;
   const value = Number(trimmed);
   return Number.isInteger(value) && value <= MAX_TIMER_TIMEOUT_MS ? value : null;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }

--- a/packages/agenc-sdk/src/startup-child.ts
+++ b/packages/agenc-sdk/src/startup-child.ts
@@ -1,0 +1,72 @@
+export interface StartupChild {
+  once(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
+  removeListener(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  removeListener(event: "error", listener: (error: Error) => void): unknown;
+  kill(signal: NodeJS.Signals): boolean;
+  readonly stderr?: {
+    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+    removeListener(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+  } | null;
+}
+
+export function waitForStartupChild(
+  child: StartupChild,
+  signal: AbortSignal,
+  onData: (chunk: Buffer | string) => void,
+): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stopping = false;
+    let failure: unknown;
+    let escalation: ReturnType<typeof setTimeout> | undefined;
+    let cleanupTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (code: number | null, cleanupFailed = false): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(escalation);
+      clearTimeout(cleanupTimeout);
+      signal.removeEventListener("abort", onAbort);
+      child.removeListener("close", onClose);
+      child.removeListener("error", onError);
+      child.stderr?.removeListener("data", onData);
+      if (cleanupFailed) {
+        reject(new AggregateError([failure], "Daemon starter did not close within 1000ms of cancellation", { cause: failure }));
+      } else if (stopping) {
+        reject(failure);
+      } else {
+        resolve(code);
+      }
+    };
+    const terminate = (terminationSignal: NodeJS.Signals): void => {
+      try {
+        child.kill(terminationSignal);
+      } catch {
+        return;
+      }
+    };
+    const stop = (reason: unknown): void => {
+      if (settled || stopping) return;
+      stopping = true;
+      failure = reason;
+      escalation = setTimeout(() => terminate("SIGKILL"), 100);
+      cleanupTimeout = setTimeout(() => finish(null, true), 1_000);
+      terminate("SIGTERM");
+    };
+    const onAbort = (): void => stop(signal.reason);
+    const onError = (error: Error): void => stop(error);
+    const onClose = (code: number | null): void => {
+      if (signal.aborted && !stopping) {
+        stopping = true;
+        failure = signal.reason;
+      }
+      finish(code);
+    };
+    child.once("close", onClose);
+    child.on("error", onError);
+    child.stderr?.on("data", onData);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}

--- a/packages/agenc-sdk/src/startup-deadline.ts
+++ b/packages/agenc-sdk/src/startup-deadline.ts
@@ -7,7 +7,7 @@ export class StartupDeadline {
   readonly #timeoutError: Error;
   readonly #externalSignal: AbortSignal | undefined;
   readonly #onExternalAbort: () => void;
-  #timer: ReturnType<typeof setTimeout> | undefined;
+  readonly #timer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(timeoutMs: number, message: string, externalSignal?: AbortSignal) {
     if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647) {

--- a/packages/agenc-sdk/src/startup-deadline.ts
+++ b/packages/agenc-sdk/src/startup-deadline.ts
@@ -1,0 +1,77 @@
+import { performance } from "node:perf_hooks";
+
+export class StartupDeadline {
+  readonly #controller = new AbortController();
+  readonly signal: AbortSignal = this.#controller.signal;
+  readonly #expiresAt: number;
+  readonly #timeoutError: Error;
+  readonly #externalSignal: AbortSignal | undefined;
+  readonly #onExternalAbort: () => void;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(timeoutMs: number, message: string, externalSignal?: AbortSignal) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647) {
+      throw new RangeError("readyTimeoutMs must be positive and no greater than 2147483647");
+    }
+    this.#expiresAt = performance.now() + timeoutMs;
+    this.#timeoutError = new Error(message);
+    this.#externalSignal = externalSignal;
+    this.#onExternalAbort = () => this.#controller.abort(externalSignal?.reason);
+    externalSignal?.addEventListener("abort", this.#onExternalAbort, { once: true });
+    if (externalSignal?.aborted) this.#onExternalAbort();
+    if (!this.signal.aborted) {
+      this.#timer = setTimeout(() => this.#controller.abort(this.#timeoutError), timeoutMs);
+    }
+  }
+
+  assertActive(): void {
+    if (!this.signal.aborted && performance.now() >= this.#expiresAt) {
+      this.#controller.abort(this.#timeoutError);
+    }
+    this.signal.throwIfAborted();
+  }
+
+  remainingMs(): number {
+    this.assertActive();
+    return Math.max(1, Math.ceil(this.#expiresAt - performance.now()));
+  }
+
+  run<Result>(operation: () => Promise<Result>): Promise<Result> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (result: { value: Result } | { error: unknown }): void => {
+        if (settled) return;
+        settled = true;
+        this.signal.removeEventListener("abort", onAbort);
+        if ("error" in result) {
+          reject(result.error);
+          return;
+        }
+        try {
+          this.assertActive();
+          resolve(result.value);
+        } catch (error) {
+          reject(error);
+        }
+      };
+      const onAbort = (): void => finish({ error: this.signal.reason });
+      this.signal.addEventListener("abort", onAbort, { once: true });
+      if (this.signal.aborted) {
+        onAbort();
+        return;
+      }
+      Promise.resolve().then(() => {
+        this.assertActive();
+        return operation();
+      }).then(
+        (value) => finish({ value }),
+        (error: unknown) => finish({ error }),
+      );
+    });
+  }
+
+  dispose(): void {
+    if (this.#timer !== undefined) clearTimeout(this.#timer);
+    this.#externalSignal?.removeEventListener("abort", this.#onExternalAbort);
+  }
+}

--- a/packages/agenc/src/launcher.mjs
+++ b/packages/agenc/src/launcher.mjs
@@ -5,11 +5,13 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { setTimeout as delay } from "node:timers/promises";
 import { resolveAgenCHome } from "../lib/home-authority.mjs";
 
 export { resolveAgenCHome } from "../lib/home-authority.mjs";
 
-const DEFAULT_READY_TIMEOUT_MS = 2000;
+const DEFAULT_READY_TIMEOUT_MS = 45_000;
 const DEFAULT_POLL_MS = 25;
 const READY_TIMEOUT_ENV = "AGENC_DAEMON_READY_TIMEOUT_MS";
 const AUTOSTART_ENV = "AGENC_DAEMON_AUTOSTART";
@@ -26,7 +28,7 @@ export function resolveReadyTimeoutMs(env = process.env) {
   const raw = env[READY_TIMEOUT_ENV]?.trim();
   if (raw === undefined || raw.length === 0) return DEFAULT_READY_TIMEOUT_MS;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed <= 0) {
+  if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed <= 0 || parsed > 2_147_483_647) {
     throw new Error(`${READY_TIMEOUT_ENV} must be a positive integer`);
   }
   return parsed;
@@ -148,6 +150,8 @@ export async function spawnNodeScript(
     spawnFn = spawn,
     nodeBin = process.execPath,
     nodeLibraryPath,
+    signal,
+    registerCleanup,
   } = {},
 ) {
   const childEnv = { ...env };
@@ -162,6 +166,15 @@ export async function spawnNodeScript(
     // search an operator-controlled ambient library path before that exact
     // directory.
     childEnv.LD_LIBRARY_PATH = nodeLibraryPath;
+  }
+  signal?.throwIfAborted();
+  if (signal !== undefined) {
+    const child = spawnFn(nodeBin, [scriptPath, ...args], { cwd, env: childEnv, stdio });
+    const result = observeStarter(child, signal);
+    registerCleanup?.(result.then(() => {}, (error) => {
+      if (error instanceof AggregateError) throw error;
+    }));
+    return result;
   }
   return new Promise((resolveExit, reject) => {
     const child = spawnFn(nodeBin, [scriptPath, ...args], {
@@ -213,14 +226,22 @@ export async function isDaemonReady(
 export async function waitForDaemonReady(options = {}) {
   const timeoutMs = options.timeoutMs ?? resolveReadyTimeoutMs(options.env);
   const pollMs = options.pollMs ?? DEFAULT_POLL_MS;
-  const startedAt = Date.now();
-  const sleep = options.sleep ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
-
-  while (Date.now() - startedAt < timeoutMs) {
-    if (await isDaemonReady(options)) return true;
-    await sleep(pollMs);
+  const deadline = options.deadline ?? launchDeadline(timeoutMs, options.signal);
+  try {
+    for (;;) {
+      if (await withinLaunchDeadline(deadline, () => isDaemonReady(options))) return true;
+      if (options.probeOnly) return false;
+      const pause = Math.min(pollMs, deadline.remaining());
+      await withinLaunchDeadline(deadline, () => options.sleep
+        ? options.sleep(pause)
+        : delay(pause, undefined, { signal: deadline.signal }));
+    }
+  } catch (error) {
+    if (options.deadline === undefined && error === deadline.timeoutError) return false;
+    throw error;
+  } finally {
+    if (options.deadline === undefined) deadline.dispose();
   }
-  return isDaemonReady(options);
 }
 
 export async function ensureDaemonForLaunch({
@@ -235,35 +256,134 @@ export async function ensureDaemonForLaunch({
   signalPid = process.kill,
   spawnDaemonFn = spawnDaemon,
   waitForReadyFn = waitForDaemonReady,
+  signal,
 } = {}) {
   if (isDaemonCommand(argv)) return { status: "skipped-daemon-command" };
   if (!shouldAutostartDaemon(env)) return { status: "disabled" };
 
-  if (
-    await waitForReadyFn({
-      env,
-      userHome,
-      readText,
-      signalPid,
-      timeoutMs: 1,
-      pollMs: 1,
-      sleep: async () => {},
-    })
-  ) {
-    return { status: "already-running" };
-  }
+  const deadline = launchDeadline(resolveReadyTimeoutMs(env), signal);
+  const cleanups = [];
+  const probeOptions = { env, userHome, readText, signalPid, deadline, signal: deadline.signal };
+  try {
+    if (await withinLaunchDeadline(deadline, () => waitForReadyFn({
+      ...probeOptions, timeoutMs: deadline.remaining(), probeOnly: true,
+    }))) return { status: "already-running" };
 
-  await spawnDaemonFn(runtimeBin, {
-    env,
-    cwd,
-    nodeBin: runtimeNodeBin,
-    nodeLibraryPath: runtimeNodeLibraryPath,
-  });
-  const ready = await waitForReadyFn({ env, userHome, readText, signalPid });
-  if (!ready) {
-    throw new Error("AgenC daemon did not become ready before timeout");
+    await withinLaunchDeadline(deadline, () => spawnDaemonFn(runtimeBin, {
+      env: { ...env, [READY_TIMEOUT_ENV]: String(deadline.remaining()) },
+      cwd,
+      nodeBin: runtimeNodeBin,
+      nodeLibraryPath: runtimeNodeLibraryPath,
+      signal: deadline.signal,
+      registerCleanup: (cleanup) => {
+        cleanup.catch(() => {});
+        cleanups.push(cleanup);
+      },
+    }));
+    const ready = await withinLaunchDeadline(deadline, () => waitForReadyFn({
+      ...probeOptions, timeoutMs: deadline.remaining(),
+    }));
+    if (!ready) throw deadline.timeoutError;
+    return { status: "started" };
+  } catch (error) {
+    deadline.abort(error);
+    throw error;
+  } finally {
+    deadline.dispose();
+    await Promise.all(cleanups);
   }
-  return { status: "started" };
+}
+
+function launchDeadline(timeoutMs, externalSignal) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647) {
+    throw new RangeError("Daemon readiness timeout must be positive and no greater than 2147483647");
+  }
+  const controller = new AbortController();
+  const expires = performance.now() + timeoutMs;
+  const timeoutError = new Error(`AgenC daemon did not become ready within ${timeoutMs}ms`);
+  const abort = (reason) => controller.abort(reason);
+  const forwardAbort = () => abort(externalSignal.reason);
+  externalSignal?.addEventListener("abort", forwardAbort, { once: true });
+  if (externalSignal?.aborted) forwardAbort();
+  const timer = setTimeout(() => abort(timeoutError), timeoutMs);
+  return {
+    signal: controller.signal,
+    timeoutError,
+    abort,
+    remaining() {
+      if (performance.now() >= expires) abort(timeoutError);
+      controller.signal.throwIfAborted();
+      return Math.max(1, Math.ceil(expires - performance.now()));
+    },
+    dispose() {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener("abort", forwardAbort);
+    },
+  };
+}
+
+function withinLaunchDeadline(deadline, operation) {
+  return new Promise((resolveResult, reject) => {
+    const onAbort = () => reject(deadline.signal.reason);
+    deadline.signal.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve().then(() => {
+      deadline.remaining();
+      return operation();
+    }).then((value) => {
+      deadline.remaining();
+      resolveResult(value);
+    }).catch(reject).finally(() => deadline.signal.removeEventListener("abort", onAbort));
+  });
+}
+
+function observeStarter(child, signal) {
+  return new Promise((resolveExit, reject) => {
+    let finished = false;
+    let cancelled = false;
+    let reason;
+    let killTimer;
+    let reapTimer;
+    const complete = (code, cleanupFailed = false) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(killTimer);
+      clearTimeout(reapTimer);
+      child.removeListener("close", onClose);
+      child.removeListener("error", onError);
+      signal.removeEventListener("abort", onAbort);
+      if (cleanupFailed) {
+        reject(new AggregateError([reason], "Daemon starter did not close within 1000ms of cancellation", { cause: reason }));
+      } else if (cancelled) {
+        reject(reason);
+      } else {
+        resolveExit(code ?? 1);
+      }
+    };
+    const kill = (terminationSignal) => {
+      try { child.kill(terminationSignal); } catch { return; }
+    };
+    const cancel = (error) => {
+      if (finished || cancelled) return;
+      cancelled = true;
+      reason = error;
+      killTimer = setTimeout(() => kill("SIGKILL"), 100);
+      reapTimer = setTimeout(() => complete(null, true), 1_000);
+      kill("SIGTERM");
+    };
+    const onError = (error) => cancel(error);
+    const onAbort = () => cancel(signal.reason);
+    const onClose = (code, exitSignal) => {
+      if (!cancelled && (signal.aborted || exitSignal)) {
+        cancelled = true;
+        reason = signal.aborted ? signal.reason : new Error(`agenc runtime exited from signal ${exitSignal}`);
+      }
+      complete(code);
+    };
+    child.on("error", onError);
+    child.once("close", onClose);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
 }
 
 export async function main(

--- a/packages/agenc/test/launcher.test.mjs
+++ b/packages/agenc/test/launcher.test.mjs
@@ -38,7 +38,7 @@ test("daemon autostart env opt-out disables launcher startup", () => {
 });
 
 test("ready timeout env must be a positive integer", () => {
-  assert.equal(resolveReadyTimeoutMs({}), 2000);
+  assert.equal(resolveReadyTimeoutMs({}), 45_000);
   assert.equal(resolveReadyTimeoutMs({ AGENC_DAEMON_READY_TIMEOUT_MS: "50" }), 50);
   assert.throws(
     () => resolveReadyTimeoutMs({ AGENC_DAEMON_READY_TIMEOUT_MS: "0" }),
@@ -107,7 +107,7 @@ test("waitForDaemonReady requires a running pid and non-empty cookie", async () 
     const ready = await waitForDaemonReady({
       env,
       userHome: home,
-      timeoutMs: 1,
+      timeoutMs: 100,
       pollMs: 1,
       signalPid: (pid, signal) => {
         assert.equal(pid, 4201);
@@ -164,13 +164,16 @@ test("ensureDaemonForLaunch starts daemon and waits for health check", async () 
       spawnDaemonFn: async (runtimeBin, options) => {
         assert.equal(runtimeBin, "/tmp/runtime-bin");
         assert.equal(options.cwd, "/tmp/project");
-        assert.equal(options.env, env);
+        assert.equal(options.env.AGENC_HOME, env.AGENC_HOME);
+        assert.ok(Number(options.env.AGENC_DAEMON_READY_TIMEOUT_MS) <= 25);
+        assert.notEqual(options.env, env);
         assert.equal(options.nodeBin, "/tmp/private-node");
         assert.equal(options.nodeLibraryPath, "/tmp/private-node-library");
       },
     });
     assert.equal(result.status, "started");
-    assert.deepEqual(calls, [1, undefined]);
+    assert.equal(calls.length, 2);
+    assert.ok(calls.every((timeout) => timeout > 0 && timeout <= 25));
   });
 });
 

--- a/packages/agenc/test/startup-deadline.test.mjs
+++ b/packages/agenc/test/startup-deadline.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { EventEmitter, getEventListeners, once } from "node:events";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+import { ensureDaemonForLaunch, spawnDaemon, spawnNodeScript, waitForDaemonReady } from "../src/launcher.mjs";
+
+function fakeChild(closeOn = "SIGTERM") {
+  const child = new EventEmitter();
+  child.signals = [];
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    if (signal === closeOn) {
+      child.emit("exit", null, signal);
+      child.emit("close", null, signal);
+    }
+    return true;
+  };
+  return child;
+}
+
+function launchWithChild(child, options = {}) {
+  return ensureDaemonForLaunch({
+    argv: [], env: { AGENC_DAEMON_READY_TIMEOUT_MS: "10" }, runtimeBin: "/unused/runtime.mjs",
+    waitForReadyFn: async () => false,
+    spawnDaemonFn: (runtimeBin, spawnOptions) => spawnDaemon(runtimeBin, {
+      ...spawnOptions, spawnFn: () => child,
+    }),
+    ...options,
+  });
+}
+
+async function boundedOutcome(operation) {
+  let timer;
+  try {
+    return await Promise.race([
+      operation.then((value) => ({ value }), (error) => ({ error })),
+      new Promise((resolve) => { timer = setTimeout(() => resolve({ pending: true }), 300); }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test("launcher readiness budget bounds a never-settling daemon starter", async () => {
+  let started = false;
+  const outcome = await boundedOutcome(ensureDaemonForLaunch({
+    argv: [], env: { AGENC_DAEMON_READY_TIMEOUT_MS: "10" }, runtimeBin: "/unused/runtime.mjs",
+    waitForReadyFn: async () => false,
+    spawnDaemonFn: () => {
+      started = true;
+      return new Promise(() => {});
+    },
+  }));
+  assert.equal(started, true);
+  assert.equal(outcome.pending, undefined, "startup stayed pending beyond its readiness budget");
+  assert.match(outcome.error?.message ?? "", /timeout|timed out|within.*ms/iu);
+});
+
+test("disabled autostart still returns without starting a child", async () => {
+  const result = await ensureDaemonForLaunch({
+    argv: [], env: { AGENC_DAEMON_AUTOSTART: "0" },
+    spawnDaemonFn: () => { throw new Error("disabled startup spawned a child"); },
+  });
+  assert.deepEqual(result, { status: "disabled" });
+});
+
+test("timeout reaps a managed child and removes its listeners", async () => {
+  const child = fakeChild();
+  await assert.rejects(launchWithChild(child), /within 10ms/);
+  assert.deepEqual(child.signals, ["SIGTERM"]);
+  assert.deepEqual(child.eventNames(), []);
+});
+
+test("termination escalates and waits for the child's close event", async () => {
+  const child = fakeChild("SIGKILL");
+  await assert.rejects(launchWithChild(child), /within 10ms/);
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+  assert.deepEqual(child.eventNames(), []);
+});
+
+test("an unresponsive child reports failed cleanup after a bounded wait", async () => {
+  const child = fakeChild(null);
+  await assert.rejects(launchWithChild(child), (error) => {
+    assert.ok(error instanceof AggregateError);
+    assert.match(error.message, /did not close/);
+    assert.match(error.cause.message, /within 10ms/);
+    return true;
+  });
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+  assert.deepEqual(child.eventNames(), []);
+});
+
+test("launcher kills and reaps its real starter before rejecting", async () => {
+  let child;
+  let closed = false;
+  try {
+    await assert.rejects(ensureDaemonForLaunch({
+      argv: [], runtimeBin: "/unused/runtime.mjs",
+      env: { AGENC_DAEMON_READY_TIMEOUT_MS: "150" },
+      waitForReadyFn: async () => false,
+      spawnDaemonFn: (runtimeBin, options) => spawnDaemon(runtimeBin, {
+        ...options,
+        spawnFn: () => {
+          child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+          child.once("close", () => { closed = true; });
+          return child;
+        },
+      }),
+    }), /within 150ms/);
+    assert.equal(closed, true);
+    assert.equal(typeof child.pid, "number");
+    assert.throws(() => process.kill(child.pid, 0));
+  } finally {
+    if (child && !closed) {
+      const reaped = once(child, "close");
+      child.kill("SIGKILL");
+      await reaped;
+    }
+  }
+});
+
+test("a slow initial probe and starter share the final readiness budget", async (context) => {
+  let now = 0;
+  context.mock.method(performance, "now", () => now);
+  const env = { AGENC_DAEMON_READY_TIMEOUT_MS: "100" };
+  let nestedBudget;
+  const timeouts = [];
+  const result = await ensureDaemonForLaunch({
+    argv: [], env, runtimeBin: "/unused/runtime.mjs",
+    waitForReadyFn: async (options) => {
+      timeouts.push(options.timeoutMs);
+      if (options.probeOnly) { now = 30; return false; }
+      return true;
+    },
+    spawnDaemonFn: async (_runtimeBin, options) => {
+      nestedBudget = options.env.AGENC_DAEMON_READY_TIMEOUT_MS;
+      now = 80;
+    },
+  });
+  assert.equal(result.status, "started");
+  assert.equal(nestedBudget, "70");
+  assert.deepEqual(timeouts, [100, 20]);
+  assert.equal(env.AGENC_DAEMON_READY_TIMEOUT_MS, "100");
+});
+
+test("monotonic expiry prevents a spawn even before timers have fired", async (context) => {
+  let now = 0;
+  context.mock.method(performance, "now", () => now);
+  await assert.rejects(ensureDaemonForLaunch({
+    argv: [], env: { AGENC_DAEMON_READY_TIMEOUT_MS: "10" }, runtimeBin: "/unused/runtime.mjs",
+    waitForReadyFn: async () => { now = 11; return false; },
+    spawnDaemonFn: () => { assert.fail("spawned after the initial probe expired"); },
+  }), /within 10ms/);
+});
+
+test("caller cancellation during spawn preserves its reason after cleanup", async () => {
+  const controller = new AbortController();
+  const reason = { cancel: "startup" };
+  const child = fakeChild();
+  await assert.rejects(launchWithChild(child, {
+    signal: controller.signal,
+    spawnDaemonFn: (runtimeBin, options) => spawnDaemon(runtimeBin, {
+      ...options, spawnFn: () => { controller.abort(reason); return child; },
+    }),
+  }), (error) => error === reason);
+  assert.deepEqual(child.signals, ["SIGTERM"]);
+  assert.deepEqual(child.eventNames(), []);
+  assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+});
+
+test("already cancelled startup never probes or spawns", async () => {
+  const reason = new Error("cancelled before startup");
+  await assert.rejects(ensureDaemonForLaunch({
+    argv: [], runtimeBin: "/unused/runtime.mjs", signal: AbortSignal.abort(reason),
+    waitForReadyFn: () => assert.fail("cancelled startup probed"),
+    spawnDaemonFn: () => assert.fail("cancelled startup spawned"),
+  }), (error) => error === reason);
+});
+
+test("a wedged initial read is bounded without spawning", async () => {
+  await assert.rejects(ensureDaemonForLaunch({
+    argv: [], env: { AGENC_DAEMON_READY_TIMEOUT_MS: "10" }, runtimeBin: "/unused/runtime.mjs",
+    readText: () => new Promise(() => {}),
+    spawnDaemonFn: () => assert.fail("spawned after a wedged read"),
+  }), /within 10ms/);
+});
+
+test("standalone polling bounds its initial and final file probes", async () => {
+  assert.equal(await waitForDaemonReady({
+    timeoutMs: 10, readText: () => new Promise(() => {}),
+  }), false);
+});
+
+test("normal CLI commands still run without a startup deadline", async () => {
+  const child = fakeChild();
+  const operation = spawnNodeScript("/unused/runtime.mjs", ["agent"], { spawnFn: () => child });
+  child.emit("exit", 0, null);
+  assert.equal(await operation, 0);
+  assert.deepEqual(child.signals, []);
+});

--- a/runtime/tests/sdk-package/socket-autostart-stderr.test.ts
+++ b/runtime/tests/sdk-package/socket-autostart-stderr.test.ts
@@ -29,11 +29,14 @@ function fakeSpawner(
     calls.push({ command, args, stdio: options.stdio });
     const child = new EventEmitter() as EventEmitter & {
       stderr: EventEmitter | null;
+      kill: () => boolean;
     };
+    child.kill = () => { child.emit("close", null, "SIGTERM"); return true; };
     child.stderr = stderrText === null ? null : new EventEmitter();
     setImmediate(() => {
       if (stderrText !== null) child.stderr?.emit("data", Buffer.from(stderrText));
       child.emit("exit", code);
+      child.emit("close", code, null);
     });
     return child;
   };

--- a/runtime/tests/sdk-package/socket-timeout-policy.contract.test.ts
+++ b/runtime/tests/sdk-package/socket-timeout-policy.contract.test.ts
@@ -107,7 +107,8 @@ describe.skipIf(process.platform === "win32")(
           cookiePath,
           autostart: false,
         });
-        const sdkOptions = connectTransport.mock.calls[0]?.[0];
+        expect(connectTransport).toHaveBeenCalledTimes(2);
+        const sdkOptions = connectTransport.mock.calls.at(-1)?.[0];
         expect(sdkOptions?.requestTimeoutMs, testCase.label).toBe(runtimeValue);
         await client.close();
       }

--- a/runtime/tests/sdk-package/startup-connection.test.ts
+++ b/runtime/tests/sdk-package/startup-connection.test.ts
@@ -1,0 +1,180 @@
+import { EventEmitter, getEventListeners } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AgencSocketTransport, connect } from "../../../packages/agenc-sdk/src/socket.js";
+
+const mocks = vi.hoisted(() => ({ socket: vi.fn(), cookie: vi.fn() }));
+vi.mock("node:net", async (original) => ({ ...await original<object>(), createConnection: mocks.socket }));
+vi.mock("node:fs/promises", async (original) => ({ ...await original<object>(), readFile: mocks.cookie }));
+
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  onWrite: (text: string) => void = () => {};
+
+  setEncoding(): this { return this; }
+  write(text: string): boolean { this.onWrite(text); return true; }
+  destroy(): this {
+    this.destroyed = true;
+    this.emit("close");
+    return this;
+  }
+}
+
+describe("SDK connection phases share the startup deadline", () => {
+  let home: string;
+  let sockets: FakeSocket[];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-sdk-connect-deadline-"));
+    sockets = [];
+    mocks.cookie.mockReset().mockResolvedValue("cookie");
+    mocks.socket.mockReset().mockImplementation(() => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      queueMicrotask(() => socket.emit("connect"));
+      return socket;
+    });
+  });
+
+  afterEach(() => {
+    for (const socket of sockets) socket.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("bounds a cookie read that never settles", async () => {
+    mocks.cookie.mockImplementation(() => new Promise(() => {}));
+    await expect(connect({ env: { AGENC_HOME: home }, readyTimeoutMs: 10 })).rejects.toThrow(/within 10ms/);
+    expect(mocks.socket).not.toHaveBeenCalled();
+  });
+
+  test("destroys an initial socket probe that never connects", async () => {
+    const socket = new FakeSocket();
+    sockets.push(socket);
+    mocks.socket.mockReturnValue(socket);
+    const spawn = vi.fn();
+    await expect(connect({ env: { AGENC_HOME: home }, readyTimeoutMs: 10, spawn })).rejects.toThrow(/within 10ms/);
+    expect(socket.destroyed).toBe(true);
+    expect(socket.eventNames()).toEqual([]);
+    expect(spawn).not.toHaveBeenCalled();
+    socket.emit("connect");
+    expect(socket.eventNames()).toEqual([]);
+  });
+
+  test("destroys a final connection that never connects", async () => {
+    const initial = new FakeSocket();
+    const final = new FakeSocket();
+    sockets.push(initial, final);
+    mocks.socket.mockImplementationOnce(() => {
+      queueMicrotask(() => initial.emit("connect"));
+      return initial;
+    }).mockReturnValue(final);
+    await expect(connect({ env: { AGENC_HOME: home }, readyTimeoutMs: 10 })).rejects.toThrow(/within 10ms/);
+    expect(initial.destroyed).toBe(true);
+    expect(final.destroyed).toBe(true);
+    expect(final.eventNames()).toEqual([]);
+    final.emit("connect");
+    expect(final.eventNames()).toEqual([]);
+  });
+
+  test("bounds initialize and closes its transport instead of waiting for the control timeout", async () => {
+    await expect(connect({ env: { AGENC_HOME: home }, readyTimeoutMs: 10, requestTimeoutMs: 5000 }))
+      .rejects.toThrow(/within 10ms/);
+    expect(sockets).toHaveLength(2);
+    expect(sockets.every((socket) => socket.destroyed)).toBe(true);
+  });
+
+  test("cancellation during initialize preserves the reason and closes both sockets", async () => {
+    const controller = new AbortController();
+    const reason = { cancel: "initialize" };
+    mocks.socket.mockImplementation(() => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      socket.onWrite = () => controller.abort(reason);
+      queueMicrotask(() => socket.emit("connect"));
+      return socket;
+    });
+    await expect(connect({ env: { AGENC_HOME: home }, signal: controller.signal })).rejects.toBe(reason);
+    expect(sockets.every((socket) => socket.destroyed)).toBe(true);
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+  });
+
+  test("rejects a successful handshake that arrives after monotonic expiry", async () => {
+    let now = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    mocks.cookie.mockImplementation(async () => { now = 40; return "cookie"; });
+    mocks.socket.mockImplementation(() => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      queueMicrotask(() => { now += 20; socket.emit("connect"); });
+      socket.onWrite = (text) => {
+        now = 101;
+        socket.emit("data", JSON.stringify({
+          jsonrpc: "2.0", id: JSON.parse(text).id,
+          result: { type: "initialized", protocolVersion: "1.10.0", protocol: { version: "1.10.0" }, capabilities: {} },
+        }) + "\n");
+      };
+      return socket;
+    });
+    await expect(connect({ env: { AGENC_HOME: home }, readyTimeoutMs: 100 })).rejects.toThrow(/within 100ms/);
+    expect(sockets.every((socket) => socket.destroyed)).toBe(true);
+  });
+
+  test("successful connection keeps its separate RPC budget and ignores later startup cancellation", async () => {
+    const controller = new AbortController();
+    mocks.socket.mockImplementation(() => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      queueMicrotask(() => socket.emit("connect"));
+      socket.onWrite = (text) => {
+        const request = JSON.parse(text);
+        if (request.method !== "initialize") return;
+        socket.emit("data", JSON.stringify({
+          jsonrpc: "2.0", id: request.id,
+          result: { type: "initialized", protocolVersion: "1.10.0", protocol: { version: "1.10.0" }, capabilities: {} },
+        }) + "\n");
+      };
+      return socket;
+    });
+    const client = await connect({ env: { AGENC_HOME: home }, readyTimeoutMs: 50, requestTimeoutMs: 500, signal: controller.signal });
+    try {
+      controller.abort(new Error("after connection"));
+      expect(sockets[1]?.destroyed).toBe(false);
+      expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+      vi.useFakeTimers();
+      const request = client.request("health.ping", {});
+      const rejected = expect(request).rejects.toThrow(/Timed out waiting.*health.ping/);
+      await vi.advanceTimersByTimeAsync(50);
+      expect(vi.getTimerCount()).toBe(1);
+      await vi.advanceTimersByTimeAsync(450);
+      await rejected;
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("transport cancellation preserves the reason and ignores a late connect", async () => {
+    const socket = new FakeSocket();
+    sockets.push(socket);
+    mocks.socket.mockReturnValue(socket);
+    const controller = new AbortController();
+    const reason = new Error("cancel socket");
+    const operation = AgencSocketTransport.connect({ socketPath: "unused", signal: controller.signal });
+    controller.abort(reason);
+    socket.emit("connect");
+    await expect(operation).rejects.toBe(reason);
+    expect(socket.destroyed).toBe(true);
+    expect(socket.eventNames()).toEqual([]);
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+  });
+
+  test("an already aborted transport never opens a socket", async () => {
+    const reason = new Error("cancelled first");
+    await expect(AgencSocketTransport.connect({ socketPath: "unused", signal: AbortSignal.abort(reason) })).rejects.toBe(reason);
+    expect(mocks.socket).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/sdk-package/startup-deadline.test.ts
+++ b/runtime/tests/sdk-package/startup-deadline.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter, getEventListeners, once } from "node:events";
+import { spawn as spawnChild, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { connect } from "../../../packages/agenc-sdk/src/socket.js";
+import { StartupDeadline } from "../../../packages/agenc-sdk/src/startup-deadline.js";
+import { waitForStartupChild } from "../../../packages/agenc-sdk/src/startup-child.js";
+
+const homes: string[] = [];
+
+class Starter extends EventEmitter {
+  readonly stderr = new EventEmitter();
+  readonly signals: NodeJS.Signals[] = [];
+  closeOn: NodeJS.Signals | null = "SIGTERM";
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.signals.push(signal);
+    if (signal === this.closeOn) {
+      this.emit("exit", null, signal);
+      this.emit("close", null, signal);
+    }
+    return true;
+  }
+}
+
+function home(): string {
+  const directory = mkdtempSync(join(tmpdir(), "agenc-sdk-startup-deadline-"));
+  homes.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  for (const directory of homes.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("SDK startup deadline", () => {
+  test("bounds a starter that never exits", async () => {
+    const child = new Starter();
+    const started = connect({
+      env: { AGENC_HOME: home() }, readyTimeoutMs: 10, spawn: () => child,
+    });
+    const result = started.then(() => ({ connected: true }), (error: unknown) => ({ error }));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const outcome = await Promise.race([
+        result,
+        new Promise<{ pending: true }>((resolve) => {
+          timer = setTimeout(() => resolve({ pending: true }), 300);
+        }),
+      ]);
+      expect(outcome).not.toEqual({ pending: true });
+      expect(outcome).toMatchObject({ error: expect.objectContaining({
+        message: expect.stringMatching(/timeout|timed out|within.*ms/iu),
+      }) });
+      expect(child.signals).toEqual(["SIGTERM"]);
+      expect(child.eventNames()).toEqual([]);
+      expect(child.stderr.eventNames()).toEqual([]);
+    } finally {
+      clearTimeout(timer);
+      child.emit("exit", 1);
+      child.emit("close", 1, null);
+      await result;
+    }
+  });
+
+  test("autostart opt-out rejects without invoking a spawner", async () => {
+    await expect(connect({
+      env: { AGENC_HOME: home() }, autostart: false, readyTimeoutMs: 10,
+      spawn: () => { throw new Error("disabled startup spawned a child"); },
+    })).rejects.toThrow("autostart is disabled");
+  });
+
+  test("reaps a real starter before rejecting the connection", async () => {
+    let child: ChildProcess | undefined;
+    let closed = false;
+    try {
+      await expect(connect({
+        env: { AGENC_HOME: home() }, readyTimeoutMs: 150,
+        spawn: () => {
+          child = spawnChild(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+          child.once("close", () => { closed = true; });
+          return child;
+        },
+      })).rejects.toThrow(/within 150ms/);
+      expect(closed).toBe(true);
+      expect(child?.pid).toBeTypeOf("number");
+      expect(() => process.kill(child!.pid!, 0)).toThrow();
+    } finally {
+      if (child !== undefined && !closed) {
+        const reaped = once(child, "close");
+        child.kill("SIGKILL");
+        await reaped;
+      }
+    }
+  });
+
+  test("passes only the remaining budget to the nested starter", async () => {
+    const child = new Starter();
+    const env = { AGENC_HOME: home(), AGENC_DAEMON_READY_TIMEOUT_MS: "9000" };
+    let nestedBudget = 0;
+    await expect(connect({
+      env, readyTimeoutMs: 60,
+      spawn: (_command, _args, options) => {
+        nestedBudget = Number(options.env.AGENC_DAEMON_READY_TIMEOUT_MS);
+        setTimeout(() => child.emit("close", 0, null), 40);
+        return child;
+      },
+    })).rejects.toThrow(/within 60ms/);
+    expect(nestedBudget).toBeGreaterThan(0);
+    expect(nestedBudget).toBeLessThanOrEqual(60);
+    expect(child.signals).toEqual([]);
+    expect(env.AGENC_DAEMON_READY_TIMEOUT_MS).toBe("9000");
+  });
+
+  test("preserves cancellation that occurs inside a spawner", async () => {
+    const controller = new AbortController();
+    const reason = { stopped: "by caller" };
+    const child = new Starter();
+    await expect(connect({
+      env: { AGENC_HOME: home() }, readyTimeoutMs: 500, signal: controller.signal,
+      spawn: () => { controller.abort(reason); return child; },
+    })).rejects.toBe(reason);
+    expect(child.signals).toEqual(["SIGTERM"]);
+    expect(child.eventNames()).toEqual([]);
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+  });
+
+  test("does not spawn for an already cancelled caller", async () => {
+    const reason = new Error("cancel before startup");
+    const spawn = vi.fn(() => new Starter());
+    await expect(connect({ env: { AGENC_HOME: home() }, signal: AbortSignal.abort(reason), spawn }))
+      .rejects.toBe(reason);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test("escalates termination and waits for close rather than exit", async () => {
+    vi.useFakeTimers();
+    const child = new Starter();
+    child.closeOn = "SIGKILL";
+    const controller = new AbortController();
+    const reason = new Error("cancel starter");
+    const result = waitForStartupChild(child, controller.signal, () => {});
+    const rejected = expect(result).rejects.toBe(reason);
+    controller.abort(reason);
+    child.emit("exit", null, "SIGTERM");
+    expect(child.listenerCount("close")).toBe(1);
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(child.eventNames()).toEqual([]);
+    expect(child.stderr.eventNames()).toEqual([]);
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("reports cleanup failure instead of claiming an unresponsive child was reaped", async () => {
+    vi.useFakeTimers();
+    const child = new Starter();
+    child.closeOn = null;
+    const reason = new Error("stop now");
+    const result = waitForStartupChild(child, AbortSignal.abort(reason), () => {});
+    const rejected = expect(result).rejects.toMatchObject({
+      name: "AggregateError", cause: reason, message: expect.stringContaining("did not close"),
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    await rejected;
+    expect(child.eventNames()).toEqual([]);
+    expect(child.stderr.eventNames()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("successful close wins once and removes cancellation and stderr listeners", async () => {
+    const child = new Starter();
+    const controller = new AbortController();
+    const result = waitForStartupChild(child, controller.signal, () => {});
+    child.emit("close", 0, null);
+    controller.abort(new Error("late cancellation"));
+    child.emit("close", 1, null);
+    await expect(result).resolves.toBe(0);
+    expect(child.signals).toEqual([]);
+    expect(child.eventNames()).toEqual([]);
+    expect(child.stderr.eventNames()).toEqual([]);
+  });
+
+  test("deadline removes listeners when a late operation fails", async () => {
+    const deadline = new StartupDeadline(10, "startup timed out");
+    let rejectOperation: (reason: unknown) => void = () => {};
+    try {
+      await expect(deadline.run(() => new Promise((_resolve, reject) => { rejectOperation = reject; })))
+        .rejects.toThrow("startup timed out");
+      rejectOperation(new Error("late failure"));
+      await Promise.resolve();
+      expect(getEventListeners(deadline.signal, "abort")).toHaveLength(0);
+    } finally {
+      deadline.dispose();
+    }
+  });
+
+  test.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])("rejects invalid readiness duration %s", async (readyTimeoutMs) => {
+    const spawn = vi.fn(() => new Starter());
+    await expect(connect({ env: { AGENC_HOME: home() }, readyTimeoutMs, spawn })).rejects.toThrow(/readyTimeoutMs/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Changes

Close #2089 by applying one monotonic readiness deadline to the launcher and SDK. Initial probes, daemon starter completion, polling, final socket connection, and SDK initialize consume the same budget. Nested daemon-start commands receive only the remaining duration.

Owned starters receive SIGTERM on timeout or cancellation, then SIGKILL after 100 ms if necessary. Completion waits for close, with a 1,000 ms cleanup cap and an explicit AggregateError if reaping cannot be confirmed. Caller cancellation preserves its reason. Child, stderr, and abort listeners are removed at completion. Failed or late socket connections are destroyed, and an expired initialize closes its transport.

The launcher default changes from 2 seconds of post-starter polling to 45 seconds for the whole startup. Normal CLI execution remains unbounded by this startup deadline, and the launcher still continues to the requested command after autostart fails. SDK control RPC timeouts remain separate. Custom SDK spawners must support termination, close observation, and listener removal; the README documents the adapter migration. No protocol, stored-state, package-version, or release changes.

Cleanup targets only the starter created by this attempt. It does not signal an existing daemon or claim to terminate a daemon already detached by the starter. Custom launcher callbacks must honor the passed signal and register bounded cleanup for hidden child resources.

## Validation

- Baseline regressions reproduced in both packages, each with one expected failure and one passing opt-out control.
- Launcher focused tests pass, 27 tests, including real child reaping and monotonic shared-budget checks.
- Both runtime TypeScript configurations and all SDK tests pass, 216 tests across 20 files.
- SDK typecheck, generated contract checks, and package build pass.
- New and changed stderr-test TypeScript checks pass. The legacy timeout-policy test retains one pre-existing extensionless-import diagnostic; virtual baseline comparison reports one before and after, with no added diagnostics or suppressions.
- GitNexus staged analysis reports the expected 14 files and one connection flow, medium risk. Runtime sources and the FND measured-input artifact are unchanged.
- Full local suite, build, PTY startup, and Linux native checks are running. Final results will be recorded before merge.

Automatic GitHub Actions remain disabled. No workflow has been enabled, dispatched, or rerun. Independent app review is required before manual squash merge. This is the final issue in the sweep at the user's request.

Closes #2089

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default launcher wait from 2s to 45s and alters process lifecycle on every autostart path; incorrect cleanup could leave stray starters but does not signal existing daemons.
> 
> **Overview**
> Unifies **daemon readiness timing** across the published launcher and `agenc-sdk`: one monotonic budget (default **45s**, up from **2s** launcher-only polling) covers the initial probe, owned starter, readiness polling, socket connect, and SDK `initialize`, with the nested `daemon start` receiving only **remaining** `AGENC_DAEMON_READY_TIMEOUT_MS`.
> 
> **Cancellation and cleanup** on timeout or `AbortSignal`: owned starters get `SIGTERM`, `SIGKILL` after 100ms, and up to 1s wait for `close`; failed reap reports `AggregateError`. Socket connects honor `signal` and use the shared deadline; post-connect RPC timeouts stay separate. Custom `AgencSpawnFn` / launcher `spawnDaemonFn` must implement the new child contract (`kill`, `close`, listener removal) and honor `signal` / `registerCleanup`.
> 
> Docs and tests document the contract and cover shared budgets, monotonic expiry, and real-child reaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22380bb92a2b7b54965ffafde7a3124964d2eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->