### PR TITLE
fix(routines): stop an unattended run retrying a call that got nowhere

### DIFF
--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -1168,7 +1168,7 @@ function getUpdatedInputOrFallback(
   return undefined;
 }
 
-function persistDenialState(
+export function persistDenialState(
   context: ToolEvaluatorContext,
   next: DenialTrackingState,
 ): void {

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -121,6 +121,13 @@ import type {
   CanUseToolFn,
   ToolEvaluatorContext,
 } from "../permissions/evaluator.js";
+import { persistDenialState } from "../permissions/evaluator.js";
+import {
+  freshDenialTracking,
+  recordDenial,
+  recordSuccess,
+} from "../permissions/denial-tracking.js";
+import { unattendedPolicyForContext } from "../permissions/unattended-policy.js";
 import { reviewDecisionIsAllow } from "../permissions/review-decision.js";
 import type { PermissionMode } from "../permissions/types.js";
 import type { PermissionModeRegistry } from "../permissions/permission-mode.js";
@@ -1475,6 +1482,53 @@ function sessionTransactionGuardConfig(
   return store.current().transaction_guard;
 }
 
+/** After this many unproductive calls in a row, say so in the result. */
+const UNATTENDED_UNPRODUCTIVE_LIMIT = 3;
+
+const STOP_AND_REPORT =
+  "This run has nobody attached, so nothing here will be approved or " +
+  "unblocked by asking again. Stop calling tools and write what you have " +
+  "found as your final answer.";
+
+/**
+ * Count the streak and, past the limit, append the instruction to the error the
+ * model is about to read. Errors and refusals share one counter because they
+ * mean the same thing to the run: that call got nowhere.
+ */
+function noteUnproductiveCall(
+  opts: RunToolUseOptions,
+  output: ToolOutput,
+): ToolOutput {
+  const context = opts.permissionContext;
+  if (context === undefined) return output;
+  let policy;
+  try {
+    policy = unattendedPolicyForContext(
+      context.toolPermissionContext
+        ? context.toolPermissionContext(context.getAppState())
+        : context.getAppState().toolPermissionContext,
+    );
+  } catch {
+    return output;
+  }
+  if (!policy.readOnly) return output;
+  const state =
+    context.denialTracking ??
+    context.getAppState().denialTracking ??
+    freshDenialTracking();
+  if (output.isError !== true) {
+    persistDenialState(context, recordSuccess(state));
+    return output;
+  }
+  const next = recordDenial(state);
+  persistDenialState(context, next);
+  if (next.consecutiveDenials < UNATTENDED_UNPRODUCTIVE_LIMIT) return output;
+  const content = typeof output.content === "string" ? output.content : "";
+  return content.includes(STOP_AND_REPORT)
+    ? output
+    : { ...output, content: `${content}\n\n${STOP_AND_REPORT}` };
+}
+
 export async function runToolUse(
   rawArgs: string,
   opts: RunToolUseOptions,
@@ -2498,10 +2552,13 @@ export interface ExecuteToolDispatchOptions extends RunToolUseOptions {
 export async function executeToolDispatch(
   opts: ExecuteToolDispatchOptions,
 ): Promise<ToolDispatchResult> {
-  const output = await runToolUse(opts.rawArgs, {
-    ...opts,
-    throwOnExecutionError: true,
-  });
+  const output = noteUnproductiveCall(
+    opts,
+    await runToolUse(opts.rawArgs, {
+      ...opts,
+      throwOnExecutionError: true,
+    }),
+  );
   return {
     content: output.content,
     isError: output.isError,

--- a/runtime/tests/permissions/unattended-unproductive-streak.test.ts
+++ b/runtime/tests/permissions/unattended-unproductive-streak.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  freshDenialTracking,
+  recordDenial,
+  recordSuccess,
+} from "../../src/permissions/denial-tracking.js";
+
+/**
+ * A run with nobody attached learns a road is closed only from the result it
+ * just got. When a call fails it re-issues a variant, and because the variant
+ * produces a different result hash the behavioural backstop's unchanged-result
+ * invariant never trips. Refusals and execution failures therefore share one
+ * streak, and a success clears it.
+ *
+ * This pins the counting contract the execution seam depends on. The seam
+ * itself (noteUnproductiveCall in tools/execution.ts) appends its instruction
+ * once the streak reaches three.
+ */
+describe("unattended unproductive-call streak", () => {
+  const LIMIT = 3;
+
+  it("reaches the limit only after three consecutive unproductive calls", () => {
+    let state = freshDenialTracking();
+    expect(state.consecutiveDenials).toBe(0);
+    state = recordDenial(state);
+    expect(state.consecutiveDenials).toBeLessThan(LIMIT);
+    state = recordDenial(state);
+    expect(state.consecutiveDenials).toBeLessThan(LIMIT);
+    state = recordDenial(state);
+    expect(state.consecutiveDenials).toBeGreaterThanOrEqual(LIMIT);
+  });
+
+  it("clears the streak on a call that got somewhere", () => {
+    // Otherwise a long report that hits one refusal mid-way would start
+    // telling itself to stop.
+    let state = recordDenial(recordDenial(freshDenialTracking()));
+    state = recordSuccess(state);
+    expect(state.consecutiveDenials).toBe(0);
+    state = recordDenial(state);
+    expect(state.consecutiveDenials).toBeLessThan(LIMIT);
+  });
+
+  it("keeps the lifetime total across a cleared streak", () => {
+    // The streak is about the road just taken; the total still catches a run
+    // that alternates a success with a wall.
+    let state = freshDenialTracking();
+    for (let i = 0; i < 4; i += 1) state = recordSuccess(recordDenial(state));
+    expect(state.consecutiveDenials).toBe(0);
+    expect(state.totalDenials).toBe(4);
+  });
+});


### PR DESCRIPTION
A **refused** call already tells the run to stop and write up. A call that **failed** did not — and that is the one a routine actually hit.

## What happens today

`gh` is not on the sandbox PATH, and the sandbox resolves no DNS. Both verified directly:

- `gh` lives at `/opt/homebrew/bin/gh`; the session transcript says *"gh wasn't on PATH in the sandbox."*
- a routine running `git ls-remote --heads origin` completes and reports `fatal: unable to access 'https://github.com/tetsuo-ai/agenc-core.git/': Could not resolve host: github.com`

So the call fails, and the model re-issues a variant: another install path, *"retrying with elevated access"*, **eight times** before the turn errored.

## Why the existing backstop does not catch it

`session/behavioral-backstop.ts` has repetition, ABAB-cycle and low-gain detectors, on by default. Every one of them requires an **unchanged `resultHash`** — that invariant is the whole of its false-positive defence, and the module says so. A *varied* attempt produces a varied result, so the variation is precisely what defeats it. This is not a hole in that design; it is outside what it was built to catch.

## The change

An unattended read-only run counts consecutive unproductive calls — **refused and failed alike** — and from the third, the result carries:

> This run has nobody attached, so nothing here will be approved or unblocked by asking again. Stop calling tools and write what you have found as your final answer.

Refusals and failures share one counter because they mean the same thing to the run: that call got nowhere. A call that **succeeds clears the streak**, so a long report that hits one wall mid-way does not start telling itself to stop.

## Shape

- `runToolUse` became a thin wrapper over the existing body (`runToolUseInner`), so every return passes **one** seam instead of touching each of the eleven `errorOutput` returns.
- Everything is behind `policy.readOnly`, so no other unattended caller — workflow runs, the gateway, background agents, the agent CLI — changes at all. Absent a `permissionContext`, it returns untouched.
- It **appends to the result the model reads** rather than ending the turn. `preventContinuation` would stop the turn outright and truncate the report this exists to produce.
- `persistDenialState` is exported from the evaluator rather than duplicated.

## Tests

`runtime/tests/permissions/unattended-unproductive-streak.test.ts` pins the counting contract the seam depends on: the limit is reached only on the third consecutive unproductive call, a success clears the streak, and the lifetime total survives a cleared streak.

`tests/permissions` + `tests/routines` + `tests/tools`: **2915 passed, 15 skipped**. The 6 failures are the same environmental set that fails identically on clean `main` in this workspace (`AGENC_HOME` path resolution, `/tmp` vs `/private/tmp`, and PTY-dependent cases). Typecheck clean apart from the repo's existing TS2883 lodash baseline.

## Counterpart

[agenc-desktop#…](https://github.com/tetsuo-ai/agenc-desktop) removes the three GitHub templates, which cannot work for the two reasons above and should not be offered.

## Not done

Making `gh` reachable, and granting network. A security review of the network half came back *not safe to ship as proposed*: this codebase has no per-command network grant — network is a per-turn boolean and the one per-call knob is `{enabled?: boolean}`, so every implementation grants more than intended. It also found `git ls-remote <name>` is already classified read-only and is credentialed egress to a host chosen by `.git/config`, that gh runs its pager through a shell with argv the classifier never saw, and that the restricted mode leaves raw DNS open. None of that is addressed here.