### PR TITLE
Add authenticated session-owned Desktop control tools

### DIFF
--- a/packages/agenc-sdk/src/protocol-wire.generated.ts
+++ b/packages/agenc-sdk/src/protocol-wire.generated.ts
@@ -586,11 +586,23 @@ export interface SessionMcpServerConfig extends JsonObject {
     readonly endpoint?: string;
     readonly enabled?: boolean;
     readonly required?: boolean;
+    /** Ephemeral HTTP authentication; never written to canonical configuration. */
+    readonly headers?: {
+        readonly [key: string]: string;
+    };
+    /** Restrict this attachment to trusted local daemon turns (not remote/browser input). */
+    readonly localOnly?: boolean;
+    readonly desktopAuthority?: {
+        readonly id: string;
+        readonly signature: string;
+    };
 }
 
 export interface SessionMcpAddServerParams extends JsonObject {
     readonly sessionId: string;
     readonly config: SessionMcpServerConfig;
+    /** Replace only an existing session-owned overlay; canonical definitions stay protected. */
+    readonly replace?: boolean;
 }
 
 export interface MessageSendParams extends JsonObject {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -39,6 +39,7 @@
     "typecheck:test-support": "tsc --noEmit --project tsconfig.test-support.json",
     "check:package-entrypoints": "node scripts/check-package-entrypoints.mjs",
     "check:sdk-generated-types": "node scripts/check-sdk-generated-types.mjs",
+    "check:desktop-mcp-delivery": "node scripts/check-desktop-mcp-delivery.mjs",
     "check:recovery-million-event": "tsx scripts/check-recovery-million-event.ts",
     "check:tui-runtime-startup": "node scripts/check-tui-runtime-startup.mjs",
     "check:tui-e2e": "node scripts/check-tui-e2e/runner.mjs",

--- a/runtime/scripts/check-desktop-mcp-delivery.mjs
+++ b/runtime/scripts/check-desktop-mcp-delivery.mjs
@@ -5,13 +5,18 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { randomBytes, randomUUID, generateKeyPairSync, createHash, sign } from "node:crypto";
-import { readFile, mkdir, writeFile, appendFile, mkdtemp, chmod, realpath, rm } from "node:fs/promises";
+import { readFile, mkdir, writeFile, appendFile, mkdtemp, chmod, realpath, rm, access } from "node:fs/promises";
+import { constants } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connect } from "../../packages/agenc-sdk/dist/index.js";
 import { createTuiGateState, createTuiGateProject, writeTuiGateDefaultConfig, writeTuiGateTrust, startTuiGateDaemon, teardownTuiGateState } from "./tui-gate-state.mjs";
 
 const bin = fileURLToPath(new URL("../dist/bin/agenc.js", import.meta.url));
+// Desktop inventory runs the CLI directly. Official package mode
+// canonicalization intentionally leaves dist JS non-executable; use the
+// shipped executable wrapper, as an installed app does.
+const desktopBin = fileURLToPath(new URL("../bin/agenc", import.meta.url));
 const sdkRequests = [];
 const calls = [];
 let token = randomBytes(24).toString("hex");
@@ -157,7 +162,8 @@ try {
   const before = await readFile(configPath, "utf8");
   await startTuiGateDaemon(state, bin);
   if (serve) {
-    const launch = { bin, project, provider: "openai", model, env: state.env, prompt: "DESKTOP_CONTROL_SMOKE: inspect Desktop state and window, then open Appearance settings using the authenticated Desktop tools." };
+    await access(desktopBin, constants.X_OK);
+    const launch = { bin: desktopBin, project, provider: "openai", model, env: state.env, prompt: "DESKTOP_CONTROL_SMOKE: inspect Desktop state and window, then open Appearance settings using the authenticated Desktop tools." };
     const path = join(state.root, "desktop-launch.json");
     await writeFile(path, JSON.stringify(launch, null, 2), { mode: 0o600 });
     console.log(JSON.stringify({ status: "READY", launchRecipe: path, agencHome: state.agencHome, modelBaseUrl: provider.url, project }));

--- a/runtime/scripts/check-desktop-mcp-delivery.mjs
+++ b/runtime/scripts/check-desktop-mcp-delivery.mjs
@@ -224,12 +224,19 @@ try {
     const restrictedResult = await refused.result();
     assert.equal(calls.length, 1, "restricted session dispatched an unsandboxed native terminal operation");
     const restrictedTranscript = JSON.stringify(await attached.session.transcript());
-    const restrictedToolResults = sdkRequests.slice(restrictedRequestStart).flatMap(request => (request.messages ?? request.input ?? []).filter(message => message.role === "tool" || message.type === "function_call_output"));
+    const restrictedToolResults = sdkRequests.slice(restrictedRequestStart).flatMap(request => {
+      const messages = request.messages ?? request.input ?? [];
+      const terminalCalls = new Set(messages.flatMap(message => message.type === "function_call" ? [message] : message.tool_calls ?? [])
+        .filter(call => (call.name ?? call.function?.name)?.endsWith("terminal_open"))
+        .map(call => call.call_id ?? call.id));
+      return messages.filter(message => (message.role === "tool" || message.type === "function_call_output") && terminalCalls.has(message.call_id ?? message.tool_call_id));
+    });
     if (!/sandbox|full-access|permission denied|not permitted|write target/i.test(JSON.stringify(restrictedToolResults))) {
       const diagnostic = JSON.stringify({ restrictedEvents, restrictedResult, restrictedTranscript, restrictedToolResults });
       for (const secret of secrets) assert(!diagnostic.includes(secret));
       console.error("Restricted terminal diagnostic", diagnostic.slice(-12000));
     }
+    assert(restrictedToolResults.length > 0, "restricted session did not attempt the terminal tool");
     assert(/sandbox|full-access|permission denied|not permitted|write target/i.test(JSON.stringify(restrictedToolResults)), "restricted terminal refusal was not surfaced to the model");
     for (const secret of secrets) assert(!JSON.stringify({ restrictedEvents, restrictedResult, restrictedTranscript }).includes(secret));
     console.log(JSON.stringify({ terminalPolicy: "PASS", fullAccessDispatched: true, restrictedDispatched: false, restrictedSessionId: attached.session.sessionId }));

--- a/runtime/scripts/check-desktop-mcp-delivery.mjs
+++ b/runtime/scripts/check-desktop-mcp-delivery.mjs
@@ -1,0 +1,242 @@
+/** Real built daemon + SDK + scripted loopback model + authenticated HTTP MCP.
+ * No operator profile, cloud provider, global MCP config, or Electron instance.
+ * Run after build: node scripts/check-desktop-mcp-delivery.mjs
+ */
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { randomBytes, randomUUID, generateKeyPairSync, createHash, sign } from "node:crypto";
+import { readFile, mkdir, writeFile, appendFile, mkdtemp, chmod, realpath, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { connect } from "../../packages/agenc-sdk/dist/index.js";
+import { createTuiGateState, createTuiGateProject, writeTuiGateDefaultConfig, writeTuiGateTrust, startTuiGateDaemon, teardownTuiGateState } from "./tui-gate-state.mjs";
+
+const bin = fileURLToPath(new URL("../dist/bin/agenc.js", import.meta.url));
+const sdkRequests = [];
+const calls = [];
+let token = randomBytes(24).toString("hex");
+const secrets = [token];
+let initializes = 0;
+let callId = 0;
+let keys;
+const model = "gpt-4.1-mini"; // Wire-compatible fixture only; every request stays on loopback.
+const namespace = "mcp.agenc-desktop-control.";
+const serve = process.argv.includes("--serve");
+const terminalPolicy = process.argv.includes("--terminal-policy");
+assert(!(serve && terminalPolicy), "terminal-policy cannot be combined with serve");
+const steps = terminalPolicy ? ["terminal_open"] : ["desktop_state", "desktop_window_state", "desktop_settings_open"];
+const providerEnv = url => ({ AGENC_PROVIDER: "openai", AGENC_MODEL: model, OPENAI_BASE_URL: `${url}/v1`, OPENAI_API_KEY: "isolated-scripted-key", AGENC_AUTH_MANAGED_KEYS_ENABLED: "0" });
+
+async function bodyOf(request) {
+  let raw = "";
+  for await (const chunk of request) { raw += chunk; assert(raw.length < 4_000_000); }
+  return raw ? JSON.parse(raw) : {};
+}
+function json(response, status, value) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+async function listen(handler, socketPath) {
+  const server = createServer((request, response) => {
+    Promise.resolve(handler(request, response)).catch(error => { console.error("Fixture request error:", error.message); json(response, 500, { error: String(error.message) }); });
+  });
+  await new Promise((resolve, reject) => { server.once("error", reject); if (socketPath) server.listen(socketPath, resolve); else server.listen(0, "127.0.0.1", resolve); });
+  if (socketPath) await chmod(socketPath, 0o600);
+  return { server, socketPath, url: socketPath ? "http://127.0.0.1:43117" : `http://127.0.0.1:${server.address().port}`, close: async () => { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); } };
+}
+function replyModel(response, body, call) {
+  if (Array.isArray(body.input)) {
+    const id = `desktop_smoke_${++callId}`;
+    const item = call ? { type: "function_call", id: `fc_${id}`, call_id: id, name: call.name, arguments: JSON.stringify(call.args), status: "completed" }
+      : { type: "message", id: `msg_${id}`, role: "assistant", status: "completed", content: [{ type: "output_text", text: "DESKTOP_MCP_DELIVERY_OK", annotations: [] }] };
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    const events = [{ type: "response.output_item.done", output_index: 0, item }, { type: "response.completed", response: { id: `resp_${id}`, status: "completed", model: body.model, output: [item], usage: { input_tokens: 100, output_tokens: 10, total_tokens: 110 } } }];
+    if (!call) events.unshift({ type: "response.output_text.delta", delta: "DESKTOP_MCP_DELIVERY_OK" });
+    for (const event of events) response.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+    response.end();
+    return;
+  }
+  const frame = (delta, finish_reason = null) => ({ id: `local-${callId}`, object: "chat.completion.chunk", created: 1, model: body.model ?? model, choices: [{ index: 0, delta, finish_reason }] });
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  const chunks = [frame({ role: "assistant" })];
+  if (call) chunks.push(frame({ tool_calls: [{ index: 0, id: `desktop_smoke_${++callId}`, type: "function", function: { name: call.name, arguments: JSON.stringify(call.args) } }] }));
+  else chunks.push(frame({ content: "DESKTOP_MCP_DELIVERY_OK" }));
+  chunks.push({ ...frame({}, call ? "tool_calls" : "stop"), usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 } });
+  for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  response.end("data: [DONE]\n\n");
+}
+
+let state;
+let client;
+let provider;
+let mcp;
+let socketRoot;
+const deadline = setTimeout(() => { console.error("Desktop MCP delivery gate timed out"); process.exitCode = 1; void cleanup(); }, serve ? 12 * 60 * 60 * 1000 : 150_000);
+let cleaning;
+function cleanup() {
+  return cleaning ??= (async () => {
+    clearTimeout(deadline);
+    await client?.close();
+    if (state) await teardownTuiGateState(state, bin);
+    await mcp?.close();
+    if (socketRoot) await rm(socketRoot, { recursive: true, force: true });
+    await provider?.close();
+  })();
+}
+try {
+  provider = await listen(async (request, response) => {
+    if (request.method === "GET" && request.url === "/v1/models") return json(response, 200, { object: "list", data: [{ id: model, object: "model", owned_by: "fixture" }] });
+    if (request.url === "/api/show") return json(response, 404, { error: "not an Ollama fixture" });
+    assert(["/v1/chat/completions", "/v1/responses"].includes(request.url));
+    const body = await bodyOf(request);
+    sdkRequests.push(body);
+    console.log(`Scripted provider request ${sdkRequests.length}`);
+    for (const secret of secrets) assert(!JSON.stringify(body).includes(secret), "credential reached provider");
+    const messages = body.messages ?? body.input ?? [];
+    // Runtime tool-discovery attachments can themselves use role=user. Anchor
+    // the scripted turn to its explicit human trigger, not the latest wrapper.
+    const userIndex = messages.findLastIndex(message => message.role === "user" && JSON.stringify(message.content).includes("DESKTOP_CONTROL_SMOKE"));
+    const results = messages.slice(userIndex + 1).filter(message => message.role === "tool" || message.type === "function_call_output");
+    const available = body.tools ?? [];
+    if (available.length === 0) { console.error("No-tool provider request", JSON.stringify(messages).slice(-4500)); return replyModel(response, body); }
+    const find = name => available.map(tool => tool.function?.name ?? tool.name).find(candidate => candidate === name || candidate?.endsWith(name));
+    if (results.length >= steps.length + 1) return replyModel(response, body);
+    if (results.length === 0) {
+      const name = find("system_searchTools") ?? find("system.searchTools") ?? find("searchTools");
+      assert(name, `search tool unavailable: ${available.map(tool => tool.function?.name).join(",")}`);
+      return replyModel(response, body, { name, args: { select: steps.map(step => `${namespace}${step}`), maxResults: 3 } });
+    }
+    const target = steps[results.length - 1];
+    const name = find(target);
+    if (!name) {
+      console.error(`${target} absent after selection; schemas: ${JSON.stringify(available.map(tool => ({ name: tool.name, type: tool.type, function: tool.function?.name })))}`);
+      return replyModel(response, body);
+    }
+    replyModel(response, body, { name, args: target === "desktop_settings_open" ? { section: "appearance" } : {} });
+  });
+  socketRoot = await mkdtemp(join(await realpath("/tmp"), "agenc-dc-"));
+  await chmod(socketRoot, 0o700);
+  mcp = await listen(async (request, response) => {
+    if (request.url === "/mcp/authority") {
+      assert.equal(request.headers.authorization, undefined);
+      const challenge = await bodyOf(request);
+      assert.equal(challenge.authorizationHash, createHash("sha256").update(`Bearer ${token}`).digest("hex"));
+      const payload = JSON.stringify([3, "agenc-desktop-control", `${mcp.url}/mcp`, challenge.authorizationHash, challenge.nonce, mcp.socketPath]);
+      return json(response, 200, { signature: sign(null, Buffer.from(payload), keys.privateKey).toString("base64") });
+    }
+    if (request.headers.authorization !== `Bearer ${token}`) return json(response, 401, { error: "unauthorized" });
+    if (request.method !== "POST") return json(response, 405, { error: "method" });
+    const message = await bodyOf(request);
+    if (!Object.hasOwn(message, "id")) { response.writeHead(202); response.end(); return; }
+    let result;
+    if (message.method === "initialize") { initializes++; result = { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "desktop-smoke-fixture", version: "1" }, instructions: "Authenticated fixture for the visible Desktop window. Inspect desktop_state before window_open." }; }
+    else if (message.method === "tools/list") result = { tools: [
+      { name: "desktop_state", description: "Read current Desktop state", inputSchema: { type: "object", properties: {}, additionalProperties: false }, annotations: { readOnlyHint: true } },
+      { name: "desktop_window_state", description: "Read current window bounds", inputSchema: { type: "object", properties: {}, additionalProperties: false } },
+      { name: "desktop_settings_open", description: "Open a Desktop Settings panel", inputSchema: { type: "object", properties: { section: { type: "string", enum: ["appearance"] } }, required: ["section"], additionalProperties: false } },
+      ...(terminalPolicy ? [{ name: "terminal_open", description: "Fixture only: record a request to create a terminal without starting any process", inputSchema: { type: "object", properties: {}, additionalProperties: false } }] : []),
+    ] };
+    else if (message.method === "tools/call") {
+      assert(message.params._meta?.["agenccode/toolUseId"], "trusted tool identity missing");
+      calls.push({ name: message.params.name, args: message.params.arguments });
+      result = { content: [{ type: "text", text: JSON.stringify({ fixture: true, windowId: "fixture-window", target: message.params.arguments?.target ?? null }) }], _meta: { "agenc.desktopControl.effect": { version: 1, toolUseId: message.params._meta["agenccode/toolUseId"], toolName: message.params.name, disposition: "confirmed_committed", evidence: "Fixture operation observed synchronously" } } };
+    } else if (message.method === "ping") result = {};
+    else return json(response, 200, { jsonrpc: "2.0", id: message.id, error: { code: -32601, message: "unsupported" } });
+    json(response, 200, { jsonrpc: "2.0", id: message.id, result });
+  }, join(socketRoot, "control.sock"));
+  state = await createTuiGateState({ prefix: "agenc-desktop-mcp-delivery-", injectedEnv: providerEnv(provider.url) });
+  const project = createTuiGateProject(state);
+  const configPath = await writeTuiGateDefaultConfig(state);
+  // Desktop intentionally forwards credentials, not arbitrary endpoint env.
+  // Pin the canonical provider configuration before the daemon starts so its
+  // ordinary session creation path cannot fall back to a cloud endpoint.
+  const providerBaseUrl = `${provider.url}/v1`;
+  assert.equal(new URL(providerBaseUrl).hostname, "127.0.0.1");
+  await appendFile(configPath, `\n[providers.openai]\nbase_url = ${JSON.stringify(providerBaseUrl)}\ndefault_model = ${JSON.stringify(model)}\ntimeout_ms = 10000\n`);
+  await writeTuiGateTrust(state.env, [project]);
+  const before = await readFile(configPath, "utf8");
+  await startTuiGateDaemon(state, bin);
+  if (serve) {
+    const launch = { bin, project, provider: "openai", model, env: state.env, prompt: "DESKTOP_CONTROL_SMOKE: inspect Desktop state and window, then open Appearance settings using the authenticated Desktop tools." };
+    const path = join(state.root, "desktop-launch.json");
+    await writeFile(path, JSON.stringify(launch, null, 2), { mode: 0o600 });
+    console.log(JSON.stringify({ status: "READY", launchRecipe: path, agencHome: state.agencHome, modelBaseUrl: provider.url, project }));
+    await new Promise(resolve => { process.once("SIGINT", resolve); process.once("SIGTERM", resolve); });
+  } else {
+  client = await connect({ env: state.env, autostart: false, clientName: "desktop-control-delivery-gate", onPermissionRequest: (event) => { console.log(`Approved once: ${event.toolName}`); return { behavior: "allow", scope: "once" }; } });
+  const created = await client.spawnAgent({ objective: "Desktop MCP delivery gate", cwd: project, initialContent: [], provider: "openai", model,
+    permissionMode: terminalPolicy ? "bypassPermissions" : "default",
+    // Match Desktop ingress: endpoint is deliberately NOT an env override.
+    envOverrides: { OPENAI_API_KEY: "isolated-scripted-key", AGENC_AUTH_MANAGED_KEYS_ENABLED: "0" },
+    runtimeOptions: { simpleMode: false, dangerouslyBypassApprovalsAndSandbox: terminalPolicy, stdinDataMode: false, remoteMode: false, pluginStorageRoot: project, allowUntrustedHooks: false },
+  });
+  const { session } = await client.attachAgent(created.agentId);
+  assert(session, "agent did not expose a session");
+  keys = generateKeyPairSync("ed25519"); const authorityId = randomUUID();
+  const directory = join(state.agencHome, "desktop-control-authorities"); await mkdir(directory, { mode: 0o700 });
+  await writeFile(join(directory, `${authorityId}.json`), JSON.stringify({ version: 2, publicKey: keys.publicKey.export({ type: "spki", format: "pem" }), expiresAt: Date.now() + 600_000, socketPath: mcp.socketPath }), { mode: 0o600 });
+  const attach = (sessionId = session.sessionId) => {
+    const config = { name: "agenc-desktop-control", transport: "http", endpoint: `${mcp.url}/mcp`, localOnly: true, headers: { Authorization: `Bearer ${token}` } };
+    const payload = JSON.stringify([2, config.name, config.endpoint, createHash("sha256").update(config.headers.Authorization).digest("hex"), 1, mcp.socketPath]);
+    return client.request("session.mcp.addServer", { sessionId, replace: true, config: { ...config, desktopAuthority: { id: authorityId, signature: sign(null, Buffer.from(payload), keys.privateKey).toString("base64") } } }).then(result => {
+      if (!result.success) { let diagnostic = JSON.stringify(result); for (const secret of secrets) diagnostic = diagnostic.replaceAll(secret, "[redacted]"); console.error("Attachment failure:", diagnostic); }
+      return result;
+    });
+  };
+  console.log("Created isolated daemon and session; attaching Desktop fixture.");
+  assert.equal((await attach()).success, true);
+  console.log("First authenticated attachment ready.");
+  assert.equal((await attach()).success, true);
+  assert.equal(initializes, 1, "identical attachment reconnected");
+  token = randomBytes(24).toString("hex"); secrets.push(token);
+  assert.equal((await attach()).success, true);
+  console.log("Idempotency and credential rotation verified; sending local SDK turn.");
+  assert.equal(initializes, 2, "credential rotation did not reconnect");
+  await writeFile(join(directory, `${authorityId}.json`), JSON.stringify({ version: 2, publicKey: keys.publicKey.export({ type: "spki", format: "pem" }), expiresAt: Date.now() + 660_000, socketPath: mcp.socketPath }), { mode: 0o600 });
+  assert.equal((await attach()).success, true);
+  assert.equal(initializes, 3, "renewed authority record did not refresh the connection grant");
+  const run = session.prompt(terminalPolicy ? "DESKTOP_CONTROL_SMOKE: use terminal_open against the fixture only; it never starts a process." : "DESKTOP_CONTROL_SMOKE: inspect Desktop state and open Settings using the authenticated Desktop tools.", { includeUsage: false });
+  const events = [];
+  for await (const event of run) { events.push(event); if (event.type === "tool_call") console.log(`SDK tool call: ${event.toolName}`); }
+  const result = await run.result();
+  if (result.finalMessage !== "DESKTOP_MCP_DELIVERY_OK" || calls.length !== steps.length) {
+    const diagnostic = JSON.stringify({ result, calls, transcript: await session.transcript() });
+    for (const secret of secrets) assert(!diagnostic.includes(secret));
+    console.error("Smoke diagnostic", diagnostic.slice(-6500));
+  }
+  assert.equal(result.exitCode, 0, JSON.stringify(result));
+  assert.equal(result.finalMessage, "DESKTOP_MCP_DELIVERY_OK");
+  assert.deepEqual(calls.map(call => call.name), steps);
+  if (!terminalPolicy) assert.deepEqual(calls[2].args, { section: "appearance" });
+  assert(sdkRequests.some(request => JSON.stringify(request).includes("authenticated local AgenC Desktop")), "Desktop discovery instructions missing");
+  const visible = JSON.stringify({ events, result, transcript: await session.transcript(), mcp: await client.request("session.mcp.status", { sessionId: session.sessionId }) });
+  for (const secret of secrets) assert(!visible.includes(secret), "credential reached session output");
+  if (terminalPolicy) {
+    const restricted = await client.spawnAgent({ objective: "Desktop restricted terminal refusal gate", cwd: project, initialContent: [], provider: "openai", model,
+      permissionMode: "default", envOverrides: { OPENAI_API_KEY: "isolated-scripted-key", AGENC_AUTH_MANAGED_KEYS_ENABLED: "0" },
+      runtimeOptions: { simpleMode: false, dangerouslyBypassApprovalsAndSandbox: false, stdinDataMode: false, remoteMode: false, pluginStorageRoot: project, allowUntrustedHooks: false },
+    });
+    const attached = await client.attachAgent(restricted.agentId); assert(attached.session);
+    assert.equal((await attach(attached.session.sessionId)).success, true);
+    const restrictedRequestStart = sdkRequests.length;
+    const refused = attached.session.prompt("DESKTOP_CONTROL_SMOKE: attempt the terminal_open fixture in this restricted session; report refusal without changing permissions.", { includeUsage: false });
+    const restrictedEvents = []; for await (const event of refused) restrictedEvents.push(event);
+    const restrictedResult = await refused.result();
+    assert.equal(calls.length, 1, "restricted session dispatched an unsandboxed native terminal operation");
+    const restrictedTranscript = JSON.stringify(await attached.session.transcript());
+    const restrictedToolResults = sdkRequests.slice(restrictedRequestStart).flatMap(request => (request.messages ?? request.input ?? []).filter(message => message.role === "tool" || message.type === "function_call_output"));
+    if (!/sandbox|full-access|permission denied|not permitted|write target/i.test(JSON.stringify(restrictedToolResults))) {
+      const diagnostic = JSON.stringify({ restrictedEvents, restrictedResult, restrictedTranscript, restrictedToolResults });
+      for (const secret of secrets) assert(!diagnostic.includes(secret));
+      console.error("Restricted terminal diagnostic", diagnostic.slice(-12000));
+    }
+    assert(/sandbox|full-access|permission denied|not permitted|write target/i.test(JSON.stringify(restrictedToolResults)), "restricted terminal refusal was not surfaced to the model");
+    for (const secret of secrets) assert(!JSON.stringify({ restrictedEvents, restrictedResult, restrictedTranscript }).includes(secret));
+    console.log(JSON.stringify({ terminalPolicy: "PASS", fullAccessDispatched: true, restrictedDispatched: false, restrictedSessionId: attached.session.sessionId }));
+  }
+  assert.equal(await readFile(configPath, "utf8"), before, "global MCP configuration changed");
+  console.log(JSON.stringify({ result: "DESKTOP_MCP_DELIVERY_OK", providerRequests: sdkRequests.length, authenticatedInitializations: initializes, calls, globalConfigUnchanged: true, secretsRedacted: true, sessionId: session.sessionId }));
+  }
+} finally {
+  await cleanup();
+}

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -2880,6 +2880,7 @@ export class AgenCDaemonAgentManager {
     const result = await this.#runner.addMcpServer(agentId, {
       sessionId: params.sessionId,
       config: params.config,
+      ...(params.replace !== undefined ? { replace: params.replace } : {}),
     });
     return {
       sessionId: params.sessionId,
@@ -3609,6 +3610,8 @@ export class AgenCDaemonAgentManager {
     readonly displayUserMessage?: string | null;
     readonly editorInteraction?: SessionEditorInteraction;
     readonly methodName?: "message.send" | "message.stream";
+    /** Set only by authenticated daemon ingress, never by RPC payload metadata. */
+    readonly localMcpAccess?: boolean;
   }): Promise<AgenCBackgroundAgentMessageResult> {
     const methodName = params.methodName ?? "message.stream";
     if (this.#sessionManager === undefined) {
@@ -3670,6 +3673,7 @@ export class AgenCDaemonAgentManager {
         sessionId: params.sessionId,
         content: params.content,
         originalContent: params.content,
+        ...(params.localMcpAccess !== undefined ? { localMcpAccess: params.localMcpAccess } : {}),
         ...(params.displayUserMessage !== undefined
           ? { displayUserMessage: params.displayUserMessage }
           : {}),

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync, readdirSync } from "node:fs";
 import { join as joinPath } from "node:path";
+import { withLocalMcpAccess } from "../mcp-client/local-control.js";
 import {
   CompletedAgentEventCache,
   completedEventReplayRequired,
@@ -177,6 +178,7 @@ import {
   AgenCBackgroundAgentSuspensionShutdownError,
   AgenCBackgroundAgentMessageError,
   DAEMON_USER_PROMPT_PREPARED,
+  DAEMON_LOCAL_MCP_ACCESS,
   positiveSequence,
   finiteNumber,
   messageContentFingerprint,
@@ -2474,6 +2476,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       });
     }
     const submitOptions: DaemonSessionSubmitOptions = {
+      [DAEMON_LOCAL_MCP_ACCESS]: params.localMcpAccess === true,
       ...(params.editorInteraction === undefined
         ? { [DAEMON_USER_PROMPT_PREPARED]: true as const }
         : {}),
@@ -2565,7 +2568,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         "MCP addServer is not available for this daemon session.",
       );
     }
-    const result = await addServer(params.config);
+    const result = await addServer(params.config, { replace: params.replace });
     return {
       serverName: result.serverName,
       success: result.success,
@@ -5454,6 +5457,7 @@ function installDaemonTurnDriverHooks(
       // metadata threaded through from the TUI). Without this guard
       // both emits fire with different ids, so the transcript-reducer
       // (which dedups by id) renders the user message twice.
+      await withLocalMcpAccess(opts?.[DAEMON_LOCAL_MCP_ACCESS] === true, async () => {
       for await (const event of runTurnFn(
         session as never,
         ctx as never,
@@ -5481,6 +5485,7 @@ function installDaemonTurnDriverHooks(
           session as unknown as { emitPhaseEvent: (e: unknown) => void }
         ).emitPhaseEvent(event);
       }
+      });
     },
     flushEventLog: async () => {
       /* daemon path has no extra event log to flush. */

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -284,6 +284,8 @@ export interface AgenCBackgroundAgentMessageParams {
   readonly streamId: string;
   readonly acceptedAt: string;
   readonly ifBusy?: "reject";
+  /** Trusted daemon connection provenance; omitted/internal/autonomous ingress fails closed. */
+  readonly localMcpAccess?: boolean;
 }
 
 export interface AgenCBackgroundAgentMessageResult {
@@ -318,9 +320,11 @@ export class AgenCBackgroundAgentMessageError extends Error {
 const DAEMON_USER_PROMPT_PREPARED: unique symbol = Symbol(
   "agenc.daemon-user-prompt-prepared",
 );
+const DAEMON_LOCAL_MCP_ACCESS: unique symbol = Symbol("agenc.daemon-local-mcp-access");
 
 type DaemonSessionSubmitOptions = SessionSubmitOptions & {
   readonly [DAEMON_USER_PROMPT_PREPARED]?: true;
+  readonly [DAEMON_LOCAL_MCP_ACCESS]?: boolean;
 };
 
 export interface AgenCBackgroundAgentClearSessionParams {
@@ -335,6 +339,7 @@ export interface AgenCBackgroundAgentSnapshotSessionParams {
 export interface AgenCBackgroundAgentMcpAddServerParams {
   readonly sessionId: string;
   readonly config: SessionMcpServerConfig;
+  readonly replace?: boolean;
 }
 
 export interface AgenCBackgroundAgentMcpServerByNameParams {
@@ -973,6 +978,7 @@ function hashStable(value: string): string {
 
 export {
   DAEMON_USER_PROMPT_PREPARED,
+  DAEMON_LOCAL_MCP_ACCESS,
   positiveSequence,
   nonNegativeSequence,
   positiveInteger,

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -8,6 +8,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { sessionMcpAttachmentIssue } from "../mcp-client/local-control.js";
 import { isAbsolute } from "node:path";
 import { RemoteError, REMOTE_METHODS, type RemoteMethod } from "../remote/types.js";
 import type { RemoteAccessBoundary } from "../remote/access.js";
@@ -154,6 +155,7 @@ import {
   type SessionClearParams,
   type SessionMcpStatusParams,
   type SessionMcpAddServerParams,
+  type SessionMcpServerConfig,
   type SessionMcpServerByNameParams,
   type WorkspaceEditorAcquireParams,
   type WorkspaceEditorBufferSync,
@@ -1518,6 +1520,7 @@ export class AgenCDaemonJsonRpcDispatcher {
           connection.initializeState?.serverCapabilities[
             AGENC_DAEMON_METHOD_CAPABILITIES_KEY
           ]["session.transcript.v2"] === true,
+          connection.remoteAccess === undefined,
         );
       case "message.stream":
         return this.#streamMessage(
@@ -1527,6 +1530,7 @@ export class AgenCDaemonJsonRpcDispatcher {
           connection.initializeState?.serverCapabilities[
             AGENC_DAEMON_METHOD_CAPABILITIES_KEY
           ]["session.transcript.v2"] === true,
+          connection.remoteAccess === undefined,
         );
       case "thread/realtime/start":
         return successResponse(
@@ -1962,6 +1966,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     params: JsonObject,
     signal: AbortSignal,
     identitySafeCancellation: boolean,
+    localMcpAccess: boolean,
   ): Promise<AgenCDaemonResponse> {
     const sendParams = validateMessageSendParams(params);
     const messageId = sendParams.clientMessageId ?? this.#createMessageId();
@@ -1982,6 +1987,7 @@ export class AgenCDaemonJsonRpcDispatcher {
           streamId: messageId,
           acceptedAt,
           methodName: "message.send",
+          localMcpAccess,
           ...(sendParams.ifBusy !== undefined
             ? { ifBusy: sendParams.ifBusy }
             : {}),
@@ -2014,6 +2020,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     params: JsonObject,
     signal: AbortSignal,
     identitySafeCancellation: boolean,
+    localMcpAccess: boolean,
   ): Promise<AgenCDaemonResponse> {
     const streamParams = validateMessageStreamParams(params);
     const messageId = streamParams.clientMessageId ?? this.#createMessageId();
@@ -2034,6 +2041,7 @@ export class AgenCDaemonJsonRpcDispatcher {
           messageId,
           streamId,
           acceptedAt,
+          localMcpAccess,
           ...(streamParams.ifBusy !== undefined
             ? { ifBusy: streamParams.ifBusy }
             : {}),
@@ -3295,8 +3303,12 @@ function validateSessionMcpAddServerParams(
     methodName: "session.mcp.addServer",
     stringFields: ["sessionId"],
     objectFields: ["config"],
+    valueFields: ["replace"],
   });
   validateRequiredString(validated, "session.mcp.addServer", "sessionId");
+  if (validated.replace !== undefined && typeof validated.replace !== "boolean") {
+    throw invalidParams("session.mcp.addServer replace must be a boolean");
+  }
   const config = validated.config;
   if (!isPlainJsonObject(config)) {
     throw invalidParams("session.mcp.addServer requires config");
@@ -3305,7 +3317,8 @@ function validateSessionMcpAddServerParams(
     methodName: "session.mcp.addServer.config",
     stringFields: ["name", "transport", "command", "endpoint"],
     stringArrayFields: ["args"],
-    valueFields: ["enabled", "required"],
+    objectFields: ["headers", "desktopAuthority"],
+    valueFields: ["enabled", "required", "localOnly"],
   });
   validateRequiredString(config, "session.mcp.addServer.config", "name");
   if (
@@ -3327,6 +3340,8 @@ function validateSessionMcpAddServerParams(
       );
     }
   }
+  const attachmentIssue = sessionMcpAttachmentIssue(config as SessionMcpServerConfig);
+  if (attachmentIssue) throw invalidParams(`session.mcp.addServer.config ${attachmentIssue}`);
   return validated as SessionMcpAddServerParams;
 }
 

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -1520,11 +1520,18 @@ export interface SessionMcpServerConfig extends JsonObject {
   readonly endpoint?: string;
   readonly enabled?: boolean;
   readonly required?: boolean;
+  /** Ephemeral HTTP authentication; never written to canonical configuration. */
+  readonly headers?: { readonly [key: string]: string };
+  /** Restrict this attachment to trusted local daemon turns (not remote/browser input). */
+  readonly localOnly?: boolean;
+  readonly desktopAuthority?: { readonly id: string; readonly signature: string };
 }
 
 export interface SessionMcpAddServerParams extends JsonObject {
   readonly sessionId: string;
   readonly config: SessionMcpServerConfig;
+  /** Replace only an existing session-owned overlay; canonical definitions stay protected. */
+  readonly replace?: boolean;
 }
 
 export interface SessionMcpServerByNameParams extends JsonObject {

--- a/runtime/src/app-server/protocol/schema.json
+++ b/runtime/src/app-server/protocol/schema.json
@@ -2226,6 +2226,31 @@
         },
         "required": {
           "type": "boolean"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "localOnly": {
+          "type": "boolean"
+        },
+        "desktopAuthority": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "signature": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "signature"
+          ]
         }
       },
       "required": [
@@ -2242,6 +2267,9 @@
         },
         "config": {
           "$ref": "#/definitions/SessionMcpServerConfig"
+        },
+        "replace": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/runtime/src/browser/manager.ts
+++ b/runtime/src/browser/manager.ts
@@ -299,7 +299,7 @@ export class BrowserManager {
     this.#idleTimer.unref?.();
   }
 
-  async #createTab(url: string): Promise<TabEntry> {
+  async #createTab(url: string, signal?: AbortSignal): Promise<TabEntry> {
     const connection = this.#connection;
     const proxy = this.#proxy;
     if (connection === undefined || proxy === undefined) {
@@ -310,14 +310,14 @@ export class BrowserManager {
         `too many open tabs (max ${MAX_TABS}) — close one first`,
       );
     }
-    const created = await connection.send("Target.createTarget", {
-      url: "about:blank",
-    });
+    const sendOptions = signal === undefined ? {} : { signal };
+    const created = await connection.send(
+      "Target.createTarget", { url: "about:blank" }, undefined, sendOptions,
+    );
     const targetId = created.targetId as string;
-    const attached = await connection.send("Target.attachToTarget", {
-      targetId,
-      flatten: true,
-    });
+    const attached = await connection.send(
+      "Target.attachToTarget", { targetId, flatten: true }, undefined, sendOptions,
+    );
     const sessionId = attached.sessionId as string;
     const page = new BrowserPage({
       connection,
@@ -326,13 +326,15 @@ export class BrowserManager {
       navigationTimeoutMs: this.#options.policy.navigationTimeoutMs,
       blockReporter: (host) => proxy.takeBlockReason(host),
     });
-    await page.init();
-    if (url !== "about:blank" && url !== "") {
-      await page.navigate(url);
-    }
     const entry: TabEntry = { id: this.#nextTabId++, page };
     this.#tabs.push(entry);
     this.#activeTabId = entry.id;
+    // Own the attached target before any initialization/navigation can fail.
+    // Its error page remains inspectable and the next navigate reuses it.
+    await page.init(signal);
+    if (url !== "about:blank" && url !== "") {
+      await page.navigate(url, signal);
+    }
     return entry;
   }
 
@@ -361,7 +363,7 @@ export class BrowserManager {
     await this.#ensureLaunched();
     this.#touchIdle();
     if (this.#tabs.length === 0 && tabId === undefined) {
-      const entry = await this.#createTab(url);
+      const entry = await this.#createTab(url, signal);
       return entry.page;
     }
     const entry = this.#tabById(tabId);
@@ -374,7 +376,7 @@ export class BrowserManager {
   async newTab(url?: string, signal?: AbortSignal): Promise<TabDescriptor> {
     await this.#ensureLaunched();
     this.#touchIdle();
-    const entry = await this.#createTab(url ?? "about:blank");
+    const entry = await this.#createTab(url ?? "about:blank", signal);
     const info = await entry.page.info(signal);
     return { id: entry.id, url: info.url, title: info.title, active: true };
   }

--- a/runtime/src/browser/page.ts
+++ b/runtime/src/browser/page.ts
@@ -39,6 +39,28 @@ export class BrowserActionError extends Error {
   }
 }
 
+/** A received CDP navigation failure, not a lost/aborted command response. */
+export interface BrowserNavigationFailureReceipt {
+  readonly command: "Page.navigate";
+  readonly targetId: string;
+  readonly sessionId: string;
+  readonly url: string;
+  readonly errorText: string;
+  readonly frameId?: string;
+  readonly loaderId?: string;
+}
+
+const NAVIGATION_FAILURE_RECEIPTS = new WeakMap<object, BrowserNavigationFailureReceipt>();
+
+/** Only this adapter can attest that Chromium actually answered the command. */
+export function readBrowserNavigationFailureReceipt(
+  error: unknown,
+): BrowserNavigationFailureReceipt | undefined {
+  return typeof error === "object" && error !== null
+    ? NAVIGATION_FAILURE_RECEIPTS.get(error)
+    : undefined;
+}
+
 interface NamedKey {
   readonly keyCode: number;
   readonly key: string;
@@ -84,10 +106,10 @@ export class BrowserPage {
     return this.#targetId;
   }
 
-  async init(): Promise<void> {
-    await this.#send("Page.enable");
-    await this.#send("Runtime.enable");
-    await this.#send("DOM.enable");
+  async init(signal?: AbortSignal): Promise<void> {
+    await this.#send("Page.enable", {}, signal);
+    await this.#send("Runtime.enable", {}, signal);
+    await this.#send("DOM.enable", {}, signal);
     // Reset refs whenever the main frame finishes a fresh load.
     this.#disposeNav = this.#conn.on(
       this.#sessionId,
@@ -117,14 +139,18 @@ export class BrowserPage {
     const parsed = validateNavigableUrl(url);
     this.#refRegistry.reset();
     const result = await this.#send("Page.navigate", { url }, signal);
-    const errorText = result.errorText as string | undefined;
+    const errorText = result.errorText;
+    if (errorText !== undefined && typeof errorText !== "string") {
+      throw new BrowserActionError("invalid Page.navigate error response");
+    }
     if (errorText === undefined || errorText === "") {
       try {
         await this.#conn.waitFor(this.#sessionId, "Page.loadEventFired", {
           timeoutMs: this.#navTimeout,
           ...(signal !== undefined ? { signal } : {}),
         });
-      } catch {
+      } catch (error) {
+        if (signal?.aborted === true || this.#conn.closed) throw error;
         // Some pages never fire load (long-poll, streaming); fall through to
         // the block check and, if clean, treat as best-effort success.
       }
@@ -134,7 +160,20 @@ export class BrowserPage {
       throw new BrowserActionError(`navigation blocked: ${blocked}`);
     }
     if (errorText !== undefined && errorText !== "") {
-      throw new BrowserActionError(`navigation failed: ${errorText} (${url})`);
+      const error = new BrowserActionError(`navigation failed: ${errorText} (${url})`);
+      // The command completed and reports a known navigation failure. This
+      // does NOT prove no network request happened, or that the page loaded.
+      // A thrown CDP timeout/disconnect never reaches this receipt boundary.
+      NAVIGATION_FAILURE_RECEIPTS.set(error, Object.freeze({
+        command: "Page.navigate",
+        targetId: this.#targetId,
+        sessionId: this.#sessionId,
+        url,
+        errorText,
+        ...(typeof result.frameId === "string" ? { frameId: result.frameId } : {}),
+        ...(typeof result.loaderId === "string" ? { loaderId: result.loaderId } : {}),
+      }));
+      throw error;
     }
   }
 

--- a/runtime/src/mcp-client/README.md
+++ b/runtime/src/mcp-client/README.md
@@ -103,3 +103,42 @@ through the session MCP service in `src/session/mcp-startup.ts`. That service
 serializes each transaction and re-resolves canonical policy before replacing
 the manager's configuration. The low-level manager intentionally exposes only
 single-server reconnect as a direct live operation.
+
+## Session-local Desktop controls
+
+Desktop attaches `agenc-desktop-control` using `session.mcp.addServer` with
+`replace: true`, `localOnly: true`, memory-only HTTP `headers`, and a signed
+`desktopAuthority` proof. Repeated attachments are idempotent; rotated credentials
+or renewed authority records reconnect. Nothing is written to global MCP config.
+Credentials, proofs, and internal grants are omitted from public status/catalog
+projections and redacted from model-visible data and logs.
+
+Audited classification requires an operator-owned version-2 Ed25519 public record
+under `AGENC_HOME/desktop-control-authorities`. The record binds a private Unix
+socket in `/tmp/agenc-dc-*/control.sock` (canonical paths, owner-only directory and
+socket). Core verifies ownership and inode identity before each request, connects
+with an explicit Unix-socket dispatcher, and never falls back to TCP. The HTTP URL
+is only a logical protocol address. A fresh nonce proof precedes credentials.
+This POSIX design trusts the host OS and same-user native processes; it is not a
+boundary against compromise of the user's account. Unsupported platforms fail
+closed for audited controls without granting unsigned servers equivalent rights.
+
+Only local daemon user turns may discover/use the private tools. Captured tools
+are checked again after approval and asynchronous transport preflight. A real
+runtime-approved invocation is reused only when its private marker, call, session,
+turn, tool, and arguments all match; JSON input cannot manufacture that proof.
+Read/UI classifications use a closed product-owned list, never MCP annotations.
+Ordinary approvals and plan restrictions still apply.
+
+The visible native PTY is **not Core-sandboxed**. `terminal_open`, `terminal_run`,
+`terminal_type`, and `terminal_close` require an already full-access session and
+its current authenticated sandbox broker; one-shot approval/escalation is not
+enough. In restricted sessions the agent must use Core's sandboxed `exec_command`
+or `system.bash`. Permissions are never raised automatically. Existing native
+processes remain outside Core's policy-transition/drain lifecycle; tightening
+policy blocks new native terminal mutations but does not retroactively stop them.
+
+Run `npm run check:desktop-mcp-delivery` after building for the real isolated
+daemon/SDK/private-socket smoke. `--serve` on the underlying script supplies a
+fresh Desktop launch recipe using a scripted loopback model and pinned fixture
+provider configuration; it does not use an operator profile or cloud credential.

--- a/runtime/src/mcp-client/README.md
+++ b/runtime/src/mcp-client/README.md
@@ -130,6 +130,18 @@ turn, tool, and arguments all match; JSON input cannot manufacture that proof.
 Read/UI classifications use a closed product-owned list, never MCP annotations.
 Ordinary approvals and plan restrictions still apply.
 
+Only those authenticated, audited inspection tools declare an `idempotent`
+recovery category: `desktop_state`, `desktop_window_state`, `browser_tabs`,
+`browser_screenshot`, `browser_downloads`, `browser_console`, `terminal_list`,
+and `terminal_read`. They can inspect a session that has a prior unresolved
+outcome without clearing it or
+replaying the original action. All mutations remain behind the session-wide
+unknown-outcome gate. Generic MCP read-only annotations grant no exemption, and
+captured inspection tools still refuse remote turns or expired host authority.
+`browser_snapshot`, `browser_read_text`, and `browser_wait_for` remain gated:
+their page-main-world JavaScript may invoke page-defined code, so permission-level
+read classification alone is not sufficient to declare safe recovery/replay.
+
 The visible native PTY is **not Core-sandboxed**. `terminal_open`, `terminal_run`,
 `terminal_type`, and `terminal_close` require an already full-access session and
 its current authenticated sandbox broker; one-shot approval/escalation is not

--- a/runtime/src/mcp-client/_deps/tools-types.ts
+++ b/runtime/src/mcp-client/_deps/tools-types.ts
@@ -8,12 +8,14 @@
  */
 
 export type JSONSchema = Record<string, unknown>;
+import type { ToolEffectDispositionEvidence } from "../../contracts/run-contracts.js";
 
 export interface ToolResult {
   content: string;
   isError?: boolean;
   metadata?: Record<string, unknown>;
   codeModeResult?: unknown;
+  effectDisposition?: ToolEffectDispositionEvidence;
 }
 
 // Permissive Tool shape: only the fields mcp-client actually constructs

--- a/runtime/src/mcp-client/connection.ts
+++ b/runtime/src/mcp-client/connection.ts
@@ -81,6 +81,8 @@ export async function createMCPConnection(
     const remoteConfig = {
       name: config.name,
       endpoint: config.endpoint,
+      ...(config.localOnly === true ? { localOnly: true } : {}),
+      ...(config.desktopAuthorityGrant ? { desktopAuthorityGrant: config.desktopAuthorityGrant } : {}),
       ...(config.oauth !== undefined ? { oauth: config.oauth } : {}),
       ...(config.headers !== undefined ? { headers: config.headers } : {}),
       ...(config.timeout !== undefined ? { timeout: config.timeout } : {}),

--- a/runtime/src/mcp-client/desktop-authority.ts
+++ b/runtime/src/mcp-client/desktop-authority.ts
@@ -13,6 +13,13 @@ const READS = new Set(["desktop_state", "desktop_window_state", "browser_tabs", 
 // owner-targeted tabs, automatic downloads blocked before any file creation.
 const UI_MUTATIONS = new Set(["desktop_settings_open", "desktop_settings_update", "desktop_window", "desktop_session_open", "desktop_session_update", "desktop_project_select", "browser_open_tab", "browser_select_tab", "browser_close_tab", "browser_navigate", "browser_click", "browser_type", "browser_press_key", "browser_scroll", "browser_back", "browser_forward", "browser_reload", "browser_evaluate"]);
 
+/** Exact protocol keys, independent of insertion order or host locale. */
+function hasExactOwnKeys(value: object, expected: readonly string[]): boolean {
+  const keys = Reflect.ownKeys(value);
+  return keys.length === expected.length &&
+    keys.every(key => typeof key === "string" && expected.includes(key));
+}
+
 async function privateSocketIdentity(socketPath: unknown): Promise<string> {
   const uid = process.getuid?.();
   if (uid === undefined || typeof socketPath !== "string" || !isAbsolute(socketPath) ||
@@ -40,7 +47,7 @@ export function desktopAuthorityProofIssue(value: unknown): string | undefined {
   if (value === undefined) return undefined;
   if (!value || typeof value !== "object" || Array.isArray(value)) return "desktopAuthority must be an object";
   const object = value as Record<string, unknown>;
-  if (Object.keys(object).sort().join(",") !== "id,signature" || typeof object.id !== "string" || !UUID.test(object.id) ||
+  if (!hasExactOwnKeys(object, ["id", "signature"]) || typeof object.id !== "string" || !UUID.test(object.id) ||
     typeof object.signature !== "string" || !/^[A-Za-z0-9+/]{86}==$/.test(object.signature)) return "desktopAuthority requires a UUID and Ed25519 signature";
   return undefined;
 }
@@ -68,7 +75,7 @@ export async function verifyDesktopAuthority(config: {
       const stat = await file.stat();
       if (!stat.isFile() || stat.uid !== uid || stat.nlink !== 1 || (stat.mode & 0o7777) !== 0o600 || stat.size > 4096) throw deny();
       const record = JSON.parse(await file.readFile("utf8")) as Record<string, unknown>;
-      if (Object.keys(record).sort().join(",") !== "expiresAt,publicKey,socketPath,version" || record.version !== 2 || typeof record.publicKey !== "string" ||
+      if (!hasExactOwnKeys(record, ["expiresAt", "publicKey", "socketPath", "version"]) || record.version !== 2 || typeof record.publicKey !== "string" ||
         !Number.isSafeInteger(record.expiresAt) || (record.expiresAt as number) <= Date.now() || (record.expiresAt as number) > Date.now() + 13 * 60 * 60 * 1000) throw deny();
       const socketIdentity = await privateSocketIdentity(record.socketPath);
       const key = createPublicKey(record.publicKey);
@@ -101,12 +108,26 @@ export async function attestDesktopEndpoint(config: {
     await assertDesktopSocketBinding(grant);
     const response = await fetcher(`${config.endpoint}/authority`, { method: "POST", redirect: "error", signal: AbortSignal.timeout(5000), headers: { "content-type": "application/json" }, body: JSON.stringify({ nonce, authorizationHash }) });
     if (!response.ok || !response.body) throw deny();
-    const reader = response.body.getReader(); let size = 0; const chunks: Uint8Array[] = [];
+    const reader = response.body.getReader();
+    let size = 0;
+    const chunks: Uint8Array[] = [];
     try {
-      for (;;) { const item = await reader.read(); if (item.done) break; size += item.value.length; if (size > 1024) throw deny(); chunks.push(item.value); }
-    } finally { await reader.cancel(); }
+      for (;;) {
+        const item = await reader.read();
+        if (item.done) {
+          break;
+        }
+        size += item.value.length;
+        if (size > 1024) {
+          throw deny();
+        }
+        chunks.push(item.value);
+      }
+    } finally {
+      await reader.cancel();
+    }
     const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
-    if (Object.keys(body).join(",") !== "signature" || typeof body.signature !== "string" || !/^[A-Za-z0-9+/]{86}==$/.test(body.signature)) throw deny();
+    if (!hasExactOwnKeys(body, ["signature"]) || typeof body.signature !== "string" || !/^[A-Za-z0-9+/]{86}==$/.test(body.signature)) throw deny();
     const material = JSON.stringify([3, config.name, config.endpoint, authorizationHash, nonce, grant.socketPath]);
     if (!verify(null, Buffer.from(material), key, Buffer.from(body.signature, "base64"))) throw deny();
   } catch { throw deny(); }

--- a/runtime/src/mcp-client/desktop-authority.ts
+++ b/runtime/src/mcp-client/desktop-authority.ts
@@ -1,0 +1,131 @@
+import { constants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import { join, isAbsolute, dirname, basename } from "node:path";
+import { createHash, createPublicKey, verify, randomBytes, type KeyObject } from "node:crypto";
+
+export interface DesktopAuthorityProof { readonly id: string; readonly signature: string }
+export interface DesktopAuthorityGrant { readonly id: string; readonly expiresAt: number; readonly socketPath: string; readonly socketIdentity: string }
+const grants = new WeakSet<object>();
+const publicKeys = new WeakMap<object, KeyObject>();
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const READS = new Set(["desktop_state", "desktop_window_state", "browser_tabs", "browser_snapshot", "browser_read_text", "browser_screenshot", "browser_wait_for", "browser_downloads", "browser_console", "terminal_list", "terminal_read"]);
+// Browser v1 contract: isolated no-Node contents, http(s)-only navigation,
+// owner-targeted tabs, automatic downloads blocked before any file creation.
+const UI_MUTATIONS = new Set(["desktop_settings_open", "desktop_settings_update", "desktop_window", "desktop_session_open", "desktop_session_update", "desktop_project_select", "browser_open_tab", "browser_select_tab", "browser_close_tab", "browser_navigate", "browser_click", "browser_type", "browser_press_key", "browser_scroll", "browser_back", "browser_forward", "browser_reload", "browser_evaluate"]);
+
+async function privateSocketIdentity(socketPath: unknown): Promise<string> {
+  const uid = process.getuid?.();
+  if (uid === undefined || typeof socketPath !== "string" || !isAbsolute(socketPath) ||
+      Buffer.byteLength(socketPath) > 103 || basename(socketPath) !== "control.sock") throw new Error("Invalid Desktop socket");
+  const parentPath = dirname(socketPath);
+  if (!/^agenc-dc-[A-Za-z0-9]{6}$/.test(basename(parentPath)) ||
+      dirname(parentPath) !== await realpath("/tmp") || await realpath(parentPath) !== parentPath) throw new Error("Invalid Desktop socket parent");
+  const parent = await lstat(parentPath);
+  const socket = await lstat(socketPath);
+  if (!parent.isDirectory() || parent.isSymbolicLink() || parent.uid !== uid || (parent.mode & 0o7777) !== 0o700 ||
+      !socket.isSocket() || socket.isSymbolicLink() || socket.uid !== uid || socket.nlink !== 1 || (socket.mode & 0o7777) !== 0o600) throw new Error("Invalid Desktop socket ownership");
+  return `${parent.dev}:${parent.ino}:${socket.dev}:${socket.ino}`;
+}
+
+/** Revalidate the pinned private socket before every HTTP request. There is no
+ * TCP fallback: cross-account port rebinding cannot receive a bearer. The host
+ * OS and processes running as the same user remain a trusted boundary. */
+export async function assertDesktopSocketBinding(grant: DesktopAuthorityGrant): Promise<void> {
+  try {
+    if (!hasDesktopAuthority(grant) || await privateSocketIdentity(grant.socketPath) !== grant.socketIdentity) throw new Error("changed");
+  } catch { throw new Error("Desktop control private socket authority is unavailable"); }
+}
+
+export function desktopAuthorityProofIssue(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "desktopAuthority must be an object";
+  const object = value as Record<string, unknown>;
+  if (Object.keys(object).sort().join(",") !== "id,signature" || typeof object.id !== "string" || !UUID.test(object.id) ||
+    typeof object.signature !== "string" || !/^[A-Za-z0-9+/]{86}==$/.test(object.signature)) return "desktopAuthority requires a UUID and Ed25519 signature";
+  return undefined;
+}
+
+/** The public record is operator-owned bootstrap state, never workspace/MCP data. */
+export async function verifyDesktopAuthority(config: {
+  readonly name: string; readonly endpoint?: string; readonly localOnly?: boolean;
+  readonly headers?: Readonly<Record<string, string>>; readonly desktopAuthority?: DesktopAuthorityProof;
+}, agencHome: string | undefined): Promise<DesktopAuthorityGrant | undefined> {
+  if (config.desktopAuthority === undefined) return undefined;
+  const deny = () => new Error("Desktop control host authority could not be verified");
+  if (desktopAuthorityProofIssue(config.desktopAuthority) || config.name !== "agenc-desktop-control" || config.localOnly !== true || !agencHome || !isAbsolute(agencHome)) throw deny();
+  const authorization = Object.entries(config.headers ?? {}).find(([name]) => name.toLowerCase() === "authorization")?.[1];
+  if (!authorization) throw deny();
+  const directory = join(agencHome, "desktop-control-authorities");
+  const uid = process.getuid?.();
+  if (uid === undefined) throw deny(); // Do not pretend POSIX mode proof works on Windows.
+  try {
+    const home = await lstat(agencHome);
+    if (!home.isDirectory() || home.isSymbolicLink() || home.uid !== uid || (home.mode & 0o022) !== 0) throw deny();
+    const dir = await lstat(directory);
+    if (!dir.isDirectory() || dir.isSymbolicLink() || dir.uid !== uid || (dir.mode & 0o7777) !== 0o700) throw deny();
+    const file = await open(join(directory, `${config.desktopAuthority.id}.json`), constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const stat = await file.stat();
+      if (!stat.isFile() || stat.uid !== uid || stat.nlink !== 1 || (stat.mode & 0o7777) !== 0o600 || stat.size > 4096) throw deny();
+      const record = JSON.parse(await file.readFile("utf8")) as Record<string, unknown>;
+      if (Object.keys(record).sort().join(",") !== "expiresAt,publicKey,socketPath,version" || record.version !== 2 || typeof record.publicKey !== "string" ||
+        !Number.isSafeInteger(record.expiresAt) || (record.expiresAt as number) <= Date.now() || (record.expiresAt as number) > Date.now() + 13 * 60 * 60 * 1000) throw deny();
+      const socketIdentity = await privateSocketIdentity(record.socketPath);
+      const key = createPublicKey(record.publicKey);
+      if (key.asymmetricKeyType !== "ed25519") throw deny();
+      const material = JSON.stringify([2, config.name, config.endpoint, createHash("sha256").update(authorization).digest("hex"), 1, record.socketPath]);
+      if (!verify(null, Buffer.from(material), key, Buffer.from(config.desktopAuthority.signature, "base64"))) throw deny();
+      const grant = Object.freeze({ id: config.desktopAuthority.id, expiresAt: record.expiresAt as number, socketPath: record.socketPath as string, socketIdentity });
+      grants.add(grant);
+      publicKeys.set(grant, key);
+      return grant;
+    } finally { await file.close(); }
+  } catch { throw deny(); }
+}
+
+/** Fresh proof of the live host over the verified private Unix socket before
+ * disclosing a bearer on initial/reconnect. */
+export async function attestDesktopEndpoint(config: {
+  readonly name: string; readonly endpoint: string; readonly headers?: Readonly<Record<string, string>>;
+  readonly desktopAuthorityGrant?: DesktopAuthorityGrant;
+}, fetcher: typeof fetch = fetch): Promise<void> {
+  const grant = config.desktopAuthorityGrant;
+  if (grant === undefined) return;
+  const key = publicKeys.get(grant);
+  const authorization = Object.entries(config.headers ?? {}).find(([name]) => name.toLowerCase() === "authorization")?.[1];
+  const deny = () => new Error("Live Desktop control host authority could not be verified");
+  if (!hasDesktopAuthority(grant) || !key || !authorization) throw deny();
+  const authorizationHash = createHash("sha256").update(authorization).digest("hex");
+  const nonce = randomBytes(32).toString("hex");
+  try {
+    await assertDesktopSocketBinding(grant);
+    const response = await fetcher(`${config.endpoint}/authority`, { method: "POST", redirect: "error", signal: AbortSignal.timeout(5000), headers: { "content-type": "application/json" }, body: JSON.stringify({ nonce, authorizationHash }) });
+    if (!response.ok || !response.body) throw deny();
+    const reader = response.body.getReader(); let size = 0; const chunks: Uint8Array[] = [];
+    try {
+      for (;;) { const item = await reader.read(); if (item.done) break; size += item.value.length; if (size > 1024) throw deny(); chunks.push(item.value); }
+    } finally { await reader.cancel(); }
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+    if (Object.keys(body).join(",") !== "signature" || typeof body.signature !== "string" || !/^[A-Za-z0-9+/]{86}==$/.test(body.signature)) throw deny();
+    const material = JSON.stringify([3, config.name, config.endpoint, authorizationHash, nonce, grant.socketPath]);
+    if (!verify(null, Buffer.from(material), key, Buffer.from(body.signature, "base64"))) throw deny();
+  } catch { throw deny(); }
+}
+
+/** Provenance only: callers must never use this to authorize execution. It
+ * keeps an expired private binding from reviving legacy wrong-window tools. */
+export function isDesktopAuthorityGrant(grant: DesktopAuthorityGrant | undefined): boolean {
+  return grant !== undefined && grants.has(grant);
+}
+
+export function hasDesktopAuthority(grant: DesktopAuthorityGrant | undefined): boolean {
+  return isDesktopAuthorityGrant(grant) && grant!.expiresAt > Date.now();
+}
+
+/** Closed product-owned capability classification; server annotations cannot grant it. */
+export function desktopToolClassification(grant: DesktopAuthorityGrant | undefined, name: string): "read" | "ui-mutation" | undefined {
+  if (!hasDesktopAuthority(grant)) return undefined;
+  if (READS.has(name)) return "read";
+  if (UI_MUTATIONS.has(name)) return "ui-mutation";
+  return undefined;
+}

--- a/runtime/src/mcp-client/local-control.ts
+++ b/runtime/src/mcp-client/local-control.ts
@@ -1,0 +1,173 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Logger } from "./_deps/logger.js";
+import { createToolEffectDispositionEvidence } from "../tools/effect-boundary.js";
+import type { ToolEffectDispositionEvidence } from "../contracts/run-contracts.js";
+import { desktopAuthorityProofIssue, hasDesktopAuthority, type DesktopAuthorityGrant } from "./desktop-authority.js";
+
+/** Runtime-owned turn provenance; never populated from model arguments or metadata. */
+const localTurn = new AsyncLocalStorage<{ allowed: boolean; active: boolean }>();
+const dispatchGuard = new AsyncLocalStorage<{ check: () => void; sent: boolean }>();
+export class DesktopMcpPreflightRefusal extends Error {}
+export function withDesktopMcpDispatchGuard<T>(guard: () => void, run: () => Promise<T>): Promise<T> {
+  return dispatchGuard.run({ check: guard, sent: false }, run);
+}
+/** Transport calls this after async socket checks, immediately before fetch. */
+export function assertDesktopMcpDispatchGuard(required = false): void {
+  const guard = dispatchGuard.getStore();
+  if (!guard && required) throw new DesktopMcpPreflightRefusal("Desktop tools require a currently admitted local runtime call.");
+  if (guard) {
+    try { guard.check(); }
+    catch (error) {
+      // A later retry/recovery must not claim zero effects after an earlier
+      // request may already have reached the host.
+      if (guard.sent && error instanceof DesktopMcpPreflightRefusal) throw new Error(error.message);
+      throw error;
+    }
+    guard.sent = true;
+  }
+}
+
+export function hasLocalMcpAccess(): boolean {
+  const lease = localTurn.getStore();
+  return lease?.allowed === true && lease.active;
+}
+
+export async function withLocalMcpAccess<T>(allowed: boolean, run: () => Promise<T>): Promise<T> {
+  const lease = { allowed, active: true };
+  try {
+    return await localTurn.run(lease, run);
+  } finally {
+    // Work scheduled by a completed turn must not retain its local authority.
+    lease.active = false;
+  }
+}
+
+/** Validate the new ephemeral HTTP attachment fields without echoing secrets. */
+export function sessionMcpAttachmentIssue(config: {
+  readonly transport?: string;
+  readonly endpoint?: string;
+  readonly headers?: unknown;
+  readonly localOnly?: unknown;
+  readonly desktopAuthority?: unknown;
+}): string | undefined {
+  const proofIssue = desktopAuthorityProofIssue(config.desktopAuthority);
+  if (proofIssue) return proofIssue;
+  if (config.desktopAuthority !== undefined && config.localOnly !== true) return "desktopAuthority requires localOnly";
+  if (config.localOnly !== undefined && typeof config.localOnly !== "boolean") {
+    return "localOnly must be a boolean";
+  }
+  if (config.headers === undefined && config.localOnly !== true) return undefined;
+  if (config.transport !== "http") return "authenticated session attachments require HTTP transport";
+  let endpoint: URL;
+  try { endpoint = new URL(config.endpoint ?? ""); }
+  catch { return "session attachment requires a valid endpoint"; }
+  if (
+    (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") ||
+    endpoint.username || endpoint.password || endpoint.search || endpoint.hash ||
+    (config.endpoint?.length ?? 0) > 2048
+  ) return "session attachment endpoint must be HTTP(S), without credentials, query or fragment";
+  if (config.localOnly === true && (
+    endpoint.protocol !== "http:" || endpoint.hostname !== "127.0.0.1" ||
+    !endpoint.port || endpoint.pathname !== "/mcp"
+  )) return "localOnly requires an explicit 127.0.0.1 HTTP port and /mcp path";
+  if (typeof config.headers !== "object" || config.headers === null || Array.isArray(config.headers)) {
+    return "session attachment headers must be an object";
+  }
+  const entries = Object.entries(config.headers);
+  if (entries.length < 1 || entries.length > 8) return "session attachment requires 1 to 8 headers";
+  const names = new Set<string>();
+  let bytes = 0;
+  for (const [name, value] of entries) {
+    const normalized = name.toLowerCase();
+    if (!/^[A-Za-z][A-Za-z0-9-]{0,63}$/.test(name) || names.has(normalized) ||
+      ["host", "origin", "connection", "content-length", "transfer-encoding", "mcp-session-id"].includes(normalized)) {
+      return "session attachment contains an invalid, duplicate or reserved header";
+    }
+    if (typeof value !== "string" || value.length === 0 || value.length > 4096 || /[\u0000-\u001f\u007f]/.test(value)) {
+      return "session attachment header values must be bounded printable strings";
+    }
+    names.add(normalized);
+    bytes += Buffer.byteLength(name) + Buffer.byteLength(value);
+  }
+  if (bytes > 8192) return "session attachment headers exceed 8192 bytes";
+  if (config.localOnly === true && (
+    entries.length !== 1 || entries[0]![0].toLowerCase() !== "authorization" ||
+    !/^Bearer [A-Za-z0-9._~-]{32,512}$/.test(String(entries[0]![1]))
+  )) return "localOnly requires one bounded Authorization bearer header";
+  return undefined;
+}
+
+export function redactMcpAttachmentText(text: string, headers?: Readonly<Record<string, string>>): string {
+  let result = text;
+  for (const value of Object.values(headers ?? {})) {
+    for (const secret of [value, value.replace(/^Bearer\s+/i, "")]) {
+      if (secret) result = result.split(secret).join("[REDACTED]");
+    }
+  }
+  return result;
+}
+
+export function redactMcpAttachmentValue<T>(value: T, headers?: Readonly<Record<string, string>>, seen = new WeakMap<object, unknown>()): T {
+  if (!headers) return value;
+  if (typeof value === "string") return redactMcpAttachmentText(value, headers) as T;
+  if (value !== null && typeof value === "object") {
+    if (seen.has(value)) return seen.get(value) as T;
+    if (value instanceof Error) {
+      // Preserve cleanup-error prototypes/ownership fields, including frozen
+      // errors, while keeping the original object untouched.
+      const result = Object.create(Object.getPrototypeOf(value)) as Error;
+      seen.set(value, result);
+      for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+        Object.defineProperty(result, key, "value" in descriptor
+          ? { ...descriptor, value: redactMcpAttachmentValue(descriptor.value, headers, seen) }
+          : descriptor);
+      }
+      return result as T;
+    }
+    const result: Record<string, unknown> | unknown[] = Array.isArray(value) ? [] : {};
+    seen.set(value, result);
+    for (const [key, item] of Object.entries(value)) Object.defineProperty(result, redactMcpAttachmentText(key, headers), {
+      value: redactMcpAttachmentValue(item, headers, seen), enumerable: true, configurable: true, writable: true,
+    });
+    return result as T;
+  }
+  return value;
+}
+
+/** Accept a bound receipt only from the explicitly attached local Desktop endpoint. */
+export function desktopControlEffectReceipt(raw: unknown, options: {
+  readonly serverName: string;
+  readonly toolName: string;
+  readonly toolUseId?: string;
+  readonly localOnly?: boolean;
+  readonly sensitiveHeaders?: Readonly<Record<string, string>>;
+  readonly desktopAuthorityGrant?: DesktopAuthorityGrant;
+}): ToolEffectDispositionEvidence | undefined {
+  if (options.serverName !== "agenc-desktop-control" || options.localOnly !== true ||
+    !options.sensitiveHeaders || !options.toolUseId || !hasLocalMcpAccess() ||
+    !hasDesktopAuthority(options.desktopAuthorityGrant)) return undefined;
+  if (raw === null || typeof raw !== "object") return undefined;
+  const meta = (raw as Record<string, unknown>)._meta;
+  if (meta === null || typeof meta !== "object") return undefined;
+  const receipt = (meta as Record<string, unknown>)["agenc.desktopControl.effect"];
+  if (receipt === null || typeof receipt !== "object" || Array.isArray(receipt)) return undefined;
+  const value = receipt as Record<string, unknown>;
+  if (Object.keys(value).some(key => !["version", "toolUseId", "toolName", "disposition", "evidence"].includes(key)) ||
+    value.version !== 1 || value.toolUseId !== options.toolUseId || value.toolName !== options.toolName ||
+    (value.disposition !== "confirmed_committed" && value.disposition !== "confirmed_no_effect") ||
+    typeof value.evidence !== "string" || value.evidence.trim().length === 0 || value.evidence.length > 2048) return undefined;
+  const evidence = redactMcpAttachmentText(value.evidence, options.sensitiveHeaders);
+  return createToolEffectDispositionEvidence({
+    disposition: value.disposition,
+    evidenceKind: "provider_receipt",
+    evidenceRef: `desktop-mcp:${options.toolUseId}:${options.toolName}`,
+    evidenceMaterial: JSON.stringify({ ...value, evidence }),
+  });
+}
+
+export function attachmentLogger(logger: Logger, headers?: Readonly<Record<string, string>>): Logger {
+  if (!headers) return logger;
+  const level = (name: keyof Logger) => (message: string, ...args: unknown[]) =>
+    logger[name](redactMcpAttachmentText(message, headers), ...args.map(arg => redactMcpAttachmentValue(arg, headers)));
+  return { debug: level("debug"), info: level("info"), warn: level("warn"), error: level("error") };
+}

--- a/runtime/src/mcp-client/manager.ts
+++ b/runtime/src/mcp-client/manager.ts
@@ -20,6 +20,8 @@ import type {
 import type { Tool, ToolResult } from "./_deps/tools-types.js";
 import type { Logger } from "./_deps/logger.js";
 import { silentLogger } from "./_deps/logger.js";
+import { hasLocalMcpAccess, attachmentLogger, redactMcpAttachmentText, redactMcpAttachmentValue } from "./local-control.js";
+import { hasDesktopAuthority } from "./desktop-authority.js";
 import { createMCPConnection } from "./connection.js";
 import type { ProviderEnvironment } from "../llm/provider-options.js";
 import {
@@ -1074,7 +1076,8 @@ export class MCPManager {
   getTools(): Tool[] {
     if (this.isSandboxExecutionAuthorityClosed()) return [];
     const tools: Tool[] = [];
-    for (const bridge of this.bridges.values()) {
+    for (const [name, bridge] of this.bridges) {
+      if (this.getServerConfig(name)?.localOnly === true && !hasLocalMcpAccess()) continue;
       tools.push(...bridge.tools);
     }
     return tools;
@@ -1170,11 +1173,21 @@ export class MCPManager {
    */
   getServerInstructions(name: string): string | undefined {
     if (this.isSandboxExecutionAuthorityClosed()) return undefined;
+    if (this.getServerConfig(name)?.localOnly === true) {
+      if (!hasLocalMcpAccess() || !this.bridges.has(name)) return undefined;
+      if (name !== "agenc-desktop-control" || !hasDesktopAuthority(this.getServerConfig(name)?.desktopAuthorityGrant)) return this.serverInstructions.get(name);
+      const tools = this.getToolsByServer(name).slice(0, 32).map(tool => tool.name).join(", ");
+      return `This is authenticated local AgenC Desktop app control, not a web page or the isolated Browser tool. Discover its tools with system.searchTools, then select the exact MCP tool name before calling it. Available tools: ${tools}. Use only for the user's requested app operation; this capability does not grant additional permissions. Native visible-terminal mutations require an explicitly full-access session. In restricted sessions use Core exec_command/system.bash for sandboxed commands; never loosen permissions just to control the visible terminal.\n\n${this.serverInstructions.get(name) ?? ""}`;
+    }
     return this.serverInstructions.get(name);
   }
 
   getConfiguredServers(): readonly MCPServerConfig[] {
-    return this.configs;
+    return this.configs.map(config => {
+      if (config.origin?.scope !== "session" || config.headers === undefined) return config;
+      const { headers: _headers, desktopAuthority: _proof, desktopAuthorityGrant: _grant, ...publicConfig } = config;
+      return publicConfig;
+    });
   }
 
   getServerConfig(name: string): MCPServerConfig | undefined {
@@ -1518,6 +1531,15 @@ export class MCPManager {
     startupGate?: StartupGate,
     isCurrent: () => boolean = () => true,
   ): Promise<RefreshedCompanionBridges> {
+    if (config.localOnly === true) {
+      // Local app control is a tool-only surface: no server-initiated skill,
+      // resource or prompt can escape the turn-scoped execution boundary.
+      const previous = [this.resourceBridges.get(config.name), this.promptBridges.get(config.name)];
+      this.resourceBridges.delete(config.name);
+      this.promptBridges.delete(config.name);
+      await Promise.all(previous.filter(value => value !== undefined).map(value => invokeDisposal(value)));
+      return {};
+    }
     let createdResourceBridge: MCPResourceBridge | undefined;
     let createdPromptBridge: MCPPromptBridge | undefined;
     const abandonCreatedBridges = async (): Promise<void> => {
@@ -1612,17 +1634,20 @@ export class MCPManager {
     startupGate: StartupGate,
     isCurrent: () => boolean,
   ): Promise<MCPToolBridge> {
+    const sensitiveHeaders = config.origin?.scope === "session" ? config.headers : undefined;
+    const logger = attachmentLogger(this.logger, sensitiveHeaders);
     let client: Awaited<ReturnType<typeof createMCPConnection>>;
     try {
       client = await createMCPConnection(
         config,
-        this.logger,
-        this.elicitationHandlers,
-        this.samplingHandlers,
+        logger,
+        config.localOnly === true ? undefined : this.elicitationHandlers,
+        config.localOnly === true ? undefined : this.samplingHandlers,
         this.sandboxExecutionBroker,
         this.environment,
       );
     } catch (error) {
+      error = redactMcpAttachmentValue(error, sensitiveHeaders);
       if (isMCPTransportCleanupFailure(error)) {
         this.retainUnownedCleanupFailure(config.name, error);
         throw new MCPConnectionCleanupError(config.name, error, [error]);
@@ -1638,11 +1663,12 @@ export class MCPManager {
       // value is immutable for the lifetime of the connection.
       const capabilities = readClientCapabilities(client);
       const serverInfo = readClientServerInfo(client);
-      const instructions = readClientInstructions(client);
+      const rawInstructions = readClientInstructions(client);
+      const instructions = rawInstructions === undefined ? undefined : redactMcpAttachmentText(rawInstructions, sensitiveHeaders);
       const rawBridge = await createToolBridge(
         client,
         config.name,
-        this.logger,
+        logger,
         {
           listToolsTimeoutMs: config.timeout,
           callToolTimeoutMs: config.timeout,
@@ -1661,7 +1687,7 @@ export class MCPManager {
       // already-registered tools (from earlier servers). Bail the
       // whole bridge — the caller can re-configure the namespace.
       this.assertNoNameShadowing(config.name, rawBridge);
-      bridge = new ResilientMCPBridge(config, rawBridge, this.logger, {
+      bridge = new ResilientMCPBridge(config, rawBridge, logger, {
         ...(this.permissionOptions !== undefined
           ? { permissions: this.permissionOptions }
           : {}),
@@ -1675,10 +1701,10 @@ export class MCPManager {
         // resilient bridge re-registers them on the fresh client it spawns
         // during reconnect — otherwise server-initiated elicitation breaks
         // silently after a transient drop.
-        ...(this.elicitationHandlers !== undefined
+        ...(config.localOnly !== true && this.elicitationHandlers !== undefined
           ? { elicitationHandlers: this.elicitationHandlers }
           : {}),
-        ...(this.samplingHandlers !== undefined
+        ...(config.localOnly !== true && this.samplingHandlers !== undefined
           ? { samplingHandlers: this.samplingHandlers }
           : {}),
         ...(this.sandboxExecutionBroker !== undefined
@@ -1743,7 +1769,7 @@ export class MCPManager {
         capabilities,
         ...(serverInfo !== undefined ? { serverInfo } : {}),
         ...(instructions !== undefined ? { instructions } : {}),
-        config: toScopedMcpServerConfig(config),
+        config: toScopedMcpServerConfig(sensitiveHeaders === undefined ? config : { ...config, headers: undefined }),
         cleanup: async () => {
           await this.disconnectServer(
             config.name,
@@ -1754,6 +1780,7 @@ export class MCPManager {
       this.connectionStates.set(config.name, { type: "connected" });
       return bridge;
     } catch (error) {
+      error = redactMcpAttachmentValue(error, sensitiveHeaders);
       if (bridge !== undefined && this.bridges.get(config.name) === bridge) {
         this.bridges.delete(config.name);
       }

--- a/runtime/src/mcp-client/resilient-client.ts
+++ b/runtime/src/mcp-client/resilient-client.ts
@@ -72,11 +72,17 @@ export function toToolCatalogPolicyConfig(
     deniedTools === undefined &&
     defaultToolsApprovalMode === undefined &&
     virtualNoFsWriteTools === undefined &&
-    config.tools === undefined
+    config.tools === undefined &&
+    config.localOnly !== true &&
+    !(config.origin?.scope === "session" && config.headers !== undefined)
   ) {
     return undefined;
   }
   return {
+    ...(config.localOnly === true ? { localOnly: true } : {}),
+    ...(config.desktopAuthorityGrant ? { desktopAuthorityGrant: config.desktopAuthorityGrant } : {}),
+    ...(config.origin?.scope === "session" && config.headers !== undefined
+      ? { sensitiveHeaders: config.headers } : {}),
     ...(allowedTools !== undefined ? { allowedTools } : {}),
     ...(deniedTools !== undefined ? { deniedTools } : {}),
     ...(config.pinnedCatalogSha256 !== undefined
@@ -288,6 +294,7 @@ export class ResilientMCPBridge implements MCPToolBridge {
 
   private createProxyTool(namespacedName: string, templateTool: Tool): Tool {
     return {
+      ...templateTool,
       name: namespacedName,
       description: templateTool.description,
       inputSchema: templateTool.inputSchema,
@@ -322,7 +329,9 @@ export class ResilientMCPBridge implements MCPToolBridge {
 
         const result = await innerTool.execute(args);
 
-        if (result.isError && isConnectionError(result.content)) {
+        // A bound provider receipt describes a known terminal tool outcome,
+        // not a transport loss inferred from arbitrary result text/URLs.
+        if (result.isError && result.effectDisposition === undefined && isConnectionError(result.content)) {
           this.scheduleReconnect();
           return { content: `MCP server "${this.serverName}" lost connection — reconnecting...`, isError: true };
         }

--- a/runtime/src/mcp-client/tools.ts
+++ b/runtime/src/mcp-client/tools.ts
@@ -630,6 +630,13 @@ function exactDesktopInvocation(
 }
 
 const DESKTOP_NATIVE_TERMINALS = new Set(["terminal_open", "terminal_run", "terminal_type", "terminal_close"]);
+// Narrower than permission-level reads: snapshot/read_text/wait_for execute
+// page-main-world JavaScript and may invoke page-defined getters or setters.
+// Do not replay those while another effect is unresolved.
+const DESKTOP_IDEMPOTENT_INSPECTIONS = new Set([
+  "desktop_state", "desktop_window_state", "browser_tabs", "browser_screenshot",
+  "browser_downloads", "browser_console", "terminal_list", "terminal_read",
+]);
 function nativeDesktopTerminalAllowed(args: Record<string, unknown>, callId: string,
   toolName: string, options: MCPToolBridgePermissionOptions | undefined): boolean {
   const context = exactDesktopInvocation(args, callId, toolName, options);
@@ -944,7 +951,9 @@ export async function createToolBridge(
 
   const tools: Tool[] = providerSafeMcpTools.map((mcpTool) => {
     const namespacedName = `mcp.${serverName}.${mcpTool.name}`;
-    const desktopClass = desktopToolClassification(options.serverConfig?.desktopAuthorityGrant, mcpTool.name);
+    const desktopClass = serverName === "agenc-desktop-control" && options.serverConfig?.localOnly === true
+      ? desktopToolClassification(options.serverConfig.desktopAuthorityGrant, mcpTool.name)
+      : undefined;
     const defaultPermissionMode = perMcpToolApprovalMode(
       options.serverConfig,
       mcpTool.name,
@@ -974,7 +983,12 @@ export async function createToolBridge(
       ...(virtualNoFsWrites || desktopClass === "ui-mutation"
         ? { metadata: { mutating: true, virtualNoFsWrites: true } }
         : {}),
+      // Only the signed product-owned inspection list is safe to repeat after
+      // an unknown effect. Generic MCP readOnlyHint/isReadOnly annotations are
+      // not recovery authority. Live local/host checks below still apply.
       ...(desktopClass === "read" ? { isReadOnly: true, metadata: { mutating: false } } : {}),
+      ...(desktopClass === "read" && DESKTOP_IDEMPOTENT_INSPECTIONS.has(mcpTool.name)
+        ? { recoveryCategory: "idempotent" as const } : {}),
       ...(desktopClass === "ui-mutation" || (hasDesktopAuthority(options.serverConfig?.desktopAuthorityGrant) && DESKTOP_NATIVE_TERMINALS.has(mcpTool.name)) ? { requiresApproval: true } : {}),
       ...(defaultPermissionMode !== undefined ? { defaultPermissionMode } : {}),
 

--- a/runtime/src/mcp-client/tools.ts
+++ b/runtime/src/mcp-client/tools.ts
@@ -8,6 +8,11 @@
  */
 
 import type { Tool, ToolResult, JSONSchema } from "./_deps/tools-types.js";
+import { hasLocalMcpAccess, redactMcpAttachmentText, redactMcpAttachmentValue, desktopControlEffectReceipt, withDesktopMcpDispatchGuard, DesktopMcpPreflightRefusal } from "./local-control.js";
+import { desktopToolClassification, hasDesktopAuthority } from "./desktop-authority.js";
+import { preEffectRefusal } from "../tools/results.js";
+import { readToolRuntimeContext, type ToolRuntimeAttemptContext } from "../tools/runtimes/context.js";
+import { readSandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import type { MCPToolBridge } from "./types.js";
 import type { Logger } from "./_deps/logger.js";
 import { silentLogger } from "./_deps/logger.js";
@@ -75,6 +80,9 @@ import {
  * I-74 supply-chain pin.
  */
 export interface MCPToolCatalogPolicyConfig {
+  readonly desktopAuthorityGrant?: import("./desktop-authority.js").DesktopAuthorityGrant;
+  readonly localOnly?: boolean;
+  readonly sensitiveHeaders?: Readonly<Record<string, string>>;
   readonly allowedTools?: readonly string[];
   readonly deniedTools?: readonly string[];
   readonly pinnedCatalogSha256?: string;
@@ -599,6 +607,42 @@ async function authorizeMcpClientToolCall(
   return { ok: true, args: executionArgs };
 }
 
+/** Reuse only the executor's exact, already-approved invocation. JSON/model
+ * arguments cannot mint the private runtime-context marker. The Desktop bridge
+ * otherwise asks twice with the same call ID, leaving SDK clients waiting on a
+ * duplicate approval they have correctly deduplicated. */
+function exactDesktopInvocation(
+  args: Record<string, unknown>,
+  callId: string,
+  toolName: string,
+  options: MCPToolBridgePermissionOptions | undefined,
+): ToolRuntimeAttemptContext | undefined {
+  const context = readToolRuntimeContext(args);
+  const session = options?.session ?? options?.permissionContext?.session;
+  if (!context || !session ||
+      context.callId !== callId || context.toolName !== toolName ||
+      context.invocation.callId !== callId || context.invocation.session !== session ||
+      context.invocation.turn.subId !== options?.getActiveTurnId?.()) return undefined;
+  try {
+    return JSON.stringify(JSON.parse(context.rawArgs)) ===
+      JSON.stringify(withoutMcpExecutionOnlyArgs(args)) ? context : undefined;
+  } catch { return undefined; }
+}
+
+const DESKTOP_NATIVE_TERMINALS = new Set(["terminal_open", "terminal_run", "terminal_type", "terminal_close"]);
+function nativeDesktopTerminalAllowed(args: Record<string, unknown>, callId: string,
+  toolName: string, options: MCPToolBridgePermissionOptions | undefined): boolean {
+  const context = exactDesktopInvocation(args, callId, toolName, options);
+  const broker = readSandboxExecutionBroker(args);
+  // The existing Electron PTY is not a child of Core's sandbox. Neither an
+  // ordinary tool approval nor a one-shot escalation can sandbox that process.
+  if (!context || context.sandboxMode !== "danger_full_access" ||
+      context.requestedSandboxMode !== "danger_full_access" || !broker ||
+      broker !== context.invocation.session.services.sandboxExecutionBroker ||
+      broker.mode !== "danger_full_access") return false;
+  try { broker.assertReady("tool"); return true; } catch { return false; }
+}
+
 function responseScopeFromDecision(
   decision: ReviewDecision | null,
 ): RequestPermissionsResponse["scope"] {
@@ -900,6 +944,7 @@ export async function createToolBridge(
 
   const tools: Tool[] = providerSafeMcpTools.map((mcpTool) => {
     const namespacedName = `mcp.${serverName}.${mcpTool.name}`;
+    const desktopClass = desktopToolClassification(options.serverConfig?.desktopAuthorityGrant, mcpTool.name);
     const defaultPermissionMode = perMcpToolApprovalMode(
       options.serverConfig,
       mcpTool.name,
@@ -916,22 +961,32 @@ export async function createToolBridge(
         modelFacingName: encodeMcpToolNameForWire(namespacedName),
         canonicalName: namespacedName,
         rawToolName: mcpTool.name,
-        rawDescription: mcpTool.description,
+        rawDescription: redactMcpAttachmentText(mcpTool.description ?? "", options.serverConfig?.sensitiveHeaders),
       }),
       inputSchema: modelFacingMcpInputSchema(
         serverName,
         mcpTool.name,
-        mcpTool.inputSchema ?? { type: "object", properties: {} },
+        redactMcpAttachmentValue(mcpTool.inputSchema ?? { type: "object", properties: {} }, options.serverConfig?.sensitiveHeaders),
         logger,
       ),
       serverId: serverName,
       mcpInfo: { serverName, toolName: mcpTool.name },
-      ...(virtualNoFsWrites
+      ...(virtualNoFsWrites || desktopClass === "ui-mutation"
         ? { metadata: { mutating: true, virtualNoFsWrites: true } }
         : {}),
+      ...(desktopClass === "read" ? { isReadOnly: true, metadata: { mutating: false } } : {}),
+      ...(desktopClass === "ui-mutation" || (hasDesktopAuthority(options.serverConfig?.desktopAuthorityGrant) && DESKTOP_NATIVE_TERMINALS.has(mcpTool.name)) ? { requiresApproval: true } : {}),
       ...(defaultPermissionMode !== undefined ? { defaultPermissionMode } : {}),
 
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
+        // A previously discovered/captured proxy still checks trusted turn
+        // provenance before any approval, observer, reconnect or remote call.
+        if (options.serverConfig?.localOnly === true && !hasLocalMcpAccess()) {
+          return preEffectRefusal(namespacedName, "This app-control tool is available only during a local daemon user turn.");
+        }
+        if (options.serverConfig?.desktopAuthorityGrant && !hasDesktopAuthority(options.serverConfig.desktopAuthorityGrant)) {
+          return preEffectRefusal(namespacedName, "Desktop host authority expired; reattach from the local app.");
+        }
         const effectSignal = abortSignalFromArgs(args);
         effectSignal?.throwIfAborted();
         if (disposed) {
@@ -947,6 +1002,11 @@ export async function createToolBridge(
         const trustedCallId = trustedCallIdFromArgs(args);
         const callId = trustedCallId ??
           `mcp-${serverName}-${mcpTool.name}-${randomCallId()}`;
+        const nativeTerminal = serverName === "agenc-desktop-control" &&
+          hasDesktopAuthority(options.serverConfig?.desktopAuthorityGrant) && DESKTOP_NATIVE_TERMINALS.has(mcpTool.name);
+        const terminalRefusal = () => preEffectRefusal(namespacedName,
+          "The visible Desktop terminal is not sandboxed by Core and requires an explicitly full-access session. Use the Core exec_command/system.bash tools for sandboxed commands; do not change permissions just to use this terminal.");
+        if (nativeTerminal && !nativeDesktopTerminalAllowed(args, callId, namespacedName, options.permissions)) return terminalRefusal();
         const progressCallback = progressCallbackFromArgs(args);
         if (
           mcpTool.name === MCP_REQUEST_PERMISSIONS_TOOL_NAME &&
@@ -957,7 +1017,10 @@ export async function createToolBridge(
         const startedAtMs = Date.now();
 
         try {
-          const authorization = await authorizeMcpClientToolCall(
+          const authorization: PermissionResolution = (desktopClass !== undefined || nativeTerminal) &&
+            exactDesktopInvocation(args, callId, namespacedName, options.permissions)?.approvalResolved === true
+            ? { ok: true, args }
+            : await authorizeMcpClientToolCall(
             bridgeTool,
             serverName,
             mcpTool,
@@ -968,6 +1031,15 @@ export async function createToolBridge(
           if (!authorization.ok) {
             return authorization.result;
           }
+          // Approval can outlive the originating turn. A captured proxy must
+          // not carry a revoked local lease across that asynchronous boundary.
+          if (options.serverConfig?.localOnly === true && !hasLocalMcpAccess()) {
+            return preEffectRefusal(namespacedName, "The local app-control turn has ended.");
+          }
+          if (options.serverConfig?.desktopAuthorityGrant && !hasDesktopAuthority(options.serverConfig.desktopAuthorityGrant)) {
+            return preEffectRefusal(namespacedName, "Desktop host authority expired during authorization.");
+          }
+          if (nativeTerminal && !nativeDesktopTerminalAllowed(args, callId, namespacedName, options.permissions)) return terminalRefusal();
           const executionArgs = withoutMcpExecutionOnlyArgs(
             authorization.args,
           );
@@ -983,8 +1055,12 @@ export async function createToolBridge(
           const rawResult = await withRPCDeadline<unknown>(
             `MCP tool "${mcpTool.name}" callTool`,
             callToolTimeoutMs,
-            (signal) =>
-              client.callTool(
+            (signal) => withDesktopMcpDispatchGuard(() => {
+              if (options.serverConfig?.localOnly === true && !hasLocalMcpAccess()) throw new DesktopMcpPreflightRefusal("The local app-control turn has ended.");
+              if (options.serverConfig?.desktopAuthorityGrant && !hasDesktopAuthority(options.serverConfig.desktopAuthorityGrant)) throw new DesktopMcpPreflightRefusal("Desktop host authority expired before dispatch.");
+              if (signal.aborted || effectSignal?.aborted) throw new DesktopMcpPreflightRefusal("The app-control operation was cancelled before dispatch.");
+              if (nativeTerminal && !nativeDesktopTerminalAllowed(args, callId, namespacedName, options.permissions)) throw new DesktopMcpPreflightRefusal("The visible terminal no longer has full-access authority.");
+            }, () => client.callTool(
                 {
                   name: mcpTool.name,
                   arguments: executionArgs,
@@ -1008,7 +1084,7 @@ export async function createToolBridge(
                     ? {
                         onprogress: (progress: unknown) => {
                           forwardMcpProgress(
-                            progress,
+                            redactMcpAttachmentValue(progress, options.serverConfig?.sensitiveHeaders),
                             progressCallback,
                             logger,
                             mcpTool.name,
@@ -1017,16 +1093,24 @@ export async function createToolBridge(
                       }
                     : {}),
                 },
-              ),
+              )),
             effectSignal,
           );
           const result = await normalizeMcpToolOutput({
-            raw: rawResult,
+            raw: redactMcpAttachmentValue(rawResult, options.serverConfig?.sensitiveHeaders),
             serverName,
             toolName: mcpTool.name,
             callId,
             environment,
             logger,
+          });
+          const effectDisposition = desktopControlEffectReceipt(rawResult, {
+            serverName,
+            toolName: mcpTool.name,
+            ...(options.serverConfig?.desktopAuthorityGrant ? { desktopAuthorityGrant: options.serverConfig.desktopAuthorityGrant } : {}),
+            ...(trustedCallId !== undefined ? { toolUseId: trustedCallId } : {}),
+            ...(options.serverConfig?.localOnly === true ? { localOnly: true } : {}),
+            ...(options.serverConfig?.sensitiveHeaders !== undefined ? { sensitiveHeaders: options.serverConfig.sensitiveHeaders } : {}),
           });
 
           const content = result.content;
@@ -1040,7 +1124,7 @@ export async function createToolBridge(
             isError,
             durationMs,
           });
-          return result;
+          return effectDisposition === undefined ? result : { ...result, effectDisposition };
         } catch (error) {
           const effectiveError = effectSignal?.aborted
             ? effectSignal.reason
@@ -1048,7 +1132,7 @@ export async function createToolBridge(
           const rawErrorMessage =
             `MCP tool "${mcpTool.name}" failed: ${effectiveError instanceof Error ? effectiveError.message : String(effectiveError)}`;
           const errMessage = sanitizeMcpOutputText(
-            truncateMcpUtf8(rawErrorMessage, 16 * 1024),
+            truncateMcpUtf8(redactMcpAttachmentText(rawErrorMessage, options.serverConfig?.sensitiveHeaders), 16 * 1024),
           );
           const durationMs = Date.now() - startedAtMs;
           options.callObserver?.onEnd?.({
@@ -1059,6 +1143,7 @@ export async function createToolBridge(
             isError: true,
             durationMs,
           });
+          if (error instanceof DesktopMcpPreflightRefusal) return preEffectRefusal(namespacedName, errMessage);
           effectSignal?.throwIfAborted();
           return {
             content: errMessage,

--- a/runtime/src/mcp-client/transports/http.ts
+++ b/runtime/src/mcp-client/transports/http.ts
@@ -10,6 +10,7 @@
  */
 
 import { VERSION } from "../../version.js";
+import { Agent as UndiciAgent } from "undici";
 import type { Logger } from "../_deps/logger.js";
 import { silentLogger } from "../_deps/logger.js";
 import type { MCPElicitationHandlers } from "../types.js";
@@ -24,8 +25,12 @@ import { getProxyFetchOptions } from "../../utils/proxy.js";
 import type { ProviderEnvironment } from "../../llm/provider-options.js";
 import { EMPTY_MCP_REQUEST_ENVIRONMENT } from "../environment.js";
 import type { McpOAuthConfig } from "../../config/mcp-oauth.js";
+import { attestDesktopEndpoint, assertDesktopSocketBinding, type DesktopAuthorityGrant } from "../desktop-authority.js";
+import { assertDesktopMcpDispatchGuard } from "../local-control.js";
 
 export interface MCPServerHttpConfig {
+  readonly desktopAuthorityGrant?: DesktopAuthorityGrant;
+  readonly localOnly?: boolean;
   readonly oauth?: McpOAuthConfig;
   readonly name: string;
   readonly endpoint: string;
@@ -51,11 +56,41 @@ export async function createHttpMCPConnection(
   );
 
   const timeout = config.timeout ?? 30_000;
-  const proxyOptions = getProxyFetchOptions({ environment });
+  const socketAgent = config.desktopAuthorityGrant === undefined ? undefined :
+    new UndiciAgent({ connect: { socketPath: config.desktopAuthorityGrant.socketPath } });
+  const proxyOptions = socketAgent ? { dispatcher: socketAgent } : getProxyFetchOptions({
+    // This supplies an explicit direct dispatcher, avoiding even a process-
+    // global fetch proxy while retaining the existing owned agent lifecycle.
+    environment: config.localOnly === true ? EMPTY_MCP_REQUEST_ENVIRONMENT : environment,
+  });
 
   const url = new URL(config.endpoint);
+  const privateFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    if (config.desktopAuthorityGrant) await assertDesktopSocketBinding(config.desktopAuthorityGrant);
+    if (config.desktopAuthorityGrant) {
+      // SDK tool-call bodies are JSON strings. Protocol initialization/listing
+      // may run outside a user turn; actual execution requires its live guard.
+      let toolCall = false;
+      if (typeof init?.body === "string") {
+        try { toolCall = JSON.parse(init.body)?.method === "tools/call"; } catch { /* SDK validates protocol bodies */ }
+      }
+      if (toolCall) assertDesktopMcpDispatchGuard(true);
+    }
+    return fetch(input, { ...init, ...proxyOptions, redirect: "error" });
+  };
+  try {
+  await attestDesktopEndpoint(config, privateFetch);
   const oauth = config.oauth === undefined ? undefined : await import("../../services/mcp/interactive-auth.js");
   const transport = new StreamableHTTPClientTransport(url, {
+    ...(config.localOnly === true ? {
+      // A private loopback credential must never follow an endpoint redirect
+      // or inherit an operator's outbound HTTP proxy.
+      fetch: (input: string | URL | Request, init?: RequestInit) => {
+        const target = new URL(input instanceof Request ? input.url : String(input));
+        if (target.href !== url.href) return Promise.reject(new Error("Local MCP endpoint changed"));
+        return privateFetch(input, init);
+      },
+    } : {}),
     ...(oauth === undefined || config.oauth === undefined ? {} : {
       authProvider: oauth.runtimeMcpOAuthProvider(config.name, config.endpoint, "http", config.oauth, environment, config.headers),
       fetch: oauth.mcpOAuthTransportFetch(environment, fetch, config),
@@ -76,6 +111,13 @@ export async function createHttpMCPConnection(
       ),
     },
   );
+  if (socketAgent) {
+    const closeClient = client.close.bind(client);
+    let closing: Promise<void> | undefined;
+    client.close = () => closing ??= (async () => {
+      try { await closeClient(); } finally { await socketAgent.close(); }
+    })();
+  }
   configureMcpHostRequestHandlers(
     client,
     config.name,
@@ -98,4 +140,8 @@ export async function createHttpMCPConnection(
 
   logger.info(`Connected to MCP HTTP server "${config.name}"`);
   return client;
+  } catch (error) {
+    await socketAgent?.destroy().catch(() => {});
+    throw error;
+  }
 }

--- a/runtime/src/mcp-client/types.ts
+++ b/runtime/src/mcp-client/types.ts
@@ -69,6 +69,11 @@ export interface MCPServerConfig {
   readonly endpoint?: string;
   /** Optional headers to send on the initial request (SSE/HTTP/WebSocket). */
   readonly headers?: Readonly<Record<string, string>>;
+  /** Runtime-only session attachment restriction, never loaded from configuration. */
+  readonly localOnly?: boolean;
+  readonly desktopAuthority?: import("./desktop-authority.js").DesktopAuthorityProof;
+  /** Process-minted authority; never accepted from JSON or persisted config. */
+  readonly desktopAuthorityGrant?: import("./desktop-authority.js").DesktopAuthorityGrant;
   /** Optional environment variables for the child process (stdio only). */
   readonly env?: Readonly<Record<string, string>>;
   /** Optional parent environment variable names to copy into stdio process env. */

--- a/runtime/src/prompts/attachments/mcp-delta.ts
+++ b/runtime/src/prompts/attachments/mcp-delta.ts
@@ -43,6 +43,7 @@ interface SessionLikeForMcpInstructions {
 }
 
 interface McpManagerLikeForInstructions {
+  getConfiguredServers?(): readonly { readonly name: string; readonly localOnly?: boolean }[];
   /** AgenC public surface today (returns server names). */
   getConnectedServers?(): readonly string[];
   /**
@@ -77,18 +78,23 @@ export const mcpInstructionsDeltaProducer: AttachmentProducer = async (
   trackingState,
 ) => {
   const currentMap = readConnectedInstructions(opts.sessionKey);
-  const prior = trackingState.lastMcpInstructionsMap;
+  let prior = trackingState.lastMcpInstructionsMap;
 
   if (prior === undefined) {
-    // First turn — seed without emitting. Initial connections are
-    // already announced through the system prompt's MCP section.
+    // Ordinary bootstrap connections already appear in the system prompt.
+    // Session-local app controls attach after that prompt is built, even when
+    // they arrive before the first user turn. Announce those on their first
+    // eligible local turn; the manager hides them from remote turns.
     trackingState.lastMcpInstructionsMap = currentMap;
-    return [];
+    const lateLocalNames = new Set((opts.sessionKey as SessionLikeForMcpInstructions)
+      .services?.mcpManager?.getConfiguredServers?.()
+      .filter(server => server.localOnly === true).map(server => server.name) ?? []);
+    prior = new Map([...currentMap].filter(([name]) => !lateLocalNames.has(name)));
   }
 
   const added: { name: string; block: string }[] = [];
   for (const [name, block] of currentMap) {
-    if (!prior.has(name)) added.push({ name, block });
+    if (prior.get(name) !== block) added.push({ name, block });
   }
   const removed: string[] = [];
   for (const name of prior.keys()) {

--- a/runtime/src/sandbox/desktop-authority-protection.ts
+++ b/runtime/src/sandbox/desktop-authority-protection.ts
@@ -1,0 +1,67 @@
+import { lstatSync, realpathSync } from "node:fs";
+import path from "node:path";
+import { resolveHomeContext } from "../config/home.js";
+import type { PermissionProfile } from "./engine/index.js";
+
+/** Resolve missing leaves through their existing ancestor; never trust a tool's env. */
+export function canonicalAuthorityPath(target: string): string {
+  let ancestor = path.resolve(target);
+  const suffix: string[] = [];
+  for (;;) {
+    try {
+      return path.join(realpathSync(ancestor), ...suffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) throw error;
+      suffix.unshift(path.basename(ancestor));
+      ancestor = parent;
+    }
+  }
+}
+
+export function desktopAuthorityRoot(
+  boundHome?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const home = boundHome ?? resolveHomeContext(environment).path;
+  if (!path.isAbsolute(home)) throw new Error("Desktop authority home must be absolute");
+  const root = path.join(canonicalAuthorityPath(home), "desktop-control-authorities");
+  try {
+    if (!lstatSync(root).isDirectory()) throw new Error("Desktop authority directory must not be a symlink or file");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return root;
+}
+
+export function isWithinAuthorityPath(target: string, root: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+/** Also disallow file-tool operations naming an ancestor (remove/move/replace). */
+export function overlapsDesktopAuthority(target: string, root: string): boolean {
+  const canonical = canonicalAuthorityPath(target);
+  return isWithinAuthorityPath(canonical, root) || isWithinAuthorityPath(root, canonical);
+}
+
+/** Internal, non-grantable reservation. Explicit unsandboxed modes remain operator trust. */
+export function protectDesktopAuthority(
+  profile: PermissionProfile,
+  root: string,
+): PermissionProfile {
+  return {
+    ...profile,
+    fileSystem: {
+      ...profile.fileSystem,
+      kind: "restricted",
+      entries: profile.fileSystem.kind === "restricted" ? profile.fileSystem.entries : [
+        { path: { kind: "special", value: { kind: "root" } }, access: "write" },
+      ],
+      reservedReadOnlyPaths: [...new Set([
+        ...(profile.fileSystem.reservedReadOnlyPaths ?? []), root,
+      ])],
+    },
+  };
+}

--- a/runtime/src/sandbox/engine/index.ts
+++ b/runtime/src/sandbox/engine/index.ts
@@ -12,6 +12,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { canonicalAuthorityPath, isWithinAuthorityPath } from "../desktop-authority-protection.js";
 
 export const AGENC_LINUX_SANDBOX_ARG0 = "agenc-linux-sandbox";
 export const PROTECTED_METADATA_PATH_NAMES = [".git", ".agenc", ".agents"] as const;
@@ -60,6 +61,8 @@ export interface FileSystemSandboxPolicy {
   readonly entries: readonly FileSystemSandboxEntry[];
   readonly globScanMaxDepth?: number;
   readonly includePlatformDefaults?: boolean;
+  /** Native runtime reservations, never overrideable by additional/model grants. */
+  readonly reservedReadOnlyPaths?: readonly string[];
 }
 
 export interface NetworkPermissions {
@@ -88,6 +91,7 @@ export interface WritableRoot {
   readonly root: string;
   readonly readOnlySubpaths: readonly string[];
   readonly protectedMetadataNames?: readonly string[];
+  readonly reservedReadOnlyPaths?: readonly string[];
 }
 
 export interface SandboxCommand {
@@ -176,6 +180,7 @@ export function restrictedFileSystemPolicy(
   options: {
     readonly globScanMaxDepth?: number;
     readonly includePlatformDefaults?: boolean;
+    readonly reservedReadOnlyPaths?: readonly string[];
   } = {},
 ): FileSystemSandboxPolicy {
   return {
@@ -186,6 +191,9 @@ export function restrictedFileSystemPolicy(
       : {}),
     ...(options.includePlatformDefaults !== undefined
       ? { includePlatformDefaults: options.includePlatformDefaults }
+      : {}),
+    ...(options.reservedReadOnlyPaths !== undefined
+      ? { reservedReadOnlyPaths: [...options.reservedReadOnlyPaths] }
       : {}),
   };
 }
@@ -332,6 +340,9 @@ export function getWritableRootsWithCwd(
   const writableRoots = dedupPaths(writableEntries, true);
 
   return writableRoots.map((root) => {
+    const reservedReadOnlyPaths = (policy.reservedReadOnlyPaths ?? []).filter(
+      (reserved) => isWithinAuthorityPath(reserved, canonicalAuthorityPath(root)),
+    );
     const preserveRawCarveoutPaths = !isFilesystemRoot(root);
     const rawWritableRoots = writableEntries.filter(
       (entry) => normalizeEffectivePath(entry) === root,
@@ -357,10 +368,12 @@ export function getWritableRootsWithCwd(
     const readOnlySubpaths = dedupPaths([
       ...defaultCarveouts,
       ...explicitCarveouts,
+      ...reservedReadOnlyPaths,
     ]);
     return {
       root,
       readOnlySubpaths,
+      ...(reservedReadOnlyPaths.length > 0 ? { reservedReadOnlyPaths } : {}),
       protectedMetadataNames: protectedMetadataNamesForWritableRoot(
         policy,
         root,
@@ -456,6 +469,9 @@ export function canWritePathWithCwd(
   cwd: string,
   sessionTempRoot: string,
 ): boolean {
+  if ((policy.reservedReadOnlyPaths ?? []).some((root) =>
+    isWithinAuthorityPath(canonicalAuthorityPath(path.resolve(cwd, target)), root)
+  )) return false;
   if (
     !canWriteAccess(
       resolveAccessWithCwd(policy, target, cwd, sessionTempRoot),
@@ -466,6 +482,7 @@ export function canWritePathWithCwd(
 }
 
 export function hasFullDiskWriteAccess(policy: FileSystemSandboxPolicy): boolean {
+  if ((policy.reservedReadOnlyPaths?.length ?? 0) > 0) return false;
   switch (policy.kind) {
     case "unrestricted":
     case "external_sandbox":

--- a/runtime/src/sandbox/engine/policy-transforms.ts
+++ b/runtime/src/sandbox/engine/policy-transforms.ts
@@ -115,6 +115,7 @@ function effectiveFileSystemSandboxPolicy(
         permissions.globScanMaxDepth,
       ),
       includePlatformDefaults: fileSystemPolicy.includePlatformDefaults,
+      reservedReadOnlyPaths: fileSystemPolicy.reservedReadOnlyPaths,
     },
   );
 }

--- a/runtime/src/sandbox/engine/seatbelt.ts
+++ b/runtime/src/sandbox/engine/seatbelt.ts
@@ -186,12 +186,14 @@ export function createSeatbeltCommandArgs(
     fileSystemSandboxPolicy,
     sandboxPolicyCwd,
   );
+  const [reservedWritePolicy, reservedWriteParams] = buildReservedWritePolicy(fileSystemSandboxPolicy);
 
   const policySections = [
     getMacosSeatbeltBasePolicy(),
     fileReadPolicy,
     fileWritePolicy,
     denyReadPolicy,
+    reservedWritePolicy,
     networkPolicy,
   ];
   if (includePlatformDefaults(fileSystemSandboxPolicy)) {
@@ -205,6 +207,7 @@ export function createSeatbeltCommandArgs(
   const dirParams = [
     ...fileReadDirParams,
     ...fileWriteDirParams,
+    ...reservedWriteParams,
     ...macosDirParams(),
     ...unixSocketDirParams(proxy),
   ];
@@ -215,6 +218,25 @@ export function createSeatbeltCommandArgs(
     "--",
     ...command,
   ];
+}
+
+function buildReservedWritePolicy(policy: FileSystemSandboxPolicy): readonly [string, readonly (readonly [string, string])[]] {
+  const rules: string[] = [];
+  const params: [string, string][] = [];
+  const ancestors = new Set<string>();
+  for (const [index, root] of (policy.reservedReadOnlyPaths ?? []).entries()) {
+    const key = `RESERVED_READ_ONLY_${index}`;
+    params.push([key, root]);
+    rules.push(`(deny file-write* (subpath (param "${key}")))`);
+    // A writable ancestor must not be renamed/replaced to bypass the subtree.
+    for (let parent = root; parent !== path.dirname(parent); parent = path.dirname(parent)) ancestors.add(parent);
+  }
+  for (const [index, ancestor] of [...ancestors].entries()) {
+    const key = `RESERVED_ANCESTOR_${index}`;
+    params.push([key, ancestor]);
+    rules.push(`(deny file-write-unlink (literal (param "${key}")))`);
+  }
+  return [rules.join("\n"), params];
 }
 
 export function spawnSeatbeltCommand(

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -51,6 +51,7 @@ import {
   type SandboxPreparedSpawn,
 } from "./execution-prepared-spawn.js";
 import { resolveSessionTempRoot } from "../session/runtime-options.js";
+import { desktopAuthorityRoot, protectDesktopAuthority } from "./desktop-authority-protection.js";
 
 export {
   SandboxExecutionLeaseCleanupError,
@@ -295,6 +296,9 @@ function immutablePermissionProfile(
     fileSystem: Object.freeze({
       ...profile.fileSystem,
       entries: Object.freeze(entries),
+      ...(profile.fileSystem.reservedReadOnlyPaths === undefined ? {} : {
+        reservedReadOnlyPaths: Object.freeze([...profile.fileSystem.reservedReadOnlyPaths]),
+      }),
     }),
   });
 }
@@ -509,6 +513,7 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
     UnifiedExecRuntimeSandbox["windowsSandboxLevel"]
   >;
   readonly #windowsSandboxPrivateDesktop: boolean;
+  readonly #desktopAuthorityRoot: string;
   #allowGpu: boolean;
   #permissionProfile: PermissionProfile | undefined;
   readonly #probe: NonNullable<SandboxExecutionBrokerOptions["probe"]>;
@@ -531,6 +536,7 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
       : 0;
     this.#cwd = path.resolve(options.cwd);
     this.#env = { ...(options.env ?? process.env) };
+    this.#desktopAuthorityRoot = desktopAuthorityRoot(undefined, this.#env);
     this.#platform = options.platform ?? process.platform;
     this.#sandboxManager = options.sandboxManager ?? defaultSandboxManager;
     this.#explicitLinuxHelper = options.agencLinuxSandboxExe;
@@ -966,11 +972,13 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
     if (!this.required) return undefined;
     const status = this.#assertReadyAfterLifecycleAdmission(surface);
     return {
-      permissionProfile:
+      permissionProfile: protectDesktopAuthority(
         this.#permissionProfile ??
         permissionProfileForSandboxMode(this.mode, {
           cwd: this.#cwd,
         }),
+        this.#desktopAuthorityRoot,
+      ),
       sandboxPolicyCwd: this.#cwd,
       sessionTempRoot: this.#sessionTempRoot,
       preference: "require",
@@ -1014,7 +1022,7 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
         this.mode === "workspace_write"
           ? {
               ...modeSandbox,
-              permissionProfile: command.permissionProfileOverride,
+              permissionProfile: protectDesktopAuthority(command.permissionProfileOverride, this.#desktopAuthorityRoot),
             }
           : modeSandbox;
       const resolvedProgram = resolveSpawnExecutable({

--- a/runtime/src/sandbox/linux-launcher/bwrap.ts
+++ b/runtime/src/sandbox/linux-launcher/bwrap.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { canonicalAuthorityPath, isWithinAuthorityPath } from "../desktop-authority-protection.js";
 
 import {
   hasFullDiskReadAccess,
@@ -275,6 +276,10 @@ function createFilesystemArgs(
     appendReadOnlyIfExists(args, root);
   }
   for (const root of options.extraWritableBindRoots ?? []) {
+    const canonical = canonicalAuthorityPath(root);
+    if ((policy.reservedReadOnlyPaths ?? []).some((reserved) =>
+      isWithinAuthorityPath(canonical, reserved) || isWithinAuthorityPath(reserved, canonical)
+    )) throw new Error("extra writable bind overlaps reserved Desktop authority");
     appendBindIfExists(args, root);
   }
   for (const root of unreadableTargets.filter(isNestedUnreadable)) {
@@ -298,12 +303,30 @@ function appendWritableRoot(
   protectedCreateTargets: string[],
 ): void {
   appendBindIfExists(args, root.root);
+  // Self-bind each writable ancestor before the read-only leaf. A mountpoint
+  // cannot be renamed, so `mv home; mkdir home` cannot replace the trust root.
+  // Apply these before the root's ordinary carve-outs, never over their masks.
+  const canonicalRoot = canonicalAuthorityPath(root.root);
+  const anchors = new Set<string>();
+  for (const reserved of root.reservedReadOnlyPaths ?? []) {
+    for (let ancestor = path.dirname(reserved);
+      ancestor !== canonicalRoot && isWithinAuthorityPath(ancestor, canonicalRoot);
+      ancestor = path.dirname(ancestor)) {
+      if (!fs.existsSync(ancestor)) throw new Error(`cannot enforce missing reserved authority ancestor: ${ancestor}`);
+      anchors.add(ancestor);
+    }
+  }
+  for (const ancestor of [...anchors].sort((a, b) => a.length - b.length)) appendBindIfExists(args, ancestor);
   const handledProtectedNames = new Set<string>();
   for (const subpath of root.readOnlySubpaths) {
     if (fs.existsSync(subpath)) {
       rejectSymlinkCrossing(subpath, root.root, "read-only subpath");
       appendReadOnlyIfExists(args, subpath);
     } else {
+      if (root.reservedReadOnlyPaths?.includes(subpath)) {
+        appendReadOnlyEmptyDirectory(args, subpath);
+        continue;
+      }
       const protectedName = protectedMetadataNameForPath(root.root, subpath);
       if (protectedName !== null) {
         handledProtectedNames.add(protectedName);

--- a/runtime/src/sandbox/linux-launcher/cli.ts
+++ b/runtime/src/sandbox/linux-launcher/cli.ts
@@ -45,6 +45,7 @@ const FILE_SYSTEM_KEYS: ReadonlySet<string> = new Set([
   "entries",
   "globScanMaxDepth",
   "includePlatformDefaults",
+  "reservedReadOnlyPaths",
 ]);
 const ENTRY_KEYS: ReadonlySet<string> = new Set(["path", "access"]);
 const PATH_KEYS: Readonly<Record<string, ReadonlySet<string>>> = {
@@ -291,6 +292,11 @@ function assertFileSystem(value: unknown): void {
   for (const entry of candidate.entries) {
     assertFileSystemEntry(entry);
   }
+  if (candidate.reservedReadOnlyPaths !== undefined && (
+    !Array.isArray(candidate.reservedReadOnlyPaths) ||
+    candidate.reservedReadOnlyPaths.length > 32 ||
+    candidate.reservedReadOnlyPaths.some((root) => typeof root !== "string" || !path.isAbsolute(root) || root.includes(NUL_BYTE))
+  )) throw new LinuxSandboxCliError("permission profile reservedReadOnlyPaths must be bounded absolute paths");
 }
 
 function assertFileSystemEntry(value: unknown): void {

--- a/runtime/src/sandbox/linux-launcher/landlock-exec.ts
+++ b/runtime/src/sandbox/linux-launcher/landlock-exec.ts
@@ -153,6 +153,11 @@ export function planLandlockConfinement(input: LandlockPlanInput): LandlockPlan 
   }
   const protectedCreateTargets: string[] = [];
   for (const root of writableRoots) {
+    // A watcher cannot prevent a forged key from being written before it fires.
+    // Fail closed even when the reserved trust directory does not exist yet.
+    if ((root.reservedReadOnlyPaths?.length ?? 0) > 0) {
+      return { kind: "refused", reason: "reserved Desktop authority paths require non-overridable read-only carve-outs; bubblewrap is required" };
+    }
     // Landlock rulesets compose by union along the path hierarchy: a grant
     // on the root covers its whole subtree, and nothing can subtract a
     // child. An EXISTING protected subpath (a real .git under a writable

--- a/runtime/src/session/mcp-startup.ts
+++ b/runtime/src/session/mcp-startup.ts
@@ -25,6 +25,7 @@ import type {
   CreateMessageResultWithTools,
   SamplingMessageContentBlock,
 } from "@modelcontextprotocol/sdk/types.js";
+import { isDeepStrictEqual } from "node:util";
 
 import type { MCPManager, MCPManagerStartOpts } from "../mcp-client/manager.js";
 import {
@@ -84,6 +85,8 @@ import { createSessionMcpElicitationHandlers } from "../elicitation/mcp.js";
 import type { McpGranularElicitationPolicy } from "../elicitation/mcp.js";
 import { logForDebugging } from "../utils/debug.js";
 import { redactSecrets } from "../secrets/index.js";
+import { sessionMcpAttachmentIssue, redactMcpAttachmentText } from "../mcp-client/local-control.js";
+import { isDesktopAuthorityGrant, verifyDesktopAuthority } from "../mcp-client/desktop-authority.js";
 
 export interface McpStartupCancellationToken {
   readonly signal: AbortSignal;
@@ -798,6 +801,19 @@ function toRuntimeMcpServerConfig(
   } as MCPServerConfig;
 }
 
+/** Only the exact old native global registration is superseded. A similarly
+ * named user/project/plugin service is not evidence of Desktop ownership. */
+function isLegacyNativeDesktopServer(config: MCPServerConfig): boolean {
+  if (config.origin?.scope !== "user" ||
+      (config.name !== "agenc-desktop" && config.name !== "agenc-browser") ||
+      config.transport !== "http") return false;
+  const endpoint = /^http:\/\/127\.0\.0\.1:([1-9]\d{0,4})\/mcp$/.exec(config.endpoint ?? "");
+  if (!endpoint || Number(endpoint[1]) > 65535) return false;
+  const headers = Object.entries(config.headers ?? {});
+  return headers.length === 1 && headers[0]![0].toLowerCase() === "authorization" &&
+    /^Bearer [0-9a-f]{48}$/.test(headers[0]![1]);
+}
+
 /** Resolve one complete policy-checked MCP lifecycle plan for a live session. */
 export async function resolveSessionMcpPlan(
   authority: CanonicalSettingsAuthority,
@@ -832,11 +848,26 @@ export async function resolveSessionMcpPlan(
     scopedSessionServers,
     enabledOverrides,
   );
+  const configs: MCPServerConfig[] = Object.entries(servers).map(([name, config]) => ({
+      ...toRuntimeMcpServerConfig(name, config),
+      // This restriction is runtime-owned, not a configurable permission grant.
+      ...(sessionDispositions[name] === "active" && sessionServers[name]?.localOnly === true
+        ? { localOnly: true, ...(sessionServers[name]?.desktopAuthorityGrant ? { desktopAuthorityGrant: sessionServers[name].desktopAuthorityGrant } : {}) } : {}),
+    }));
+  const privateDesktopActive = configs.some(config =>
+    config.name === "agenc-desktop-control" && config.origin?.scope === "session" &&
+    config.enabled !== false && config.localOnly === true &&
+    // Expiry denies private execution; it must never reactivate an unrelated
+    // old global window. Only explicit disable/removal restores that fallback.
+    isDesktopAuthorityGrant(config.desktopAuthorityGrant));
+  const superseded = new Set(privateDesktopActive
+    ? configs.filter(isLegacyNativeDesktopServer).map(config => config.name)
+    : []);
   return {
-    configs: Object.entries(servers).map(([name, config]) =>
-      toRuntimeMcpServerConfig(name, config),
-    ),
-    definitions,
+    // Reconciliation retires removed bridges, including already captured tool
+    // proxies. This is a session projection, never a global config migration.
+    configs: configs.filter(config => !superseded.has(config.name)),
+    definitions: new Map(Array.from(definitions).filter(([name]) => !superseded.has(name))),
     knownDefinitionIds,
     pluginDefinitionKnowledgeComplete,
     authoritySnapshot,
@@ -1507,7 +1538,10 @@ export function createSessionMcpService(
   };
   const addSessionServerUnlocked = async (
     config: McpSessionServerConfig,
+    replace = false,
   ): Promise<McpServerMutationResult> => {
+    const attachmentIssue = sessionMcpAttachmentIssue(config);
+    if (attachmentIssue) return mcpMutationFailure(config.name, new Error(attachmentIssue));
     const serverNameIssue = mcpServerNameValidationIssue(config.name);
     if (serverNameIssue !== undefined) {
       return {
@@ -1518,10 +1552,15 @@ export function createSessionMcpService(
       };
     }
     const { args: inputArgs, ...inputConfig } = config;
+    let desktopAuthorityGrant;
+    try { desktopAuthorityGrant = await verifyDesktopAuthority(config, options.environment.AGENC_HOME); }
+    catch (error) { return mcpMutationFailure(config.name, error); }
     const candidate: MCPServerConfig = {
       ...inputConfig,
       ...(inputArgs !== undefined ? { args: [...inputArgs] } : {}),
+      ...(config.headers !== undefined ? { headers: Object.freeze({ ...config.headers }) } : {}),
       origin: { scope: "session" },
+      ...(desktopAuthorityGrant ? { desktopAuthorityGrant } : {}),
     };
     try {
       toScopedMcpServerConfig(candidate);
@@ -1548,14 +1587,26 @@ export function createSessionMcpService(
       existingConfig?.origin?.scope === "default" ||
       existingConfig?.origin?.scope === "plugin";
     if (
-      baseline.servers.has(config.name) ||
-      (existingConfig !== undefined && !existingCanBeShadowed)
+      (baseline.servers.has(config.name) && !replace) ||
+      (existingConfig !== undefined && !existingCanBeShadowed &&
+        !(replace && baseline.servers.has(config.name) && existingConfig.origin?.scope === "session"))
     ) {
       return rejectAfterCanonicalReconciliation(
         config.name,
         baseline,
         new Error(`MCP server "${config.name}" is already configured.`),
       );
+    }
+    if (baseline.servers.get(config.name)?.localOnly === true && candidate.localOnly !== true) {
+      return mcpMutationFailure(config.name, new Error("A local-only attachment cannot be downgraded by replacement."));
+    }
+    if (replace && isDeepStrictEqual(baseline.servers.get(config.name), candidate) &&
+      appliedAuthorityGeneration === authorityGeneration &&
+      options.authority.current() === baselinePlan.authoritySnapshot &&
+      baselinePlan.sessionDispositions[config.name] === "active" &&
+      isDeepStrictEqual(existingConfig, runtimeManager.getServerConfig?.(config.name)) &&
+      manager.getConnectionState(config.name)?.type === "connected") {
+      return { serverName: config.name, success: true, toolCount: manager.getToolsByServer(config.name).length };
     }
     const candidateState: SessionMcpOverlayState = {
       servers: new Map(baseline.servers).set(candidate.name, candidate),
@@ -1858,10 +1909,17 @@ export function createSessionMcpService(
       enqueueServerMutation(name, () => setServerEnabledUnlocked(name, true)),
     disableServer: (name) =>
       enqueueServerMutation(name, () => setServerEnabledUnlocked(name, false)),
-    addServer: (config) =>
-      enqueueServerMutation(config.name, () =>
-        addSessionServerUnlocked(config),
-      ),
+    addServer: (config, mutationOptions) => {
+      // Snapshot at ingress; callers cannot mutate credentials while queued.
+      const snapshot = { ...config, ...(config.headers ? { headers: { ...config.headers } } : {}),
+        ...(config.desktopAuthority ? { desktopAuthority: { ...config.desktopAuthority } } : {}),
+        ...(config.args ? { args: [...config.args] } : {}) };
+      return enqueueServerMutation(config.name, () =>
+        addSessionServerUnlocked(snapshot, mutationOptions?.replace === true),
+      ).then(result => result.error === undefined ? result : {
+        ...result, error: redactMcpAttachmentText(result.error, snapshot.headers),
+      });
+    },
     callTool: (serverName, toolName, args, callOptions) => {
       if (closed) return Promise.reject(closedError());
       return manager.callTool(serverName, toolName, args, callOptions);
@@ -2028,9 +2086,12 @@ function createMcpPermissionOptionsForSession(
         };
       },
     }),
-    ...(services.approvalResolver !== undefined
-      ? { approvalResolver: services.approvalResolver }
-      : {}),
+    // The daemon installs its interactive approval bridge after bootstrap.
+    // Do not retain bootstrap's headless resolver inside long-lived MCP tools.
+    approvalResolver: {
+      request: (ctx) => services.approvalResolver?.request(ctx) ??
+        Promise.resolve({ kind: "denied" as const }),
+    },
     ...(services.guardianApprovalReviewer !== undefined
       ? { guardianApprovalReviewer: services.guardianApprovalReviewer }
       : {}),

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -1081,7 +1081,7 @@ export interface McpManager {
   reconnectServer?(name: string): Promise<McpServerMutationResult>;
   enableServer?(name: string): Promise<McpServerMutationResult>;
   disableServer?(name: string): Promise<McpServerMutationResult>;
-  addServer?(config: McpSessionServerConfig): Promise<McpServerMutationResult>;
+  addServer?(config: McpSessionServerConfig, options?: { readonly replace?: boolean }): Promise<McpServerMutationResult>;
   /**
    * Canonical live-manager tool boundary for callers that have already
    * acquired session effect admission. Callers must propagate that admitted
@@ -1176,6 +1176,9 @@ export interface McpSessionServerConfig {
   readonly endpoint?: string;
   readonly enabled?: boolean;
   readonly required?: boolean;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly localOnly?: boolean;
+  readonly desktopAuthority?: { readonly id: string; readonly signature: string };
 }
 
 export interface McpSessionToolInfo {

--- a/runtime/src/tools/BrowserTool/tool.ts
+++ b/runtime/src/tools/BrowserTool/tool.ts
@@ -15,11 +15,13 @@
 
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
 import { validationErrorToolResult } from "../results.js";
+import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 import type { FunctionCallOutputContentItem } from "../context.js";
 import type { PermissionResult, PermissionUpdate } from "../../permissions/types.js";
 import type { ToolEvaluatorContext } from "../../permissions/evaluator.js";
 import { getRuleByContentsForTool } from "../../permissions/rules.js";
 import { BrowserManager } from "../../browser/manager.js";
+import { readBrowserNavigationFailureReceipt } from "../../browser/page.js";
 import {
   isSandboxExecutionBrokerDisposed,
   registerSandboxExecutionLifecycleParticipant,
@@ -90,7 +92,8 @@ function errorResult(message: string): ToolResult {
 /**
  * A refusal made before the browser was touched. A bare error from this
  * mutating tool is filed as an unknown outcome and gates the session behind
- * /resolve (#2190); a failed browser action keeps the bare form.
+ * /resolve (#2190). Only a received navigation failure has a separate,
+ * authoritative completed-command receipt; other action failures stay unknown.
  */
 function refuse(message: string): ToolResult {
   return validationErrorToolResult("tool:Browser:validation", message);
@@ -517,7 +520,24 @@ export function createBrowserTool(
         return await dispatch(input, signal, sandboxExecutionBroker);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        return errorResult(`Browser action failed: ${message}`);
+        const result = errorResult(`Browser action failed: ${message}`);
+        const receipt = readBrowserNavigationFailureReceipt(err);
+        if (
+          receipt === undefined ||
+          (input.action !== "navigate" && input.action !== "new_tab") ||
+          receipt.url !== str(input.url)
+        ) return result;
+        return {
+          ...result,
+          effectDisposition: createToolEffectDispositionEvidence({
+            // Chromium completed the attempted command with an error. This
+            // is not a successful page load and must never claim no effect.
+            disposition: "confirmed_committed",
+            evidenceKind: "provider_receipt",
+            evidenceRef: "tool:Browser:cdp-navigation-response",
+            evidenceMaterial: JSON.stringify(receipt),
+          }),
+        };
       }
     },
   };

--- a/runtime/src/tools/runtimes/sandboxing.ts
+++ b/runtime/src/tools/runtimes/sandboxing.ts
@@ -35,6 +35,7 @@ import type { ToolRuntimeAttemptContext } from "./context.js";
 import { analyzeApplyPatchRuntimeWrites } from "./apply-patch.js";
 import { resolveRuntimePathTarget } from "./paths.js";
 import { analyzeShellRuntimeAccess } from "./shell.js";
+import { desktopAuthorityRoot, overlapsDesktopAuthority, protectDesktopAuthority } from "../../sandbox/desktop-authority-protection.js";
 
 export interface RuntimeSandboxProfileOptions {
   readonly cwd: string;
@@ -293,7 +294,17 @@ export function permissionProfileForRuntimeContext(
         network,
       })
     : permissionProfileFromRuntimePermissions(fileSystem, network);
-  return applyRuntimeAdditionalPermissions(profile, context, options.cwd);
+  return protectDesktopAuthority(
+    applyRuntimeAdditionalPermissions(profile, context, options.cwd),
+    runtimeDesktopAuthorityRoot(context),
+  );
+}
+
+function runtimeDesktopAuthorityRoot(context: ToolRuntimeAttemptContext): string {
+  const session = context.invocation.session as {
+    readonly services?: { readonly configStore?: { readonly homeContext?: { readonly path?: string } } };
+  } | undefined;
+  return desktopAuthorityRoot(session?.services?.configStore?.homeContext?.path);
 }
 
 function applyRuntimeAdditionalPermissions(
@@ -387,6 +398,14 @@ export function enforceRuntimeSandboxAttempt(
   }
   if (!toolMayMutate(input.tool)) return;
   const writes = analyzeWrites(input.tool, input.args, cwd);
+  const authorityRoot = runtimeDesktopAuthorityRoot(input.context);
+  for (const target of writes.targets) {
+    if (overlapsDesktopAuthority(target, authorityRoot)) {
+      throw new SandboxDeniedError("Desktop authority records are reserved for the native host", {
+        denial: "filesystem", target, policy,
+      });
+    }
+  }
   if (writes.indeterminate) {
     if (
       policy.kind === "workspace_write" &&

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -59,6 +59,7 @@ import {
   AgenCBackgroundAgentSuspensionShutdownError,
 } from "./background-agent-runner.js";
 import { resolveAgentRuntimeOptions } from "../session/runtime-options.js";
+import { RemoteAccessBoundary } from "../remote/access.js";
 import {
   MAX_ADDITIONAL_WORKING_DIRECTORIES,
 } from "../contracts/additional-working-directories.js";
@@ -6731,9 +6732,55 @@ describe("AgenC background agent lifecycle", () => {
           messageId: "portal-message-1",
           streamId: "portal-message-1",
           acceptedAt: "2026-05-01T12:10:02.000Z",
+          localMcpAccess: true,
         },
       },
     ]);
+  });
+
+  it("keeps actual remote portal messages non-local through the manager and runner", async () => {
+    const sessions = new AgenCDaemonSessionManager({
+      createSessionId: () => "session_remote_portal",
+      now: () => "2026-09-09T00:00:00.000Z",
+    });
+    const submitted = vi.fn(async () => {});
+    const agents = new AgenCDaemonAgentManager({
+      sessionManager: sessions,
+      runner: {
+        startAgent: async () => ({ agentId: "agent_remote_portal", startedAt: "2026-09-09T00:00:00.000Z", status: "running" }),
+        submitAgentMessage: submitted,
+      },
+    });
+    await createTestAgent(agents, { cwd: process.cwd(), objective: "remote portal provenance" });
+    const remoteAccess = new RemoteAccessBoundary({
+      workspaceId: "workspace_remote_portal",
+      workspacePath: process.cwd(),
+      sessionIds: ["session_remote_portal"],
+      role: "control",
+      allowFiles: false,
+      allowApprovals: false,
+    }, () => true, (id) => sessions.getSession(id), tmpdir());
+    const connection = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: agents,
+      sessionManager: sessions,
+      now: () => "2026-09-09T00:00:01.000Z",
+    }).createConnection({ remoteAccess });
+    await expect(connection.dispatch({
+      jsonrpc: JSON_RPC_VERSION, id: "initialize", method: "initialize",
+      params: { protocol: { version: "1.0.0" }, clientName: "agenc-desktop" },
+    })).resolves.toMatchObject({ result: { type: "initialized" } });
+    const params = { sessionId: "session_remote_portal", content: "remote request", clientMessageId: "remote-message", ifBusy: "reject" };
+    await expect(connection.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "send", method: "message.send", params })).resolves.toMatchObject({ result: { messageId: "remote-message" } });
+    expect(submitted).toHaveBeenCalledExactlyOnceWith("agent_remote_portal", {
+      sessionId: "session_remote_portal", content: "remote request", originalContent: "remote request",
+      messageId: "remote-message", streamId: "remote-message", acceptedAt: "2026-09-09T00:00:01.000Z",
+      ifBusy: "reject", localMcpAccess: false,
+    });
+    // The real browser boundary is stricter than generic daemon ingress:
+    // metadata cannot spoof provenance, and streaming RPC is not admitted.
+    await expect(connection.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "forged", method: "message.send", params: { ...params, metadata: { localMcpAccess: true } } })).resolves.toMatchObject({ error: { data: { code: "REMOTE_MESSAGE_INVALID" } } });
+    await expect(connection.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "stream", method: "message.stream", params })).resolves.toMatchObject({ error: { data: { code: "REMOTE_METHOD_DENIED" } } });
+    expect(submitted).toHaveBeenCalledOnce();
   });
 
   it("dispatches portal background agent dashboard list/start/stop through JSON-RPC", async () => {
@@ -7039,6 +7086,7 @@ describe("AgenC background agent lifecycle", () => {
           messageId: "portal-structured",
           streamId: "portal-structured",
           acceptedAt: "2026-05-01T12:20:02.000Z",
+          localMcpAccess: true,
         },
       },
     ]);

--- a/runtime/tests/app-server/daemon-dispatcher.session-control.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.session-control.contract.test.ts
@@ -24,6 +24,45 @@ async function initialize(connection: {
 }
 
 describe("daemon session-control internal method dispatch", () => {
+  it("validates ephemeral authenticated MCP attachment fields without echoing credentials", async () => {
+    const addMcpServerToSession = vi.fn(async () => ({ sessionId: "session_1", serverName: "agenc-desktop-control", success: true, toolCount: 1 }));
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: { addMcpServerToSession } as never });
+    const connection = dispatcher.createConnection();
+    await initialize(connection);
+    const token = "a".repeat(48);
+    const config = { name: "agenc-desktop-control", transport: "http", endpoint: "http://127.0.0.1:43118/mcp", localOnly: true, headers: { Authorization: `Bearer ${token}` } };
+    const params = { sessionId: "session_1", replace: true, config };
+    await expect(connection.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "attach", method: "session.mcp.addServer", params })).resolves.toMatchObject({ result: { success: true } });
+    expect(addMcpServerToSession).toHaveBeenLastCalledWith(params);
+    for (const malformed of [
+      { ...params, replace: "yes" },
+      { ...params, config: { ...config, localOnly: "yes" } },
+      { ...params, config: { ...config, endpoint: `http://127.0.0.1:43118/mcp?token=${token}` } },
+      { ...params, config: { ...config, headers: { Authorization: `${token}\r\n` } } },
+      { ...params, config: { ...config, headers: { Host: token } } },
+    ]) {
+      const result = await connection.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "invalid", method: "session.mcp.addServer", params: malformed });
+      expect(result).toMatchObject({ error: { code: -32602 } });
+      expect(JSON.stringify(result)).not.toContain(token);
+    }
+    expect(addMcpServerToSession).toHaveBeenCalledOnce();
+  });
+
+  it("derives local/remote turn authority from the connection, not user metadata", async () => {
+    const streamAgentMessage = vi.fn(async () => ({ disposition: "started", acceptedAt: "2026-09-09T00:00:00Z" }));
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: { streamAgentMessage } as never });
+    const local = dispatcher.createConnection();
+    await initialize(local);
+    await local.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "local", method: "message.send", params: { sessionId: "s", content: "open settings", metadata: { localMcpAccess: false } } });
+    expect(streamAgentMessage).toHaveBeenLastCalledWith(expect.objectContaining({ localMcpAccess: true }));
+    const remote = dispatcher.createConnection({ remoteAccess: { authorize: async (method: string) => { if (method === "session.mcp.addServer") throw new Error("denied"); }, allowsMethod: () => true, projection: () => ({}) } as never });
+    await initialize(remote);
+    await remote.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "remote", method: "message.send", params: { sessionId: "s", content: "open settings", metadata: { localMcpAccess: true } } });
+    expect(streamAgentMessage).toHaveBeenLastCalledWith(expect.objectContaining({ localMcpAccess: false }));
+    const forged = await local.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "forged", method: "message.send", params: { sessionId: "s", content: "open settings", localMcpAccess: true } });
+    expect(forged).toMatchObject({ error: { code: -32602 } });
+  });
+
   it("routes the exact SDK 0.3.0 tool-resolution shape and rejects partial hybrids", async () => {
     const resolveSessionToolCall = vi.fn(async () => ({
       sessionId: "session_1",

--- a/runtime/tests/app-server/daemon-dispatcher.session-control.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.session-control.contract.test.ts
@@ -48,18 +48,18 @@ describe("daemon session-control internal method dispatch", () => {
     expect(addMcpServerToSession).toHaveBeenCalledOnce();
   });
 
-  it("derives local/remote turn authority from the connection, not user metadata", async () => {
+  it.each(["message.send", "message.stream"])("derives %s local/remote turn authority from the connection, not user metadata", async (method) => {
     const streamAgentMessage = vi.fn(async () => ({ disposition: "started", acceptedAt: "2026-09-09T00:00:00Z" }));
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: { streamAgentMessage } as never });
     const local = dispatcher.createConnection();
     await initialize(local);
-    await local.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "local", method: "message.send", params: { sessionId: "s", content: "open settings", metadata: { localMcpAccess: false } } });
+    await local.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "local", method, params: { sessionId: "s", content: "open settings", metadata: { localMcpAccess: false } } });
     expect(streamAgentMessage).toHaveBeenLastCalledWith(expect.objectContaining({ localMcpAccess: true }));
     const remote = dispatcher.createConnection({ remoteAccess: { authorize: async (method: string) => { if (method === "session.mcp.addServer") throw new Error("denied"); }, allowsMethod: () => true, projection: () => ({}) } as never });
     await initialize(remote);
-    await remote.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "remote", method: "message.send", params: { sessionId: "s", content: "open settings", metadata: { localMcpAccess: true } } });
+    await remote.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "remote", method, params: { sessionId: "s", content: "open settings", metadata: { localMcpAccess: true } } });
     expect(streamAgentMessage).toHaveBeenLastCalledWith(expect.objectContaining({ localMcpAccess: false }));
-    const forged = await local.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "forged", method: "message.send", params: { sessionId: "s", content: "open settings", localMcpAccess: true } });
+    const forged = await local.dispatch({ jsonrpc: JSON_RPC_VERSION, id: "forged", method, params: { sessionId: "s", content: "open settings", localMcpAccess: true } });
     expect(forged).toMatchObject({ error: { code: -32602 } });
   });
 

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -463,6 +463,25 @@ describe("AgenC daemon protocol surface", () => {
     ).toBe(false);
   });
 
+  it("publishes the private Desktop attachment without loosening other request fields", () => {
+    const validate = compileRequestValidator(readProtocolSchema());
+    const config = {
+      name: "agenc-desktop-control", transport: "http",
+      endpoint: "http://127.0.0.1:12345/mcp", localOnly: true,
+      headers: { Authorization: "Bearer fixture-only" },
+      desktopAuthority: { id: "fixture-authority", signature: "fixture-proof" },
+    };
+    const request = (patch: Record<string, unknown> = {}) => ({
+      jsonrpc: JSON_RPC_VERSION, id: "desktop-attach", method: "session.mcp.addServer",
+      params: { sessionId: "session_1", config, replace: true, ...patch },
+    });
+    expect(validate(request()), JSON.stringify(validate.errors)).toBe(true);
+    expect(validate(request({ config: { ...config, headers: { Authorization: 1 } } }))).toBe(false);
+    expect(validate(request({ config: { ...config, desktopAuthority: { ...config.desktopAuthority, trusted: true } } }))).toBe(false);
+    expect(validate(request({ replace: "true" }))).toBe(false);
+    expect(validate(request({ trusted: true }))).toBe(false);
+  });
+
   it("publishes only passive, non-authority MCP status fields", () => {
     const validate = compileDefinitionValidator(
       readProtocolSchema(),

--- a/runtime/tests/bin/agenc.user-prompt-submit.test.ts
+++ b/runtime/tests/bin/agenc.user-prompt-submit.test.ts
@@ -11,6 +11,8 @@ import {
   type PreparedTurnRuntimeInputs,
 } from "./agenc-main.js";
 import { __installDaemonTurnDriverHooksForTest } from "../app-server/background-agent-runner.js";
+import { DAEMON_LOCAL_MCP_ACCESS, DAEMON_USER_PROMPT_PREPARED } from "../app-server/background-agent-runner/shared.js";
+import { hasLocalMcpAccess } from "../mcp-client/local-control.js";
 import { defaultConfig } from "../config/schema.js";
 import {
   resolveProjectTrustRootSync,
@@ -620,6 +622,24 @@ describe("UserPromptSubmit prompt ingress", () => {
         }),
       }),
     );
+  });
+
+  it("carries trusted local MCP authority through the actual turn driver and revokes it afterward", async () => {
+    const { session } = fakeSession("/workspace");
+    const observed: boolean[] = [];
+    const runTurnFn = vi.fn(async function* () {
+      await Promise.resolve();
+      observed.push(hasLocalMcpAccess());
+      yield { type: "turn_complete", content: "ok", usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 }, stopReason: "completed" } satisfies PhaseEvent;
+      return { reason: "completed" };
+    });
+    __installDaemonTurnDriverHooksForTest(session as never, { current: () => defaultConfig } as never, runTurnFn as never);
+    await session.submit("local", { [DAEMON_USER_PROMPT_PREPARED]: true, [DAEMON_LOCAL_MCP_ACCESS]: true });
+    expect(hasLocalMcpAccess()).toBe(false);
+    await session.submit("remote", { [DAEMON_USER_PROMPT_PREPARED]: true, [DAEMON_LOCAL_MCP_ACCESS]: false });
+    await session.submit("unknown", { [DAEMON_USER_PROMPT_PREPARED]: true, localMcpAccess: true });
+    expect(observed).toEqual([true, false, false]);
+    expect(hasLocalMcpAccess()).toBe(false);
   });
 
   it("runs the owning daemon session hook exactly once and sends its context to the model", async () => {

--- a/runtime/tests/browser/manager-navigation-failure.test.ts
+++ b/runtime/tests/browser/manager-navigation-failure.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChildProcess } from "node:child_process";
+
+const { launchBrowserMock } = vi.hoisted(() => ({ launchBrowserMock: vi.fn() }));
+vi.mock("../../src/browser/cdp.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/browser/cdp.js")>(),
+  launchBrowser: launchBrowserMock,
+}));
+vi.mock("../../src/browser/proxy.js", () => ({
+  BrowserProxy: class {
+    async start() { return 4321; }
+    async stop() {}
+    takeBlockReason() { return undefined; }
+  },
+}));
+vi.mock("../../src/utils/supervisedProcess.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/utils/supervisedProcess.js")>(),
+  terminateProcessTreeAndWait: vi.fn(async () => {}),
+  signalProcessTree: vi.fn(),
+}));
+
+import { BrowserManager } from "../../src/browser/manager.js";
+import { CdpError, type CdpConnection, type CdpSendOptions } from "../../src/browser/cdp.js";
+import { readBrowserNavigationFailureReceipt } from "../../src/browser/page.js";
+
+let profileRoot = "";
+const managers: BrowserManager[] = [];
+
+beforeEach(async () => {
+  profileRoot = await mkdtemp(join(tmpdir(), "agenc-browser-navigation-test-"));
+});
+afterEach(async () => {
+  for (const manager of managers.splice(0)) await manager.closeAll();
+  await rm(profileRoot, { recursive: true, force: true });
+  launchBrowserMock.mockReset();
+});
+
+function fakeManager(navigation: (options: CdpSendOptions) => Promise<Record<string, unknown>>) {
+  let created = 0;
+  let currentUrl = "about:blank";
+  const connection = {
+    closed: false,
+    close() { this.closed = true; },
+    on: vi.fn(() => () => {}),
+    waitFor: vi.fn(async () => ({})),
+    send: vi.fn(async (
+      method: string,
+      params: Record<string, unknown> = {},
+      _sessionId?: string,
+      options: CdpSendOptions = {},
+    ): Promise<Record<string, unknown>> => {
+      if (options.signal?.aborted) throw new CdpError(`CDP command aborted: ${method}`);
+      if (method === "Target.createTarget") return { targetId: `target-${++created}` };
+      if (method === "Target.attachToTarget") return { sessionId: `session-${created}` };
+      if (method === "Page.navigate") {
+        const result = await navigation(options);
+        currentUrl = result.errorText ? "chrome-error://chromewebdata/" : String(params.url);
+        return result;
+      }
+      if (method === "Runtime.evaluate") {
+        return { result: { value: JSON.stringify({ url: currentUrl, title: "Test tab" }) } };
+      }
+      return {};
+    }),
+  };
+  launchBrowserMock.mockResolvedValue({
+    child: new EventEmitter() as ChildProcess,
+    connection: connection as unknown as CdpConnection,
+  });
+  const manager = new BrowserManager({
+    agencHome: profileRoot,
+    policy: {
+      executablePath: process.execPath,
+      headless: true, allowPrivateNetwork: false, noSandbox: false, navigationTimeoutMs: 1_000,
+    },
+  });
+  managers.push(manager);
+  return { manager, connection };
+}
+
+describe("failed browser navigation retains its target", () => {
+  it("keeps a first failed navigation inspectable and reuses its tab on the next navigate", async () => {
+    const response = vi.fn()
+      .mockResolvedValueOnce({ frameId: "frame-1", errorText: "net::ERR_HTTP2_PROTOCOL_ERROR" })
+      .mockResolvedValue({ frameId: "frame-1" });
+    const { manager, connection } = fakeManager(response);
+    const error = await manager.navigate("https://example.com/first").catch((failure: unknown) => failure);
+    expect(readBrowserNavigationFailureReceipt(error)).toMatchObject({
+      targetId: "target-1", sessionId: "session-1", errorText: "net::ERR_HTTP2_PROTOCOL_ERROR",
+    });
+    expect(await manager.listTabs()).toEqual([{
+      id: 1, active: true, title: "Test tab", url: "chrome-error://chromewebdata/",
+    }]);
+    await manager.navigate("https://example.com/second");
+    expect(await manager.listTabs()).toMatchObject([{ id: 1, url: "https://example.com/second" }]);
+    expect(connection.send.mock.calls.filter(([method]) => method === "Target.createTarget")).toHaveLength(1);
+  });
+
+  it("keeps a new_tab navigation failure addressable by its tab id", async () => {
+    const { manager, connection } = fakeManager(async () => ({ errorText: "net::ERR_HTTP2_PROTOCOL_ERROR" }));
+    await expect(manager.newTab("https://example.com/first")).rejects.toThrow("navigation failed");
+    expect(await manager.listTabs()).toHaveLength(1);
+    await manager.closeTab(1);
+    expect(connection.send).toHaveBeenCalledWith("Target.closeTarget", { targetId: "target-1" });
+    expect(await manager.listTabs()).toEqual([]);
+  });
+
+  it.each(["navigate", "new_tab"] as const)("propagates the caller signal throughout first %s", async (action) => {
+    const { manager, connection } = fakeManager(async () => ({ frameId: "frame-1" }));
+    const controller = new AbortController();
+    if (action === "navigate") await manager.navigate("https://example.com/", undefined, controller.signal);
+    else await manager.newTab("https://example.com/", controller.signal);
+    for (const method of ["Target.createTarget", "Target.attachToTarget", "Page.enable", "Runtime.enable", "DOM.enable", "Page.navigate"]) {
+      const call = connection.send.mock.calls.find(([called]) => called === method);
+      expect(call?.[3]?.signal, method).toBe(controller.signal);
+    }
+  });
+
+  it("keeps a first-navigation abort unknown and its already-created tab tracked", async () => {
+    const started = Promise.withResolvers<void>();
+    const { manager } = fakeManager(async (options) => new Promise((_resolve, reject) => {
+      started.resolve();
+      if (!options.signal) {
+        reject(new Error("missing caller signal"));
+        return;
+      }
+      options.signal.addEventListener("abort", () => reject(new CdpError("CDP command aborted: Page.navigate")), { once: true });
+    }));
+    const controller = new AbortController();
+    const pending = manager.navigate("https://example.com/", undefined, controller.signal)
+      .catch((error: unknown) => error);
+    await started.promise;
+    controller.abort();
+    const error = await pending;
+    expect(error).toBeInstanceOf(CdpError);
+    expect(readBrowserNavigationFailureReceipt(error)).toBeUndefined();
+    expect(await manager.listTabs()).toHaveLength(1);
+  });
+});

--- a/runtime/tests/browser/navigation-outcome.test.ts
+++ b/runtime/tests/browser/navigation-outcome.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  BrowserActionError,
+  BrowserPage,
+  readBrowserNavigationFailureReceipt,
+} from "../../src/browser/page.js";
+import { CdpError, type CdpConnection, type CdpSendOptions } from "../../src/browser/cdp.js";
+import { createBrowserTool } from "../../src/tools/BrowserTool/tool.js";
+import {
+  SandboxExecutionBroker,
+  attachSandboxExecutionBroker,
+} from "../../src/sandbox/execution-broker.js";
+import { disposeSandboxExecutionBroker } from "../../src/sandbox/execution-lifecycle.js";
+import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
+import { bindAdmittedToolHarness } from "../helpers/admitted-tool-harness.js";
+
+const URL = "https://example.com/article";
+const HTTP2_FAILURE = {
+  frameId: "frame-1", loaderId: "loader-1", errorText: "net::ERR_HTTP2_PROTOCOL_ERROR",
+};
+const brokers: SandboxExecutionBroker[] = [];
+
+afterEach(async () => {
+  for (const broker of brokers.splice(0)) await disposeSandboxExecutionBroker(broker);
+});
+
+function fakePage(navigate: () => Promise<Record<string, unknown>>) {
+  const connection = {
+    closed: false,
+    send: vi.fn(async (method: string, _params?: unknown, _session?: string, _options?: CdpSendOptions) => {
+      if (method === "Page.navigate") return navigate();
+      if (method === "Runtime.evaluate") {
+        return { result: { value: JSON.stringify({ url: URL, title: "Article" }) } };
+      }
+      return {};
+    }),
+    waitFor: vi.fn(async () => ({})),
+  };
+  const page = new BrowserPage({
+    connection: connection as unknown as CdpConnection,
+    targetId: "target-1", sessionId: "cdp-session-1", navigationTimeoutMs: 1_000,
+  });
+  return { page, connection };
+}
+
+function fakeBrowser(navigate: () => Promise<Record<string, unknown>>) {
+  const { page, connection } = fakePage(navigate);
+  const manager = {
+    navigate: vi.fn(async (url: string, _tab?: number, signal?: AbortSignal) => {
+      await page.navigate(url, signal);
+      return page;
+    }),
+    closeAll: vi.fn(async () => {}),
+  };
+  const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd: process.cwd() });
+  brokers.push(broker);
+  const tool = createBrowserTool({ manager: manager as never });
+  const args: Record<string, unknown> = { action: "navigate", url: URL };
+  attachSandboxExecutionBroker(args, broker, "browser");
+  return { tool, args, manager, page, connection };
+}
+
+describe("known browser navigation outcomes", () => {
+  it("attests only the received Page.navigate failure with its exact CDP identity", async () => {
+    const { page, connection } = fakePage(async () => HTTP2_FAILURE);
+    const error = await page.navigate(URL).catch((failure: unknown) => failure);
+    expect(error).toBeInstanceOf(BrowserActionError);
+    expect(readBrowserNavigationFailureReceipt(error)).toEqual({
+      command: "Page.navigate", targetId: "target-1", sessionId: "cdp-session-1",
+      url: URL, ...HTTP2_FAILURE,
+    });
+    expect(connection.waitFor).not.toHaveBeenCalled();
+    expect(readBrowserNavigationFailureReceipt(new BrowserActionError(
+      `navigation failed: ${HTTP2_FAILURE.errorText} (${URL})`,
+    ))).toBeUndefined();
+    expect(readBrowserNavigationFailureReceipt({ ...readBrowserNavigationFailureReceipt(error) })).toBeUndefined();
+  });
+
+  it("keeps the visible error and supplies committed-command evidence, never no-effect", async () => {
+    const browser = fakeBrowser(async () => HTTP2_FAILURE);
+    const result = await browser.tool.execute(browser.args);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(HTTP2_FAILURE.errorText);
+    expect(result.effectDisposition).toEqual({
+      disposition: "confirmed_committed", evidenceKind: "provider_receipt",
+      evidenceRef: "tool:Browser:cdp-navigation-response",
+      evidenceSha256: createHash("sha256").update(JSON.stringify({
+        command: "Page.navigate", targetId: "target-1", sessionId: "cdp-session-1",
+        url: URL, errorText: HTTP2_FAILURE.errorText,
+        frameId: "frame-1", loaderId: "loader-1",
+      })).digest("hex"),
+    });
+    expect(result.content).not.toContain("evidenceSha256");
+  });
+
+  it.each(["CDP command timed out: Page.navigate", "CDP connection closed", "CDP command aborted: Page.navigate"])(
+    "does not manufacture a receipt for %s", async (message) => {
+      const error = new CdpError(message);
+      const browser = fakeBrowser(async () => { throw error; });
+      const result = await browser.tool.execute(browser.args);
+      expect(result).toMatchObject({ isError: true });
+      expect(result.effectDisposition).toBeUndefined();
+      expect(readBrowserNavigationFailureReceipt(error)).toBeUndefined();
+    },
+  );
+
+  it("does not accept a malformed error response as success or receipt", async () => {
+    const browser = fakeBrowser(async () => ({ errorText: 123 }));
+    const result = await browser.tool.execute(browser.args);
+    expect(result).toMatchObject({ isError: true });
+    expect(result.effectDisposition).toBeUndefined();
+  });
+
+  it("does not reuse a received navigation receipt for another URL", async () => {
+    const { page } = fakePage(async () => HTTP2_FAILURE);
+    const earlier = await page.navigate(URL).catch((error: unknown) => error);
+    const browser = fakeBrowser(async () => { throw earlier; });
+    browser.args.url = "https://example.com/other";
+    const result = await browser.tool.execute(browser.args);
+    expect(result.isError).toBe(true);
+    expect(result.effectDisposition).toBeUndefined();
+  });
+
+  it("keeps a proxy policy refusal distinct from a received network error", async () => {
+    const { connection } = fakePage(async () => HTTP2_FAILURE);
+    const page = new BrowserPage({
+      connection: connection as unknown as CdpConnection,
+      targetId: "target-1", sessionId: "session-1", navigationTimeoutMs: 1_000,
+      blockReporter: () => "private destination denied",
+    });
+    const error = await page.navigate(URL).catch((failure: unknown) => failure);
+    expect(error).toBeInstanceOf(BrowserActionError);
+    expect(String(error)).toContain("navigation blocked");
+    expect(readBrowserNavigationFailureReceipt(error)).toBeUndefined();
+  });
+
+  it("preserves abort and transport loss during the post-navigation load wait", async () => {
+    for (const stopped of ["abort", "disconnect"]) {
+      const controller = new AbortController();
+      const { page, connection } = fakePage(async () => ({ frameId: "frame-1" }));
+      const error = new CdpError("load wait interrupted");
+      connection.waitFor.mockImplementation(async () => {
+        if (stopped === "abort") controller.abort();
+        else connection.closed = true;
+        throw error;
+      });
+      await expect(page.navigate(URL, controller.signal)).rejects.toBe(error);
+      expect(readBrowserNavigationFailureReceipt(error)).toBeUndefined();
+    }
+  });
+});
+
+describe("browser admitted effect settlement", () => {
+  it("records a received navigation error as committed and permits a later operation", async () => {
+    const response = vi.fn()
+      .mockResolvedValueOnce(HTTP2_FAILURE)
+      .mockResolvedValue({ frameId: "frame-1" });
+    const browser = fakeBrowser(response);
+    const harness = bindAdmittedToolHarness({ workspaceRoot: process.cwd(), label: "browser-known" });
+    const invoke = () => browser.tool.execute(browser.args);
+    const first = await runAdmittedToolCall({
+      session: harness.session, tool: browser.tool, args: browser.args,
+      turnId: "turn-browser-known", callId: "known-failure",
+      invoke: async ({ crossEffectBoundary }) => { crossEffectBoundary(); return invoke(); },
+    });
+    expect(first.isError).toBe(true);
+    expect(harness.events.filter((event) => event.msg.type === "effect_unknown_outcome")).toHaveLength(0);
+    expect(harness.events.find((event) => event.msg.type === "effect_result")?.msg).toMatchObject({
+      type: "effect_result", payload: { outcome: "committed", effectBoundary: "crossed" },
+    });
+    await expect(runAdmittedToolCall({
+      session: harness.session, tool: browser.tool, args: browser.args,
+      turnId: "turn-browser-known", callId: "next-navigation",
+      invoke: async ({ crossEffectBoundary }) => { crossEffectBoundary(); return invoke(); },
+    })).resolves.toMatchObject({ content: expect.stringContaining("Navigated to") });
+    expect(browser.manager.navigate).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps real unknown outcomes gated and never resolves an older record", async () => {
+    const browser = fakeBrowser(async () => { throw new CdpError("CDP connection closed"); });
+    const harness = bindAdmittedToolHarness({ workspaceRoot: process.cwd(), label: "browser-unknown" });
+    await runAdmittedToolCall({
+      session: harness.session, tool: browser.tool, args: browser.args,
+      turnId: "turn-browser-unknown", callId: "lost-ack",
+      invoke: async ({ crossEffectBoundary }) => {
+        crossEffectBoundary(); return browser.tool.execute(browser.args);
+      },
+    });
+    expect(harness.events.find((event) => event.msg.type === "effect_unknown_outcome")?.msg).toMatchObject({
+      type: "effect_unknown_outcome", payload: {
+        callId: "lost-ack", requiresReview: true,
+        reason: "tool_error_result_without_authoritative_effect_disposition",
+      },
+    });
+    const later = vi.fn(async () => ({ content: "must not execute" }));
+    await expect(runAdmittedToolCall({
+      session: harness.session, tool: browser.tool, args: browser.args,
+      turnId: "turn-browser-unknown", callId: "later-navigation", invoke: later,
+    })).rejects.toThrow("live effect settlement is unresolved");
+    expect(later).not.toHaveBeenCalled();
+    expect(browser.manager.navigate).toHaveBeenCalledOnce();
+    expect(harness.events.filter((event) => event.msg.type === "effect_review_resolved")).toHaveLength(0);
+  });
+});

--- a/runtime/tests/mcp-client/desktop-authority.test.ts
+++ b/runtime/tests/mcp-client/desktop-authority.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, chmod, rm, symlink, realpath, rename } from "node:fs/promises";
+import { createServer, type Server } from "node:net";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createHash, generateKeyPairSync, randomUUID, sign } from "node:crypto";
+import { desktopAuthorityProofIssue, verifyDesktopAuthority, desktopToolClassification, hasDesktopAuthority, attestDesktopEndpoint, assertDesktopSocketBinding } from "./desktop-authority.js";
+import { createToolBridge } from "./tools.js";
+import { ResilientMCPBridge, toToolCatalogPolicyConfig } from "./resilient-client.js";
+import { withLocalMcpAccess, desktopControlEffectReceipt } from "./local-control.js";
+import { hasPermissionsToUseTool } from "../permissions/evaluator.js";
+import { createEmptyToolPermissionContext } from "../permissions/types.js";
+import { freshDenialTracking } from "../permissions/denial-tracking.js";
+import { attachToolRuntimeContext, type ToolRuntimeAttemptContext } from "../tools/runtimes/context.js";
+import { SandboxExecutionBroker, attachSandboxExecutionBroker } from "../sandbox/execution-broker.js";
+
+const roots: string[] = [];
+const servers: Server[] = [];
+afterEach(async () => { vi.useRealTimers(); await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => server.close(() => resolve())))); await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))); });
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "agenc-desktop-authority-")); roots.push(root);
+  await chmod(root, 0o700);
+  const directory = join(root, "desktop-control-authorities"); await mkdir(directory, { mode: 0o700 });
+  const keys = generateKeyPairSync("ed25519");
+  const socketRoot = await mkdtemp(join(await realpath("/tmp"), "agenc-dc-")); roots.push(socketRoot); await chmod(socketRoot, 0o700);
+  const socketPath = join(socketRoot, "control.sock");
+  const socketServer = createServer(); servers.push(socketServer);
+  await new Promise<void>((resolve, reject) => { socketServer.once("error", reject); socketServer.listen(socketPath, resolve); }); await chmod(socketPath, 0o600);
+  const id = randomUUID(); const file = join(directory, `${id}.json`);
+  const config = { name: "agenc-desktop-control", endpoint: "http://127.0.0.1:43219/mcp", transport: "http" as const, localOnly: true, headers: { Authorization: `Bearer ${"a".repeat(48)}` }, origin: { scope: "session" as const } };
+  const payload = JSON.stringify([2, config.name, config.endpoint, createHash("sha256").update(config.headers.Authorization).digest("hex"), 1, socketPath]);
+  const proof = { id, signature: sign(null, Buffer.from(payload), keys.privateKey).toString("base64") };
+  const record = { version: 2, publicKey: keys.publicKey.export({ type: "spki", format: "pem" }), expiresAt: Date.now() + 600_000, socketPath };
+  await writeFile(file, JSON.stringify(record), { mode: 0o600 });
+  return { root, directory, file, record, keys, socketRoot, socketPath, config: { ...config, desktopAuthority: proof } };
+}
+describe("operator-bootstrapped Desktop control authority", () => {
+  it("requires a signed, private operator record bound to endpoint and credential", async () => {
+    const f = await fixture();
+    const grant = await verifyDesktopAuthority(f.config, f.root);
+    expect(hasDesktopAuthority(grant)).toBe(true);
+    await writeFile(f.file, JSON.stringify({ ...f.record, expiresAt: f.record.expiresAt + 60_000 }));
+    const renewed = await verifyDesktopAuthority(f.config, f.root);
+    expect(renewed?.expiresAt).toBe(f.record.expiresAt + 60_000);
+    expect(renewed).not.toEqual(grant);
+    expect(desktopToolClassification(grant, "desktop_state")).toBe("read");
+    expect(desktopToolClassification(grant, "desktop_settings_open")).toBe("ui-mutation");
+    expect(desktopToolClassification({ ...grant! }, "desktop_state")).toBeUndefined();
+    for (const name of ["terminal_open", "terminal_run", "terminal_type", "terminal_close", "browser_download", "desktop_evil"]) expect(desktopToolClassification(grant, name)).toBeUndefined();
+    for (const override of [{ endpoint: "http://127.0.0.1:43220/mcp" }, { name: "other" }, { localOnly: false }, { headers: { Authorization: `Bearer ${"b".repeat(48)}` } }, { desktopAuthority: { ...f.config.desktopAuthority, signature: Buffer.alloc(64).toString("base64") } }]) {
+      await expect(verifyDesktopAuthority({ ...f.config, ...override }, f.root)).rejects.toThrow("could not be verified");
+    }
+    expect(await verifyDesktopAuthority({ ...f.config, desktopAuthority: undefined }, undefined)).toBeUndefined();
+    await expect(verifyDesktopAuthority(f.config, undefined)).rejects.toThrow("could not be verified");
+  });
+  it("accepts only call-bound outcomes from a live verified Desktop authority", async () => {
+    const f = await fixture(); const grant = await verifyDesktopAuthority(f.config, f.root);
+    const receipt = { version: 1, toolUseId: "call-1", toolName: "browser_open_tab", disposition: "confirmed_committed", evidence: "Navigation reached a known error page." };
+    const raw = { isError: true, _meta: { "agenc.desktopControl.effect": receipt } };
+    const options = { serverName: f.config.name, toolName: receipt.toolName, toolUseId: receipt.toolUseId, localOnly: true, sensitiveHeaders: f.config.headers, desktopAuthorityGrant: grant };
+    await withLocalMcpAccess(true, async () => {
+      expect(desktopControlEffectReceipt(raw, options)).toMatchObject({ disposition: "confirmed_committed", evidenceKind: "provider_receipt" });
+      for (const override of [{ serverName: "other" }, { localOnly: false }, { toolUseId: "other" }, { toolName: "other" }, { sensitiveHeaders: undefined }, { desktopAuthorityGrant: undefined }, { desktopAuthorityGrant: { ...grant! } }]) expect(desktopControlEffectReceipt(raw, { ...options, ...override })).toBeUndefined();
+      for (const override of [{ version: 2 }, { disposition: "remains_unknown" }, { evidence: "" }, { evidence: "x".repeat(2049) }, { extra: true }]) expect(desktopControlEffectReceipt({ _meta: { "agenc.desktopControl.effect": { ...receipt, ...override } } }, options)).toBeUndefined();
+    });
+  });
+  it("requires fresh live proof without sending Authorization to a fake rebound port", async () => {
+    const f = await fixture(); const grant = await verifyDesktopAuthority(f.config, f.root);
+    const config = { ...f.config, desktopAuthorityGrant: grant };
+    const requests: RequestInit[] = [];
+    const live: typeof fetch = async (_url, init) => {
+      requests.push(init!);
+      const body = JSON.parse(String(init?.body));
+      const material = JSON.stringify([3, config.name, config.endpoint, body.authorizationHash, body.nonce, f.socketPath]);
+      return new Response(JSON.stringify({ signature: sign(null, Buffer.from(material), f.keys.privateKey).toString("base64") }));
+    };
+    await attestDesktopEndpoint(config, live);
+    await attestDesktopEndpoint(config, live);
+    expect(requests[0].body).not.toBe(requests[1].body);
+    for (const request of requests) {
+      expect(new Headers(request.headers).has("authorization")).toBe(false);
+      expect(String(request.body)).not.toContain(config.headers.Authorization);
+    }
+    const rebound = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({ signature: Buffer.alloc(64).toString("base64") })));
+    await expect(attestDesktopEndpoint(config, rebound)).rejects.toThrow("Live Desktop");
+    expect(rebound).toHaveBeenCalledOnce();
+    expect(new Headers(rebound.mock.calls[0][1]?.headers).has("authorization")).toBe(false);
+  });
+  it("fails closed on expired records, unsafe modes, symlinks and malformed proof", async () => {
+    const f = await fixture();
+    for (const value of [null, {}, { id: "../escape", signature: f.config.desktopAuthority.signature }, { ...f.config.desktopAuthority, extra: true }]) expect(desktopAuthorityProofIssue(value)).toBeTruthy();
+    await chmod(f.file, 0o644); await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow();
+    await chmod(f.file, 0o600);
+    await chmod(f.directory, 0o755); await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow();
+    await chmod(f.directory, 0o700);
+    await writeFile(f.file, JSON.stringify({ ...f.record, expiresAt: Date.now() - 1 })); await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow();
+    await rm(f.file); await symlink(join(f.root, "outside"), f.file); await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow();
+  });
+  it("pins a private Unix socket identity and rejects unsafe or replaced endpoints", async () => {
+    const f = await fixture(); const grant = (await verifyDesktopAuthority(f.config, f.root))!;
+    await expect(assertDesktopSocketBinding(grant)).resolves.toBeUndefined();
+    await chmod(f.socketPath, 0o666); await expect(assertDesktopSocketBinding(grant)).rejects.toThrow("private socket authority");
+    await chmod(f.socketPath, 0o600);
+    await chmod(f.socketRoot, 0o755); await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow();
+    await chmod(f.socketRoot, 0o700);
+    await rename(f.socketPath, join(f.socketRoot, "old.sock"));
+    const replacement = createServer(); servers.push(replacement);
+    await new Promise<void>(resolve => replacement.listen(f.socketPath, resolve)); await chmod(f.socketPath, 0o600);
+    await expect(assertDesktopSocketBinding(grant)).rejects.toThrow("private socket authority");
+    const next = await verifyDesktopAuthority(f.config, f.root);
+    expect(next?.socketIdentity).not.toBe(grant.socketIdentity);
+    await writeFile(f.file, JSON.stringify({ ...f.record, version: 1 }));
+    await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow();
+  });
+  it("classifies only verified operations, retains approvals and revokes expired proxies", async () => {
+    const f = await fixture();
+    const grant = await verifyDesktopAuthority(f.config, f.root);
+    const callTool = vi.fn(async () => ({ content: [] }));
+    const client = { listTools: async () => ({ tools: ["desktop_state", "desktop_settings_open", "terminal_run"].map(name => ({ name, annotations: { readOnlyHint: true } })) }), callTool, close: async () => {} };
+    const config = { ...f.config, desktopAuthorityGrant: grant };
+    const bridge = await createToolBridge(client, config.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig(config) });
+    const resilient = new ResilientMCPBridge(config, bridge);
+    expect(resilient.tools[0]).toMatchObject({ isReadOnly: true, metadata: { mutating: false } });
+    expect(resilient.tools[1]).toMatchObject({ requiresApproval: true, metadata: { mutating: true, virtualNoFsWrites: true } });
+    expect(resilient.tools[2].isReadOnly).toBeUndefined(); expect(resilient.tools[2].metadata?.virtualNoFsWrites).toBeUndefined();
+    for (const mode of ["default", "plan"] as const) {
+      const context = { session: { services: {} } as never, getAppState: () => ({ toolPermissionContext: { ...createEmptyToolPermissionContext(), mode }, denialTracking: freshDenialTracking(), autoModeActive: false }) };
+      expect((await hasPermissionsToUseTool(resilient.tools[0], {}, context)).behavior).toBe("allow");
+      expect((await hasPermissionsToUseTool(resilient.tools[1], {}, context)).behavior).toBe(mode === "plan" ? "deny" : "ask");
+    }
+    vi.useFakeTimers(); vi.setSystemTime(f.record.expiresAt + 1);
+    const refused = await withLocalMcpAccess(true, () => resilient.tools[0].execute({}));
+    expect(refused).toMatchObject({ isError: true, effectDisposition: { disposition: "confirmed_no_effect" } });
+    expect(callTool).not.toHaveBeenCalled();
+    await resilient.dispose();
+    const unsigned = await createToolBridge(client, f.config.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig(f.config) });
+    expect(unsigned.tools[0].isReadOnly).toBeUndefined(); expect(unsigned.tools[1].metadata?.virtualNoFsWrites).toBeUndefined();
+    await unsigned.dispose();
+  });
+  it("reuses only an exact runtime-approved Desktop invocation, never forged or stale context", async () => {
+    const f = await fixture();
+    const grant = await verifyDesktopAuthority(f.config, f.root);
+    const session = { services: {} } as never;
+    const canUseTool = vi.fn(async () => ({ behavior: "deny" as const, message: "unapproved" }));
+    const callTool = vi.fn(async () => ({ content: [] }));
+    const toolName = "mcp.agenc-desktop-control.desktop_settings_open";
+    const bridge = await createToolBridge({ listTools: async () => ({ tools: [{ name: "desktop_settings_open" }] }), callTool, close: async () => {} }, f.config.name, undefined, {
+      environment: {}, serverConfig: toToolCatalogPolicyConfig({ ...f.config, desktopAuthorityGrant: grant }),
+      permissions: { session, getActiveTurnId: () => "turn-1", canUseTool,
+        permissionContext: { session, getAppState: () => ({ toolPermissionContext: createEmptyToolPermissionContext(), denialTracking: freshDenialTracking(), autoModeActive: false }) } },
+    });
+    const invoke = async (override: Partial<ToolRuntimeAttemptContext> = {}, forge = false, local = true) => {
+      const args = { section: "appearance" };
+      Object.defineProperty(args, "__callId", { value: "call-1" });
+      const context = { callId: "call-1", toolName, approvalResolved: true, sandboxMode: "workspace_write", rawArgs: JSON.stringify(args), invocation: { callId: "call-1", session, turn: { subId: "turn-1" } }, ...override } as ToolRuntimeAttemptContext;
+      if (forge) Object.defineProperty(args, "__toolRuntimeContext", { value: context });
+      else attachToolRuntimeContext(args, context);
+      return withLocalMcpAccess(local, () => bridge.tools[0].execute(args));
+    };
+    expect((await invoke()).isError).not.toBe(true);
+    expect(canUseTool).not.toHaveBeenCalled(); expect(callTool).toHaveBeenCalledOnce();
+    for (const override of [{ callId: "other" }, { toolName: "other" }, { approvalResolved: false }, { rawArgs: '{}' }, { invocation: { callId: "call-1", session, turn: { subId: "old" } } as never }, { invocation: { callId: "call-1", session: {} as never, turn: { subId: "turn-1" } } as never }]) expect((await invoke(override)).isError).toBe(true);
+    expect((await invoke({}, true)).isError).toBe(true);
+    expect((await invoke({}, false, false)).isError).toBe(true);
+    expect(callTool).toHaveBeenCalledOnce();
+    await bridge.dispose();
+  });
+  it("never upgrades native PTY authority with ordinary approvals or one-shot escalation", async () => {
+    const f = await fixture(); const grant = await verifyDesktopAuthority(f.config, f.root);
+    const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd: f.root });
+    const session = { services: { sandboxExecutionBroker: broker } } as never;
+    const callTool = vi.fn(async () => ({ content: [] }));
+    const canUseTool = vi.fn(async () => ({ behavior: "allow" as const }));
+    const bridge = await createToolBridge({ listTools: async () => ({ tools: ["terminal_open", "terminal_run", "terminal_type", "terminal_close"].map(name => ({ name })) }), callTool, close: async () => {} }, f.config.name, undefined, {
+      environment: {}, serverConfig: toToolCatalogPolicyConfig({ ...f.config, desktopAuthorityGrant: grant }), permissions: { session, getActiveTurnId: () => "turn-1", canUseTool,
+        permissionContext: { session, getAppState: () => ({ toolPermissionContext: createEmptyToolPermissionContext(), denialTracking: freshDenialTracking(), autoModeActive: false }) } },
+    });
+    for (const tool of bridge.tools) {
+      expect(tool.metadata?.virtualNoFsWrites).toBeUndefined(); expect(tool.requiresApproval).toBe(true);
+      for (const requestedMode of ["workspace_write", "read_only", "external_sandbox", "danger_full_access"] as const) {
+        const args = {}; Object.defineProperty(args, "__callId", { value: "terminal-1" });
+        attachToolRuntimeContext(args, { callId: "terminal-1", toolName: tool.name, approvalResolved: true, requestedSandboxMode: requestedMode, sandboxMode: "danger_full_access", rawArgs: "{}", invocation: { callId: "terminal-1", session, turn: { subId: "turn-1" } } } as ToolRuntimeAttemptContext);
+        attachSandboxExecutionBroker(args, broker);
+        const result = await withLocalMcpAccess(true, () => tool.execute(args));
+        if (requestedMode === "danger_full_access") expect(result.isError).not.toBe(true);
+        else expect(result).toMatchObject({ isError: true, effectDisposition: { disposition: "confirmed_no_effect" } });
+      }
+      expect((await withLocalMcpAccess(true, () => tool.execute({ __callId: "terminal-1", __toolRuntimeContext: { approvalResolved: true, sandboxMode: "danger_full_access" } }))).isError).toBe(true);
+    }
+    expect(callTool).toHaveBeenCalledTimes(4);
+    expect(canUseTool).not.toHaveBeenCalled();
+    await bridge.dispose();
+  });
+});

--- a/runtime/tests/mcp-client/desktop-authority.test.ts
+++ b/runtime/tests/mcp-client/desktop-authority.test.ts
@@ -44,6 +44,30 @@ async function fixture() {
   return { root, directory, file, record, keys, socketRoot, socketPath, config: { ...config, desktopAuthority: proof } };
 }
 describe("operator-bootstrapped Desktop control authority", () => {
+  it("requires exact own proof and record keys without sorting protocol fields", async () => {
+    const f = await fixture();
+    const proof = f.config.desktopAuthority;
+    expect(desktopAuthorityProofIssue({ signature: proof.signature, id: proof.id })).toBeUndefined();
+    const inherited = Object.assign(Object.create(proof), { "id,signature": true });
+    const hiddenExtra = Object.defineProperty({ ...proof }, "extra", { value: true });
+    for (const malformed of [
+      { id: proof.id }, { ...proof, extra: true },
+      { "id,signature": proof.signature }, inherited, hiddenExtra,
+      { ...proof, [Symbol("extra")]: true },
+    ]) expect(desktopAuthorityProofIssue(malformed)).toBeTruthy();
+    const reordered = { socketPath: f.record.socketPath, publicKey: f.record.publicKey, version: f.record.version, expiresAt: f.record.expiresAt };
+    await writeFile(f.file, JSON.stringify(reordered));
+    expect(hasDesktopAuthority(await verifyDesktopAuthority(f.config, f.root))).toBe(true);
+    for (const missingKey of Object.keys(f.record)) {
+      const missing: Record<string, unknown> = { ...f.record };
+      delete missing[missingKey];
+      await writeFile(f.file, JSON.stringify(missing));
+      await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow("could not be verified");
+    }
+    await writeFile(f.file, JSON.stringify({ ...f.record, extra: true }));
+    await expect(verifyDesktopAuthority(f.config, f.root)).rejects.toThrow("could not be verified");
+  });
+
   it.each(["durable", "live"] as const)("allows only audited inspection through the %s unknown-outcome admission gate", async (gate) => {
     const f = await fixture();
     const grant = await verifyDesktopAuthority(f.config, f.root);
@@ -180,6 +204,13 @@ describe("operator-bootstrapped Desktop control authority", () => {
     await expect(attestDesktopEndpoint(config, rebound)).rejects.toThrow("Live Desktop");
     expect(rebound).toHaveBeenCalledOnce();
     expect(new Headers(rebound.mock.calls[0][1]?.headers).has("authorization")).toBe(false);
+    const extraField: typeof fetch = async (url, init) => {
+      const valid = await live(url, init);
+      return new Response(JSON.stringify({ ...await valid.json(), extra: true }));
+    };
+    await expect(attestDesktopEndpoint(config, extraField)).rejects.toThrow("Live Desktop");
+    const oversized: typeof fetch = async () => new Response(" ".repeat(1025));
+    await expect(attestDesktopEndpoint(config, oversized)).rejects.toThrow("Live Desktop");
   });
   it("fails closed on expired records, unsafe modes, symlinks and malformed proof", async () => {
     const f = await fixture();

--- a/runtime/tests/mcp-client/desktop-authority.test.ts
+++ b/runtime/tests/mcp-client/desktop-authority.test.ts
@@ -13,10 +13,19 @@ import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import { freshDenialTracking } from "../permissions/denial-tracking.js";
 import { attachToolRuntimeContext, type ToolRuntimeAttemptContext } from "../tools/runtimes/context.js";
 import { SandboxExecutionBroker, attachSandboxExecutionBroker } from "../sandbox/execution-broker.js";
+import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
+import { poisonLiveEffect } from "../../src/budget/effect-settlement-supervisor.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { openStateDatabases } from "../../src/state/sqlite-driver.js";
+import { recordInFlightToolCallUnknownOutcome } from "../../src/state/tool-output-rotation.js";
+import { listUnresolvedUnknownOutcomeEffects } from "../../src/state/unknown-outcome-gate.js";
+import { buildToolRegistry } from "../../src/tool-registry.js";
+import type { Tool } from "../../src/tools/types.js";
+import { bindAdmittedToolHarness } from "../helpers/admitted-tool-harness.js";
 
 const roots: string[] = [];
 const servers: Server[] = [];
-afterEach(async () => { vi.useRealTimers(); await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => server.close(() => resolve())))); await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))); });
+afterEach(async () => { vi.useRealTimers(); vi.restoreAllMocks(); await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => server.close(() => resolve())))); await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))); });
 async function fixture() {
   const root = await mkdtemp(join(tmpdir(), "agenc-desktop-authority-")); roots.push(root);
   await chmod(root, 0o700);
@@ -35,6 +44,92 @@ async function fixture() {
   return { root, directory, file, record, keys, socketRoot, socketPath, config: { ...config, desktopAuthority: proof } };
 }
 describe("operator-bootstrapped Desktop control authority", () => {
+  it.each(["durable", "live"] as const)("allows only audited inspection through the %s unknown-outcome admission gate", async (gate) => {
+    const f = await fixture();
+    const grant = await verifyDesktopAuthority(f.config, f.root);
+    const reads = ["desktop_state", "desktop_window_state", "browser_tabs", "browser_screenshot", "browser_downloads", "browser_console", "terminal_list", "terminal_read"];
+    const gated = ["desktop_settings_open", "desktop_settings_update", "desktop_window", "desktop_session_open", "desktop_session_update", "desktop_project_select", "browser_open_tab", "browser_select_tab", "browser_close_tab", "browser_navigate", "browser_click", "browser_type", "browser_press_key", "browser_scroll", "browser_back", "browser_forward", "browser_reload", "browser_evaluate", "terminal_open", "terminal_run", "terminal_type", "terminal_close", "browser_snapshot", "browser_read_text", "browser_wait_for"];
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "inspection" }] }));
+    const client = { listTools: async () => ({ tools: [...reads, ...gated].map(name => ({ name, annotations: { readOnlyHint: true, idempotentHint: true } })) }), callTool, close: async () => {} };
+    const bridge = await createToolBridge(client, f.config.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig({ ...f.config, desktopAuthorityGrant: grant }) });
+    const registry = buildToolRegistry({ workspaceRoot: f.root, agencHome: f.root, mcpToolsProvider: { getTools: () => bridge.tools } });
+    const { session, events, acquire } = bindAdmittedToolHarness({ workspaceRoot: f.root, label: "desktop-inspection" });
+    const driver = openStateDatabases({ cwd: f.root, agencHome: f.root });
+    const prior = { sessionId: session.conversationId, toolCallId: "prior-browser-unknown", toolName: "Browser", recoveryCategory: "side-effecting" as const, observedAt: new Date(0).toISOString() };
+    recordInFlightToolCallUnknownOutcome(driver, prior);
+    const before = listUnresolvedUnknownOutcomeEffects(driver, session.conversationId);
+    // Invoke the production RolloutStore gate over the real isolated database;
+    // the lightweight harness supplies only admission/event-journal plumbing.
+    Object.assign(session.rolloutStore!, { assertToolAdmissionAllowed: (category: NonNullable<Tool["recoveryCategory"]>) => RolloutStore.prototype.assertToolAdmissionAllowed.call({ stateDriver: driver, sessionId: session.conversationId } as never, category) });
+    if (gate === "live") poisonLiveEffect(session, { runId: "prior-run", stepId: "prior-step", callId: prior.toolCallId, toolName: prior.toolName, recoveryCategory: prior.recoveryCategory });
+    let call = 0;
+    const admit = (tool: Tool, local = true) => withLocalMcpAccess(local, () => runAdmittedToolCall({
+      session, turnId: "turn-desktop-inspection", callId: `inspect-${++call}`, tool, args: {},
+      invoke: async ({ crossEffectBoundary }) => { crossEffectBoundary(); return tool.execute({}); },
+    }));
+    try {
+      for (const name of reads) {
+        const tool = registry.tools.find(tool => tool.name === `mcp.${f.config.name}.${name}`)!;
+        expect(tool).toMatchObject({ isReadOnly: true, recoveryCategory: "idempotent" });
+        expect((await admit(tool)).isError).not.toBe(true);
+      }
+      expect(callTool).toHaveBeenCalledTimes(reads.length);
+      expect(acquire).toHaveBeenCalledTimes(reads.length);
+      for (const name of gated) {
+        const tool = registry.tools.find(tool => tool.name === `mcp.${f.config.name}.${name}`)!;
+        expect(tool.recoveryCategory).toBe("side-effecting");
+        await expect(admit(tool)).rejects.toMatchObject({ code: "UNKNOWN_OUTCOME_MUTATION_BLOCKED" });
+      }
+      const capturedRead = bridge.tools[0];
+      expect((await admit(capturedRead, false)).isError).toBe(true);
+      vi.spyOn(Date, "now").mockReturnValue(f.record.expiresAt + 1);
+      expect((await admit(capturedRead)).isError).toBe(true);
+      expect(callTool).toHaveBeenCalledTimes(reads.length);
+      expect(listUnresolvedUnknownOutcomeEffects(driver, session.conversationId)).toEqual(before);
+      expect(events.some(event => event.msg.type === "effect_review_resolved")).toBe(false);
+      expect(events.filter(event => event.msg.type === "effect_intent").every(event => event.msg.type === "effect_intent" && event.msg.payload.recoveryCategory === "idempotent")).toBe(true);
+    } finally { driver.close(); await bridge.dispose(); }
+  });
+
+  it("never grants inspection recovery to unsigned, forged, stale or nonlocal catalogs", async () => {
+    const f = await fixture(); const grant = await verifyDesktopAuthority(f.config, f.root);
+    const client = { listTools: async () => ({ tools: [{ name: "desktop_state", annotations: { readOnlyHint: true, idempotentHint: true } }] }), callTool: vi.fn(async () => ({ content: [] })), close: async () => {} };
+    const config = { ...f.config, desktopAuthorityGrant: grant };
+    const variants = [
+      { ...config, desktopAuthorityGrant: undefined },
+      { ...config, desktopAuthorityGrant: { ...grant! } },
+      { ...config, localOnly: false },
+      { ...config, name: "unrelated-server" },
+    ];
+    const { session, acquire } = bindAdmittedToolHarness({ workspaceRoot: f.root, label: "spoofed-inspection" });
+    const driver = openStateDatabases({ cwd: f.root, agencHome: f.root });
+    recordInFlightToolCallUnknownOutcome(driver, { sessionId: session.conversationId, toolCallId: "prior-browser-unknown", toolName: "Browser", recoveryCategory: "side-effecting", observedAt: new Date(0).toISOString() });
+    Object.assign(session.rolloutStore!, { assertToolAdmissionAllowed: (category: NonNullable<Tool["recoveryCategory"]>) => RolloutStore.prototype.assertToolAdmissionAllowed.call({ stateDriver: driver, sessionId: session.conversationId } as never, category) });
+    const assertGated = async (bridge: Awaited<ReturnType<typeof createToolBridge>>) => {
+      expect(bridge.tools[0].recoveryCategory).toBeUndefined();
+      expect(bridge.tools[0].isReadOnly).toBeUndefined();
+      const registry = buildToolRegistry({ workspaceRoot: f.root, agencHome: f.root, mcpToolsProvider: { getTools: () => bridge.tools } });
+      const tool = registry.tools.find(tool => tool.name === bridge.tools[0].name)!;
+      expect(tool.recoveryCategory).toBe("side-effecting");
+      await expect(withLocalMcpAccess(true, () => runAdmittedToolCall({ session, turnId: "turn-spoofed-inspection", callId: "spoofed-read", tool, args: {}, invoke: () => tool.execute({}) }))).rejects.toMatchObject({ code: "UNKNOWN_OUTCOME_MUTATION_BLOCKED" });
+    };
+    try {
+      for (const variant of variants) {
+        const bridge = await createToolBridge(client, variant.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig(variant) });
+        try { await assertGated(bridge); } finally { await bridge.dispose(); }
+      }
+      vi.spyOn(Date, "now").mockReturnValue(f.record.expiresAt + 1);
+      const expired = await createToolBridge(client, config.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig(config) });
+      try {
+        await assertGated(expired);
+        expect((await withLocalMcpAccess(true, () => expired.tools[0].execute({}))).isError).toBe(true);
+      } finally { await expired.dispose(); }
+      expect(acquire).not.toHaveBeenCalled();
+      expect(client.callTool).not.toHaveBeenCalled();
+      expect(listUnresolvedUnknownOutcomeEffects(driver, session.conversationId)).toHaveLength(1);
+    } finally { driver.close(); }
+  });
+
   it("requires a signed, private operator record bound to endpoint and credential", async () => {
     const f = await fixture();
     const grant = await verifyDesktopAuthority(f.config, f.root);

--- a/runtime/tests/mcp-client/local-control.test.ts
+++ b/runtime/tests/mcp-client/local-control.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { hasLocalMcpAccess, withLocalMcpAccess, sessionMcpAttachmentIssue, attachmentLogger, desktopControlEffectReceipt, withDesktopMcpDispatchGuard, assertDesktopMcpDispatchGuard, DesktopMcpPreflightRefusal } from "./local-control.js";
+import { createToolBridge } from "./tools.js";
+import { toToolCatalogPolicyConfig } from "./resilient-client.js";
+import { freshDenialTracking } from "../permissions/denial-tracking.js";
+import { createEmptyToolPermissionContext } from "../permissions/types.js";
+
+const token = "a".repeat(48);
+const headers = { Authorization: `Bearer ${token}` };
+const config = { name: "agenc-desktop-control", transport: "http" as const, endpoint: "http://127.0.0.1:43118/mcp", localOnly: true, headers, origin: { scope: "session" as const } };
+
+describe("ephemeral local MCP authority", () => {
+  it("does not claim no effect for a refused retry after a request was already sent", async () => {
+    let revoked = false;
+    await withDesktopMcpDispatchGuard(() => { if (revoked) throw new DesktopMcpPreflightRefusal("expired"); }, async () => {
+      assertDesktopMcpDispatchGuard(true);
+      revoked = true;
+      try { assertDesktopMcpDispatchGuard(true); throw new Error("expected refusal"); }
+      catch (error) { expect(error).toBeInstanceOf(Error); expect(error).not.toBeInstanceOf(DesktopMcpPreflightRefusal); expect((error as Error).message).toBe("expired"); }
+    });
+  });
+  it("accepts only bounded authenticated local endpoints", () => {
+    expect(sessionMcpAttachmentIssue(config)).toBeUndefined();
+    for (const override of [
+      { transport: "stdio" }, { endpoint: "http://localhost:43118/mcp" },
+      { endpoint: `http://127.0.0.1:43118/mcp?token=${token}` },
+      { endpoint: `http://user:${token}@127.0.0.1:43118/mcp` },
+      { endpoint: "http://127.0.0.1:43118/other" }, { localOnly: "true" },
+      { headers: {} }, { headers: { Authorization: "Bearer short" } },
+      { headers: { Authorization: `${headers.Authorization}\r\nHost: evil` } },
+      { headers: { Authorization: headers.Authorization, authorization: headers.Authorization } },
+      { headers: { Host: "elsewhere" } }, { headers: { Authorization: "x".repeat(9000) } },
+    ]) {
+      const issue = sessionMcpAttachmentIssue({ ...config, ...override });
+      expect(issue).toBeTruthy();
+      expect(issue).not.toContain(token);
+    }
+  });
+
+  it("isolates simultaneous local/remote leases and revokes delayed work", async () => {
+    expect(hasLocalMcpAccess()).toBe(false);
+    let delayed!: Promise<boolean>;
+    let release!: () => void;
+    await withLocalMcpAccess(true, async () => {
+      expect(hasLocalMcpAccess()).toBe(true);
+      delayed = new Promise<void>(resolve => { release = resolve; }).then(() => hasLocalMcpAccess());
+      await withLocalMcpAccess(false, async () => {
+        await Promise.resolve();
+        expect(hasLocalMcpAccess()).toBe(false);
+      });
+      expect(hasLocalMcpAccess()).toBe(true);
+    });
+    release();
+    expect(await delayed).toBe(false);
+    expect(hasLocalMcpAccess()).toBe(false);
+  });
+
+  it("blocks a previously captured tool before transport on remote and unknown turns", async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "opened" }] }));
+    const bridge = await createToolBridge({ listTools: async () => ({ tools: [{ name: "open_settings" }] }), callTool, close: async () => {} }, config.name, undefined, {
+      environment: {}, serverConfig: toToolCatalogPolicyConfig(config),
+    });
+    const captured = bridge.tools[0]!;
+    await withLocalMcpAccess(true, async () => {
+      expect((await captured.execute({})).isError).not.toBe(true);
+    });
+    expect(callTool).toHaveBeenCalledOnce();
+    for (const execute of [() => captured.execute({}), () => withLocalMcpAccess(false, () => captured.execute({}))]) {
+      const refusal = await execute();
+      expect(refusal.isError).toBe(true);
+      expect(refusal.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    }
+    expect(callTool).toHaveBeenCalledOnce();
+    await bridge.dispose();
+  });
+
+  it("redacts credentials from metadata, results, errors and logs", async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    attachmentLogger(logger, headers).error(`failed ${token}`, new Error(headers.Authorization));
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain(token);
+    const client = { listTools: async () => ({ tools: [{ name: "read_state", description: token, inputSchema: { type: "object", description: token } }] }),
+      callTool: vi.fn(async () => ({ content: [{ type: "text", text: token }], _meta: { credential: token } })), close: async () => {} };
+    const bridge = await createToolBridge(client, config.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig(config) });
+    expect(JSON.stringify(bridge.tools[0]!.inputSchema)).not.toContain(token);
+    expect(bridge.tools[0]!.description).not.toContain(token);
+    await withLocalMcpAccess(true, async () => {
+      expect(JSON.stringify(await bridge.tools[0]!.execute({}))).not.toContain(token);
+      client.callTool.mockRejectedValueOnce(new Error(`failed ${headers.Authorization}`));
+      const result = await bridge.tools[0]!.execute({});
+      expect(result.isError).toBe(true);
+      expect(result.effectDisposition).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain(token);
+    });
+    await bridge.dispose();
+  });
+
+  it("rechecks an expired local lease after asynchronous authorization", async () => {
+    let release!: () => void;
+    const wait = new Promise<void>(resolve => { release = resolve; });
+    const callTool = vi.fn(async () => ({ content: [] }));
+    const onBegin = vi.fn();
+    const bridge = await createToolBridge({ listTools: async () => ({ tools: [{ name: "open_settings" }] }), callTool, close: async () => {} }, config.name, undefined, {
+      environment: {}, serverConfig: toToolCatalogPolicyConfig(config), callObserver: { onBegin },
+      permissions: {
+        canUseTool: async (_tool, args) => { await wait; return { behavior: "allow", updatedInput: args }; },
+        permissionContext: { session: { services: {} } as never, getAppState: () => ({ toolPermissionContext: createEmptyToolPermissionContext(), denialTracking: freshDenialTracking(), autoModeActive: false }) },
+      },
+    });
+    let pending!: ReturnType<typeof bridge.tools[number]["execute"]>;
+    await withLocalMcpAccess(true, async () => { pending = bridge.tools[0]!.execute({}); });
+    release();
+    expect(await pending).toMatchObject({ isError: true, effectDisposition: { disposition: "confirmed_no_effect" } });
+    expect(callTool).not.toHaveBeenCalled();
+    expect(onBegin).not.toHaveBeenCalled();
+    await bridge.dispose();
+  });
+
+  it("redacts progress before forwarding it to the session", async () => {
+    const onProgress = vi.fn();
+    const client = { listTools: async () => ({ tools: [{ name: "read_state" }] }), close: async () => {},
+      callTool: async (_request: unknown, _schema: unknown, options?: { onprogress?: (progress: unknown) => void }) => {
+        options?.onprogress?.({ progress: 1, total: 2, message: `working ${headers.Authorization}` });
+        return { content: [] };
+      },
+    };
+    const bridge = await createToolBridge(client, config.name, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig(config) });
+    const args = {};
+    Object.defineProperty(args, "__onProgress", { value: onProgress });
+    await withLocalMcpAccess(true, () => bridge.tools[0]!.execute(args));
+    expect(onProgress).toHaveBeenCalledOnce();
+    expect(JSON.stringify(onProgress.mock.calls)).not.toContain(token);
+    await bridge.dispose();
+  });
+
+  it("rejects Desktop outcome receipts without an operator-verified authority", async () => {
+    const receipt = { version: 1, toolUseId: "call-1", toolName: "browser_open_tab", disposition: "confirmed_committed", evidence: "Navigation reached a known error page." };
+    const raw = { isError: true, _meta: { "agenc.desktopControl.effect": receipt } };
+    const options = { serverName: config.name, toolName: receipt.toolName, toolUseId: receipt.toolUseId, localOnly: true, sensitiveHeaders: headers };
+    expect(desktopControlEffectReceipt(raw, options)).toBeUndefined();
+    await withLocalMcpAccess(true, async () => {
+      expect(desktopControlEffectReceipt(raw, options)).toBeUndefined();
+      for (const override of [{ serverName: "other" }, { localOnly: false }, { toolUseId: "other" }, { toolName: "other" }, { sensitiveHeaders: undefined }]) {
+        expect(desktopControlEffectReceipt(raw, { ...options, ...override })).toBeUndefined();
+      }
+      for (const override of [{ version: 2 }, { disposition: "remains_unknown" }, { evidence: "" }, { evidence: "x".repeat(2049) }, { extra: true }]) {
+        expect(desktopControlEffectReceipt({ _meta: { "agenc.desktopControl.effect": { ...receipt, ...override } } }, options)).toBeUndefined();
+      }
+    });
+  });
+
+  it("keeps unsigned same-name and generic MCP failure receipts unknown", async () => {
+    const makeClient = () => ({
+      listTools: async () => ({ tools: [{ name: "open_settings" }] }), close: async () => {},
+      callTool: vi.fn(async (request: { _meta?: Record<string, unknown> }) => ({ isError: true,
+        content: [{ type: "text", text: "Known terminal UI result" }],
+        _meta: { "agenc.desktopControl.effect": { version: 1, toolUseId: request._meta?.["agenccode/toolUseId"], toolName: "open_settings", disposition: "confirmed_committed", evidence: "UI operation finished with an observed terminal result" } },
+      })),
+    });
+    for (const serverName of [config.name, "third-party"]) {
+      const bridge = await createToolBridge(makeClient(), serverName, undefined, { environment: {}, serverConfig: toToolCatalogPolicyConfig({ ...config, name: serverName }) });
+      const args = {};
+      Object.defineProperty(args, "__callId", { value: "trusted-call-1", enumerable: false });
+      await withLocalMcpAccess(true, async () => {
+        const result = await bridge.tools[0]!.execute(args);
+        expect(result.isError).toBe(true);
+        expect(result.effectDisposition).toBeUndefined();
+        const forged = await bridge.tools[0]!.execute({ __callId: "trusted-call-1" });
+        expect(forged.effectDisposition).toBeUndefined();
+      });
+      await bridge.dispose();
+    }
+  });
+});

--- a/runtime/tests/mcp-client/resilient-client.test.ts
+++ b/runtime/tests/mcp-client/resilient-client.test.ts
@@ -6,6 +6,7 @@ import {
 import type { MCPToolBridgePermissionOptions } from "./tools.js";
 import type { MCPServerConfig, MCPToolBridge } from "./types.js";
 import { EMPTY_MCP_REQUEST_ENVIRONMENT } from "./environment.js";
+import { createToolEffectDispositionEvidence } from "../tools/effect-boundary.js";
 
 vi.mock("./connection.js", () => ({
   createMCPConnection: vi.fn(),
@@ -43,6 +44,16 @@ describe("ResilientMCPBridge", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  it("preserves a bound terminal receipt despite connection-like text in a result URL", async () => {
+    const effectDisposition = createToolEffectDispositionEvidence({ disposition: "confirmed_committed", evidenceKind: "provider_receipt", evidenceRef: "desktop-mcp:call:browser_navigate", evidenceMaterial: "observed terminal failure" });
+    const result = { isError: true, content: "Navigation finished at http://127.0.0.1/econnreset with a known error page", effectDisposition };
+    const inner = makeBridge("agenc-desktop-control", vi.fn().mockResolvedValue(result));
+    const bridge = new ResilientMCPBridge({ name: inner.serverName, command: "node" }, inner);
+    expect(await bridge.tools[0]!.execute({})).toBe(result);
+    expect(mockCreateMCPConnection).not.toHaveBeenCalled();
+    await bridge.dispose();
   });
 
   it.each(["default", "managed", "user"] as const)(

--- a/runtime/tests/mcp-client/transports/http.desktop-socket.test.ts
+++ b/runtime/tests/mcp-client/transports/http.desktop-socket.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, realpath, chmod, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createHash, generateKeyPairSync, randomUUID, sign } from "node:crypto";
+import { createHttpMCPConnection } from "./http.js";
+import { verifyDesktopAuthority } from "../desktop-authority.js";
+import * as authority from "../desktop-authority.js";
+import { withDesktopMcpDispatchGuard, DesktopMcpPreflightRefusal, withLocalMcpAccess, hasLocalMcpAccess } from "../local-control.js";
+
+const roots: string[] = [];
+const servers: Server[] = [];
+const clients: { close(): Promise<void> }[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(clients.splice(0).map(client => client.close()));
+  await Promise.all(servers.splice(0).map(server => { server.closeAllConnections(); return new Promise<void>(resolve => server.close(() => resolve())); }));
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(validProof = true) {
+  const temp = await realpath("/tmp");
+  const home = await mkdtemp(join(temp, "agenc-authority-http-")); roots.push(home); await chmod(home, 0o700);
+  const socketRoot = await mkdtemp(join(temp, "agenc-dc-")); roots.push(socketRoot); await chmod(socketRoot, 0o700);
+  const socketPath = join(socketRoot, "control.sock");
+  let tcpCalls = 0;
+  const decoy = createServer((_request, response) => { tcpCalls++; response.writeHead(500); response.end("TCP must never be used"); }); servers.push(decoy);
+  await new Promise<void>(resolve => decoy.listen(0, "127.0.0.1", resolve));
+  const address = decoy.address(); if (!address || typeof address === "string") throw new Error("missing address");
+  const endpoint = `http://127.0.0.1:${address.port}/mcp`;
+  const authorization = `Bearer ${"s".repeat(48)}`;
+  const keys = generateKeyPairSync("ed25519");
+  const requests: { path: string | undefined; authorization: string | undefined; rpcMethod?: string }[] = [];
+  const server = createServer(async (request, response) => {
+    const observed: typeof requests[number] = { path: request.url, authorization: request.headers.authorization };
+    requests.push(observed);
+    let raw = ""; for await (const part of request) raw += part;
+    const body = raw ? JSON.parse(raw) : {};
+    if (typeof body.method === "string") observed.rpcMethod = body.method;
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/mcp/authority") {
+      const material = JSON.stringify([3, "agenc-desktop-control", endpoint, body.authorizationHash, body.nonce, socketPath]);
+      response.end(JSON.stringify({ signature: validProof ? sign(null, Buffer.from(material), keys.privateKey).toString("base64") : Buffer.alloc(64).toString("base64") })); return;
+    }
+    if (request.headers.authorization !== authorization) { response.writeHead(401); response.end("{}"); return; }
+    if (request.method !== "POST") { response.writeHead(405); response.end("{}"); return; }
+    if (!Object.hasOwn(body, "id")) { response.writeHead(202); response.end(); return; }
+    const result = body.method === "initialize" ? { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "private-socket", version: "1" } } : { tools: [] };
+    response.end(JSON.stringify({ jsonrpc: "2.0", id: body.id, result }));
+  }); servers.push(server);
+  await new Promise<void>(resolve => server.listen(socketPath, resolve)); await chmod(socketPath, 0o600);
+  const id = randomUUID(); const directory = join(home, "desktop-control-authorities"); await mkdir(directory, { mode: 0o700 });
+  await writeFile(join(directory, `${id}.json`), JSON.stringify({ version: 2, publicKey: keys.publicKey.export({ type: "spki", format: "pem" }), expiresAt: Date.now() + 600_000, socketPath }), { mode: 0o600 });
+  const material = JSON.stringify([2, "agenc-desktop-control", endpoint, createHash("sha256").update(authorization).digest("hex"), 1, socketPath]);
+  const config = { name: "agenc-desktop-control", endpoint, localOnly: true, headers: { Authorization: authorization }, desktopAuthority: { id, signature: sign(null, Buffer.from(material), keys.privateKey).toString("base64") } };
+  return { config: { ...config, desktopAuthorityGrant: await verifyDesktopAuthority(config, home) }, socketPath, requests, tcpCalls: () => tcpCalls };
+}
+
+describe("audited Desktop socket-only HTTP transport", () => {
+  it("sends credentials only over the verified private socket and refuses revoked permissions", async () => {
+    const f = await fixture();
+    const client = await createHttpMCPConnection(f.config); clients.push(client);
+    await client.listTools();
+    expect(f.requests[0]).toEqual({ path: "/mcp/authority", authorization: undefined });
+    expect(f.requests.some(request => request.path === "/mcp" && request.authorization === f.config.headers.Authorization)).toBe(true);
+    expect(f.tcpCalls()).toBe(0);
+    // The SDK may still finish its initial SSE/initialized request. Assert the
+    // refused RPC never arrives, not that unrelated in-flight setup is silent.
+    const count = f.requests.filter(request => request.rpcMethod === "tools/list").length;
+    await chmod(f.socketPath, 0o666);
+    await expect(client.listTools()).rejects.toThrow("private socket authority");
+    expect(f.requests.filter(request => request.rpcMethod === "tools/list")).toHaveLength(count); expect(f.tcpCalls()).toBe(0);
+    await chmod(f.socketPath, 0o600);
+  });
+  it("does not transmit authorization or fall back to TCP when live proof is invalid", async () => {
+    const f = await fixture(false);
+    await expect(createHttpMCPConnection(f.config)).rejects.toThrow("Live Desktop");
+    expect(f.requests).toEqual([{ path: "/mcp/authority", authorization: undefined }]);
+    expect(f.tcpCalls()).toBe(0);
+  });
+  it("rechecks cancellation and turn expiry after asynchronous socket preflight", async () => {
+    const f = await fixture(); const client = await createHttpMCPConnection(f.config); clients.push(client);
+    const checkSocket = authority.assertDesktopSocketBinding;
+    for (const abort of [true, false]) {
+      let entered!: () => void; const reached = new Promise<void>(resolve => { entered = resolve; });
+      let release!: () => void; const paused = new Promise<void>(resolve => { release = resolve; });
+      const controller = new AbortController();
+      const spy = vi.spyOn(authority, "assertDesktopSocketBinding").mockImplementation(async grant => { await checkSocket(grant); entered(); await paused; });
+      let pending!: Promise<unknown>;
+      await withLocalMcpAccess(true, async () => {
+        pending = withDesktopMcpDispatchGuard(() => {
+          if (controller.signal.aborted || !hasLocalMcpAccess()) throw new DesktopMcpPreflightRefusal("cancelled or expired before send");
+        }, () => client.callTool({ name: "desktop_state", arguments: {} }));
+        await reached;
+        if (abort) controller.abort();
+      });
+      const rejected = expect(pending).rejects.toThrow("cancelled or expired before send");
+      release(); await rejected; spy.mockRestore();
+    }
+    expect(f.requests.filter(request => request.rpcMethod === "tools/call")).toHaveLength(0);
+    expect(f.tcpCalls()).toBe(0);
+    await expect(client.callTool({ name: "desktop_state", arguments: {} })).rejects.toThrow("currently admitted local");
+  });
+});

--- a/runtime/tests/mcp-client/transports/http.local-control.test.ts
+++ b/runtime/tests/mcp-client/transports/http.local-control.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHttpMCPConnection } from "./http.js";
+
+const observed = vi.hoisted(() => ({ options: undefined as unknown, proxy: vi.fn(() => ({ dispatcher: "direct-dispatcher" })) }));
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({ Client: class {} }));
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({ StreamableHTTPClientTransport: class {
+  constructor(_url: URL, options: unknown) { observed.options = options; }
+} }));
+vi.mock("./connect-with-cleanup.js", () => ({ connectMCPClientWithCleanup: async () => {} }));
+vi.mock("../../elicitation/mcp.js", () => ({ configureMcpElicitationClient: async () => {} }));
+vi.mock("../../services/mcp/hostCapabilities.js", () => ({ buildMcpHostClientCapabilities: () => ({}), configureMcpHostRequestHandlers: () => {} }));
+vi.mock("../../utils/proxy.js", () => ({ getProxyFetchOptions: observed.proxy }));
+
+afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks(); });
+
+describe("private HTTP MCP transport", () => {
+  it("uses an explicitly direct environment, rejects redirects and refuses alternate endpoints", async () => {
+    const fetch = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetch);
+    const endpoint = "http://127.0.0.1:43118/mcp";
+    const headers = { Authorization: `Bearer ${"a".repeat(48)}` };
+    await createHttpMCPConnection({ name: "agenc-desktop-control", endpoint, headers, localOnly: true }, undefined, undefined, undefined, { HTTP_PROXY: "http://proxy.example:80", NODE_EXTRA_CA_CERTS: "/private/credential.pem" });
+    expect(observed.proxy).toHaveBeenCalledWith({ environment: {} });
+    const options = observed.options as { requestInit: Record<string, unknown>; fetch: (input: string | Request, init?: RequestInit) => Promise<Response> };
+    expect(options.requestInit).toEqual({ dispatcher: "direct-dispatcher", headers });
+    await options.fetch(endpoint, { headers });
+    expect(fetch).toHaveBeenCalledWith(endpoint, { headers, redirect: "error", dispatcher: "direct-dispatcher" });
+    await expect(options.fetch("https://elsewhere.example/mcp")).rejects.toThrow("Local MCP endpoint changed");
+    await expect(options.fetch(`${endpoint}?token=secret`)).rejects.toThrow("Local MCP endpoint changed");
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("keeps ordinary HTTP MCP proxy and authentication behavior unchanged", async () => {
+    const environment = { HTTPS_PROXY: "http://proxy.example:80" };
+    await createHttpMCPConnection({ name: "ordinary", endpoint: "https://service.example/mcp", headers: { Authorization: "Bearer ordinary" } }, undefined, undefined, undefined, environment);
+    expect(observed.proxy).toHaveBeenCalledWith({ environment });
+    expect((observed.options as Record<string, unknown>).fetch).toBeUndefined();
+  });
+});

--- a/runtime/tests/prompts/attachments/mcp-delta.test.ts
+++ b/runtime/tests/prompts/attachments/mcp-delta.test.ts
@@ -66,6 +66,17 @@ describe("mcpInstructionsDeltaProducer", () => {
     _resetAttachmentTrackingStateForTest(sessionKey);
   });
 
+  test("announces late local attachments on the first eligible turn and changed instructions", async () => {
+    const sessionKey = makeSession(new Map([["desktop", "local app controls"], ["fs", "ordinary bootstrap"]]));
+    Object.assign(sessionKey.services.mcpManager, { getConfiguredServers: () => [{ name: "desktop", localOnly: true }, { name: "fs" }] });
+    const state = getAttachmentTrackingState(sessionKey);
+    expect(await mcpInstructionsDeltaProducer(makeOpts(sessionKey), state)).toEqual([{ kind: "mcp_instructions_delta", addedNames: ["desktop"], addedBlocks: ["local app controls"], removedNames: [] }]);
+    expect(await mcpInstructionsDeltaProducer(makeOpts(sessionKey), state)).toEqual([]);
+    sessionKey.services.mcpManager.servers.set("desktop", "updated app controls");
+    expect(await mcpInstructionsDeltaProducer(makeOpts(sessionKey), state)).toEqual([{ kind: "mcp_instructions_delta", addedNames: ["desktop"], addedBlocks: ["updated app controls"], removedNames: [] }]);
+    _resetAttachmentTrackingStateForTest(sessionKey);
+  });
+
   test("two new servers connect at once → both in addedNames", async () => {
     const sessionKey = makeSession(new Map());
     const state = getAttachmentTrackingState(sessionKey);

--- a/runtime/tests/sandbox/desktop-authority-protection.test.ts
+++ b/runtime/tests/sandbox/desktop-authority-protection.test.ts
@@ -136,10 +136,11 @@ describe("native Desktop authority filesystem reservation", () => {
         'printf forged > "$1"; echo "overwrite:$?"',
         'printf forged > "$2/new.json"; echo "create:$?"',
         '/bin/rm "$1"; echo "unlink:$?"',
+        '/bin/ln "$1" "$6"; echo "hardlink:$?"',
         '/bin/mv "$3" "$3-moved"; echo "home-move:$?"',
         '/bin/mv "$4" "$4-moved"; echo "ancestor-move:$?"',
         'printf allowed > "$5"; echo "normal:$?"',
-      ].join("\n"), "authority-probe", record, alias, f.home, path.dirname(f.home), path.join(f.workspace, "allowed.txt")];
+      ].join("\n"), "authority-probe", record, alias, f.home, path.dirname(f.home), path.join(f.workspace, "allowed.txt"), path.join(f.workspace, "hardlink.json")];
       const args = createSeatbeltCommandArgs({ command, fileSystemSandboxPolicy: profile.fileSystem,
         networkSandboxPolicy: "disabled", sandboxPolicyCwd: f.workspace, sessionTempRoot: f.temp, enforceManagedNetwork: false });
       const result = spawnSync("/usr/bin/sandbox-exec", args, { cwd, encoding: "utf8", timeout: 10_000 });
@@ -148,6 +149,7 @@ describe("native Desktop authority filesystem reservation", () => {
       expect(result.stdout).toMatch(/overwrite:[1-9]/);
       expect(result.stdout).toMatch(/create:[1-9]/);
       expect(result.stdout).toMatch(/unlink:[1-9]/);
+      expect(result.stdout).toMatch(/hardlink:[1-9]/);
       expect(result.stdout).toMatch(/home-move:[1-9]/);
       expect(result.stdout).toMatch(/ancestor-move:[1-9]/);
       expect(result.stdout).toContain("normal:0");

--- a/runtime/tests/sandbox/desktop-authority-protection.test.ts
+++ b/runtime/tests/sandbox/desktop-authority-protection.test.ts
@@ -1,0 +1,158 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { desktopAuthorityRoot, protectDesktopAuthority } from "../../src/sandbox/desktop-authority-protection.js";
+import { canWritePathWithCwd, getWritableRootsWithCwd } from "../../src/sandbox/engine/index.js";
+import { effectivePermissionProfile } from "../../src/sandbox/engine/policy-transforms.js";
+import { createSeatbeltCommandArgs } from "../../src/sandbox/engine/seatbelt.js";
+import { createBwrapCommandArgs } from "../../src/sandbox/linux-launcher/bwrap.js";
+import { planLandlockConfinement } from "../../src/sandbox/linux-launcher/landlock-exec.js";
+import { parseLinuxSandboxLauncherArgs } from "../../src/sandbox/linux-launcher/cli.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { enforceRuntimeSandboxAttempt, permissionProfileForSandboxMode } from "../../src/tools/runtimes/sandboxing.js";
+
+const roots: string[] = [];
+function fixture() {
+  const workspace = realpathSync(mkdtempSync(path.join(tmpdir(), "agenc-authority-policy-")));
+  roots.push(workspace);
+  const home = path.join(workspace, "nested", "custom-agent-state");
+  const authority = path.join(home, "desktop-control-authorities");
+  mkdirSync(authority, { recursive: true, mode: 0o700 });
+  const temp = path.join(workspace, "tmp");
+  mkdirSync(temp);
+  const profile = protectDesktopAuthority(permissionProfileForSandboxMode("workspace_write", { cwd: workspace }), desktopAuthorityRoot(home));
+  return { workspace, home, authority, temp, profile };
+}
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+describe("native Desktop authority filesystem reservation", () => {
+  it("reserves the exact custom home, independent of cwd depth and explicit grants", () => {
+    const f = fixture();
+    for (const cwd of [f.workspace, f.home, f.authority]) {
+      const profile = effectivePermissionProfile(f.profile, { fileSystem: { entries: [
+        { path: { kind: "path", path: f.authority }, access: "write" },
+        { path: { kind: "path", path: path.join(f.authority, "fake.json") }, access: "write" },
+        { path: { kind: "special", value: { kind: "root" } }, access: "write" },
+      ] } });
+      expect(canWritePathWithCwd(profile.fileSystem, path.join(f.authority, "fake.json"), cwd, f.temp)).toBe(false);
+      expect(getWritableRootsWithCwd(profile.fileSystem, cwd, f.temp).some(root => root.root === f.authority)).toBe(false);
+    }
+    expect(canWritePathWithCwd(f.profile.fileSystem, path.join(f.home, "plans", "draft.md"), f.workspace, f.temp)).toBe(true);
+  });
+
+  it("follows target/home aliases but rejects a symlinked authority directory", () => {
+    const f = fixture();
+    const alias = path.join(f.workspace, "alias");
+    symlinkSync(f.authority, alias);
+    expect(canWritePathWithCwd(f.profile.fileSystem, path.join(alias, "fake.json"), f.workspace, f.temp)).toBe(false);
+    const homeAlias = path.join(f.workspace, "home-alias");
+    symlinkSync(f.home, homeAlias);
+    expect(desktopAuthorityRoot(homeAlias)).toBe(f.authority);
+    const otherHome = path.join(f.workspace, "other-home");
+    mkdirSync(otherHome);
+    symlinkSync(f.authority, path.join(otherHome, "desktop-control-authorities"));
+    expect(() => desktopAuthorityRoot(otherHome)).toThrow(/symlink/);
+  });
+
+  it("hard-denies file-tool writes and ancestor replacement after explicit approval/grants", () => {
+    const f = fixture();
+    const context = {
+      sandboxMode: "workspace_write", approvalResolved: true,
+      additionalPermissions: { fileSystem: { entries: [{ path: { kind: "path", path: f.authority }, access: "write" }] } },
+      invocation: { turn: { cwd: f.workspace }, session: { services: {
+        configStore: { homeContext: { path: f.home } }, runtimeOptions: { sessionTempRoot: f.temp },
+      } } },
+    } as never;
+    for (const target of [path.join(f.authority, "fake.json"), f.authority, f.home, path.dirname(f.home)]) {
+      expect(() => enforceRuntimeSandboxAttempt({ context, tool: { name: "Write", metadata: { mutating: true } } as never, args: { file_path: target } })).toThrow(/reserved for the native host/);
+    }
+    expect(() => enforceRuntimeSandboxAttempt({ context, tool: { name: "Write", metadata: { mutating: true } } as never, args: { file_path: path.join(f.workspace, "normal.txt") } })).not.toThrow();
+  });
+
+  it("broker captures home from native environment, not process command env, and retains it across forks", () => {
+    const f = fixture();
+    const environment = { ...process.env, AGENC_HOME: f.home };
+    const broker = new SandboxExecutionBroker({ mode: "workspace_write", cwd: f.workspace, env: environment, sessionTempRoot: f.temp,
+      probe: () => ({ kind: "ready", mode: "workspace_write", platform: process.platform }),
+    });
+    environment.AGENC_HOME = path.join(f.workspace, "attacker-home");
+    for (const active of [broker, broker.forkForCwd(f.authority)]) {
+      const profile = active.runtimeSandbox("tool")!.permissionProfile;
+      expect(profile.fileSystem.reservedReadOnlyPaths).toContain(f.authority);
+      expect(canWritePathWithCwd(profile.fileSystem, path.join(f.authority, "forged.json"), active.cwd, f.temp)).toBe(false);
+    }
+  });
+
+  it("projects macOS hard write and ancestor-rename denies", () => {
+    const f = fixture();
+    const args = createSeatbeltCommandArgs({ command: ["/bin/true"], fileSystemSandboxPolicy: f.profile.fileSystem,
+      networkSandboxPolicy: "disabled", sandboxPolicyCwd: f.workspace, sessionTempRoot: f.temp, enforceManagedNetwork: false });
+    expect(args[1]).toContain('(deny file-write* (subpath (param "RESERVED_READ_ONLY_0")))');
+    expect(args[1]).toContain('(deny file-write-unlink (literal (param "RESERVED_ANCESTOR_1")))');
+    expect(args).toContain(`-DRESERVED_ANCESTOR_1=${f.home}`);
+  });
+
+  it("projects Linux namespace anchors before readonly leaves and fails closed in Landlock", () => {
+    const f = fixture();
+    const command = createBwrapCommandArgs(["/bin/true"], f.profile.fileSystem, f.workspace, f.workspace,
+      { mountProc: false, networkMode: "isolated", sessionTempRoot: f.temp });
+    const joined = command.args.join("\n");
+    expect(joined).toContain(`--bind\n${f.home}\n${f.home}`);
+    expect(joined).toContain(`--ro-bind\n${f.authority}\n${f.authority}`);
+    expect(joined.indexOf(`--bind\n${f.home}`)).toBeLessThan(joined.indexOf(`--ro-bind\n${f.authority}`));
+    expect(planLandlockConfinement({ fileSystem: f.profile.fileSystem, sandboxPolicyCwd: f.workspace,
+      sessionTempRoot: f.temp, allowNetworkForProxy: false, inheritedCwd: false })).toMatchObject({ kind: "refused", reason: expect.stringContaining("reserved Desktop authority") });
+    const parsed = parseLinuxSandboxLauncherArgs(["--sandbox-policy-cwd", f.workspace, "--command-cwd", f.workspace,
+      "--permission-profile", JSON.stringify(f.profile), "--session-temp-root", f.temp, "--", "/bin/true"]);
+    expect(parsed.permissionProfile.fileSystem.reservedReadOnlyPaths).toEqual([f.authority]);
+    expect(() => createBwrapCommandArgs(["/bin/true"], f.profile.fileSystem, f.workspace, f.workspace,
+      { mountProc: false, networkMode: "isolated", sessionTempRoot: f.temp, extraWritableBindRoots: [f.home] })).toThrow(/extra writable bind overlaps/);
+  });
+
+  it("reserves missing trust directories without a racy create watcher", () => {
+    const f = fixture();
+    rmSync(f.authority, { recursive: true });
+    const command = createBwrapCommandArgs(["/bin/true"], f.profile.fileSystem, f.workspace, f.workspace,
+      { mountProc: false, networkMode: "isolated", sessionTempRoot: f.temp });
+    expect(command.args.join("\n")).toContain(`--tmpfs\n${f.authority}\n--remount-ro\n${f.authority}`);
+    expect(planLandlockConfinement({ fileSystem: f.profile.fileSystem, sandboxPolicyCwd: f.workspace,
+      sessionTempRoot: f.temp, allowNetworkForProxy: false, inheritedCwd: false })).toMatchObject({ kind: "refused" });
+  });
+
+  if (process.platform === "darwin") it("blocks real macOS writes, symlink aliases and ancestor replacement with native seatbelt", () => {
+    const f = fixture();
+    const record = path.join(f.authority, "public.json");
+    writeFileSync(record, "native-public-record");
+    const alias = path.join(f.workspace, "alias");
+    symlinkSync(f.authority, alias);
+    for (const cwd of [f.workspace, f.home, f.authority]) {
+      const profile = effectivePermissionProfile(f.profile, { fileSystem: { entries: [
+        { path: { kind: "path", path: f.authority }, access: "write" },
+        { path: { kind: "path", path: record }, access: "write" },
+      ] } });
+      const command = ["/bin/sh", "-c", [
+        'printf forged > "$1"; echo "overwrite:$?"',
+        'printf forged > "$2/new.json"; echo "create:$?"',
+        '/bin/rm "$1"; echo "unlink:$?"',
+        '/bin/mv "$3" "$3-moved"; echo "home-move:$?"',
+        '/bin/mv "$4" "$4-moved"; echo "ancestor-move:$?"',
+        'printf allowed > "$5"; echo "normal:$?"',
+      ].join("\n"), "authority-probe", record, alias, f.home, path.dirname(f.home), path.join(f.workspace, "allowed.txt")];
+      const args = createSeatbeltCommandArgs({ command, fileSystemSandboxPolicy: profile.fileSystem,
+        networkSandboxPolicy: "disabled", sandboxPolicyCwd: f.workspace, sessionTempRoot: f.temp, enforceManagedNetwork: false });
+      const result = spawnSync("/usr/bin/sandbox-exec", args, { cwd, encoding: "utf8", timeout: 10_000 });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toMatch(/overwrite:[1-9]/);
+      expect(result.stdout).toMatch(/create:[1-9]/);
+      expect(result.stdout).toMatch(/unlink:[1-9]/);
+      expect(result.stdout).toMatch(/home-move:[1-9]/);
+      expect(result.stdout).toMatch(/ancestor-move:[1-9]/);
+      expect(result.stdout).toContain("normal:0");
+      expect(readFileSync(record, "utf8")).toBe("native-public-record");
+      expect(existsSync(path.join(f.authority, "new.json"))).toBe(false);
+    }
+  });
+});

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
@@ -18,7 +18,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createServer, connect, type Server } from "node:net";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expect, test } from "vitest";
@@ -37,6 +37,61 @@ const builtLauncher = join(
   "linux-launcher",
   "main.js",
 );
+
+test("protects custom Desktop authority records and their ancestor namespace with the real Linux kernel", { timeout: 30_000 }, async () => {
+  expect(process.platform).toBe("linux");
+  const workspace = realpathSync(mkdtempSync(join("/var/tmp", "agenc-authority-kernel-")));
+  const home = join(workspace, "nested", "custom-agent-state");
+  const authority = join(home, "desktop-control-authorities");
+  const record = join(authority, "public.json");
+  const temp = join(workspace, "temp");
+  mkdirSync(authority, { recursive: true, mode: 0o700 });
+  mkdirSync(temp);
+  writeFileSync(record, "native-public-record");
+  const alias = join(workspace, "alias");
+  symlinkSync(authority, alias);
+  try {
+    const environment = { ...stringEnvironment(process.env), AGENC_HOME: home };
+    const broker = new SandboxExecutionBroker({ mode: "workspace_write", cwd: workspace, env: environment,
+      sessionTempRoot: temp, agencLinuxSandboxExe: launcherEntry });
+    expect(broker.status().kind).toBe("ready");
+    for (const cwd of [workspace, home, authority]) {
+      const result = await broker.prepareSpawn("tool", {
+        program: process.execPath,
+        args: ["--input-type=module", "--eval", `
+          import fs from 'node:fs';
+          const [record, alias, home, ancestor, allowed] = process.argv.slice(1);
+          const attempt = (fn) => { try { fn(); return 'ALLOWED'; } catch(e) { return e.code; } };
+          const result = {
+            overwrite: attempt(() => fs.writeFileSync(record, 'forged')),
+            create: attempt(() => fs.writeFileSync(alias + '/new.json', 'forged')),
+            unlink: attempt(() => fs.unlinkSync(record)),
+            homeMove: attempt(() => fs.renameSync(home, home + '-moved')),
+            ancestorMove: attempt(() => fs.renameSync(ancestor, ancestor + '-moved')),
+            normal: attempt(() => fs.writeFileSync(allowed, 'allowed')),
+          };
+          process.stdout.write(JSON.stringify(result));
+        `, record, alias, home, dirname(home), join(workspace, "allowed.txt")],
+        cwd, env: { ...environment, AGENC_HOME: join(workspace, "untrusted-command-home") },
+        additionalPermissions: { fileSystem: { entries: [
+          { path: { kind: "path", path: authority }, access: "write" },
+          { path: { kind: "path", path: record }, access: "write" },
+        ] } },
+      }).run(command => spawnSync(command.program, [...command.args], {
+        cwd: command.cwd, env: command.env, encoding: "utf8", timeout: 8_000,
+      }));
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      const evidence = JSON.parse(result.stdout);
+      for (const key of ["overwrite", "create", "unlink", "homeMove", "ancestorMove"]) expect(evidence[key], JSON.stringify(evidence)).not.toBe("ALLOWED");
+      expect(evidence.normal).toBe("ALLOWED");
+      expect(readFileSync(record, "utf8")).toBe("native-public-record");
+      expect(existsSync(join(authority, "new.json"))).toBe(false);
+    }
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
 
 test(
   "enforces the production Linux sandbox boundary with the real kernel",

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
@@ -66,6 +66,7 @@ test("protects custom Desktop authority records and their ancestor namespace wit
             overwrite: attempt(() => fs.writeFileSync(record, 'forged')),
             create: attempt(() => fs.writeFileSync(alias + '/new.json', 'forged')),
             unlink: attempt(() => fs.unlinkSync(record)),
+            hardlink: attempt(() => fs.linkSync(record, allowed + '.link')),
             homeMove: attempt(() => fs.renameSync(home, home + '-moved')),
             ancestorMove: attempt(() => fs.renameSync(ancestor, ancestor + '-moved')),
             normal: attempt(() => fs.writeFileSync(allowed, 'allowed')),
@@ -77,13 +78,13 @@ test("protects custom Desktop authority records and their ancestor namespace wit
           { path: { kind: "path", path: authority }, access: "write" },
           { path: { kind: "path", path: record }, access: "write" },
         ] } },
-      }).run(command => spawnSync(command.program, [...command.args], {
+      }).run(async command => spawnSync(command.program, [...command.args], {
         cwd: command.cwd, env: command.env, encoding: "utf8", timeout: 8_000,
       }));
       expect(result.error).toBeUndefined();
       expect(result.status, result.stderr).toBe(0);
       const evidence = JSON.parse(result.stdout);
-      for (const key of ["overwrite", "create", "unlink", "homeMove", "ancestorMove"]) expect(evidence[key], JSON.stringify(evidence)).not.toBe("ALLOWED");
+      for (const key of ["overwrite", "create", "unlink", "hardlink", "homeMove", "ancestorMove"]) expect(evidence[key], JSON.stringify(evidence)).not.toBe("ALLOWED");
       expect(evidence.normal).toBe("ALLOWED");
       expect(readFileSync(record, "utf8")).toBe("native-public-record");
       expect(existsSync(join(authority, "new.json"))).toBe(false);

--- a/runtime/tests/session/mcp-startup.test.ts
+++ b/runtime/tests/session/mcp-startup.test.ts
@@ -6,7 +6,9 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { createHash, generateKeyPairSync, randomUUID, sign } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -37,10 +39,13 @@ import {
   createSessionMcpService as createRuntimeSessionMcpService,
   requiredMcpServerNames,
   resolveSessionMcpConfig as resolveRuntimeSessionMcpConfig,
+  resolveSessionMcpPlan,
   startMcpManagerForSession,
 } from "./mcp-startup.js";
 import type { Session } from "./session.js";
 import { ConfigStore } from "../config/store.js";
+import { withLocalMcpAccess } from "../mcp-client/local-control.js";
+import { verifyDesktopAuthority } from "../mcp-client/desktop-authority.js";
 import type { AgenCConfig } from "../config/schema.js";
 import {
   getCanonicalSettingsAuthority,
@@ -207,6 +212,21 @@ beforeEach(() => {
 });
 
 describe("mcp-startup.attachMcpManagerToSession", () => {
+  it("resolves the daemon approval bridge at call time after bootstrap", async () => {
+    const setPermissionOptions = vi.fn();
+    const { manager } = stubManager();
+    Object.assign(manager, { setPermissionOptions });
+    const services: { approvalResolver?: { request: ReturnType<typeof vi.fn> } } = {};
+    const { session } = stubSession();
+    Object.assign(session, { services, permissionModeRegistry: { current: vi.fn() }, sessionConfiguration: { cwd: "/tmp", approvalPolicy: { value: "on_request" }, sandboxPolicy: { value: "workspace_write" } } });
+    attachMcpManagerToSession(manager, session);
+    const resolver = setPermissionOptions.mock.calls[0][0].approvalResolver;
+    expect(await resolver.request({})).toEqual({ kind: "denied" });
+    services.approvalResolver = { request: vi.fn(async () => ({ kind: "approved" })) };
+    expect(await resolver.request({})).toEqual({ kind: "approved" });
+    services.approvalResolver = { request: vi.fn(async () => ({ kind: "abort" })) };
+    expect(await resolver.request({})).toEqual({ kind: "abort" });
+  });
   it("installs a call observer on the manager", () => {
     const {
       manager,
@@ -2367,7 +2387,233 @@ describe("mcp-startup session-owned manager helpers", () => {
   });
 });
 
+async function createPrivateDesktopFixture(home: string) {
+  const socketRoot = mkdtempSync(join(realpathSync("/tmp"), "agenc-dc-"));
+  chmodSync(socketRoot, 0o700);
+  const socketPath = join(socketRoot, "control.sock");
+  const socket = createServer();
+  await new Promise<void>((resolve, reject) => {
+    socket.once("error", reject);
+    socket.listen(socketPath, resolve);
+  });
+  chmodSync(socketPath, 0o600);
+  const directory = join(home, "desktop-control-authorities");
+  mkdirSync(directory, { mode: 0o700 });
+  const keys = generateKeyPairSync("ed25519");
+  const id = randomUUID();
+  const config = {
+    name: "agenc-desktop-control", transport: "http" as const,
+    endpoint: "http://127.0.0.1:43219/mcp", localOnly: true,
+    headers: { Authorization: `Bearer ${"a".repeat(48)}` },
+  };
+  const material = JSON.stringify([2, config.name, config.endpoint,
+    createHash("sha256").update(config.headers.Authorization).digest("hex"), 1, socketPath]);
+  const record = { version: 2, publicKey: keys.publicKey.export({ type: "spki", format: "pem" }),
+    expiresAt: Date.now() + 600_000, socketPath };
+  writeFileSync(join(directory, `${id}.json`), JSON.stringify(record), { mode: 0o600 });
+  const signed = { ...config, desktopAuthority: {
+    id, signature: sign(null, Buffer.from(material), keys.privateKey).toString("base64"),
+  } };
+  const grant = (await verifyDesktopAuthority(signed, home))!;
+  return {
+    config: signed, grant,
+    async cleanup() {
+      await new Promise<void>(resolve => socket.close(() => resolve()));
+      rmSync(socketRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+function legacyDesktopLines(name: string, endpoint = "http://127.0.0.1:43117/mcp", token = "b".repeat(48), transport = "http") {
+  return [`[mcp_servers.${name}]`, `transport = ${JSON.stringify(transport)}`,
+    `endpoint = ${JSON.stringify(endpoint)}`, `headers = { Authorization = ${JSON.stringify(`Bearer ${token}`)} }`];
+}
+
+describe("private Desktop session legacy migration", () => {
+  it("retires both native global bridges and captured proxies only in the attached session, then restores them on explicit disable", async () => {
+    const fixture = await createMcpAuthorityFixture({ user: [
+      ...legacyDesktopLines("agenc-desktop"), ...legacyDesktopLines("agenc-browser"),
+      '[mcp_servers.unrelated]', 'command = "other-mcp"',
+    ] });
+    const privateDesktop = await createPrivateDesktopFixture(fixture.home);
+    const originalConfig = readFileSync(fixture.userConfigPath, "utf8");
+    const manager = createSessionMcpManager([]);
+    const service = createSessionMcpService(manager, { authority: fixture.store, environment: { AGENC_HOME: fixture.home } });
+    const otherManager = createSessionMcpManager([]);
+    const otherService = createSessionMcpService(otherManager, { authority: fixture.store, environment: {} });
+    const bridges: ReturnType<typeof makeMockBridge>[] = [];
+    mockCreateToolBridge.mockImplementation(async (_client, name, _logger, options) => {
+      const bridge = makeMockBridge(name, options?.callObserver);
+      bridges.push(bridge);
+      return bridge as never;
+    });
+    try {
+      await service.refreshFromAuthority?.();
+      await otherService.refreshFromAuthority?.();
+      const captured = ["agenc-desktop", "agenc-browser"].map(name => manager.getToolsByServer(name)[0]!);
+      for (const tool of captured) await expect(tool.execute({})).resolves.toMatchObject({ content: "ok", isError: false });
+      const originalBridges = bridges.slice(0, 3).filter(bridge => bridge.serverName !== "unrelated");
+      await expect(service.addServer?.(privateDesktop.config, { replace: true })).resolves.toMatchObject({ success: true });
+      expect(manager.getConfiguredServers().map(config => config.name).sort()).toEqual(["agenc-desktop-control", "unrelated"]);
+      expect(otherManager.getConfiguredServers().map(config => config.name).sort()).toEqual(["agenc-browser", "agenc-desktop", "unrelated"]);
+      const connections = mockCreateMCPConnection.mock.calls.length;
+      for (const tool of captured) {
+        await expect(tool.execute({})).resolves.toMatchObject({ isError: true, content: expect.stringContaining("disposed") });
+      }
+      for (const bridge of originalBridges) {
+        expect(bridge.dispose).toHaveBeenCalledTimes(1);
+        expect(bridge.tools[0]!.execute).toHaveBeenCalledTimes(1);
+      }
+      expect(mockCreateMCPConnection).toHaveBeenCalledTimes(connections);
+      await expect(service.reconnectServer?.("agenc-desktop")).resolves.toMatchObject({ success: false });
+      await expect(service.enableServer?.("agenc-browser")).resolves.toMatchObject({ success: false });
+      // Rejected mutations reconcile the surviving services, but cannot open
+      // either superseded endpoint again.
+      expect(mockCreateMCPConnection.mock.calls.slice(connections).map(([config]) => config.name))
+        .not.toEqual(expect.arrayContaining(["agenc-desktop"]));
+      expect(mockCreateMCPConnection.mock.calls.slice(connections).map(([config]) => config.name))
+        .not.toEqual(expect.arrayContaining(["agenc-browser"]));
+      expect(readFileSync(fixture.userConfigPath, "utf8")).toBe(originalConfig);
+      await expect(service.disableServer?.("agenc-desktop-control")).resolves.toMatchObject({ success: true });
+      expect(manager.getConfiguredServers().map(config => config.name).sort()).toEqual(["agenc-browser", "agenc-desktop", "agenc-desktop-control", "unrelated"]);
+      expect(manager.isConnected("agenc-desktop")).toBe(true);
+      expect(manager.isConnected("agenc-browser")).toBe(true);
+      // A retired proxy stays retired; restoring the user fallback creates new ones.
+      await expect(captured[0]!.execute({})).resolves.toMatchObject({ isError: true, content: expect.stringContaining("disposed") });
+      await expect(manager.getToolsByServer("agenc-desktop")[0]!.execute({})).resolves.toMatchObject({ content: "ok" });
+      await service.dispose?.();
+      expect((await resolveSessionMcpConfig(fixture.store, {})).map(config => config.name).sort()).toEqual(["agenc-browser", "agenc-desktop", "unrelated"]);
+      expect(readFileSync(fixture.userConfigPath, "utf8")).toBe(originalConfig);
+    } finally {
+      await service.dispose?.(); await otherService.dispose?.();
+      await privateDesktop.cleanup(); fixture.cleanup();
+    }
+  });
+
+  it("requires a genuine private grant, hides legacy definitions, and never falls back just because the grant expires", async () => {
+    const fixture = await createMcpAuthorityFixture({ user: legacyDesktopLines("agenc-desktop") });
+    const privateDesktop = await createPrivateDesktopFixture(fixture.home);
+    const config = { ...privateDesktop.config, desktopAuthorityGrant: privateDesktop.grant };
+    const planFor = (attachment: MCPServerConfig) => resolveSessionMcpPlan(fixture.store, {},
+      { [attachment.name]: attachment }, new Map(), { pluginStorageRoot: TEST_PLUGIN_STORAGE_ROOT });
+    try {
+      for (const attachment of [
+        { ...config, desktopAuthorityGrant: undefined },
+        { ...config, desktopAuthorityGrant: { ...privateDesktop.grant } },
+        { ...config, localOnly: false },
+        { ...config, enabled: false },
+      ]) {
+        expect((await planFor(attachment)).configs.map(server => server.name)).toContain("agenc-desktop");
+      }
+      const active = await planFor(config);
+      expect(active.configs.map(server => server.name)).not.toContain("agenc-desktop");
+      expect(active.definitions.has("agenc-desktop")).toBe(false);
+      const now = vi.spyOn(Date, "now").mockReturnValue(privateDesktop.grant.expiresAt + 1);
+      try {
+        expect((await planFor(config)).configs.map(server => server.name)).not.toContain("agenc-desktop");
+      } finally { now.mockRestore(); }
+    } finally { await privateDesktop.cleanup(); fixture.cleanup(); }
+  });
+
+  it.each([
+    ["other-native-name", "http://127.0.0.1:43117/mcp", "b".repeat(48), "http"],
+    ["agenc-desktop", "https://127.0.0.1:43117/mcp", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://localhost:43117/mcp", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://127.0.0.1/mcp", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://127.0.0.1:43117/mcp?custom=1", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://127.0.0.1:43117/mcp#custom", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://user@127.0.0.1:43117/mcp", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://127.0.0.1:43117/custom", "b".repeat(48), "http"],
+    ["agenc-desktop", "http://127.0.0.1:43117/mcp", "B".repeat(48), "http"],
+    ["agenc-desktop", "http://127.0.0.1:43117/mcp", "b".repeat(47), "http"],
+    ["agenc-desktop", "http://127.0.0.1:43117/mcp", "b".repeat(48), "sse"],
+  ])("retains non-native configuration %s %s %s %s", async (name, endpoint, token, transport) => {
+    const fixture = await createMcpAuthorityFixture({ user: legacyDesktopLines(name, endpoint, token, transport) });
+    const privateDesktop = await createPrivateDesktopFixture(fixture.home);
+    try {
+      const configs = await resolveSessionMcpConfig(fixture.store, {}, {
+        "agenc-desktop-control": { ...privateDesktop.config, desktopAuthorityGrant: privateDesktop.grant },
+      });
+      expect(configs.map(config => config.name)).toContain(name);
+    } finally { await privateDesktop.cleanup(); fixture.cleanup(); }
+  });
+});
+
 describe("session MCP mutation transactions", () => {
+  it("attaches, idempotently replaces and rotates authenticated local HTTP state without persisting credentials", async () => {
+    const fixture = await createMcpAuthorityFixture();
+    const before = readFileSync(fixture.userConfigPath, "utf8");
+    const manager = createSessionMcpManager([]);
+    const service = createSessionMcpService(manager, { authority: fixture.store, environment: {} });
+    const token = "b".repeat(48);
+    const config = { name: "agenc-desktop-control", transport: "http" as const, endpoint: "http://127.0.0.1:43118/mcp", headers: { Authorization: `Bearer ${token}` }, localOnly: true };
+    try {
+      await expect(service.addServer?.(config, { replace: true })).resolves.toMatchObject({ success: true, toolCount: 1 });
+      expect(mockCreateMCPConnection.mock.calls[0]?.[0]).toMatchObject({ headers: config.headers, localOnly: true, origin: { scope: "session" } });
+      expect(manager.getTools()).toEqual([]);
+      expect(manager.getServerInstructions(config.name)).toBeUndefined();
+      await withLocalMcpAccess(true, async () => {
+        expect(manager.getTools().map(tool => tool.name)).toEqual(["mcp.agenc-desktop-control.echo"]);
+        // A matching server name and bearer alone cannot claim product identity.
+        expect(manager.getServerInstructions(config.name)).toBeUndefined();
+      });
+      expect(mockCreateResourceBridge).not.toHaveBeenCalled();
+      expect(mockCreatePromptBridge).not.toHaveBeenCalled();
+      for (const projection of [manager.getConfiguredServers(), manager.getConnectedConnection(config.name), service.mcpSurfaceSnapshot?.()]) {
+        expect(JSON.stringify(projection)).not.toContain(token);
+      }
+      await expect(service.addServer?.(config, { replace: true })).resolves.toMatchObject({ success: true });
+      expect(mockCreateMCPConnection).toHaveBeenCalledTimes(1);
+      const rotated = { ...config, endpoint: "http://127.0.0.1:43119/mcp", headers: { Authorization: `Bearer ${"c".repeat(48)}` } };
+      await expect(service.addServer?.(rotated, { replace: true })).resolves.toMatchObject({ success: true });
+      expect(mockCreateMCPConnection).toHaveBeenCalledTimes(2);
+      expect(mockCreateMCPConnection.mock.calls[1]?.[0]).toMatchObject(rotated);
+      await expect(service.reconnectServer?.(config.name)).resolves.toMatchObject({ success: true });
+      expect(mockCreateMCPConnection.mock.calls.at(-1)?.[0]).toMatchObject(rotated);
+      expect(mockCreateToolBridge.mock.calls.at(-1)?.[3]?.serverConfig).toMatchObject({ localOnly: true, sensitiveHeaders: rotated.headers });
+      expect(readFileSync(fixture.userConfigPath, "utf8")).toBe(before);
+      await expect(service.addServer?.({ ...rotated, localOnly: false }, { replace: true })).resolves.toMatchObject({ success: false });
+      await service.dispose?.();
+      const restored = createSessionMcpManager([]);
+      const restoredService = createSessionMcpService(restored, { authority: fixture.store, environment: {} });
+      await restoredService.refreshFromAuthority?.();
+      expect(restored.getConfiguredServers()).toEqual([]);
+      await restoredService.dispose?.();
+    } finally { await service.dispose?.(); fixture.cleanup(); }
+  });
+
+  it("does not replace canonical user MCP definitions and preserves managed exclusivity", async () => {
+    for (const settings of [
+      { user: ['[mcp_servers.owner]', 'command = "owner-mcp"'] },
+      { managed: ['[mcp_servers]'] },
+    ]) {
+      const fixture = await createMcpAuthorityFixture(settings);
+      const manager = createSessionMcpManager([]);
+      const service = createSessionMcpService(manager, { authority: fixture.store, environment: {} });
+      try {
+        await expect(service.addServer?.({ name: "owner", transport: "http", endpoint: "http://127.0.0.1:43118/mcp", headers: { Authorization: `Bearer ${"d".repeat(48)}` }, localOnly: true }, { replace: true })).resolves.toMatchObject({ success: false });
+        expect(manager.getConfiguredServers().every(config => config.localOnly !== true)).toBe(true);
+      } finally { await service.dispose?.(); fixture.cleanup(); }
+    }
+  });
+
+  it("redacts failed auth diagnostics and rolls back the prior attachment", async () => {
+    const fixture = await createMcpAuthorityFixture();
+    const manager = createSessionMcpManager([]);
+    const service = createSessionMcpService(manager, { authority: fixture.store, environment: {} });
+    const config = { name: "agenc-desktop-control", transport: "http" as const, endpoint: "http://127.0.0.1:43118/mcp", headers: { Authorization: `Bearer ${"e".repeat(48)}` }, localOnly: true };
+    try {
+      await service.addServer?.(config, { replace: true });
+      const rotatedToken = "f".repeat(48);
+      mockCreateMCPConnection.mockRejectedValueOnce(new Error(`Authentication failed: Bearer ${rotatedToken}`));
+      const result = await service.addServer?.({ ...config, headers: { Authorization: `Bearer ${rotatedToken}` } }, { replace: true });
+      expect(result?.success).toBe(false);
+      expect(JSON.stringify(result)).not.toContain(rotatedToken);
+      expect(manager.getConnectionState(config.name)?.type).toBe("connected");
+      expect(mockCreateMCPConnection.mock.calls.at(-1)?.[0]).toMatchObject(config);
+    } finally { await service.dispose?.(); fixture.cleanup(); }
+  });
+
   it("rejects malformed session additions before touching the manager", async () => {
     const fixture = await createMcpAuthorityFixture();
     const harness = createTransactionalManager();


### PR DESCRIPTION
## Summary

Add authenticated, session-owned AgenC Desktop tool delivery and fix known browser-navigation failure reporting. Includes merged Whisper/main `cc37274ae`.

- Extend `session.mcp.addServer` with bounded memory-only headers, local-only provenance, signed host authority and idempotent replacement. No global MCP configuration changes.
- Automatically deliver Desktop discovery instructions to eligible existing/new local turns. Retire captured legacy connections and suppress only recognized global `agenc-desktop` / `agenc-browser` registrations within the private session. Explicitly disabling the private attachment restores them; expiration never silently revives wrong-window controls.
- Distinguish Chromium-confirmed navigation errors from unknown transport outcomes, preserving inspectable tabs and conservative handling of disconnects/timeouts.

## Security and supported behavior

- Audited capabilities require a verified Ed25519 host record, a private owner-only Unix socket, fresh live proof before credentials, and inode/expiry checks. No TCP fallback. macOS/Linux only; Windows Desktop controls are not enabled and receive no equivalent unsigned grant.
- Only local daemon user turns may discover or execute private controls. Recheck provenance, cancellation and permission state after approval and asynchronous transport preflight; client JSON cannot manufacture runtime authority.
- Closed read/UI capability classification retains ordinary approvals and plan restrictions. The exact authority-record directory is reserved against restricted file/process writes, including extra write grants, symlink aliases and ancestor replacement.
- Visible `terminal_open/run/type/close` require an already full-access session and its authenticated current broker. These PTYs are **not Core-sandboxed**; no automatic elevation or one-shot sandbox bypass. Existing native processes are not retroactively stopped when permissions tighten. Restricted sessions use Core's sandboxed command tools instead.
- Trust boundary: host OS and same-user native processes. Desktop supplies the corresponding authenticated server and window/session ownership enforcement. No account-compromise protection claim.
- Browser recovery applies to newly observed, authoritative command responses. Previously persisted unresolved Browser outcomes remain unresolved; this change does not silently clear existing records or replace explicit recovery review.
- Eight authenticated native inspection tools have explicit idempotent recovery classification, so an unresolved outcome does not prevent diagnosis. Mutations and page-JavaScript snapshot/read/wait tools remain gated. Expired, remote, unsigned or forged registrations cannot inherit this exemption; durable and live unknown records are preserved.

## Verified

- Pinned Node 26.5.0 / npm 11.17.0: official typecheck (including test support), SDK build/generated-type checks, runtime build and package-entrypoint checks pass.
- **456 focused tests pass**: 442 Whisper/control/provenance/lifecycle/browser/protection tests plus 14 canonical protocol contracts.
- Final inspection and exact-key hardening: **137 tests / nine focused suites pass**, including the production registry, admission path, durable SQLite and live-poison unknown gates. Strict authority key matching is order-independent without locale-based sorting and rejects extra, hidden, inherited and symbol keys.
- Exact merged revision `af4176cad596ac3ce6ac5cd36e261b92325fa126`: **195 tests / 12 suites pass**, including main's configuration-layer and approval-cache comparator changes. Pinned typechecks, explicit SDK and production runtime builds pass; the resulting runtime is packaged by Desktop PR #219. Both SonarCloud checks on the final PR head pass.
- Real built Core + SDK + authenticated UDS fixture: three UI operations delivered; idempotency, credential rotation, authority renewal, secret redaction and unchanged global configuration pass. Uses a scripted loopback model, no cloud credentials or microphone.
- Real built Core terminal-policy fixture: full-access dispatch succeeds; restricted dispatch is refused. Stub only—no native PTY or host command is started.
- Linux non-root production kernel regression passes for authority-file and ancestor-namespace protection; two unrelated kernel cases were filtered. This is not a full Linux-kernel-suite pass claim.

## Full-suite status / known unchanged fixtures

- macOS full hermetic run stops after 723 passes on unchanged `daemon-cli.contract.test.ts:1059`: `/home` canonicalizes through the OS symlink to `/System/Volumes/Data/home`; the fixture expects the original string (36 tests skipped before bail).
- Linux full hermetic run stops after 879 passes on unchanged `daemon-cli.contract.test.ts:6724`: the fixture's exact unattended-policy expectation omits main's `readOnly: false` field. Source/test blob comparison confirms this predates the feature.
- Excluding the daemon fixture reached 1,703 passes before an unchanged update-CLI fixture failed: it hardcodes an x64 manifest but launches the ARM64 Node binary. Direct verifier reproduction confirms the architecture mismatch.
- A further aggregate run excluding those two files was stopped at the 15-minute resource bound. It did not produce final totals; it is **not** a full-suite pass. Additional environment-dependent native-header probes were observed. No baseline tests or sandbox policies were weakened to obtain a green result.
- Linux snapshot `3bae6217f`: all 14 changed non-kernel test files pass, **359/359 with zero skips**, including the separate cross-repo protocol lane. The later `b7c4f0366` diff is limited to audited inspection recovery, exact authority-key checks, tests and documentation; its 137 focused tests and builds pass on macOS, and it does not change sandbox/kernel paths. The exact full CI suite is not claimed green; feature-specific validation and the real kernel boundary are reported separately.

Local evidence: `/tmp/agenc-controls-delivery-final.log`, `/tmp/agenc-controls-terminal-policy-final.log`, `/tmp/agenc-controls-core-full-macos-final.log`, `/tmp/agenc-controls-kernel-runtime-full-suite.log`, `/tmp/agenc-controls-kernel-runtime-excluding-daemon-cli.log`, `/tmp/agenc-controls-kernel-reservation-profile-explicit.log`.
