### PR TITLE
fix(sort): give canonical sorts an explicit locale-independent comparator

### DIFF
--- a/runtime/src/config/layer-authority.ts
+++ b/runtime/src/config/layer-authority.ts
@@ -1,4 +1,5 @@
 import type { AgenCConfig } from "./schema.js";
+import { compareCodeUnits } from "../utils/stringUtils.js";
 
 type ConfigKey = keyof AgenCConfig & string;
 
@@ -136,7 +137,7 @@ export function assertUserConfigDocumentAuthority(
   const invalid = presentKeys(raw, MANAGED_ONLY_CONFIG_KEYS);
   if (invalid.length === 0) return;
   throw new Error(
-    `${label} contains managed-only key${invalid.length === 1 ? "" : "s"} ${invalid.sort().join(", ")}; move ${invalid.length === 1 ? "it" : "them"} to canonical managed config.toml`,
+    `${label} contains managed-only key${invalid.length === 1 ? "" : "s"} ${invalid.sort(compareCodeUnits).join(", ")}; move ${invalid.length === 1 ? "it" : "them"} to canonical managed config.toml`,
   );
 }
 
@@ -148,7 +149,7 @@ export function assertConfigPatchAuthority(
   const managed = presentKeys(patch, MANAGED_ONLY_CONFIG_KEYS);
   if (managed.length > 0) {
     throw new Error(
-      `${scope} config.toml cannot set managed-only key${managed.length === 1 ? "" : "s"} ${managed.sort().join(", ")}; deletions are allowed for repair`,
+      `${scope} config.toml cannot set managed-only key${managed.length === 1 ? "" : "s"} ${managed.sort(compareCodeUnits).join(", ")}; deletions are allowed for repair`,
     );
   }
   if (scope === "user") return;
@@ -160,7 +161,7 @@ export function assertConfigPatchAuthority(
   ];
   if (operator.length > 0) {
     throw new Error(
-      `${scope} config.toml cannot set operator-only key${operator.length === 1 ? "" : "s"} ${operator.sort().join(", ")}; use user or managed config.toml`,
+      `${scope} config.toml cannot set operator-only key${operator.length === 1 ? "" : "s"} ${operator.sort(compareCodeUnits).join(", ")}; use user or managed config.toml`,
     );
   }
 }

--- a/runtime/src/config/layer-authority.ts
+++ b/runtime/src/config/layer-authority.ts
@@ -137,7 +137,7 @@ export function assertUserConfigDocumentAuthority(
   const invalid = presentKeys(raw, MANAGED_ONLY_CONFIG_KEYS);
   if (invalid.length === 0) return;
   throw new Error(
-    `${label} contains managed-only key${invalid.length === 1 ? "" : "s"} ${invalid.sort(compareCodeUnits).join(", ")}; move ${invalid.length === 1 ? "it" : "them"} to canonical managed config.toml`,
+    `${label} contains managed-only key${invalid.length === 1 ? "" : "s"} ${[...invalid].sort(compareCodeUnits).join(", ")}; move ${invalid.length === 1 ? "it" : "them"} to canonical managed config.toml`,
   );
 }
 
@@ -149,7 +149,7 @@ export function assertConfigPatchAuthority(
   const managed = presentKeys(patch, MANAGED_ONLY_CONFIG_KEYS);
   if (managed.length > 0) {
     throw new Error(
-      `${scope} config.toml cannot set managed-only key${managed.length === 1 ? "" : "s"} ${managed.sort(compareCodeUnits).join(", ")}; deletions are allowed for repair`,
+      `${scope} config.toml cannot set managed-only key${managed.length === 1 ? "" : "s"} ${[...managed].sort(compareCodeUnits).join(", ")}; deletions are allowed for repair`,
     );
   }
   if (scope === "user") return;
@@ -161,7 +161,7 @@ export function assertConfigPatchAuthority(
   ];
   if (operator.length > 0) {
     throw new Error(
-      `${scope} config.toml cannot set operator-only key${operator.length === 1 ? "" : "s"} ${operator.sort(compareCodeUnits).join(", ")}; use user or managed config.toml`,
+      `${scope} config.toml cannot set operator-only key${operator.length === 1 ? "" : "s"} ${[...operator].sort(compareCodeUnits).join(", ")}; use user or managed config.toml`,
     );
   }
 }

--- a/runtime/src/permissions/approval-cache.ts
+++ b/runtime/src/permissions/approval-cache.ts
@@ -22,6 +22,7 @@
  */
 
 import { canonicalizeCommandForApproval } from "../shell-command/parser.js";
+import { compareCodeUnits } from "../utils/stringUtils.js";
 import type { ReviewDecision } from "./review-decision.js";
 import {
   parseRuleString,
@@ -74,7 +75,7 @@ function stableKeyNode(
     return [
       "object",
       Object.keys(obj)
-        .sort()
+        .sort(compareCodeUnits)
         .map((k) => [k, stableKeyNode(obj[k], seen)]),
     ];
   } finally {
@@ -257,7 +258,7 @@ export class SessionApprovalCache {
   }
 
   snapshot(): SessionApprovalCacheSnapshot {
-    const ruleStrings = [...this.ruleStrings].sort();
+    const ruleStrings = [...this.ruleStrings].sort(compareCodeUnits);
     return Object.freeze({
       ruleStrings: Object.freeze(ruleStrings),
       rules: Object.freeze(ruleStrings.map((rule) => normalizeRule(rule))),
@@ -379,7 +380,7 @@ export function buildShellApprovalKey(
     command: canonicalizeCommandForApproval(opts.command),
     cwd: opts.cwd,
     ...(opts.tty !== undefined ? { tty: opts.tty } : {}),
-    sandbox_permissions: [...(opts.sandbox_permissions ?? [])].sort(),
-    additional_permissions: [...(opts.additional_permissions ?? [])].sort(),
+    sandbox_permissions: [...(opts.sandbox_permissions ?? [])].sort(compareCodeUnits),
+    additional_permissions: [...(opts.additional_permissions ?? [])].sort(compareCodeUnits),
   };
 }

--- a/runtime/src/utils/stringUtils.ts
+++ b/runtime/src/utils/stringUtils.ts
@@ -242,3 +242,22 @@ export function truncateToLines(text: string, maxLines: number): string {
   }
   return lines.slice(0, maxLines).join('\n') + '…'
 }
+
+/**
+ * Order two strings by UTF-16 code unit, which is exactly what a bare
+ * `.sort()` does.
+ *
+ * Sonar's S2871 asks for an explicit comparator and suggests
+ * `String.localeCompare`. Do not use it here. Much of what this codebase sorts
+ * feeds something that has to be identical everywhere: cache keys built by
+ * `stableKeyNode`, canonical projections, config layering. `localeCompare`
+ * answers differently under different locales, so adopting it would make those
+ * keys machine-dependent — a real regression in exchange for a clean rule.
+ *
+ * This says the same thing the default already did, in a form the rule accepts
+ * and a reader can check.
+ */
+export function compareCodeUnits(left: string, right: string): number {
+  if (left < right) return -1;
+  return left > right ? 1 : 0;
+}


### PR DESCRIPTION
First slice of the reliability gate on `main`, deliberately small so the approach can be checked against the analyser before it is applied to 195 sites.

## The problem with the suggested fix

S2871 asks for a compare function and suggests `String.localeCompare`. **Adopting that would be a regression**, not a cleanup.

Much of what this codebase sorts feeds something that must be identical everywhere:

- `approval-cache.ts` `stableKeyNode` sorts object keys to build a **cache key** — the function name says what it is for
- `snapshot()` sorts rule strings
- `sandbox_permissions` / `additional_permissions` are sorted and hashed

`localeCompare` is locale-sensitive. Two machines with different locales would produce **different cache keys for the same input**. That is a real, subtle bug traded for a clean rule.

`compareCodeUnits` says exactly what a bare `.sort()` already did — UTF-16 code unit order — in a form the rule accepts and a reader can check. Behaviour is unchanged by construction.

## Scope

Seven sites, chosen to cover both kinds:

- **determinism-critical** — `runtime/src/permissions/approval-cache.ts` (4)
- **cosmetic** — `runtime/src/config/layer-authority.ts` (3), sorted key names inside error messages

## What this is for

`main` fails its quality gate on `D Reliability Rating on New Code` with **314 new-code bugs**, 195 of them this rule. I am not applying a 195-site change on an assumption about what the analyser accepts. If this PR's changed lines come back clean, the approach is proven and the rest can follow; if the rule insists on `localeCompare` specifically, then the right answer is a documented exception, not a behaviour change.

## Tests

`tests/permissions` + `tests/config`: **1935 passed**. The 8 failures are the environmental set that fails identically on clean `main` in this workspace (`AGENC_HOME` resolution, `/tmp` vs `/private/tmp`). Typecheck clean apart from the repo's TS2883 lodash baseline.

## Not in this PR

The remaining 188 sort sites and the other 119 new-code bugs (`S1143` unsafe throw, `S7727` control characters, `S6324`, `S3923` identical branches, and a long tail).