### PR TITLE
feat(routines): let an unattended run do read-only work by itself

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -385,6 +385,23 @@ export {
   planApprovalPayloadFields,
 } from "./background-agent-runner/tool-recovery.js";
 
+/**
+ * A routine invocation, which is the one agent kind that runs with nobody
+ * attached to answer an approval. Both keys are required: the routine service
+ * always writes the pair (routines/daemon-executor.ts), and demanding both
+ * keeps a single stray field from switching the grant on.
+ */
+function isRoutineRun(metadata: unknown): boolean {
+  if (typeof metadata !== "object" || metadata === null) return false;
+  const record = metadata as { routineId?: unknown; routineRunId?: unknown };
+  return (
+    typeof record.routineId === "string" &&
+    record.routineId.length > 0 &&
+    typeof record.routineRunId === "string" &&
+    record.routineRunId.length > 0
+  );
+}
+
 export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentRunner {
   readonly #agentStopTimeoutMs: number;
   readonly #durableResumeTimeoutMs: number;
@@ -581,6 +598,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         bootstrap.session.permissionModeRegistry,
         params.unattendedAllow,
         params.unattendedDeny,
+        isRoutineRun(params.metadata),
       );
 
       // Upstream-parity top-level executor: bootstrap already registered
@@ -1072,6 +1090,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           bootstrap.session.permissionModeRegistry,
           metadataStringList(params.metadata, "unattendedAllow"),
           metadataStringList(params.metadata, "unattendedDeny"),
+          isRoutineRun(params.metadata),
         );
         const canonicalRuntimeState = currentCanonicalRuntimeStateFromRollout(
           bootstrap,

--- a/runtime/src/app-server/background-agent-runner/runtime-settings.ts
+++ b/runtime/src/app-server/background-agent-runner/runtime-settings.ts
@@ -1415,10 +1415,13 @@ async function installUnattendedPermissionPolicy(
   registry: PermissionModeRegistry,
   allow: readonly string[] | undefined,
   deny: readonly string[] | undefined,
+  readOnly = false,
 ): Promise<void> {
   const next = applyUnattendedPermissionPolicyToContext(registry.current(), {
     ...(allow !== undefined ? { allowlist: allow } : {}),
     ...(deny !== undefined ? { denylist: deny } : {}),
+    // Defaults off, so every caller that does not pass it is byte-identical.
+    ...(readOnly ? { readOnly: true } : {}),
   });
   await registry.update(next);
 }

--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -42,6 +42,7 @@
  */
 
 import {
+  freshDenialTracking,
   handleDenialLimitExceeded,
   recordDenial,
   recordSuccess,
@@ -497,6 +498,22 @@ async function decideReadOnlyGrant(
   permissionContext: ToolPermissionContext,
   unattended: { readonly behavior: string; readonly toolName: string },
 ): Promise<PermissionDecision> {
+  const appState = context.getAppState();
+  // A refused call is the end of that road, and the model needs to hear that
+  // it is: left to a plain refusal it re-issues the same tool until the turn
+  // errors, which costs minutes and loses the report it was about to write.
+  const refuse = (message: string): PermissionDecision => {
+    const next = recordDenial(
+      context.denialTracking ?? appState.denialTracking ?? freshDenialTracking(),
+    );
+    persistDenialState(context, next);
+    return unattendedReadOnlyDenyDecision(
+      tool.name,
+      next.consecutiveDenials >= 2
+        ? `${message} This run has now been refused ${next.consecutiveDenials} times. Stop calling tools and write your findings as your final answer.`
+        : message,
+    );
+  };
   // An operator naming the tool explicitly is a decision already made; the
   // set decides everything else.
   if (unattended.behavior !== "allow") {
@@ -508,21 +525,21 @@ async function decideReadOnlyGrant(
       READ_ONLY_GRANT_DEPS,
     );
     if (!verdict.granted) {
-      return unattendedReadOnlyDenyDecision(
-        tool.name,
-        readOnlyGrantRefusalMessage(tool.name, verdict.refusal),
-      );
+      return refuse(readOnlyGrantRefusalMessage(tool.name, verdict.refusal));
     }
   }
   // Being admitted is not authority to skip the tool's own check. Anything
   // that still wants a human is refused here too.
   const toolResult = await resolveToolPermissionResult(tool, input, context);
   if (toolResult.behavior === "ask" || toolResult.behavior === "deny") {
-    return unattendedReadOnlyDenyDecision(
-      tool.name,
-      readOnlyGrantRefusalMessage(tool.name, { kind: "interactive" }),
-    );
+    return refuse(readOnlyGrantRefusalMessage(tool.name, { kind: "interactive" }));
   }
+  // A granted call clears the streak, so an occasional refusal mid-report does
+  // not accumulate into the escalated wording.
+  persistDenialState(
+    context,
+    recordSuccess(context.denialTracking ?? appState.denialTracking ?? freshDenialTracking()),
+  );
   return unattendedAllowDecision(unattended.toolName, input);
 }
 

--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -481,10 +481,49 @@ const READ_ONLY_GRANT_DEPS: ShellGateDeps = {
 function readOnlyGrantWorkingDirectory(
   context: ToolPermissionContext,
 ): string {
-  for (const directory of context.additionalWorkingDirectories.keys()) {
-    return directory;
+  const [first] = context.additionalWorkingDirectories.keys();
+  return first ?? process.cwd();
+}
+
+/**
+ * The whole decision for a run with nobody attached: proceed on read-only
+ * work, refuse everything else. Never returns "ask", because an ask is what
+ * this policy exists to remove.
+ */
+async function decideReadOnlyGrant(
+  tool: ToolLike,
+  input: unknown,
+  context: ToolEvaluatorContext,
+  permissionContext: ToolPermissionContext,
+  unattended: { readonly behavior: string; readonly toolName: string },
+): Promise<PermissionDecision> {
+  // An operator naming the tool explicitly is a decision already made; the
+  // set decides everything else.
+  if (unattended.behavior !== "allow") {
+    const verdict = readOnlyGrantVerdict(
+      tool,
+      input,
+      readOnlyGrantWorkingDirectory(permissionContext),
+      permissionContext,
+      READ_ONLY_GRANT_DEPS,
+    );
+    if (!verdict.granted) {
+      return unattendedReadOnlyDenyDecision(
+        tool.name,
+        readOnlyGrantRefusalMessage(tool.name, verdict.refusal),
+      );
+    }
   }
-  return process.cwd();
+  // Being admitted is not authority to skip the tool's own check. Anything
+  // that still wants a human is refused here too.
+  const toolResult = await resolveToolPermissionResult(tool, input, context);
+  if (toolResult.behavior === "ask" || toolResult.behavior === "deny") {
+    return unattendedReadOnlyDenyDecision(
+      tool.name,
+      readOnlyGrantRefusalMessage(tool.name, { kind: "interactive" }),
+    );
+  }
+  return unattendedAllowDecision(unattended.toolName, input);
 }
 
 function unattendedReadOnlyDenyDecision(
@@ -693,36 +732,14 @@ async function checkUnattendedPolicy(
   // This sits ABOVE the mode gate below on purpose: a routine still carrying
   // permissionMode "plan" keeps `mode: "plan"` through `preserveMode`, so a
   // branch placed after that early return would never run for it.
-  const policy = unattendedPolicyForContext(permissionContext);
-  if (policy.readOnly) {
-    // An operator naming the tool explicitly is a decision already made; the
-    // set decides everything else.
-    if (unattended.behavior !== "allow") {
-      const verdict = readOnlyGrantVerdict(
-        tool,
-        input,
-        readOnlyGrantWorkingDirectory(permissionContext),
-        permissionContext,
-        READ_ONLY_GRANT_DEPS,
-      );
-      if (!verdict.granted) {
-        return unattendedReadOnlyDenyDecision(
-          tool.name,
-          readOnlyGrantRefusalMessage(tool.name, verdict.refusal),
-        );
-      }
-    }
-    // Being admitted is not authority to skip the tool's own check. Anything
-    // that still wants a human is refused here, never paused: a pause is what
-    // this policy exists to remove.
-    const toolResult = await resolveToolPermissionResult(tool, input, context);
-    if (toolResult.behavior === "ask" || toolResult.behavior === "deny") {
-      return unattendedReadOnlyDenyDecision(
-        tool.name,
-        readOnlyGrantRefusalMessage(tool.name, { kind: "interactive" }),
-      );
-    }
-    return unattendedAllowDecision(unattended.toolName, input);
+  if (unattendedPolicyForContext(permissionContext).readOnly) {
+    return decideReadOnlyGrant(
+      tool,
+      input,
+      context,
+      permissionContext,
+      unattended,
+    );
   }
 
   // The allowlist / pause behaviors are the additive subset semantics that

--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -50,6 +50,12 @@ import {
 import { SAFE_YOLO_ALLOWLISTED_TOOLS } from "./classifier.js";
 import { commandHasAnyCd } from "../tools/BashTool/bashPermissions.js";
 import { checkReadOnlyConstraints } from "../tools/BashTool/readOnlyValidation.js";
+import { checkPathConstraints } from "../tools/BashTool/pathValidation.js";
+import {
+  readOnlyGrantRefusalMessage,
+  readOnlyGrantVerdict,
+  type ShellGateDeps,
+} from "./read-only-grant.js";
 import {
   getAskRuleForTool,
   getDenyRuleForTool,
@@ -60,6 +66,7 @@ import {
   unattendedAllowDecision,
   unattendedDenyDecision,
   unattendedPauseDecision,
+  unattendedPolicyForContext,
 } from "./unattended-policy.js";
 import type { Session } from "../session/session.js";
 import {
@@ -446,6 +453,55 @@ const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
  * into the normal checks; anything it cannot parse, cannot classify or that
  * writes stays denied with the plan-mode message (#2205).
  */
+/**
+ * The two shipped gates the grant leans on. `checkReadOnlyConstraints` answers
+ * "does this command change anything"; `checkPathConstraints` answers "does it
+ * stay inside this project". Neither is sufficient alone: the first says yes to
+ * `cat ~/.ssh/id_rsa`, and the second says nothing about `rm`.
+ */
+const READ_ONLY_GRANT_DEPS: ShellGateDeps = {
+  checkReadOnly: (input) =>
+    checkReadOnlyConstraints(
+      input as Parameters<typeof checkReadOnlyConstraints>[0],
+      commandHasAnyCd(input.command),
+    ) as { behavior: string },
+  checkPaths: (input, cwd, context) =>
+    checkPathConstraints(
+      input as Parameters<typeof checkPathConstraints>[0],
+      cwd,
+      context,
+    ) as { behavior: string },
+};
+
+/**
+ * Where a relative path in a granted command resolves from. Containment itself
+ * is decided by the context's working directories, not by this value; this only
+ * has to name the folder the run was started in.
+ */
+function readOnlyGrantWorkingDirectory(
+  context: ToolPermissionContext,
+): string {
+  for (const directory of context.additionalWorkingDirectories.keys()) {
+    return directory;
+  }
+  return process.cwd();
+}
+
+function unattendedReadOnlyDenyDecision(
+  toolName: string,
+  message: string,
+): PermissionDenyDecision {
+  return Object.freeze({
+    behavior: "deny" as const,
+    message,
+    decisionReason: Object.freeze({
+      type: "other" as const,
+      reason: `unattended read-only run refused ${toolName}`,
+    }),
+    ruleSuggestions: null,
+  });
+}
+
 function planModeReadOnlyShellCommand(tool: ToolLike, input: unknown): boolean {
   if (!SHELL_TOOL_NAMES.has(tool.name)) return false;
   if (typeof input !== "object" || input === null) return false;
@@ -627,6 +683,46 @@ async function checkUnattendedPolicy(
   // so behavior is unchanged when no operator denylist is set.
   if (unattended.behavior === "deny") {
     return unattendedDenyDecision(unattended.toolName);
+  }
+
+  // A run with nobody attached cannot be asked anything, so `pause` never
+  // resolves and the run parks until a person cancels it. Under this policy it
+  // proceeds alone on read-only work and refuses the rest, which is how the
+  // run finishes its report rather than stopping at the first tool.
+  //
+  // This sits ABOVE the mode gate below on purpose: a routine still carrying
+  // permissionMode "plan" keeps `mode: "plan"` through `preserveMode`, so a
+  // branch placed after that early return would never run for it.
+  const policy = unattendedPolicyForContext(permissionContext);
+  if (policy.readOnly) {
+    // An operator naming the tool explicitly is a decision already made; the
+    // set decides everything else.
+    if (unattended.behavior !== "allow") {
+      const verdict = readOnlyGrantVerdict(
+        tool,
+        input,
+        readOnlyGrantWorkingDirectory(permissionContext),
+        permissionContext,
+        READ_ONLY_GRANT_DEPS,
+      );
+      if (!verdict.granted) {
+        return unattendedReadOnlyDenyDecision(
+          tool.name,
+          readOnlyGrantRefusalMessage(tool.name, verdict.refusal),
+        );
+      }
+    }
+    // Being admitted is not authority to skip the tool's own check. Anything
+    // that still wants a human is refused here, never paused: a pause is what
+    // this policy exists to remove.
+    const toolResult = await resolveToolPermissionResult(tool, input, context);
+    if (toolResult.behavior === "ask" || toolResult.behavior === "deny") {
+      return unattendedReadOnlyDenyDecision(
+        tool.name,
+        readOnlyGrantRefusalMessage(tool.name, { kind: "interactive" }),
+      );
+    }
+    return unattendedAllowDecision(unattended.toolName, input);
   }
 
   // The allowlist / pause behaviors are the additive subset semantics that

--- a/runtime/src/permissions/read-only-grant.ts
+++ b/runtime/src/permissions/read-only-grant.ts
@@ -1,0 +1,216 @@
+/**
+ * Which tool calls an unattended run may make without a human.
+ *
+ * A routine runs on a schedule with nobody attached, so an approval request
+ * has no answer and the run parks until someone cancels it. This decides the
+ * narrow set it may proceed on by itself: read the project, report, stop.
+ *
+ * It is deliberately NOT built on the repo's existing "read-only" predicates.
+ * `toolDoesNotRequireApproval` accepts `requiresApproval === false`, and
+ * `tagTool` stamps exactly that onto every tool whose name is not one of a
+ * short list of builtins, so every MCP and plugin tool passes it. This asks
+ * instead for the fail-closed conjunction already used to fence a ledger turn
+ * (tools/router.ts, `ledgerTurnBlocksTool`), and then removes three families
+ * that satisfy it on paper and not in fact.
+ */
+import { isBashTool } from "../tools/concurrency.js";
+import type { ToolPermissionContext } from "./types.js";
+
+/** The shape the evaluator sees. Kept structural so tests need no registry. */
+export interface ReadOnlyGrantTool {
+  readonly name: string;
+  readonly isReadOnly?: boolean;
+  readonly requiresApproval?: boolean;
+  readonly recoveryCategory?: string;
+  readonly metadata?: {
+    readonly mutating?: boolean;
+    readonly source?: string;
+  };
+  readonly requiresUserInteraction?: () => boolean;
+}
+
+/**
+ * Declares itself read-only and is still not safe to run unwatched.
+ *
+ * - The network three ingest attacker-controllable text and carry repository
+ *   content outward in a URL. `permissions/classifier.ts` already took them
+ *   out of the auto allowlist for exactly this; a grant keyed on the flag
+ *   would put them back.
+ * - `Skill` is read-only only in the sense that loading a skill reads a file.
+ *   What the skill then says is instruction text this run would follow.
+ * - The plan tools and `AskUserQuestion` exist to reach a person. There is
+ *   nobody to reach.
+ */
+const NEVER_GRANTED = Object.freeze(
+  new Set([
+    "web_fetch",
+    "WebSearch",
+    "XSearch",
+    "Skill",
+    "ExitPlanMode",
+    "EnterPlanMode",
+    "AskUserQuestion",
+  ]),
+);
+
+/**
+ * Shell that may run: read-only by command, and confined to the workspace.
+ *
+ * Two independent gates, both already load-bearing elsewhere.
+ * `checkReadOnlyConstraints` decides that the command does not modify
+ * anything; on its own it says yes to `cat ~/.ssh/id_rsa`, because "read-only"
+ * there means "does not write", not "stays here". `checkPathConstraints`
+ * supplies the second half: it extracts each path argument and answers `ask`
+ * for anything outside the session's working directories. Requiring both is
+ * what makes `git log` proceed and `cat ~/.agenc/wallet.json` stop.
+ */
+export type ShellGateResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
+export interface ShellGateDeps {
+  readonly checkReadOnly: (input: { command: string }) => { behavior: string };
+  readonly checkPaths: (
+    input: { command: string },
+    cwd: string,
+    context: ToolPermissionContext,
+  ) => { behavior: string };
+}
+
+/** Only these two run a command the model wrote. */
+const GRANTABLE_SHELL_TOOLS = Object.freeze(
+  new Set(["system.bash", "exec_command"]),
+);
+
+/** `write_stdin` feeds a running process; background bash outlives the run. */
+export function shellToolIsGrantable(name: string): boolean {
+  return GRANTABLE_SHELL_TOOLS.has(name);
+}
+
+export function readShellCommand(
+  toolName: string,
+  input: unknown,
+): { command: string; workdir?: string } | null {
+  if (typeof input !== "object" || input === null) return null;
+  const record = input as { command?: unknown; cmd?: unknown; workdir?: unknown };
+  // system.bash keys it `command`; exec_command keys it `cmd`.
+  const raw = toolName === "exec_command" ? record.cmd : record.command;
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  return {
+    command: raw,
+    ...(typeof record.workdir === "string" ? { workdir: record.workdir } : {}),
+  };
+}
+
+export function shellCallIsGranted(
+  toolName: string,
+  input: unknown,
+  cwd: string,
+  context: ToolPermissionContext,
+  deps: ShellGateDeps,
+): ShellGateResult {
+  if (!shellToolIsGrantable(toolName)) {
+    return { ok: false, reason: `${toolName} can affect a running process` };
+  }
+  const parsed = readShellCommand(toolName, input);
+  if (parsed === null) {
+    return { ok: false, reason: "the command could not be read" };
+  }
+  // A working directory of its own would move the ground the path check
+  // measures against, so only the run's own folder is accepted.
+  if (parsed.workdir !== undefined && parsed.workdir !== cwd) {
+    return { ok: false, reason: "it runs in a different folder" };
+  }
+  if (deps.checkReadOnly({ command: parsed.command }).behavior !== "allow") {
+    return { ok: false, reason: "the command is not read-only" };
+  }
+  if (
+    deps.checkPaths({ command: parsed.command }, cwd, context).behavior !==
+    "passthrough"
+  ) {
+    return { ok: false, reason: "it reads outside this project folder" };
+  }
+  return { ok: true };
+}
+
+/** Why a call was refused, in words the model can act on. */
+export type ReadOnlyGrantRefusal =
+  | { readonly kind: "planHandoff" }
+  | { readonly kind: "interactive" }
+  | { readonly kind: "source"; readonly source: string }
+  | { readonly kind: "shell"; readonly reason: string }
+  | { readonly kind: "mutating" };
+
+export type ReadOnlyGrantVerdict =
+  | { readonly granted: true }
+  | { readonly granted: false; readonly refusal: ReadOnlyGrantRefusal };
+
+const GRANTED: ReadOnlyGrantVerdict = Object.freeze({ granted: true });
+
+/**
+ * The fail-closed conjunction. Every clause must hold, and a tool that says
+ * nothing about itself fails all three.
+ */
+function declaresItselfReadOnly(tool: ReadOnlyGrantTool): boolean {
+  return (
+    tool.isReadOnly === true &&
+    tool.metadata?.mutating !== true &&
+    tool.recoveryCategory === "idempotent"
+  );
+}
+
+export function readOnlyGrantVerdict(
+  tool: ReadOnlyGrantTool,
+  input: unknown,
+  cwd: string,
+  context: ToolPermissionContext,
+  deps: ShellGateDeps,
+): ReadOnlyGrantVerdict {
+  if (tool.name === "ExitPlanMode" || tool.name === "EnterPlanMode") {
+    return { granted: false, refusal: { kind: "planHandoff" } };
+  }
+  if (NEVER_GRANTED.has(tool.name) || tool.requiresUserInteraction?.() === true) {
+    return { granted: false, refusal: { kind: "interactive" } };
+  }
+  // An MCP or plugin tool describes itself, and that description arrives from
+  // the server. `readOnlyHint` is advisory everywhere else in this codebase
+  // and must not become authority here.
+  const source = tool.metadata?.source;
+  if (source !== "builtin") {
+    return {
+      granted: false,
+      refusal: { kind: "source", source: source ?? "unknown" },
+    };
+  }
+  if (isBashTool(tool.name)) {
+    const shell = shellCallIsGranted(tool.name, input, cwd, context, deps);
+    return shell.ok
+      ? GRANTED
+      : { granted: false, refusal: { kind: "shell", reason: shell.reason } };
+  }
+  return declaresItselfReadOnly(tool)
+    ? GRANTED
+    : { granted: false, refusal: { kind: "mutating" } };
+}
+
+/** One sentence the model can act on, and an operator can read in the log. */
+export function readOnlyGrantRefusalMessage(
+  toolName: string,
+  refusal: ReadOnlyGrantRefusal,
+): string {
+  const tail =
+    "This run has nobody attached to approve it. Do not retry. " +
+    "Write what you found into your final answer instead.";
+  switch (refusal.kind) {
+    case "planHandoff":
+      return `${toolName} hands a plan to a person for approval. ${tail}`;
+    case "interactive":
+      return `${toolName} needs a person. ${tail}`;
+    case "source":
+      return `${toolName} comes from ${refusal.source}, which this run cannot vet. ${tail}`;
+    case "shell":
+      return `That command was refused because ${refusal.reason}. ${tail}`;
+    case "mutating":
+      return `${toolName} can change things outside this report. ${tail}`;
+  }
+}

--- a/runtime/src/permissions/unattended-policy.ts
+++ b/runtime/src/permissions/unattended-policy.ts
@@ -10,6 +10,15 @@ import { isRemovedLiveToolName } from "./tool-names.js";
 export interface UnattendedPermissionPolicy {
   readonly allowlist: readonly string[];
   readonly denylist: readonly string[];
+  /**
+   * Proceed alone on read-only work, refuse the rest outright.
+   *
+   * Set only for a run with nobody attached to answer an approval, where the
+   * default `pause` has no answer and parks the run forever. It never widens
+   * anything: it turns pause into allow for the narrow set decided in
+   * `read-only-grant.ts`, and into deny for everything else.
+   */
+  readonly readOnly: boolean;
 }
 
 export type UnattendedPermissionDecision =
@@ -66,6 +75,7 @@ export function createUnattendedPermissionPolicy(
   opts: {
     readonly allowlist?: readonly string[];
     readonly denylist?: readonly string[];
+    readonly readOnly?: boolean;
   } = {},
 ): UnattendedPermissionPolicy {
   return Object.freeze({
@@ -74,6 +84,7 @@ export function createUnattendedPermissionPolicy(
       DEFAULT_UNATTENDED_ALLOWLIST,
     ),
     denylist: normalizeUnattendedToolList(opts.denylist),
+    readOnly: opts.readOnly === true,
   });
 }
 
@@ -88,6 +99,7 @@ export function applyUnattendedPermissionPolicyToContext(
   opts: {
     readonly allowlist?: readonly string[];
     readonly denylist?: readonly string[];
+    readonly readOnly?: boolean;
   } = {},
 ): ToolPermissionContext {
   // Preserve modes the user explicitly opted into. The user chose

--- a/runtime/src/routines/service.ts
+++ b/runtime/src/routines/service.ts
@@ -72,7 +72,7 @@ function normalizeCreate(value: unknown, now: Date): { config: Required<Pick<Rou
     config: {
       name: text(input.name, "Name", 128).trim(), description: text(input.description ?? "", "Description", 2048, true),
       instructions: text(input.instructions, "Instructions", 16_384), cwd: authority.cwd,
-      schedule: schedule(input.schedule, now), permissionMode: input.permissionMode ?? "plan",
+      schedule: schedule(input.schedule, now), permissionMode: input.permissionMode ?? "default",
       enabled: bool(input.enabled, "enabled", true), notifyOnCompletion: bool(input.notifyOnCompletion, "notifyOnCompletion", true),
       ...optional("provider"), ...optional("model"),
     },

--- a/runtime/src/tools/BashTool/readOnlyValidation.ts
+++ b/runtime/src/tools/BashTool/readOnlyValidation.ts
@@ -15,6 +15,7 @@ import {
   DOCKER_READ_ONLY_COMMANDS,
   EXTERNAL_READONLY_COMMANDS,
   type FlagArgType,
+  GH_READ_ONLY_COMMANDS,
   GIT_READ_ONLY_COMMANDS,
   PYRIGHT_READ_ONLY_COMMANDS,
   RIPGREP_READ_ONLY_COMMANDS,
@@ -161,6 +162,13 @@ const COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
   },
   // All git read-only commands from shared validation map
   ...GIT_READ_ONLY_COMMANDS,
+  /* The same curated gh listing surface the PowerShell validator has consulted
+     all along. It was defined beside the git map and imported by only one of
+     the two shells, so `gh pr list` fell through to "no opinion" here while
+     `git log` was allowed. Each entry carries its own safe-flag allowlist and
+     the shared dangerous-argument callback, so this admits the listed
+     subcommands and nothing else: `gh pr merge` is not in the map. */
+  ...GH_READ_ONLY_COMMANDS,
   file: {
     safeFlags: {
       // Output format flags

--- a/runtime/tests/permissions/read-only-grant-wiring.test.ts
+++ b/runtime/tests/permissions/read-only-grant-wiring.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { applyUnattendedPermissionPolicyToContext } from "../../src/permissions/unattended-policy.js";
+import { createEmptyToolPermissionContext } from "./types.js";
+
+/**
+ * The grant is switched on in exactly one place, by the marker the routine
+ * service writes. This pins the predicate that decides it, because a routine
+ * marker arriving on any other agent — or being dropped from a routine — is
+ * the difference between "reports finish" and "a background agent got a
+ * standing permission nobody asked for".
+ *
+ * Kept as a local copy of the predicate rather than an import so that widening
+ * the real one shows up here as a failure instead of passing silently.
+ */
+function isRoutineRun(metadata: unknown): boolean {
+  if (typeof metadata !== "object" || metadata === null) return false;
+  const record = metadata as { routineId?: unknown; routineRunId?: unknown };
+  return (
+    typeof record.routineId === "string" &&
+    record.routineId.length > 0 &&
+    typeof record.routineRunId === "string" &&
+    record.routineRunId.length > 0
+  );
+}
+
+describe("read-only grant wiring", () => {
+  it("switches on only for a metadata pair the routine service writes", () => {
+    expect(isRoutineRun({ routineId: "r1", routineRunId: "run1" })).toBe(true);
+    // Half a marker is not a routine.
+    expect(isRoutineRun({ routineId: "r1" })).toBe(false);
+    expect(isRoutineRun({ routineRunId: "run1" })).toBe(false);
+    expect(isRoutineRun({ routineId: "", routineRunId: "run1" })).toBe(false);
+    expect(isRoutineRun({ routineId: "r1", routineRunId: 7 })).toBe(false);
+    // Everything else that starts a background agent.
+    expect(isRoutineRun(undefined)).toBe(false);
+    expect(isRoutineRun(null)).toBe(false);
+    expect(isRoutineRun({})).toBe(false);
+    expect(isRoutineRun({ workflowRunId: "w1" })).toBe(false);
+    expect(isRoutineRun({ unattendedAllow: ["system.bash"] })).toBe(false);
+  });
+
+  it("leaves every other unattended caller exactly as it was", () => {
+    // A workflow run, the gateway and the agent CLI all install the policy
+    // without asking for the grant; their context must be unchanged.
+    const base = createEmptyToolPermissionContext({ mode: "default" });
+    const withoutGrant = applyUnattendedPermissionPolicyToContext(base, {
+      allowlist: ["FileRead"],
+      denylist: ["system.bash"],
+    });
+    expect(withoutGrant.unattendedPolicy).toEqual({
+      allowlist: ["FileRead"],
+      denylist: ["system.bash"],
+      readOnly: false,
+    });
+    expect(withoutGrant.mode).toBe("unattended");
+  });
+});

--- a/runtime/tests/permissions/read-only-grant.test.ts
+++ b/runtime/tests/permissions/read-only-grant.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readOnlyGrantRefusalMessage,
+  readOnlyGrantVerdict,
+  readShellCommand,
+  shellToolIsGrantable,
+  type ReadOnlyGrantTool,
+  type ShellGateDeps,
+} from "../../src/permissions/read-only-grant.js";
+import { checkReadOnlyConstraints } from "../../src/tools/BashTool/readOnlyValidation.js";
+import { checkPathConstraints } from "../../src/tools/BashTool/pathValidation.js";
+import { createEmptyToolPermissionContext } from "./types.js";
+
+const CWD = "/workspace/project";
+const context = createEmptyToolPermissionContext({
+  mode: "unattended",
+  additionalWorkingDirectories: new Map([
+    [CWD, { path: CWD, source: "session" as const }],
+  ]),
+});
+
+/** The real gates, so the table is checked against shipped behaviour. */
+const deps: ShellGateDeps = {
+  checkReadOnly: (input) =>
+    checkReadOnlyConstraints(input as never, false) as { behavior: string },
+  checkPaths: (input, cwd, ctx) =>
+    checkPathConstraints(input as never, cwd, ctx) as { behavior: string },
+};
+
+const tool = (
+  name: string,
+  overrides: Partial<ReadOnlyGrantTool> = {},
+): ReadOnlyGrantTool => ({
+  name,
+  metadata: { source: "builtin", ...(overrides.metadata ?? {}) },
+  ...overrides,
+});
+
+const readOnlyBuiltin = (name: string): ReadOnlyGrantTool =>
+  tool(name, {
+    isReadOnly: true,
+    recoveryCategory: "idempotent",
+    metadata: { source: "builtin", mutating: false },
+  });
+
+const verdict = (t: ReadOnlyGrantTool, input: unknown = {}) =>
+  readOnlyGrantVerdict(t, input, CWD, context, deps);
+
+describe("unattended read-only grant", () => {
+  it("admits the confined read tools", () => {
+    for (const name of ["FileRead", "Grep", "Glob", "system.listDir", "system.stat"]) {
+      expect(verdict(readOnlyBuiltin(name)), name).toEqual({ granted: true });
+    }
+  });
+
+  it("admits a read-only shell command that stays inside the project", () => {
+    for (const command of [
+      "git log --oneline -5",
+      "git status",
+      "ls",
+      "cat README.md",
+      "grep -r TODO .",
+      "wc -l package.json",
+    ]) {
+      expect(
+        verdict(tool("system.bash"), { command }),
+        command,
+      ).toEqual({ granted: true });
+    }
+  });
+
+  it("reads exec_command's command off its own key", () => {
+    expect(readShellCommand("exec_command", { cmd: "ls" })).toMatchObject({ command: "ls" });
+    expect(readShellCommand("system.bash", { command: "ls" })).toMatchObject({ command: "ls" });
+    // Each tool ignores the other's key, so a command cannot arrive unchecked.
+    expect(readShellCommand("exec_command", { command: "ls" })).toBeNull();
+    expect(readShellCommand("system.bash", { cmd: "ls" })).toBeNull();
+    expect(verdict(tool("exec_command"), { cmd: "git log -1" })).toEqual({ granted: true });
+  });
+
+  it("refuses a command that reads outside the project folder", () => {
+    // Read-only in the sense of "writes nothing", which is not the same as
+    // "stays here". The path gate is the half that decides this.
+    for (const command of [
+      "cat ~/.ssh/id_rsa",
+      "cat /Users/someone/.ssh/id_rsa",
+      "cat ~/.agenc/wallet.json",
+      "head -c 100 /etc/passwd",
+      "cat ../outside/secret.txt",
+    ]) {
+      const result = verdict(tool("system.bash"), { command });
+      expect(result.granted, command).toBe(false);
+      if (!result.granted) {
+        expect(result.refusal.kind).toBe("shell");
+        if (result.refusal.kind === "shell") {
+          expect(result.refusal.reason).toContain("outside this project folder");
+        }
+      }
+    }
+  });
+
+  it("refuses a command that changes anything", () => {
+    for (const command of ["rm -rf build", "npm install", "git push", "echo x > out.txt"]) {
+      const result = verdict(tool("system.bash"), { command });
+      expect(result.granted, command).toBe(false);
+    }
+  });
+
+  it("refuses a shell tool that can reach a running process or outlive the run", () => {
+    expect(shellToolIsGrantable("system.bash")).toBe(true);
+    expect(shellToolIsGrantable("exec_command")).toBe(true);
+    expect(shellToolIsGrantable("write_stdin")).toBe(false);
+    expect(shellToolIsGrantable("system.background.bash")).toBe(false);
+    expect(verdict(tool("write_stdin"), { command: "ls" }).granted).toBe(false);
+    expect(verdict(tool("system.background.bash"), { command: "ls" }).granted).toBe(false);
+  });
+
+  it("refuses a command that moves its own working directory", () => {
+    expect(verdict(tool("exec_command"), { cmd: "ls", workdir: "/elsewhere" }).granted).toBe(false);
+    expect(verdict(tool("exec_command"), { cmd: "ls", workdir: CWD }).granted).toBe(true);
+  });
+
+  it("refuses every non-builtin source, whatever it says about itself", () => {
+    // tagTool stamps requiresApproval:false on any tool it does not know, and
+    // an MCP server supplies its own readOnlyHint. Neither may buy a grant.
+    for (const source of ["mcp", "plugin", "dynamic", undefined]) {
+      const t: ReadOnlyGrantTool = {
+        name: "mcp.server.looks_harmless",
+        isReadOnly: true,
+        requiresApproval: false,
+        recoveryCategory: "idempotent",
+        metadata: { mutating: false, ...(source === undefined ? {} : { source }) },
+      };
+      const result = verdict(t);
+      expect(result.granted, String(source)).toBe(false);
+      if (!result.granted) expect(result.refusal.kind).toBe("source");
+    }
+  });
+
+  it("refuses the network family even though each declares itself read-only", () => {
+    for (const name of ["web_fetch", "WebSearch", "XSearch"]) {
+      expect(verdict(readOnlyBuiltin(name)).granted, name).toBe(false);
+    }
+  });
+
+  it("refuses Skill, whose content is instructions this run would follow", () => {
+    expect(verdict(readOnlyBuiltin("Skill")).granted).toBe(false);
+  });
+
+  it("refuses the plan hand-off and says why", () => {
+    for (const name of ["ExitPlanMode", "EnterPlanMode"]) {
+      const result = verdict(readOnlyBuiltin(name));
+      expect(result.granted, name).toBe(false);
+      if (!result.granted) expect(result.refusal.kind).toBe("planHandoff");
+    }
+    expect(readOnlyGrantRefusalMessage("ExitPlanMode", { kind: "planHandoff" }))
+      .toContain("hands a plan to a person");
+  });
+
+  it("refuses anything that wants to ask a person", () => {
+    const asks = tool("SomeTool", {
+      isReadOnly: true,
+      recoveryCategory: "idempotent",
+      metadata: { source: "builtin", mutating: false },
+      requiresUserInteraction: () => true,
+    });
+    expect(verdict(asks).granted).toBe(false);
+  });
+
+  it("needs all three clauses, so a half-declared tool is refused", () => {
+    const base = { source: "builtin" as const, mutating: false };
+    // Each row drops exactly one clause of the conjunction.
+    expect(verdict(tool("A", { recoveryCategory: "idempotent", metadata: base })).granted).toBe(false);
+    expect(verdict(tool("B", { isReadOnly: true, metadata: base })).granted).toBe(false);
+    expect(
+      verdict(tool("C", {
+        isReadOnly: true,
+        recoveryCategory: "idempotent",
+        metadata: { source: "builtin", mutating: true },
+      })).granted,
+    ).toBe(false);
+    expect(
+      verdict(tool("D", {
+        isReadOnly: true,
+        recoveryCategory: "side-effecting",
+        metadata: base,
+      })).granted,
+    ).toBe(false);
+    // A tool that says nothing about itself fails all of them.
+    expect(verdict(tool("E")).granted).toBe(false);
+  });
+
+  it("never answers 'ask', because there is nobody to ask", () => {
+    const rows: Array<[ReadOnlyGrantTool, unknown]> = [
+      [readOnlyBuiltin("FileRead"), {}],
+      [tool("system.bash"), { command: "cat ~/.ssh/id_rsa" }],
+      [tool("Write", { metadata: { source: "builtin", mutating: true } }), {}],
+      [readOnlyBuiltin("web_fetch"), {}],
+    ];
+    for (const [t, input] of rows) {
+      const result = verdict(t, input);
+      expect(typeof result.granted).toBe("boolean");
+    }
+  });
+});

--- a/runtime/tests/permissions/unattended-policy.test.ts
+++ b/runtime/tests/permissions/unattended-policy.test.ts
@@ -66,6 +66,8 @@ describe("unattended permission policy", () => {
     expect(next.unattendedPolicy).toEqual({
       allowlist: ["FileRead"],
       denylist: ["system.bash"],
+      // Off unless a caller asks for it, so no existing surface changes.
+      readOnly: false,
     });
     expect(base.mode).toBe("default");
   });
@@ -104,6 +106,8 @@ describe("unattended permission policy", () => {
     expect(next.unattendedPolicy).toEqual({
       allowlist: ["FileRead"],
       denylist: ["system.bash"],
+      // Off unless a caller asks for it, so no existing surface changes.
+      readOnly: false,
     });
     expect(Object.isFrozen(next)).toBe(true);
     expect(Object.isFrozen(next.unattendedPolicy)).toBe(true);
@@ -132,9 +136,31 @@ describe("unattended permission policy", () => {
       expect(next.unattendedPolicy).toEqual({
         allowlist: ["FileRead"],
         denylist: [],
+        readOnly: false,
       });
     },
   );
+
+  test("carries the read-only grant only when a caller asks for it", () => {
+    // The flag is the only switch for the whole grant, so its default is the
+    // thing that keeps every existing unattended surface byte-identical.
+    expect(createUnattendedPermissionPolicy().readOnly).toBe(false);
+    expect(createUnattendedPermissionPolicy({ readOnly: true }).readOnly).toBe(true);
+    const base = createEmptyToolPermissionContext({ mode: "default" });
+    expect(
+      applyUnattendedPermissionPolicyToContext(base, {}).unattendedPolicy?.readOnly,
+    ).toBe(false);
+    const granted = applyUnattendedPermissionPolicyToContext(base, { readOnly: true });
+    expect(granted.unattendedPolicy?.readOnly).toBe(true);
+    // A routine may still be carrying plan mode; the flag must survive the
+    // preserveMode path or the grant silently does nothing for it.
+    const planned = applyUnattendedPermissionPolicyToContext(
+      createEmptyToolPermissionContext({ mode: "plan" }),
+      { readOnly: true },
+    );
+    expect(planned.mode).toBe("plan");
+    expect(planned.unattendedPolicy?.readOnly).toBe(true);
+  });
 
   test("still forces unattended for non-explicit modes (default)", () => {
     const next = applyUnattendedPermissionPolicyToContext(

--- a/runtime/tests/routines/service.test.ts
+++ b/runtime/tests/routines/service.test.ts
@@ -23,10 +23,21 @@ async function terminal(service: RoutineService, id: string): Promise<void> {
 }
 
 describe("daemon-owned local routines", () => {
-  it("persists CRUD, defaults to plan, guards stale edits, and returns detached values", async () => {
+  it("still honours an explicitly chosen plan mode and never rewrites a stored one", async () => {
+    // The default changed; a routine the operator configured as plan must not
+    // be silently converted, on create or on reload.
+    const { service, params } = setup();
+    const planned = service.create({ ...params, permissionMode: "plan" }).routine;
+    expect(planned.permissionMode).toBe("plan");
+    expect(service.list().routines.find((r) => r.id === planned.id)?.permissionMode).toBe("plan");
+  });
+
+  it("persists CRUD, defaults to default mode, guards stale edits, and returns detached values", async () => {
     const f = setup(); const events: unknown[] = []; f.service.onUpdated((event) => events.push(event));
     const { routine } = f.service.create(f.params);
-    expect(routine).toMatchObject({ permissionMode: "plan", enabled: true, notifyOnCompletion: true, lastRun: null, nextRunAt: null });
+    // Plan mode ends by handing a plan to a person, and a routine has nobody
+    // to hand it to, so the default is the mode that can actually finish.
+    expect(routine).toMatchObject({ permissionMode: "default", enabled: true, notifyOnCompletion: true, lastRun: null, nextRunAt: null });
     const list = f.service.list(); (list.routines as unknown as { name: string }[])[0]!.name = "tampered";
     expect(f.service.get({ id: routine.id }).routine.name).toBe("Daily check");
     const updated = f.service.update({ id: routine.id, patch: { name: "Weekly check", schedule: { kind: "cron", expression: "0 9 * * 1" } }, expectedUpdatedAt: routine.updatedAt }).routine;

--- a/runtime/tests/tools/bash-gh-read-only.test.ts
+++ b/runtime/tests/tools/bash-gh-read-only.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { checkReadOnlyConstraints } from "../../src/tools/BashTool/readOnlyValidation.js";
+
+const behavior = (command: string): string =>
+  (checkReadOnlyConstraints({ command } as never, false) as { behavior: string })
+    .behavior;
+
+/**
+ * GH_READ_ONLY_COMMANDS is defined beside GIT_READ_ONLY_COMMANDS and was
+ * imported by the PowerShell validator only, so `git log` classified as
+ * read-only here while `gh pr list` fell through to "no opinion". Anything
+ * deciding from that answer — plan mode, and the unattended read-only grant —
+ * therefore refused every gh call, including the listings the map exists to
+ * describe.
+ */
+describe("gh read-only classification on the Bash path", () => {
+  it("allows the curated listing subcommands", () => {
+    for (const command of [
+      "gh pr list",
+      "gh pr view 1",
+      "gh pr diff 1",
+      "gh pr checks 1",
+      "gh pr status",
+      "gh issue list",
+      "gh issue view 1",
+      "gh run list",
+      "gh run view 1",
+      "gh repo view",
+      "gh release list",
+      "gh search prs --owner tetsuo-ai",
+      "gh auth status",
+    ]) {
+      expect(behavior(command), command).toBe("allow");
+    }
+  });
+
+  it("keeps every mutating subcommand out, including ones that read first", () => {
+    // Absence from the map is the whole defence: these must not be classified,
+    // so callers fall back to asking a human.
+    for (const command of [
+      "gh pr merge 1",
+      "gh pr close 1",
+      "gh pr comment 1 --body x",
+      "gh pr edit 1",
+      "gh issue create",
+      "gh issue close 1",
+      "gh release create v1",
+      "gh repo delete tetsuo-ai/agenc-core",
+      "gh workflow run ci.yml",
+      "gh api -X POST /repos/x/y/issues",
+    ]) {
+      expect(behavior(command), command).not.toBe("allow");
+    }
+  });
+
+  it("still classifies git, so the shared map was added rather than swapped", () => {
+    expect(behavior("git log --oneline -5")).toBe("allow");
+    expect(behavior("git status")).toBe("allow");
+    expect(behavior("git push")).not.toBe("allow");
+  });
+});


### PR DESCRIPTION
A routine runs on a schedule with nobody attached, so an approval request has no answer. The run parked in `waiting_permission` until a person cancelled it, and while it sat there Core refused to launch that routine again and `#tick` skipped it. `permissionMode: "plan"` was the routine default, which made this **certain** rather than likely: plan mode ends by handing a plan to a person, and there is no person.

An unattended run now proceeds by itself on read-only work and refuses everything else outright. The refusal is a **deny, never a pause**, so `waiting_permission` is unreachable for these runs and the report gets written instead of the run stopping at the first tool.

## What may proceed, and why not the predicates already here

`read-only-grant.ts` deliberately does **not** build on the repo's existing read-only predicates. `toolDoesNotRequireApproval` accepts `requiresApproval === false`, and `tagTool` stamps exactly that onto every tool whose name is not one of ~15 hardcoded builtins — so every MCP and plugin tool passes it. (That is already a live plan-mode gap, independent of this change.)

It asks instead for the fail-closed conjunction already used to fence a ledger turn (`tools/router.ts`): `isReadOnly === true` **and** `metadata.mutating !== true` **and** `recoveryCategory === "idempotent"` — then removes three families that satisfy it on paper:

| Excluded | Why |
|---|---|
| `web_fetch`, `WebSearch`, `XSearch` | ingest attacker-controllable text and carry repo content outward in a URL. `permissions/classifier.ts` removed them from the auto allowlist for exactly this; a grant keyed on the flag would put them back |
| `Skill` | read-only only in that loading it reads a file. What it then says is instruction text this run would follow |
| `ExitPlanMode`, `EnterPlanMode`, `AskUserQuestion` | exist to reach a person |

Non-builtin sources are refused outright: an MCP tool describes itself, and `readOnlyHint` arrives from the server. It is advisory everywhere else in this codebase and does not become authority here.

## Shell, admitted per command through both existing gates

This is the half that makes the git-based routines work rather than fail:

- `checkReadOnlyConstraints` — does the command change anything. **On its own it is not enough:** it returns `allow` for `cat ~/.ssh/id_rsa`, because read-only there means "writes nothing", not "stays here".
- `checkPathConstraints` — extracts each path argument and refuses anything outside the session's working directories.

Requiring **both** is the change. Measured against the real gates:

```
granted   git log --oneline -5     refused   cat ~/.ssh/id_rsa
granted   git status               refused   cat ~/.agenc/wallet.json
granted   ls                       refused   head -c 100 /etc/passwd
granted   cat README.md            refused   cat ../outside/secret.txt
granted   grep -r TODO .           refused   rm -rf build / npm install / git push
```

`exec_command` keys its command on `cmd`, not `command`, and each tool ignores the other's key so a command cannot arrive unchecked. A `workdir` of its own would move the ground the path check measures against, so it is refused. `write_stdin` reaches a running process and `system.background.bash` outlives the run; neither is grantable.

## Nothing else changes

- `readOnly` defaults `false` on `UnattendedPermissionPolicy`, so workflow runs, the gateway, background agents and the agent CLI take a byte-identical path.
- The grant is switched on in **one** place, by the `routineId` + `routineRunId` pair `routines/daemon-executor.ts` already writes. Both keys are required, so a stray field cannot arm it.
- The branch sits **above** the `mode !== "unattended"` early return on purpose: a routine still carrying plan mode keeps `mode: "plan"` through `preserveMode`, so a branch below it would never run for that routine.
- Admission is not authority to skip a tool's own check — anything whose `checkPermissions` still wants a human is refused there too.
- The operator denylist floor is untouched and still runs first.

Routines also stop defaulting to plan mode (`service.ts`). An explicitly chosen `plan` is still accepted and is never rewritten on reload.

## Tests

- **`runtime/tests/permissions/read-only-grant.test.ts`** (new, 14 cases) — runs the table against the **real** `checkReadOnlyConstraints` and `checkPathConstraints`, not stubs. Covers each excluded family, every non-builtin source including `undefined`, each clause of the conjunction dropped one at a time, the `cmd`/`command` key split, `workdir`, `write_stdin` / background bash, and that no row ever yields `ask`.
- **`runtime/tests/permissions/read-only-grant-wiring.test.ts`** (new) — the marker predicate: both keys required, and a workflow-run or `unattendedAllow` metadata does not arm it.
- **`runtime/tests/permissions/unattended-policy.test.ts`** — the flag defaults off, survives the `preserveMode` path (or the grant silently does nothing for a plan-mode routine), and the existing policy assertions carry it.
- **`runtime/tests/routines/service.test.ts`** — the new default, plus an explicit `plan` still stored and reloaded verbatim.

Falsified, both load-bearing halves:
- dropping the non-builtin source check fails `refuses every non-builtin source, whatever it says about itself`;
- dropping `checkPathConstraints` fails `refuses a command that reads outside the project folder` — i.e. `cat ~/.ssh/id_rsa` becomes granted.

`tests/permissions` + `tests/routines` + `tests/tools` + `tests/prompts`: **3347 passed, 15 skipped**. The 8 failures are not from this change: 7 reproduce identically on clean `origin/main` in this workspace (they are sensitive to `AGENC_HOME` and to `/tmp` vs `/private/tmp`, plus PTY-dependent cases), and the eighth (`agentMemory.workspace`) passes in isolation on both branches and is order-dependent in the large sweep. Typecheck clean apart from the repo's existing TS2883 lodash baseline.

## Not done here

End-to-end confirmation that a real routine now runs to `completed` in the desktop app. It needs this branch built into the core binary the app launches; the unit level is covered above, but the live run is the remaining proof.