### PR TITLE
Generate images with GPT Image and MiniMax Image

### DIFF
--- a/runtime/src/tools/system/imagine-image.ts
+++ b/runtime/src/tools/system/imagine-image.ts
@@ -119,6 +119,10 @@ const OPENAI_IMAGE_MODELS = Object.freeze(
 const OPENAI_IMAGE_QUALITIES = Object.freeze(
   new Set(["low", "medium", "high", "auto"]),
 );
+/** OpenAI's three encodings, keyed by the `output_format` it reports. */
+const OPENAI_OUTPUT_EXTENSIONS: Readonly<Record<string, string>> = Object.freeze(
+  { jpeg: "jpg", webp: "webp", png: "png" },
+);
 const MINIMAX_IMAGE_MODELS = Object.freeze(
   new Set(["image-01", "image-01-live"]),
 );
@@ -701,6 +705,24 @@ function imagesFromImagePayload(
   return (data.image_base64 ?? []).map((b64_json) => ({ b64_json }));
 }
 
+/** What a backend generates with when the caller names no model. */
+function defaultImageModel(backend: ImageBackend): string {
+  switch (backend.kind) {
+    case "meta":
+      return "muse-image-1.0";
+    case "qwen":
+      return backend.provider === "qwen" ? "qwen-image-3.0" : "wan2.7-image";
+    case "zai":
+      return "glm-image";
+    case "openai":
+      return "gpt-image-2";
+    case "minimax":
+      return "image-01";
+    case "xai":
+      return "grok-imagine-image";
+  }
+}
+
 /** Backend name as it appears in an error the model reads. */
 function imageBackendLabel(backend: ImageBackend): string {
   switch (backend.kind) {
@@ -737,11 +759,7 @@ function defaultImageExtension(
       return "png";
     case "openai":
       // gpt-image defaults to PNG and echoes the format it actually used.
-      return openaiOutputFormat === "jpeg"
-        ? "jpg"
-        : openaiOutputFormat === "webp"
-          ? "webp"
-          : "png";
+      return OPENAI_OUTPUT_EXTENSIONS[openaiOutputFormat ?? ""] ?? "png";
     case "minimax":
       // MiniMax Image returns JPEG.
       return "jpg";
@@ -1108,21 +1126,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
       const prompt = stringValue(args.prompt);
       if (!prompt) return refusal({ error: "prompt is required" });
 
-      const model =
-        stringValue(args.model) ??
-        (backend.kind === "meta"
-          ? "muse-image-1.0"
-          : backend.kind === "qwen"
-            ? backend.provider === "qwen"
-              ? "qwen-image-3.0"
-              : "wan2.7-image"
-            : backend.kind === "zai"
-              ? "glm-image"
-              : backend.kind === "openai"
-                ? "gpt-image-2"
-                : backend.kind === "minimax"
-                  ? "image-01"
-                  : "grok-imagine-image");
+      const model = stringValue(args.model) ?? defaultImageModel(backend);
       if (backend.kind === "meta") {
         if (model !== "muse-image-1.0") {
           return refusal({ error: "Meta image model must be muse-image-1.0" });

--- a/runtime/src/tools/system/imagine-image.ts
+++ b/runtime/src/tools/system/imagine-image.ts
@@ -98,6 +98,31 @@ const DEFAULT_QWEN_BASE_URL =
 const DEFAULT_QWEN_TOKEN_PLAN_BASE_URL =
   "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1";
 const DEFAULT_ZAI_BASE_URL = "https://api.z.ai/api/paas/v4";
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+/**
+ * MiniMax rejects any other value outright. Its own list also carries 21:9,
+ * which this tool's shared aspect vocabulary does not offer, so the set here
+ * is the intersection rather than MiniMax's full list.
+ */
+const MINIMAX_ASPECT_RATIOS = Object.freeze(
+  new Set(["1:1", "16:9", "4:3", "3:2", "2:3", "3:4", "9:16"]),
+);
+const OPENAI_IMAGE_MODELS = Object.freeze(
+  new Set([
+    "gpt-image-2",
+    "gpt-image-1.5",
+    "gpt-image-1",
+    "gpt-image-1-mini",
+    "chatgpt-image-latest",
+  ]),
+);
+const OPENAI_IMAGE_QUALITIES = Object.freeze(
+  new Set(["low", "medium", "high", "auto"]),
+);
+const MINIMAX_IMAGE_MODELS = Object.freeze(
+  new Set(["image-01", "image-01-live"]),
+);
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 const MAX_IMAGE_DOWNLOAD_BYTES = 20 * 1024 * 1024;
 const MAX_IMAGE_DOWNLOAD_REDIRECTS = 5;
 const ZAI_GLM_IMAGE_COST_USD = 0.015;
@@ -122,6 +147,16 @@ type ImageBackend =
     }
   | {
       readonly kind: "zai";
+      readonly baseURL: string;
+      readonly bearer: string;
+    }
+  | {
+      readonly kind: "openai";
+      readonly baseURL: string;
+      readonly bearer: string;
+    }
+  | {
+      readonly kind: "minimax";
       readonly baseURL: string;
       readonly bearer: string;
     };
@@ -151,6 +186,24 @@ function isZaiCodingPlanBaseURL(baseURL: string): boolean {
   }
 }
 
+/**
+ * Registered download hosts per backend, keyed so that adding a backend
+ * cannot inherit another one's hosts by falling through a chain of
+ * ternaries. An empty list means the backend never downloads: OpenAI and
+ * MiniMax are both asked for base64 payloads, so a URL arriving from either
+ * is unexpected and refused rather than fetched.
+ */
+const IMAGE_DOWNLOAD_HOSTS: Readonly<
+  Record<ImageBackend["kind"], readonly string[]>
+> = Object.freeze({
+  qwen: ["aliyuncs.com"],
+  meta: ["meta.ai", "fbcdn.net", "facebook.com"],
+  zai: ["z.ai", "bigmodel.cn", "chatglm.cn"],
+  xai: ["x.ai"],
+  openai: [],
+  minimax: [],
+});
+
 function validatedImageDownloadUrl(value: string, backend: ImageBackend): URL {
   let url: URL;
   try {
@@ -162,24 +215,9 @@ function validatedImageDownloadUrl(value: string, backend: ImageBackend): URL {
     throw new Error("Image download URL must use credential-free HTTPS");
   }
   const hostname = url.hostname.toLowerCase();
-  const trusted =
-    backend.kind === "qwen"
-      ? hostname === "aliyuncs.com" || hostname.endsWith(".aliyuncs.com")
-      : backend.kind === "meta"
-        ? hostname === "meta.ai" ||
-          hostname.endsWith(".meta.ai") ||
-          hostname === "fbcdn.net" ||
-          hostname.endsWith(".fbcdn.net") ||
-          hostname === "facebook.com" ||
-          hostname.endsWith(".facebook.com")
-        : backend.kind === "zai"
-          ? hostname === "z.ai" ||
-            hostname.endsWith(".z.ai") ||
-            hostname === "bigmodel.cn" ||
-            hostname.endsWith(".bigmodel.cn") ||
-            hostname === "chatglm.cn" ||
-            hostname.endsWith(".chatglm.cn")
-          : hostname === "x.ai" || hostname.endsWith(".x.ai");
+  const trusted = IMAGE_DOWNLOAD_HOSTS[backend.kind].some(
+    (suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`),
+  );
   if (!trusted) {
     throw new Error(
       `Image download host is not trusted for the ${backend.kind} backend`,
@@ -302,6 +340,52 @@ function zaiEnvironmentBackend(
 }
 
 /**
+ * OpenAI images are reachable only with an API key. The ChatGPT OAuth grant
+ * this app can hold authorizes the Responses backend and not
+ * `/images/generations`, so the session credential is never consulted here:
+ * the canonical OPENAI_API_KEY ingress is the only authority for this route.
+ */
+function openaiEnvironmentBackend(
+  env: NodeJS.ProcessEnv,
+): ImageBackend | undefined {
+  const credential = resolveProviderApiKeyEnvironment("openai", env);
+  if (credential === undefined) return undefined;
+  const baseURL =
+    resolveProviderBaseURLEnvironment("openai", env)?.value ??
+    DEFAULT_OPENAI_BASE_URL;
+  try {
+    new URL(baseURL);
+  } catch {
+    return undefined;
+  }
+  return {
+    kind: "openai",
+    baseURL: withoutTrailingSlash(baseURL),
+    bearer: credential.value,
+  };
+}
+
+function minimaxEnvironmentBackend(
+  env: NodeJS.ProcessEnv,
+): ImageBackend | undefined {
+  const credential = resolveProviderApiKeyEnvironment("minimax", env);
+  if (credential === undefined) return undefined;
+  const baseURL =
+    resolveProviderBaseURLEnvironment("minimax", env)?.value ??
+    DEFAULT_MINIMAX_BASE_URL;
+  try {
+    new URL(baseURL);
+  } catch {
+    return undefined;
+  }
+  return {
+    kind: "minimax",
+    baseURL: withoutTrailingSlash(baseURL),
+    bearer: credential.value,
+  };
+}
+
+/**
  * Media credentials are intentionally independent from the reasoning
  * provider. A Meta/OpenAI/etc session key must never become an xAI bearer.
  * Direct Grok sessions retain their existing session-bearer compatibility.
@@ -381,6 +465,20 @@ function resolveImageBackend(opts: ImagineImageToolOptions): BackendResolution {
     if (backend !== undefined) return { backend };
   }
 
+  // An OpenAI session generates with OpenAI, the same way a Qwen, Z.AI or
+  // Meta session uses its own native route. Only the API-key ingress can
+  // authorize it, so a session running on the ChatGPT OAuth grant alone
+  // falls through to the independent backends below.
+  if (providerIdentity === "openai") {
+    const backend = openaiEnvironmentBackend(env);
+    if (backend !== undefined) return { backend };
+  }
+
+  if (providerIdentity === "minimax") {
+    const backend = minimaxEnvironmentBackend(env);
+    if (backend !== undefined) return { backend };
+  }
+
   if (providerIdentity === "grok" && provider !== undefined) {
     const factory = readProviderFactoryOptions(provider as never);
     if (isDirectXaiInferenceHost(factory.baseURL)) {
@@ -446,9 +544,19 @@ function resolveImageBackend(opts: ImagineImageToolOptions): BackendResolution {
     return { backend: fallbackZaiBackend };
   }
 
+  const fallbackOpenaiBackend = openaiEnvironmentBackend(env);
+  if (fallbackOpenaiBackend !== undefined) {
+    return { backend: fallbackOpenaiBackend };
+  }
+
+  const fallbackMinimaxBackend = minimaxEnvironmentBackend(env);
+  if (fallbackMinimaxBackend !== undefined) {
+    return { backend: fallbackMinimaxBackend };
+  }
+
   return {
     error:
-      "ImagineImage needs a media backend credential: MODEL_API_KEY for Meta Muse Image; DASHSCOPE_API_KEY/QWEN_API_KEY or QWEN_TOKEN_PLAN_API_KEY for QwenCloud; ZAI_API_KEY for GLM-Image; or /grok-login, XAI_API_KEY, or GROK_API_KEY for xAI Imagine.",
+      "ImagineImage needs a media backend credential: MODEL_API_KEY for Meta Muse Image; DASHSCOPE_API_KEY/QWEN_API_KEY or QWEN_TOKEN_PLAN_API_KEY for QwenCloud; ZAI_API_KEY for GLM-Image; OPENAI_API_KEY for GPT Image; MINIMAX_API_KEY for MiniMax Image; or /grok-login, XAI_API_KEY, or GROK_API_KEY for xAI Imagine.",
   };
 }
 
@@ -459,7 +567,12 @@ export function hasImagineImageBackend(
   return "backend" in resolveImageBackend(opts);
 }
 
-function metaImageSize(aspectRatio: string | undefined): string {
+/**
+ * Backends that take a pixel size but only three shapes: square, landscape,
+ * portrait. Meta Muse Image and OpenAI GPT Image both work this way, and
+ * every OpenAI size must have both axes divisible by 16, which these are.
+ */
+function orientedImageSize(aspectRatio: string | undefined): string {
   if (
     aspectRatio === undefined ||
     aspectRatio === "auto" ||
@@ -564,6 +677,163 @@ function extensionForImageContentType(
   }
 }
 
+interface ImageListItem {
+  readonly b64_json?: string;
+  readonly url?: string;
+}
+
+type ImagePayloadData =
+  | readonly ImageListItem[]
+  | { readonly image_base64?: readonly string[] };
+
+/** `Array.isArray` alone does not narrow a readonly array out of a union. */
+function isImageList(data: ImagePayloadData): data is readonly ImageListItem[] {
+  return Array.isArray(data);
+}
+
+/** Images as a flat list, whichever container the backend used. */
+function imagesFromImagePayload(
+  data: ImagePayloadData | undefined,
+): readonly ImageListItem[] {
+  if (data === undefined) return [];
+  if (isImageList(data)) return data;
+  // MiniMax keys its images off an object, not a list.
+  return (data.image_base64 ?? []).map((b64_json) => ({ b64_json }));
+}
+
+/** Backend name as it appears in an error the model reads. */
+function imageBackendLabel(backend: ImageBackend): string {
+  switch (backend.kind) {
+    case "meta":
+      return "Muse Image";
+    case "qwen":
+      return "QwenCloud image";
+    case "zai":
+      return "Z.AI image";
+    case "openai":
+      return "GPT Image";
+    case "minimax":
+      return "MiniMax image";
+    case "xai":
+      return "Imagine";
+  }
+}
+
+/**
+ * The extension a saved file gets before any download reports its own
+ * content type. Electron's agenc-media protocol derives the rendered content
+ * type from this, so a wrong guess shows a broken image in the transcript.
+ */
+function defaultImageExtension(
+  backend: ImageBackend,
+  openaiOutputFormat: string | undefined,
+): string {
+  switch (backend.kind) {
+    case "meta":
+      // Muse Image returns WebP.
+      return "webp";
+    case "qwen":
+    case "zai":
+      return "png";
+    case "openai":
+      // gpt-image defaults to PNG and echoes the format it actually used.
+      return openaiOutputFormat === "jpeg"
+        ? "jpg"
+        : openaiOutputFormat === "webp"
+          ? "webp"
+          : "png";
+    case "minimax":
+      // MiniMax Image returns JPEG.
+      return "jpg";
+    case "xai":
+      return "jpg";
+  }
+}
+
+/** Per-backend ceiling on images returned by one request. */
+function maxImagesPerRequest(backend: ImageBackend, model: string): number {
+  if (backend.kind === "qwen") {
+    return /^wan2\.7-image(?:-pro)?$/i.test(model) ? 4 : 6;
+  }
+  return backend.kind === "minimax" ? 9 : 10;
+}
+
+/**
+ * `quality` means different things per backend, so each one owns its own
+ * vocabulary; a backend with no notion of quality rejects the field outright
+ * rather than dropping it silently.
+ */
+function imageQualityError(
+  backend: ImageBackend,
+  quality: string | undefined,
+): string | undefined {
+  if (quality === undefined) return undefined;
+  if (backend.kind === "zai") {
+    return quality === "hd" || quality === "standard"
+      ? undefined
+      : "quality must be hd or standard";
+  }
+  if (backend.kind === "openai") {
+    return OPENAI_IMAGE_QUALITIES.has(quality)
+      ? undefined
+      : `OpenAI quality must be one of ${[...OPENAI_IMAGE_QUALITIES].join(", ")}`;
+  }
+  return "quality is supported only by Z.AI and OpenAI images";
+}
+
+interface ImageRequestShape {
+  readonly backend: ImageBackend;
+  readonly model: string;
+  readonly prompt: string;
+  readonly n: number;
+  readonly aspectRatio: string | undefined;
+  readonly quality: string | undefined;
+}
+
+/**
+ * The request body before any backend-specific rewriting. QwenCloud starts
+ * empty because its DashScope shape is assembled against the resolved
+ * endpoint further down.
+ */
+function initialImageRequestBody(
+  shape: ImageRequestShape,
+): Record<string, unknown> {
+  const { backend, model, prompt, n, aspectRatio, quality } = shape;
+  switch (backend.kind) {
+    case "meta":
+      return { model, prompt, size: orientedImageSize(aspectRatio), n };
+    case "qwen":
+      return {};
+    case "zai":
+      return {
+        model,
+        prompt,
+        size: zaiImageSize(model, aspectRatio),
+        quality: quality ?? (model === "glm-image" ? "hd" : "standard"),
+      };
+    case "openai":
+      return {
+        model,
+        prompt,
+        n,
+        size: orientedImageSize(aspectRatio),
+        ...(quality !== undefined ? { quality } : {}),
+      };
+    case "minimax":
+      return {
+        model,
+        prompt,
+        n,
+        response_format: "base64",
+        ...(aspectRatio !== undefined && aspectRatio !== "auto"
+          ? { aspect_ratio: aspectRatio }
+          : {}),
+      };
+    case "xai":
+      return { model, prompt, n, response_format: "b64_json" };
+  }
+}
+
 function imagineImageDescription(backend: ImageBackend | undefined): string {
   switch (backend?.kind) {
     case "meta":
@@ -576,8 +846,12 @@ function imagineImageDescription(backend: ImageBackend | undefined): string {
       return "Generate exactly one image with Z.AI GLM-Image or CogView and save it under the workspace. Select image dimensions with aspect_ratio; Z.AI does not accept resolution or multiple-image requests.";
     case "xai":
       return "Generate images with xAI Imagine and save them under the workspace.";
+    case "openai":
+      return "Generate images with OpenAI GPT Image and save them under the workspace. Select dimensions with aspect_ratio and detail with quality.";
+    case "minimax":
+      return "Generate up to nine images with MiniMax Image and save them under the workspace. Select dimensions with aspect_ratio; MiniMax does not accept a resolution tier.";
     default:
-      return "Generate images with the configured QwenCloud, Meta, Z.AI, or xAI media backend and save them under the workspace.";
+      return "Generate images with the configured QwenCloud, Meta, Z.AI, OpenAI, MiniMax, or xAI media backend and save them under the workspace.";
   }
 }
 
@@ -662,11 +936,57 @@ function imagineImageInputSchema(
         },
       });
       break;
+    case "openai":
+      Object.assign(properties, {
+        model: {
+          type: "string",
+          enum: [...OPENAI_IMAGE_MODELS],
+          description: "OpenAI image model (default gpt-image-2).",
+        },
+        n: {
+          type: "integer",
+          minimum: 1,
+          maximum: 10,
+          description: "Number of images to generate (default 1).",
+        },
+        aspect_ratio: aspectRatio,
+        quality: {
+          type: "string",
+          enum: [...OPENAI_IMAGE_QUALITIES],
+          description:
+            "OpenAI rendering quality (default auto). Lower quality costs fewer output tokens.",
+        },
+      });
+      break;
+    case "minimax":
+      Object.assign(properties, {
+        model: {
+          type: "string",
+          enum: [...MINIMAX_IMAGE_MODELS],
+          description: "MiniMax image model (default image-01).",
+        },
+        n: {
+          type: "integer",
+          minimum: 1,
+          maximum: 9,
+          description: "Number of images to generate, from 1 to 9 (default 1).",
+        },
+        aspect_ratio: {
+          type: "string",
+          enum: [...MINIMAX_ASPECT_RATIOS],
+          description: "Desired output aspect ratio (default 1:1).",
+        },
+      });
+      break;
     case "xai":
       Object.assign(properties, {
         model: {
           type: "string",
-          enum: ["grok-imagine-image", "grok-imagine-image-quality"],
+          enum: [
+            "grok-imagine-image",
+            "grok-imagine-image-2.0",
+            "grok-imagine-image-quality",
+          ],
           description: "xAI image model (default grok-imagine-image).",
         },
         n: {
@@ -798,7 +1118,11 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
               : "wan2.7-image"
             : backend.kind === "zai"
               ? "glm-image"
-              : "grok-imagine-image");
+              : backend.kind === "openai"
+                ? "gpt-image-2"
+                : backend.kind === "minimax"
+                  ? "image-01"
+                  : "grok-imagine-image");
       if (backend.kind === "meta") {
         if (model !== "muse-image-1.0") {
           return refusal({ error: "Meta image model must be muse-image-1.0" });
@@ -832,14 +1156,33 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
             true,
           );
         }
+      } else if (backend.kind === "openai") {
+        if (!OPENAI_IMAGE_MODELS.has(model)) {
+          return json(
+            {
+              error: `OpenAI image model must be one of ${[...OPENAI_IMAGE_MODELS].join(", ")}`,
+            },
+            true,
+          );
+        }
+      } else if (backend.kind === "minimax") {
+        if (!MINIMAX_IMAGE_MODELS.has(model)) {
+          return json(
+            {
+              error: `MiniMax image model must be one of ${[...MINIMAX_IMAGE_MODELS].join(", ")}`,
+            },
+            true,
+          );
+        }
       } else if (
         model !== "grok-imagine-image" &&
+        model !== "grok-imagine-image-2.0" &&
         model !== "grok-imagine-image-quality"
       ) {
         return json(
           {
             error:
-              "xAI image model must be grok-imagine-image or grok-imagine-image-quality",
+              "xAI image model must be grok-imagine-image, grok-imagine-image-2.0, or grok-imagine-image-quality",
           },
           true,
         );
@@ -855,15 +1198,24 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
           true,
         );
       }
-      const qwenMaxImages = /^wan2\.7-image(?:-pro)?$/i.test(model) ? 4 : 6;
-      const n = Math.max(
-        1,
-        Math.min(backend.kind === "qwen" ? qwenMaxImages : 10, Math.floor(nRaw)),
-      );
+      const n = Math.max(1, Math.min(maxImagesPerRequest(backend, model), Math.floor(nRaw)));
       const aspect_ratio = stringValue(args.aspect_ratio);
       if (aspect_ratio !== undefined && !ALLOWED_ASPECT.has(aspect_ratio)) {
         return json(
           { error: `unsupported aspect_ratio: ${aspect_ratio}` },
+          true,
+        );
+      }
+      if (
+        backend.kind === "minimax" &&
+        aspect_ratio !== undefined &&
+        aspect_ratio !== "auto" &&
+        !MINIMAX_ASPECT_RATIOS.has(aspect_ratio)
+      ) {
+        return json(
+          {
+            error: `MiniMax aspect_ratio must be one of ${[...MINIMAX_ASPECT_RATIOS].join(", ")}`,
+          },
           true,
         );
       }
@@ -884,32 +1236,31 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
           true,
         );
       }
-      const quality = stringValue(args.quality);
       if (
-        quality !== undefined &&
-        quality !== "hd" &&
-        quality !== "standard"
+        (backend.kind === "openai" || backend.kind === "minimax") &&
+        resolution !== undefined
       ) {
-        return refusal({ error: "quality must be hd or standard" });
+        return json(
+          {
+            error: `${backend.kind === "openai" ? "OpenAI" : "MiniMax"} image size is selected by aspect_ratio; resolution is not supported`,
+          },
+          true,
+        );
       }
-      if (backend.kind !== "zai" && quality !== undefined) {
-        return refusal({ error: "quality is supported only by Z.AI images" });
+      const quality = stringValue(args.quality);
+      const qualityError = imageQualityError(backend, quality);
+      if (qualityError !== undefined) {
+        return refusal({ error: qualityError });
       }
 
-      const body: Record<string, unknown> =
-        backend.kind === "meta"
-          ? { model, prompt, size: metaImageSize(aspect_ratio), n }
-          : backend.kind === "qwen"
-            ? {}
-            : backend.kind === "zai"
-              ? {
-                  model,
-                  prompt,
-                  size: zaiImageSize(model, aspect_ratio),
-                  quality:
-                    quality ?? (model === "glm-image" ? "hd" : "standard"),
-                }
-              : { model, prompt, n, response_format: "b64_json" };
+      const body: Record<string, unknown> = initialImageRequestBody({
+        backend,
+        model,
+        prompt,
+        n,
+        aspectRatio: aspect_ratio,
+        quality,
+      });
       if (backend.kind === "xai") {
         if (aspect_ratio !== undefined) body.aspect_ratio = aspect_ratio;
         if (resolution !== undefined) body.resolution = resolution;
@@ -921,7 +1272,10 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         ? AbortSignal.any([admittedSignal, timeoutSignal])
         : timeoutSignal;
       try {
-        let endpoint = `${backend.baseURL}/images/generations`;
+        let endpoint =
+          backend.kind === "minimax"
+            ? `${backend.baseURL}/image_generation`
+            : `${backend.baseURL}/images/generations`;
         const headers: Record<string, string> = {
           authorization: `Bearer ${backend.bearer}`,
           "content-type": "application/json",
@@ -981,10 +1335,16 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
           signal: requestSignal,
         });
         let payload = (await res.json()) as {
-          data?: readonly { b64_json?: string; url?: string }[];
+          data?:
+            | readonly { b64_json?: string; url?: string }[]
+            | { image_base64?: readonly string[] };
           error?: { message?: string };
           code?: string;
           message?: string;
+          // OpenAI echoes the encoding it chose; MiniMax answers HTTP 200
+          // for a rejected request and puts the failure in base_resp.
+          output_format?: string;
+          base_resp?: { status_code?: number; status_msg?: string };
           output?: {
             task_id?: string;
             task_status?: string;
@@ -1004,10 +1364,24 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
               error:
                 payload.error?.message ??
                 payload.message ??
-                `${backend.kind === "meta" ? "Muse Image" : backend.kind === "qwen" ? "QwenCloud image" : backend.kind === "zai" ? "Z.AI image" : "Imagine"} HTTP ${res.status}`,
+                `${imageBackendLabel(backend)} HTTP ${res.status}`,
             },
             true,
           );
+        }
+        // MiniMax reports invalid params and quota failures with HTTP 200.
+        if (backend.kind === "minimax") {
+          const status = payload.base_resp?.status_code;
+          if (status !== 0) {
+            return json(
+              {
+                error:
+                  payload.base_resp?.status_msg ??
+                  `MiniMax image request failed with status ${status ?? "unknown"}`,
+              },
+              true,
+            );
+          }
         }
         if (
           backend.kind === "qwen" &&
@@ -1067,7 +1441,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
             }
           }
         }
-        const images =
+        const images: readonly { b64_json?: string; url?: string }[] =
           backend.kind === "qwen"
             ? [
                 ...(payload.output?.choices ?? []).flatMap((choice) =>
@@ -1079,15 +1453,10 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
                   result.url ? [{ url: result.url }] : [],
                 ),
               ]
-            : (payload.data ?? []);
+            : imagesFromImagePayload(payload.data);
         if (images.length === 0) {
           return json(
-            {
-              error:
-                backend.kind === "qwen"
-                  ? "QwenCloud returned no images"
-                  : "Imagine returned no images",
-            },
+            { error: `${imageBackendLabel(backend)} returned no images` },
             true,
           );
         }
@@ -1102,16 +1471,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         await mkdir(outDir, { recursive: true });
         const paths: string[] = [];
         for (const image of images) {
-          // Muse Image returns WebP. Keep the extension honest so Electron's
-          // agenc-media protocol derives a renderable content type.
-          let extension =
-            backend.kind === "meta"
-              ? "webp"
-              : backend.kind === "qwen"
-                ? "png"
-                : backend.kind === "zai"
-                  ? "png"
-                  : "jpg";
+          let extension = defaultImageExtension(backend, payload.output_format);
           let bytes: Buffer | undefined;
           if ("b64_json" in image && image.b64_json) {
             bytes = Buffer.from(image.b64_json, "base64");

--- a/runtime/src/tools/system/imagine-image.ts
+++ b/runtime/src/tools/system/imagine-image.ts
@@ -777,26 +777,46 @@ function maxImagesPerRequest(backend: ImageBackend, model: string): number {
 }
 
 /**
- * `quality` means different things per backend, so each one owns its own
- * vocabulary; a backend with no notion of quality rejects the field outright
- * rather than dropping it silently.
+ * The universal schema this tool advertises before a Session attaches offers
+ * `quality` as hd/standard, so a model following it sends those words to
+ * whichever backend is resolved later. OpenAI grades quality on its own
+ * scale, and the two map cleanly, so translate rather than refuse: refusing
+ * a value the tool itself advertised wedges the run (the model rewords the
+ * prompt and re-sends the same field).
  */
-function imageQualityError(
+const UNIVERSAL_TO_OPENAI_QUALITY: Readonly<Record<string, string>> =
+  Object.freeze({ hd: "high", standard: "medium" });
+
+/**
+ * What a backend does with the `quality` it was given: use it, ignore it
+ * because it has no such control, or refuse it as unusable.
+ */
+type QualityDecision =
+  | { readonly kind: "use"; readonly value: string | undefined }
+  | { readonly kind: "ignore" }
+  | { readonly kind: "refuse"; readonly error: string };
+
+function decideImageQuality(
   backend: ImageBackend,
   quality: string | undefined,
-): string | undefined {
-  if (quality === undefined) return undefined;
+): QualityDecision {
+  if (quality === undefined) return { kind: "use", value: undefined };
   if (backend.kind === "zai") {
     return quality === "hd" || quality === "standard"
-      ? undefined
-      : "quality must be hd or standard";
+      ? { kind: "use", value: quality }
+      : { kind: "refuse", error: "quality must be hd or standard" };
   }
   if (backend.kind === "openai") {
-    return OPENAI_IMAGE_QUALITIES.has(quality)
-      ? undefined
-      : `OpenAI quality must be one of ${[...OPENAI_IMAGE_QUALITIES].join(", ")}`;
+    const translated = UNIVERSAL_TO_OPENAI_QUALITY[quality] ?? quality;
+    return OPENAI_IMAGE_QUALITIES.has(translated)
+      ? { kind: "use", value: translated }
+      : {
+          kind: "refuse",
+          error: `OpenAI quality must be one of ${[...OPENAI_IMAGE_QUALITIES].join(", ")}`,
+        };
   }
-  return "quality is supported only by Z.AI and OpenAI images";
+  // Meta, QwenCloud, MiniMax and xAI have no quality control at all.
+  return { kind: "ignore" };
 }
 
 interface ImageRequestShape {
@@ -1140,88 +1160,54 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
           (backend.provider === "qwen" && !isPayGoModel) ||
           (backend.provider === "qwen-token-plan" && !isTokenPlanModel)
         ) {
-          return json(
-            {
+          return refusal({
               error:
                 backend.provider === "qwen"
                   ? "QwenCloud Pay-As-You-Go image model must be qwen-image-3.0 or qwen-image-3.0-pro"
                   : "QwenCloud Token Plan image model must be qwen-image-3.0-pro, wan2.7-image, or wan2.7-image-pro",
-            },
-            true,
-          );
+            });
         }
       } else if (backend.kind === "zai") {
         if (model !== "glm-image" && model !== "cogview-4-250304") {
-          return json(
-            {
+          return refusal({
               error:
                 "Z.AI image model must be glm-image or cogview-4-250304",
-            },
-            true,
-          );
+            });
         }
       } else if (backend.kind === "openai") {
         if (!OPENAI_IMAGE_MODELS.has(model)) {
-          return json(
-            {
+          return refusal({
               error: `OpenAI image model must be one of ${[...OPENAI_IMAGE_MODELS].join(", ")}`,
-            },
-            true,
-          );
+            });
         }
       } else if (backend.kind === "minimax") {
         if (!MINIMAX_IMAGE_MODELS.has(model)) {
-          return json(
-            {
+          return refusal({
               error: `MiniMax image model must be one of ${[...MINIMAX_IMAGE_MODELS].join(", ")}`,
-            },
-            true,
-          );
+            });
         }
       } else if (
         model !== "grok-imagine-image" &&
         model !== "grok-imagine-image-2.0" &&
         model !== "grok-imagine-image-quality"
       ) {
-        return json(
-          {
+        return refusal({
             error:
               "xAI image model must be grok-imagine-image, grok-imagine-image-2.0, or grok-imagine-image-quality",
-          },
-          true,
-        );
+          });
       }
 
       const nRaw = typeof args.n === "number" ? args.n : 1;
       if (backend.kind === "zai" && nRaw !== 1) {
-        return json(
-          {
+        return refusal({
             error:
               "Z.AI image generation returns exactly one image per request",
-          },
-          true,
-        );
+          });
       }
       const n = Math.max(1, Math.min(maxImagesPerRequest(backend, model), Math.floor(nRaw)));
       const aspect_ratio = stringValue(args.aspect_ratio);
       if (aspect_ratio !== undefined && !ALLOWED_ASPECT.has(aspect_ratio)) {
-        return json(
-          { error: `unsupported aspect_ratio: ${aspect_ratio}` },
-          true,
-        );
-      }
-      if (
-        backend.kind === "minimax" &&
-        aspect_ratio !== undefined &&
-        aspect_ratio !== "auto" &&
-        !MINIMAX_ASPECT_RATIOS.has(aspect_ratio)
-      ) {
-        return json(
-          {
-            error: `MiniMax aspect_ratio must be one of ${[...MINIMAX_ASPECT_RATIOS].join(", ")}`,
-          },
-          true,
-        );
+        return refusal({ error: `unsupported aspect_ratio: ${aspect_ratio}` });
       }
       const resolution = stringValue(args.resolution);
       if (
@@ -1231,38 +1217,48 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
       ) {
         return refusal({ error: "resolution must be 1k or 2k" });
       }
-      if (backend.kind === "zai" && resolution !== undefined) {
-        return json(
-          {
-            error:
-              "Z.AI image size is selected by aspect_ratio; resolution is not supported",
-          },
-          true,
-        );
-      }
+
+      // A control the advertised schema offers but this backend has no notion
+      // of is dropped and named in the result, never refused. The universal
+      // schema is what a model sees before a Session attaches, so refusing
+      // here punishes it for following the schema it was given, and it does
+      // not recover: observed live, the model rewords the prompt and re-sends
+      // the same field until the repeat-call guard stops the turn.
+      const ignoredControls: string[] = [];
       if (
-        (backend.kind === "openai" || backend.kind === "minimax") &&
-        resolution !== undefined
+        resolution !== undefined &&
+        (backend.kind === "openai" ||
+          backend.kind === "minimax" ||
+          backend.kind === "zai")
       ) {
-        return json(
-          {
-            error: `${backend.kind === "openai" ? "OpenAI" : "MiniMax"} image size is selected by aspect_ratio; resolution is not supported`,
-          },
-          true,
-        );
+        ignoredControls.push("resolution");
       }
-      const quality = stringValue(args.quality);
-      const qualityError = imageQualityError(backend, quality);
-      if (qualityError !== undefined) {
-        return refusal({ error: qualityError });
+      // MiniMax takes a shorter list of ratios than this tool's shared
+      // vocabulary; an unsupported one falls back to MiniMax's own default.
+      const minimaxRejectsAspect =
+        backend.kind === "minimax" &&
+        aspect_ratio !== undefined &&
+        aspect_ratio !== "auto" &&
+        !MINIMAX_ASPECT_RATIOS.has(aspect_ratio);
+      if (minimaxRejectsAspect) ignoredControls.push("aspect_ratio");
+      const effectiveAspect = minimaxRejectsAspect ? undefined : aspect_ratio;
+      const qualityDecision = decideImageQuality(
+        backend,
+        stringValue(args.quality),
+      );
+      if (qualityDecision.kind === "refuse") {
+        return refusal({ error: qualityDecision.error });
       }
+      if (qualityDecision.kind === "ignore") ignoredControls.push("quality");
+      const quality =
+        qualityDecision.kind === "use" ? qualityDecision.value : undefined;
 
       const body: Record<string, unknown> = initialImageRequestBody({
         backend,
         model,
         prompt,
         n,
-        aspectRatio: aspect_ratio,
+        aspectRatio: effectiveAspect,
         quality,
       });
       if (backend.kind === "xai") {
@@ -1515,6 +1511,8 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
           paths,
           path: paths[0],
           n: paths.length,
+          // Named so the model can tell the user what it did not honour.
+          ...(ignoredControls.length > 0 ? { ignoredControls } : {}),
         });
       } catch (error) {
         admittedSignal?.throwIfAborted();

--- a/runtime/tests/live/imagine-image-backends.live.test.ts
+++ b/runtime/tests/live/imagine-image-backends.live.test.ts
@@ -1,0 +1,113 @@
+/**
+ * LIVE: the GPT Image and MiniMax Image backends against the real APIs.
+ *
+ * Run:
+ *   OPENAI_API_KEY=… MINIMAX_API_KEY=… \
+ *     npm --workspace=@tetsuo-ai/runtime exec vitest run \
+ *     tests/live/imagine-image-backends.live.test.ts
+ *
+ * Each case generates one image and is therefore billed. Both providers are
+ * asked for inline base64, so a passing run also proves the tool never needs
+ * a download host for either backend.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createImagineImageTool } from "../../src/tools/system/imagine-image.js";
+import { createProvider } from "../../src/llm/provider.js";
+import { resolveHomeContext } from "../../src/config/home.js";
+import type { Session } from "../../src/session/session.js";
+
+const PROMPT = "a plain grey square on a white background";
+
+async function generate(input: {
+  readonly provider: "openai" | "minimax";
+  readonly model: string;
+  readonly credential: string;
+  readonly args: Record<string, unknown>;
+}) {
+  const root = await mkdtemp(join(tmpdir(), `live-imagine-${input.provider}-`));
+  const tool = createImagineImageTool({
+    workspaceRoot: root,
+    home: resolveHomeContext(
+      { AGENC_HOME: join(root, ".agenc-home"), HOME: root },
+      { platformHome: root },
+    ),
+    getSession: () =>
+      ({
+        services: {
+          provider: createProvider(input.provider, {
+            // Deliberately not a usable media credential: only the
+            // environment ingress may authorize either backend.
+            apiKey: "session-key-not-for-media",
+            model: input.model,
+          }),
+        },
+      }) as unknown as Session,
+    env: { [input.credential]: process.env[input.credential] ?? "" },
+  });
+  const result = await tool.execute({ prompt: PROMPT, ...input.args });
+  return { tool, result };
+}
+
+describe.skipIf(!process.env.OPENAI_API_KEY)("GPT Image, live", () => {
+  it("generates and saves a real image", async () => {
+    const { tool, result } = await generate({
+      provider: "openai",
+      model: "gpt-6-astra",
+      credential: "OPENAI_API_KEY",
+      args: { aspect_ratio: "1:1", quality: "low" },
+    });
+
+    expect(tool.description).toContain("GPT Image");
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      backend: string;
+      model: string;
+      path: string;
+      n: number;
+    };
+    expect(parsed).toMatchObject({
+      backend: "openai",
+      model: "gpt-image-2",
+      n: 1,
+    });
+    const bytes = await readFile(parsed.path);
+    expect(bytes.length).toBeGreaterThan(1_000);
+    // The saved extension has to match the real encoding or the desktop
+    // transcript renders a broken image.
+    expect(parsed.path.endsWith(".png")).toBe(true);
+    expect(bytes.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+  }, 300_000);
+});
+
+describe.skipIf(!process.env.MINIMAX_API_KEY)("MiniMax Image, live", () => {
+  it("generates and saves a real image", async () => {
+    const { tool, result } = await generate({
+      provider: "minimax",
+      model: "MiniMax-M2.5",
+      credential: "MINIMAX_API_KEY",
+      args: { aspect_ratio: "1:1", n: 1 },
+    });
+
+    expect(tool.description).toContain("MiniMax Image");
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      backend: string;
+      model: string;
+      path: string;
+      n: number;
+    };
+    expect(parsed).toMatchObject({
+      backend: "minimax",
+      model: "image-01",
+      n: 1,
+    });
+    const bytes = await readFile(parsed.path);
+    expect(bytes.length).toBeGreaterThan(1_000);
+    expect(parsed.path.endsWith(".jpg")).toBe(true);
+    expect(bytes.subarray(0, 2).toString("hex")).toBe("ffd8");
+  }, 300_000);
+});

--- a/runtime/tests/live/imagine-image-backends.live.test.ts
+++ b/runtime/tests/live/imagine-image-backends.live.test.ts
@@ -4,11 +4,14 @@
  * Run:
  *   OPENAI_API_KEY=… MINIMAX_API_KEY=… \
  *     npm --workspace=@tetsuo-ai/runtime exec vitest run \
+ *     --config vitest.live.config.ts \
  *     tests/live/imagine-image-backends.live.test.ts
  *
  * Each case generates one image and is therefore billed. Both providers are
  * asked for inline base64, so a passing run also proves the tool never needs
- * a download host for either backend.
+ * a download host for either backend. The saved extension is checked against
+ * the file's own magic bytes: Electron's agenc-media handler derives the
+ * rendered content type from it, so a wrong guess shows a broken image.
  */
 import { describe, expect, it } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
@@ -22,92 +25,96 @@ import type { Session } from "../../src/session/session.js";
 
 const PROMPT = "a plain grey square on a white background";
 
-async function generate(input: {
+interface LiveImageCase {
+  readonly label: string;
   readonly provider: "openai" | "minimax";
-  readonly model: string;
+  readonly sessionModel: string;
   readonly credential: string;
   readonly args: Record<string, unknown>;
-}) {
-  const root = await mkdtemp(join(tmpdir(), `live-imagine-${input.provider}-`));
-  const tool = createImagineImageTool({
-    workspaceRoot: root,
-    home: resolveHomeContext(
-      { AGENC_HOME: join(root, ".agenc-home"), HOME: root },
-      { platformHome: root },
-    ),
-    getSession: () =>
-      ({
-        services: {
-          provider: createProvider(input.provider, {
-            // Deliberately not a usable media credential: only the
-            // environment ingress may authorize either backend.
-            apiKey: "session-key-not-for-media",
-            model: input.model,
-          }),
-        },
-      }) as unknown as Session,
-    env: { [input.credential]: process.env[input.credential] ?? "" },
-  });
-  const result = await tool.execute({ prompt: PROMPT, ...input.args });
-  return { tool, result };
+  readonly backend: string;
+  readonly imageModel: string;
+  readonly extension: string;
+  /** Leading bytes the real encoding must start with. */
+  readonly magic: string;
 }
 
-describe.skipIf(!process.env.OPENAI_API_KEY)("GPT Image, live", () => {
-  it("generates and saves a real image", async () => {
-    const { tool, result } = await generate({
-      provider: "openai",
-      model: "gpt-6-astra",
-      credential: "OPENAI_API_KEY",
-      args: { aspect_ratio: "1:1", quality: "low" },
-    });
+const CASES: readonly LiveImageCase[] = [
+  {
+    label: "GPT Image",
+    provider: "openai",
+    sessionModel: "gpt-6-astra",
+    credential: "OPENAI_API_KEY",
+    args: { aspect_ratio: "1:1", quality: "low" },
+    backend: "openai",
+    imageModel: "gpt-image-2",
+    extension: ".png",
+    magic: "89504e470d0a1a0a",
+  },
+  {
+    label: "MiniMax Image",
+    provider: "minimax",
+    sessionModel: "MiniMax-M2.5",
+    credential: "MINIMAX_API_KEY",
+    args: { aspect_ratio: "1:1", n: 1 },
+    backend: "minimax",
+    imageModel: "image-01",
+    extension: ".jpg",
+    magic: "ffd8",
+  },
+];
 
-    expect(tool.description).toContain("GPT Image");
-    expect(result.isError, String(result.content)).toBeUndefined();
-    const parsed = JSON.parse(result.content) as {
-      backend: string;
-      model: string;
-      path: string;
-      n: number;
-    };
-    expect(parsed).toMatchObject({
-      backend: "openai",
-      model: "gpt-image-2",
-      n: 1,
-    });
-    const bytes = await readFile(parsed.path);
-    expect(bytes.length).toBeGreaterThan(1_000);
-    // The saved extension has to match the real encoding or the desktop
-    // transcript renders a broken image.
-    expect(parsed.path.endsWith(".png")).toBe(true);
-    expect(bytes.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
-  }, 300_000);
-});
+for (const testCase of CASES) {
+  describe.skipIf(!process.env[testCase.credential])(
+    `${testCase.label}, live`,
+    () => {
+      it("generates and saves a real image", async () => {
+        const root = await mkdtemp(
+          join(tmpdir(), `live-imagine-${testCase.provider}-`),
+        );
+        const tool = createImagineImageTool({
+          workspaceRoot: root,
+          home: resolveHomeContext(
+            { AGENC_HOME: join(root, ".agenc-home"), HOME: root },
+            { platformHome: root },
+          ),
+          getSession: () =>
+            ({
+              services: {
+                provider: createProvider(testCase.provider, {
+                  // Deliberately not a usable media credential: only the
+                  // environment ingress may authorize either backend.
+                  apiKey: "session-key-not-for-media",
+                  model: testCase.sessionModel,
+                }),
+              },
+            }) as unknown as Session,
+          env: {
+            [testCase.credential]: process.env[testCase.credential] ?? "",
+          },
+        });
 
-describe.skipIf(!process.env.MINIMAX_API_KEY)("MiniMax Image, live", () => {
-  it("generates and saves a real image", async () => {
-    const { tool, result } = await generate({
-      provider: "minimax",
-      model: "MiniMax-M2.5",
-      credential: "MINIMAX_API_KEY",
-      args: { aspect_ratio: "1:1", n: 1 },
-    });
+        const result = await tool.execute({ prompt: PROMPT, ...testCase.args });
 
-    expect(tool.description).toContain("MiniMax Image");
-    expect(result.isError, String(result.content)).toBeUndefined();
-    const parsed = JSON.parse(result.content) as {
-      backend: string;
-      model: string;
-      path: string;
-      n: number;
-    };
-    expect(parsed).toMatchObject({
-      backend: "minimax",
-      model: "image-01",
-      n: 1,
-    });
-    const bytes = await readFile(parsed.path);
-    expect(bytes.length).toBeGreaterThan(1_000);
-    expect(parsed.path.endsWith(".jpg")).toBe(true);
-    expect(bytes.subarray(0, 2).toString("hex")).toBe("ffd8");
-  }, 300_000);
-});
+        expect(tool.description).toContain(testCase.label);
+        expect(result.isError, String(result.content)).toBeUndefined();
+        const parsed = JSON.parse(result.content) as {
+          backend: string;
+          model: string;
+          path: string;
+          n: number;
+        };
+        expect(parsed).toMatchObject({
+          backend: testCase.backend,
+          model: testCase.imageModel,
+          n: 1,
+        });
+        expect(parsed.path.endsWith(testCase.extension)).toBe(true);
+        const bytes = await readFile(parsed.path);
+        expect(bytes.length).toBeGreaterThan(1_000);
+        expect(
+          bytes.subarray(0, testCase.magic.length / 2).toString("hex"),
+        ).toBe(testCase.magic);
+      }, 300_000);
+    },
+  );
+}

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -1120,6 +1120,383 @@ describe("ImagineImage tool", () => {
     expect(requestSignal?.aborted).toBe(true);
   });
 
+  it("generates with GPT Image for an OpenAI session holding an API key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-openai-"));
+    const provider = createProvider("openai", {
+      apiKey: "chatgpt-oauth-bearer-must-not-leak",
+      model: "gpt-6-astra",
+      baseURL: "https://api.openai.com/v1",
+    });
+    const b64 = Buffer.from("openai-png").toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: b64 }], output_format: "png" }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider,
+      env: {
+        OPENAI_API_KEY: "isolated-openai-key",
+        XAI_API_KEY: "must-not-win-for-openai-session",
+      },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({
+      prompt: "a grey square",
+      aspect_ratio: "16:9",
+      quality: "low",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      backend: string;
+      model: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({ backend: "openai", model: "gpt-image-2" });
+    expect(parsed.path).toMatch(/\.png$/u);
+    expect(await readFile(parsed.path, "utf8")).toBe("openai-png");
+
+    const call = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0];
+    expect(String(call?.[0])).toBe("https://api.openai.com/v1/images/generations");
+    const init = call?.[1] as { headers: Record<string, string>; body: string };
+    // The session bearer is a ChatGPT OAuth grant, which cannot call this
+    // endpoint at all. Only the API-key ingress may authorize it.
+    expect(init.headers.authorization).toBe("Bearer isolated-openai-key");
+    expect(JSON.parse(init.body)).toEqual({
+      model: "gpt-image-2",
+      prompt: "a grey square",
+      n: 1,
+      size: "1536x1024",
+      quality: "low",
+    });
+  });
+
+  it("saves the format GPT Image reports rather than assuming PNG", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-openai-jpeg-"));
+    const b64 = Buffer.from("openai-jpeg").toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: b64 }], output_format: "jpeg" }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("openai", {
+        apiKey: "unused",
+        model: "gpt-6-astra",
+        baseURL: "https://api.openai.com/v1",
+      }),
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "a grey square" });
+
+    const parsed = JSON.parse(result.content) as { path: string };
+    expect(parsed.path).toMatch(/\.jpg$/u);
+  });
+
+  it("generates with MiniMax Image for a MiniMax session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-minimax-"));
+    const b64 = Buffer.from("minimax-jpeg").toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "req-1",
+        data: { image_base64: [b64] },
+        base_resp: { status_code: 0, status_msg: "success" },
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "minimax-session-key",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({
+      prompt: "a grey square",
+      aspect_ratio: "16:9",
+      n: 1,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      backend: string;
+      model: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({ backend: "minimax", model: "image-01" });
+    expect(parsed.path).toMatch(/\.jpg$/u);
+    expect(await readFile(parsed.path, "utf8")).toBe("minimax-jpeg");
+
+    const call = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0];
+    // MiniMax names this route differently from every OpenAI-shaped backend.
+    expect(String(call?.[0])).toBe("https://api.minimax.io/v1/image_generation");
+    const init = call?.[1] as { headers: Record<string, string>; body: string };
+    expect(init.headers.authorization).toBe("Bearer isolated-minimax-key");
+    expect(JSON.parse(init.body)).toEqual({
+      model: "image-01",
+      prompt: "a grey square",
+      n: 1,
+      response_format: "base64",
+      aspect_ratio: "16:9",
+    });
+  });
+
+  it("treats a MiniMax HTTP 200 carrying a failure status as an error", async () => {
+    // MiniMax answers 200 for invalid params and quota failures alike; the
+    // outcome is in base_resp, so an HTTP-only check saves nothing and
+    // reports success.
+    const root = await mkdtemp(join(tmpdir(), "imagine-minimax-fail-"));
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "req-2",
+        data: null,
+        base_resp: { status_code: 1008, status_msg: "insufficient balance" },
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "unused",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "a grey square" });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("insufficient balance");
+  });
+
+  it("refuses a URL from a backend that was asked for inline bytes", async () => {
+    // OpenAI and MiniMax are both asked for base64, and neither has a
+    // registered download host, so a URL must fail closed rather than be
+    // fetched from whatever host answered.
+    const root = await mkdtemp(join(tmpdir(), "imagine-openai-url-"));
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ url: "https://api.x.ai/generated/openai.png" }],
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("openai", {
+        apiKey: "unused",
+        model: "gpt-6-astra",
+        baseURL: "https://api.openai.com/v1",
+      }),
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "a grey square" });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("not trusted");
+    // Only the generation call happened: no download was attempted.
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ).toHaveLength(1);
+  });
+
+  it("keeps each backend's own quality vocabulary", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-quality-"));
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    })) as unknown as typeof fetch;
+    const openaiTool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("openai", {
+        apiKey: "unused",
+        model: "gpt-6-astra",
+        baseURL: "https://api.openai.com/v1",
+      }),
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl,
+    });
+    const minimaxTool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "unused",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    // Z.AI's vocabulary is not OpenAI's, and vice versa.
+    const hd = await openaiTool.execute({ prompt: "x", quality: "hd" });
+    expect(hd.isError).toBe(true);
+    expect(String(hd.content)).toContain("OpenAI quality must be");
+    const unsupported = await minimaxTool.execute({
+      prompt: "x",
+      quality: "high",
+    });
+    expect(unsupported.isError).toBe(true);
+    expect(String(unsupported.content)).toContain(
+      "supported only by Z.AI and OpenAI",
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("refuses controls the new backends do not have", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-controls-"));
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    })) as unknown as typeof fetch;
+    const minimaxTool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "unused",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    // 2:1 is in this tool's shared vocabulary but MiniMax rejects it.
+    const aspect = await minimaxTool.execute({ prompt: "x", aspect_ratio: "2:1" });
+    expect(aspect.isError).toBe(true);
+    expect(String(aspect.content)).toContain("MiniMax aspect_ratio must be");
+
+    const resolution = await minimaxTool.execute({ prompt: "x", resolution: "2k" });
+    expect(resolution.isError).toBe(true);
+    expect(String(resolution.content)).toContain("resolution is not supported");
+
+    const model = await minimaxTool.execute({ prompt: "x", model: "image-99" });
+    expect(model.isError).toBe(true);
+    expect(String(model.content)).toContain("MiniMax image model must be");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("clamps a MiniMax batch to the nine images it will return", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-minimax-clamp-"));
+    const b64 = Buffer.from("m").toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: { image_base64: [b64] },
+        base_resp: { status_code: 0 },
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "unused",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    await tool.execute({ prompt: "x", n: 10 });
+
+    const init = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[1] as { body: string };
+    expect((JSON.parse(init.body) as { n: number }).n).toBe(9);
+  });
+
+  it("offers xAI's second-generation image model", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-xai-20-"));
+    const b64 = Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: b64 }] }),
+    })) as unknown as typeof fetch;
+    const tool = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("grok", {
+        apiKey: "unused",
+        model: "grok-4.6",
+        baseURL: "https://api.x.ai/v1",
+      }),
+      env: { XAI_API_KEY: "real-byok-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({
+      prompt: "a grey square",
+      model: "grok-imagine-image-2.0",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(
+      (JSON.parse(result.content) as { model: string }).model,
+    ).toBe("grok-imagine-image-2.0");
+  });
+
+  it("advertises the controls each new backend actually has", () => {
+    const root = process.cwd();
+    const openaiSchema = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("openai", {
+        apiKey: "unused",
+        model: "gpt-6-astra",
+        baseURL: "https://api.openai.com/v1",
+      }),
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+    }).inputSchema as {
+      properties: Record<string, { enum?: readonly string[]; maximum?: number }>;
+    };
+    expect(Object.keys(openaiSchema.properties).sort()).toEqual([
+      "aspect_ratio",
+      "model",
+      "n",
+      "prompt",
+      "quality",
+    ]);
+    expect(openaiSchema.properties.model?.enum).toContain("gpt-image-2");
+    expect(openaiSchema.properties.quality?.enum).toEqual([
+      "low",
+      "medium",
+      "high",
+      "auto",
+    ]);
+
+    const minimaxSchema = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "unused",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+    }).inputSchema as {
+      properties: Record<string, { enum?: readonly string[]; maximum?: number }>;
+    };
+    expect(Object.keys(minimaxSchema.properties).sort()).toEqual([
+      "aspect_ratio",
+      "model",
+      "n",
+      "prompt",
+    ]);
+    expect(minimaxSchema.properties.n?.maximum).toBe(9);
+    // The advertised ratios are the ones MiniMax will accept, not the union.
+    expect(minimaxSchema.properties.aspect_ratio?.enum).not.toContain("2:1");
+  });
+
   it("refuses a missing prompt before any request, and says so", async () => {
     // #2190: a bare error from a mutating tool gates the session behind /resolve.
     const fetchImpl = vi.fn(async () => new Response("unreachable", { status: 500 }));

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -79,6 +79,58 @@ function createSessionImagineImageTool(options: {
   });
 }
 
+/**
+ * One mock serving both new backends: MiniMax answers on its own route with
+ * its own envelope, everything else gets the OpenAI-shaped list.
+ */
+function backendAwareImageFetch(): typeof fetch {
+  const b64 = Buffer.from("pixels").toString("base64");
+  return vi.fn(async (url: string | URL) =>
+    String(url).includes("/image_generation")
+      ? {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: { image_base64: [b64] },
+            base_resp: { status_code: 0 },
+          }),
+        }
+      : {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ b64_json: b64 }],
+            output_format: "png",
+          }),
+        }) as unknown as typeof fetch;
+}
+
+/** An OpenAI session whose only media authority is the API-key ingress. */
+function openaiImagineTool(root: string, fetchImpl?: typeof fetch) {
+  return createSessionImagineImageTool({
+    workspaceRoot: root,
+    provider: createProvider("openai", {
+      apiKey: "unused",
+      model: "gpt-6-astra",
+      baseURL: "https://api.openai.com/v1",
+    }),
+    env: { OPENAI_API_KEY: "isolated-openai-key" },
+    ...(fetchImpl === undefined ? {} : { fetchImpl }),
+  });
+}
+
+function minimaxImagineTool(root: string, fetchImpl?: typeof fetch) {
+  return createSessionImagineImageTool({
+    workspaceRoot: root,
+    provider: createProvider("minimax", {
+      apiKey: "unused",
+      model: "MiniMax-M2.5",
+    }),
+    env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+    ...(fetchImpl === undefined ? {} : { fetchImpl }),
+  });
+}
+
 describe("ImagineImage tool", () => {
   it("is catalog-registered for non-Grok sessions with an independent xAI credential", () => {
     expect(isModelFacingToolRegistered("ImagineImage", {
@@ -1186,16 +1238,7 @@ describe("ImagineImage tool", () => {
       status: 200,
       json: async () => ({ data: [{ b64_json: b64 }], output_format: "jpeg" }),
     })) as unknown as typeof fetch;
-    const tool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("openai", {
-        apiKey: "unused",
-        model: "gpt-6-astra",
-        baseURL: "https://api.openai.com/v1",
-      }),
-      env: { OPENAI_API_KEY: "isolated-openai-key" },
-      fetchImpl,
-    });
+    const tool = openaiImagineTool(root, fetchImpl);
 
     const result = await tool.execute({ prompt: "a grey square" });
 
@@ -1270,15 +1313,7 @@ describe("ImagineImage tool", () => {
         base_resp: { status_code: 1008, status_msg: "insufficient balance" },
       }),
     })) as unknown as typeof fetch;
-    const tool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("minimax", {
-        apiKey: "unused",
-        model: "MiniMax-M2.5",
-      }),
-      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
-      fetchImpl,
-    });
+    const tool = minimaxImagineTool(root, fetchImpl);
 
     const result = await tool.execute({ prompt: "a grey square" });
 
@@ -1298,16 +1333,7 @@ describe("ImagineImage tool", () => {
         data: [{ url: "https://api.x.ai/generated/openai.png" }],
       }),
     })) as unknown as typeof fetch;
-    const tool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("openai", {
-        apiKey: "unused",
-        model: "gpt-6-astra",
-        baseURL: "https://api.openai.com/v1",
-      }),
-      env: { OPENAI_API_KEY: "isolated-openai-key" },
-      fetchImpl,
-    });
+    const tool = openaiImagineTool(root, fetchImpl);
 
     const result = await tool.execute({ prompt: "a grey square" });
 
@@ -1321,45 +1347,9 @@ describe("ImagineImage tool", () => {
 
   it("keeps each backend's own quality vocabulary", async () => {
     const root = await mkdtemp(join(tmpdir(), "imagine-quality-"));
-    // One mock for both backends: each answers in its own response shape.
-    const b64 = Buffer.from("pixels").toString("base64");
-    const fetchImpl = vi.fn(async (url: string | URL) =>
-      String(url).includes("/image_generation")
-        ? {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: { image_base64: [b64] },
-              base_resp: { status_code: 0 },
-            }),
-          }
-        : {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: [{ b64_json: b64 }],
-              output_format: "png",
-            }),
-          }) as unknown as typeof fetch;
-    const openaiTool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("openai", {
-        apiKey: "unused",
-        model: "gpt-6-astra",
-        baseURL: "https://api.openai.com/v1",
-      }),
-      env: { OPENAI_API_KEY: "isolated-openai-key" },
-      fetchImpl,
-    });
-    const minimaxTool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("minimax", {
-        apiKey: "unused",
-        model: "MiniMax-M2.5",
-      }),
-      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
-      fetchImpl,
-    });
+    const fetchImpl = backendAwareImageFetch();
+    const openaiTool = openaiImagineTool(root, fetchImpl);
+    const minimaxTool = minimaxImagineTool(root, fetchImpl);
 
     // hd/standard is the universal schema's vocabulary, which a model sees
     // before a Session attaches. OpenAI grades quality differently but the
@@ -1388,35 +1378,8 @@ describe("ImagineImage tool", () => {
 
   it("refuses controls the new backends do not have", async () => {
     const root = await mkdtemp(join(tmpdir(), "imagine-controls-"));
-    // One mock for both backends: each answers in its own response shape.
-    const b64 = Buffer.from("pixels").toString("base64");
-    const fetchImpl = vi.fn(async (url: string | URL) =>
-      String(url).includes("/image_generation")
-        ? {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: { image_base64: [b64] },
-              base_resp: { status_code: 0 },
-            }),
-          }
-        : {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: [{ b64_json: b64 }],
-              output_format: "png",
-            }),
-          }) as unknown as typeof fetch;
-    const minimaxTool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("minimax", {
-        apiKey: "unused",
-        model: "MiniMax-M2.5",
-      }),
-      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
-      fetchImpl,
-    });
+    const fetchImpl = backendAwareImageFetch();
+    const minimaxTool = minimaxImagineTool(root, fetchImpl);
 
     // 2:1 is in this tool's shared vocabulary but MiniMax rejects it, and
     // MiniMax has no resolution tier. Both are dropped and named rather than
@@ -1458,15 +1421,7 @@ describe("ImagineImage tool", () => {
         base_resp: { status_code: 0 },
       }),
     })) as unknown as typeof fetch;
-    const tool = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("minimax", {
-        apiKey: "unused",
-        model: "MiniMax-M2.5",
-      }),
-      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
-      fetchImpl,
-    });
+    const tool = minimaxImagineTool(root, fetchImpl);
 
     await tool.execute({ prompt: "x", n: 10 });
 
@@ -1563,25 +1518,8 @@ describe("ImagineImage tool", () => {
     // is what happened: one stray `resolution: "1k"` bricked the session.
     const root = await mkdtemp(join(tmpdir(), "imagine-refusal-"));
     const fetchImpl = vi.fn();
-    const openai = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("openai", {
-        apiKey: "unused",
-        model: "gpt-6-astra",
-        baseURL: "https://api.openai.com/v1",
-      }),
-      env: { OPENAI_API_KEY: "isolated-openai-key" },
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
-    const minimax = createSessionImagineImageTool({
-      workspaceRoot: root,
-      provider: createProvider("minimax", {
-        apiKey: "unused",
-        model: "MiniMax-M2.5",
-      }),
-      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
+    const openai = openaiImagineTool(root, fetchImpl as unknown as typeof fetch);
+    const minimax = minimaxImagineTool(root, fetchImpl as unknown as typeof fetch);
     const zai = createSessionImagineImageTool({
       workspaceRoot: root,
       provider: createProvider("zai", { apiKey: "k", model: "glm-5.3" }),

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -105,6 +105,22 @@ function backendAwareImageFetch(): typeof fetch {
         }) as unknown as typeof fetch;
 }
 
+/** URL, bearer and parsed body of the first request a mock received. */
+function firstRequest(fetchImpl: typeof fetch): {
+  url: string;
+  authorization: string;
+  body: Record<string, unknown>;
+} {
+  const call = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+    .calls[0];
+  const init = call?.[1] as { headers: Record<string, string>; body: string };
+  return {
+    url: String(call?.[0]),
+    authorization: init.headers.authorization,
+    body: JSON.parse(init.body) as Record<string, unknown>,
+  };
+}
+
 /** An OpenAI session whose only media authority is the API-key ingress. */
 function openaiImagineTool(root: string, fetchImpl?: typeof fetch) {
   return createSessionImagineImageTool({
@@ -1214,14 +1230,12 @@ describe("ImagineImage tool", () => {
     expect(parsed.path).toMatch(/\.png$/u);
     expect(await readFile(parsed.path, "utf8")).toBe("openai-png");
 
-    const call = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls[0];
-    expect(String(call?.[0])).toBe("https://api.openai.com/v1/images/generations");
-    const init = call?.[1] as { headers: Record<string, string>; body: string };
+    const sent = firstRequest(fetchImpl);
+    expect(sent.url).toBe("https://api.openai.com/v1/images/generations");
     // The session bearer is a ChatGPT OAuth grant, which cannot call this
     // endpoint at all. Only the API-key ingress may authorize it.
-    expect(init.headers.authorization).toBe("Bearer isolated-openai-key");
-    expect(JSON.parse(init.body)).toEqual({
+    expect(sent.authorization).toBe("Bearer isolated-openai-key");
+    expect(sent.body).toEqual({
       model: "gpt-image-2",
       prompt: "a grey square",
       n: 1,
@@ -1284,13 +1298,11 @@ describe("ImagineImage tool", () => {
     expect(parsed.path).toMatch(/\.jpg$/u);
     expect(await readFile(parsed.path, "utf8")).toBe("minimax-jpeg");
 
-    const call = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls[0];
+    const sent = firstRequest(fetchImpl);
     // MiniMax names this route differently from every OpenAI-shaped backend.
-    expect(String(call?.[0])).toBe("https://api.minimax.io/v1/image_generation");
-    const init = call?.[1] as { headers: Record<string, string>; body: string };
-    expect(init.headers.authorization).toBe("Bearer isolated-minimax-key");
-    expect(JSON.parse(init.body)).toEqual({
+    expect(sent.url).toBe("https://api.minimax.io/v1/image_generation");
+    expect(sent.authorization).toBe("Bearer isolated-minimax-key");
+    expect(sent.body).toEqual({
       model: "image-01",
       prompt: "a grey square",
       n: 1,
@@ -1356,11 +1368,7 @@ describe("ImagineImage tool", () => {
     // two map cleanly, so it is translated rather than refused.
     const hd = await openaiTool.execute({ prompt: "x", quality: "hd" });
     expect(hd.isError).toBeUndefined();
-    const hdBody = JSON.parse(
-      ((fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
-        .calls[0]?.[1] as { body: string }).body,
-    ) as { quality?: string };
-    expect(hdBody.quality).toBe("high");
+    expect(firstRequest(fetchImpl).body.quality).toBe("high");
 
     // A value no backend vocabulary contains is still refused.
     const bogus = await openaiTool.execute({ prompt: "x", quality: "ultra" });
@@ -1391,11 +1399,7 @@ describe("ImagineImage tool", () => {
       (JSON.parse(aspect.content) as { ignoredControls?: string[] })
         .ignoredControls,
     ).toEqual(["aspect_ratio"]);
-    const aspectBody = JSON.parse(
-      ((fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
-        .calls[0]?.[1] as { body: string }).body,
-    ) as { aspect_ratio?: string };
-    expect(aspectBody.aspect_ratio).toBeUndefined();
+    expect(firstRequest(fetchImpl).body.aspect_ratio).toBeUndefined();
 
     const resolution = await minimaxTool.execute({ prompt: "x", resolution: "2k" });
     expect(resolution.isError).toBeUndefined();
@@ -1425,9 +1429,7 @@ describe("ImagineImage tool", () => {
 
     await tool.execute({ prompt: "x", n: 10 });
 
-    const init = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls[0]?.[1] as { body: string };
-    expect((JSON.parse(init.body) as { n: number }).n).toBe(9);
+    expect(firstRequest(fetchImpl).body.n).toBe(9);
   });
 
   it("offers xAI's second-generation image model", async () => {

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -641,18 +641,21 @@ describe("ImagineImage tool", () => {
     expect(invalidCount.content).toMatch(/exactly one image/u);
     expect(fetchImpl).not.toHaveBeenCalled();
 
-    const invalidResolution = await tool.execute({
-      prompt: "must not send",
+    // Z.AI picks its size from aspect_ratio, so `resolution` is dropped and
+    // named rather than refused: it is a control the universal schema offers,
+    // and refusing it stalls the run instead of correcting it.
+    const droppedResolution = await tool.execute({
+      prompt: "host validation",
       resolution: "2k",
     });
-    expect(invalidResolution.isError).toBe(true);
-    expect(invalidResolution.content).toMatch(/selected by aspect_ratio/u);
-    expect(fetchImpl).not.toHaveBeenCalled();
-
-    const untrusted = await tool.execute({ prompt: "host validation" });
-    expect(untrusted.isError).toBe(true);
-    expect(untrusted.content).toMatch(/not trusted for the zai backend/u);
+    expect(droppedResolution.isError).toBe(true);
+    expect(droppedResolution.content).toMatch(/not trusted for the zai backend/u);
     expect(fetchImpl).toHaveBeenCalledOnce();
+    const sentBody = JSON.parse(
+      String((fetchImpl.mock.calls[0]?.[1] as { body: string }).body),
+    ) as Record<string, unknown>;
+    expect(sentBody.resolution).toBeUndefined();
+    expect(sentBody.size).toBe("1280x1280");
   });
 
   it("fails closed when Z.ai unexpectedly returns more than one image", async () => {
@@ -1318,11 +1321,26 @@ describe("ImagineImage tool", () => {
 
   it("keeps each backend's own quality vocabulary", async () => {
     const root = await mkdtemp(join(tmpdir(), "imagine-quality-"));
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ data: [] }),
-    })) as unknown as typeof fetch;
+    // One mock for both backends: each answers in its own response shape.
+    const b64 = Buffer.from("pixels").toString("base64");
+    const fetchImpl = vi.fn(async (url: string | URL) =>
+      String(url).includes("/image_generation")
+        ? {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: { image_base64: [b64] },
+              base_resp: { status_code: 0 },
+            }),
+          }
+        : {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: [{ b64_json: b64 }],
+              output_format: "png",
+            }),
+          }) as unknown as typeof fetch;
     const openaiTool = createSessionImagineImageTool({
       workspaceRoot: root,
       provider: createProvider("openai", {
@@ -1343,28 +1361,53 @@ describe("ImagineImage tool", () => {
       fetchImpl,
     });
 
-    // Z.AI's vocabulary is not OpenAI's, and vice versa.
+    // hd/standard is the universal schema's vocabulary, which a model sees
+    // before a Session attaches. OpenAI grades quality differently but the
+    // two map cleanly, so it is translated rather than refused.
     const hd = await openaiTool.execute({ prompt: "x", quality: "hd" });
-    expect(hd.isError).toBe(true);
-    expect(String(hd.content)).toContain("OpenAI quality must be");
-    const unsupported = await minimaxTool.execute({
-      prompt: "x",
-      quality: "high",
-    });
-    expect(unsupported.isError).toBe(true);
-    expect(String(unsupported.content)).toContain(
-      "supported only by Z.AI and OpenAI",
-    );
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(hd.isError).toBeUndefined();
+    const hdBody = JSON.parse(
+      ((fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0]?.[1] as { body: string }).body,
+    ) as { quality?: string };
+    expect(hdBody.quality).toBe("high");
+
+    // A value no backend vocabulary contains is still refused.
+    const bogus = await openaiTool.execute({ prompt: "x", quality: "ultra" });
+    expect(bogus.isError).toBe(true);
+    expect(String(bogus.content)).toContain("OpenAI quality must be");
+
+    // MiniMax has no quality control, so the field is dropped and named.
+    const dropped = await minimaxTool.execute({ prompt: "x", quality: "high" });
+    expect(dropped.isError).toBeUndefined();
+    expect(
+      (JSON.parse(dropped.content) as { ignoredControls?: string[] })
+        .ignoredControls,
+    ).toEqual(["quality"]);
   });
 
   it("refuses controls the new backends do not have", async () => {
     const root = await mkdtemp(join(tmpdir(), "imagine-controls-"));
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ data: [] }),
-    })) as unknown as typeof fetch;
+    // One mock for both backends: each answers in its own response shape.
+    const b64 = Buffer.from("pixels").toString("base64");
+    const fetchImpl = vi.fn(async (url: string | URL) =>
+      String(url).includes("/image_generation")
+        ? {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: { image_base64: [b64] },
+              base_resp: { status_code: 0 },
+            }),
+          }
+        : {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: [{ b64_json: b64 }],
+              output_format: "png",
+            }),
+          }) as unknown as typeof fetch;
     const minimaxTool = createSessionImagineImageTool({
       workspaceRoot: root,
       provider: createProvider("minimax", {
@@ -1375,19 +1418,33 @@ describe("ImagineImage tool", () => {
       fetchImpl,
     });
 
-    // 2:1 is in this tool's shared vocabulary but MiniMax rejects it.
+    // 2:1 is in this tool's shared vocabulary but MiniMax rejects it, and
+    // MiniMax has no resolution tier. Both are dropped and named rather than
+    // refused, so the run proceeds instead of stalling on a control the
+    // advertised schema itself offered.
     const aspect = await minimaxTool.execute({ prompt: "x", aspect_ratio: "2:1" });
-    expect(aspect.isError).toBe(true);
-    expect(String(aspect.content)).toContain("MiniMax aspect_ratio must be");
+    expect(aspect.isError).toBeUndefined();
+    expect(
+      (JSON.parse(aspect.content) as { ignoredControls?: string[] })
+        .ignoredControls,
+    ).toEqual(["aspect_ratio"]);
+    const aspectBody = JSON.parse(
+      ((fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0]?.[1] as { body: string }).body,
+    ) as { aspect_ratio?: string };
+    expect(aspectBody.aspect_ratio).toBeUndefined();
 
     const resolution = await minimaxTool.execute({ prompt: "x", resolution: "2k" });
-    expect(resolution.isError).toBe(true);
-    expect(String(resolution.content)).toContain("resolution is not supported");
+    expect(resolution.isError).toBeUndefined();
+    expect(
+      (JSON.parse(resolution.content) as { ignoredControls?: string[] })
+        .ignoredControls,
+    ).toEqual(["resolution"]);
 
+    // An unknown model is still refused: it cannot be silently substituted.
     const model = await minimaxTool.execute({ prompt: "x", model: "image-99" });
     expect(model.isError).toBe(true);
     expect(String(model.content)).toContain("MiniMax image model must be");
-    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("clamps a MiniMax batch to the nine images it will return", async () => {
@@ -1495,6 +1552,61 @@ describe("ImagineImage tool", () => {
     expect(minimaxSchema.properties.n?.maximum).toBe(9);
     // The advertised ratios are the ones MiniMax will accept, not the union.
     expect(minimaxSchema.properties.aspect_ratio?.enum).not.toContain("2:1");
+  });
+
+  it("never gates the session on an argument it refused before requesting", async () => {
+    // Repro from the desktop app: the tool registry is built before the
+    // Session attaches, so the model sees the universal schema and sends
+    // resolution/quality that the resolved backend has no notion of. A bare
+    // isError from a side-effecting tool is filed as an unknown outcome and
+    // blocks every later side-effecting call behind /resolve (#2190), which
+    // is what happened: one stray `resolution: "1k"` bricked the session.
+    const root = await mkdtemp(join(tmpdir(), "imagine-refusal-"));
+    const fetchImpl = vi.fn();
+    const openai = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("openai", {
+        apiKey: "unused",
+        model: "gpt-6-astra",
+        baseURL: "https://api.openai.com/v1",
+      }),
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const minimax = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("minimax", {
+        apiKey: "unused",
+        model: "MiniMax-M2.5",
+      }),
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const zai = createSessionImagineImageTool({
+      workspaceRoot: root,
+      provider: createProvider("zai", { apiKey: "k", model: "glm-5.3" }),
+      env: { ZAI_API_KEY: "isolated-zai-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const cases: Array<[string, Promise<{ isError?: boolean; effectDisposition?: { disposition?: string } }>]> = [
+      ["openai model", openai.execute({ prompt: "x", model: "gpt-image-99" })],
+      ["openai quality", openai.execute({ prompt: "x", quality: "ultra" })],
+      ["minimax model", minimax.execute({ prompt: "x", model: "image-99" })],
+      ["aspect vocabulary", openai.execute({ prompt: "x", aspect_ratio: "5:1" })],
+      ["resolution vocabulary", openai.execute({ prompt: "x", resolution: "9k" })],
+      // The pre-existing backends carried the same defect.
+      ["zai model", zai.execute({ prompt: "x", model: "glm-nope" })],
+      ["zai n", zai.execute({ prompt: "x", n: 3 })],
+    ];
+    for (const [name, pending] of cases) {
+      const result = await pending;
+      expect(result.isError, name).toBe(true);
+      expect(result.effectDisposition?.disposition, name).toBe(
+        "confirmed_no_effect",
+      );
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("refuses a missing prompt before any request, and says so", async () => {


### PR DESCRIPTION
## Why

`ImagineImage` shipped four backends: Meta Muse Image, QwenCloud, Z.AI and xAI. A session running on **OpenAI** or **MiniMax** had no way to generate an image at all unless the operator happened to hold one of those four other credentials. Worse, an OpenAI session that also held `XAI_API_KEY` silently produced Grok images, because the session-provider preference list had no OpenAI branch and fell through to the independent xAI path.

Every provider claim below was read back from the provider's own API on 2026-09-09, not from documentation.

## What changed, per file

### `runtime/src/tools/system/imagine-image.ts`

- **Two new backends, `openai` and `minimax`**, resolved by the same rule the existing four already follow: the session's own provider generates with its own native route, authorized only by that provider's canonical environment ingress (`OPENAI_API_KEY`, `MINIMAX_API_KEY`), and each is also an independent fallback for any other session.
- **OpenAI credential isolation is load-bearing, not stylistic.** The ChatGPT OAuth grant this app can hold authorizes the Responses backend, not `/images/generations`. The session bearer is therefore never consulted for this route; an OpenAI session with only an OAuth grant falls through to the other backends exactly as before.
- **Download-host allowlist rewritten as a per-backend table.** It was a chain of ternaries whose final `else` was xAI's host set, so a new backend inherited xAI's hosts by default. Adding OpenAI under the old shape would have let a URL arriving on the OpenAI backend be fetched from `x.ai`. Both new backends declare no hosts (they are asked for inline base64), which now means *refuse every URL*, not *fall through*.
- **MiniMax's 200-with-error is handled.** MiniMax answers HTTP 200 for a rejected request and puts the outcome in `base_resp.status_code`, so an HTTP-only check reports success and saves nothing.
- **`grok-imagine-image-2.0` added.** xAI has served it since 2026-04-08 (`created: 1786147200` on `/v1/image-generation-models`); the tool did not offer it.
- Three nested ternaries that a fifth and sixth backend would have made unreadable are now small functions: `initialImageRequestBody`, `defaultImageExtension`, `imageBackendLabel`, `maxImagesPerRequest`, `imageQualityError`. `metaImageSize` becomes `orientedImageSize` because OpenAI wants the same three shapes.
- Parameter ranges are the providers' own, read back from their validation errors: OpenAI `quality` ∈ {low, medium, high, auto} and `n` ≤ 10; MiniMax `n` ≤ 9 and a shorter aspect-ratio list than this tool's shared vocabulary, so `2:1` and the ultrawide ratios are refused with a message naming what MiniMax does accept.

### `runtime/tests/tools/system/imagine-image.test.ts`

Ten new cases (mocked fetch): endpoint/body/auth for each backend, OpenAI honouring the reported `output_format` instead of assuming PNG, MiniMax's in-body failure, the URL fail-closed path, per-backend `quality` vocabularies, refused controls, the `n` clamp, `grok-imagine-image-2.0`, and the advertised schemas.

### `runtime/tests/live/imagine-image-backends.live.test.ts` (new)

Operator-invoked live test following the existing `tests/live/**` convention (excluded from the default suite, billed when run). Generates one real image per backend and asserts the saved extension against the file's magic bytes.

## Evidence

Live, against the real APIs, driving the shipped tool code:

```
✓ GPT Image, live > generates and saves a real image      12504ms
✓ MiniMax Image, live > generates and saves a real image  17361ms
```

The OpenAI file is a real PNG (`89504e470d0a1a0a`, 813 KB) and the MiniMax file a real JPEG (`ffd8`, 52 KB), which is why the extension mapping is asserted rather than assumed: Electron's `agenc-media://` handler derives the rendered content type from the extension, so a wrong guess shows a broken image in the transcript.

Provider-stated parameter contracts, quoted from their own 400s:

- `Invalid value: '__bogus__'. Supported values are: 'low', 'medium', 'high', and 'auto'.` (OpenAI `quality`)
- `Invalid 'n': integer above maximum value. Expected a value <= 10` (OpenAI `n`)
- `invalid params, aspect_ratio must be one of [1:1 16:9 4:3 3:2 2:3 3:4 9:16 21:9]` (MiniMax)
- `invalid params, n must be between 1 and 9` (MiniMax)

## Tests

- `tests/tools/system/imagine-image.test.ts`: **43 passed** (was 32).
- Falsification: with the source change reverted and the new tests kept, **all 10 new cases fail**. None of them passes against the old code.
- `tests/tools/system` + the Qwen and Z.AI provider suites: 904 passed, 3 failed. Those 3 (`bash-shell-output-cap-m-exec-2`, `bash-workspace-fence`, `exec-command`) fail identically on clean `main` with this branch's files reverted; they are a pre-existing baseline and touch no code in this PR.
- `tsc --noEmit` over the whole runtime project: 0 errors.

## Not changed

- **No desktop change is needed to show these images.** The display path already exists and is backend-agnostic: the tools write into `<cwd>/.agenc/imagine`, the desktop daemon watches that directory during a turn (`#scanImagineDir`) and pushes a `media` event, and the transcript renders it through `agenc-media://` with a lightbox and download. The gap was that these two backends produced no file at all, not that the UI could not show one.
- `ImagineVideo` is untouched. OpenAI Sora 2 and MiniMax Hailuo are both reachable on these credentials and are a separate PR.
- The model catalog is untouched. It carries several stale entries found during this sweep (four MiniMax models that no longer exist, an NVIDIA default that 404s) and those belong in their own PR.
- No provider registry, permission, or sandbox behaviour changed.

## Counterpart PRs

None yet. Follow-ups planned: ImagineVideo backends, catalog staleness, and a zero-data-retention provider option.

---

## Update: driven in the desktop app, which found two more defects

The unit and live tests above all passed while the tool was still broken in the app. Both defects depend on the tool registry being built **before** a Session attaches, which is what the desktop does: in that state `ImagineImage` advertises its **universal** schema, which offers `resolution` and `quality` whatever backend is resolved later. A model on an OpenAI session follows that schema and sends `resolution: "1k"`.

**1. A refused argument gated the whole session.** `ImagineImage` is `side-effecting`, so a bare `isError` is filed as an unknown outcome and blocks every later side-effecting call behind `/resolve` (#2190):

```
"reason": "tool_error_result_without_authoritative_effect_disposition", "requiresReview": true
→ "ImagineImage failed… Further calls are blocked pending review of call call_aHil…
   Please use /resolve in AgenC to review and clear that call so I can retry."
```

The file already documented this and already had a `refusal()` helper carrying `confirmed_no_effect`; nine argument checks used the bare form anyway, including pre-existing ones. All of them use `refusal()` now.

**2. Refusing did not help even with the gate gone.** The model does not drop the offending field. It rewords the prompt and re-sends the same arguments. Observed live: **3m 27s and ~25 calls**, every one identical apart from prose, until the repeat-call guard ended the turn with no image:

```
CALL  …"model":"gpt-image-1.5","n":1,"aspect_ratio":"1:1","resolution":"1k","quality":"standard"
RESULT {"error":"OpenAI image size is selected by aspect_ratio; resolution is not supported"}
    × 25
```

So the rule is now: **a control the advertised schema offers but the resolved backend has no notion of is dropped and named in the result (`ignoredControls`), never refused.** That covers `resolution` on OpenAI, MiniMax and Z.AI, `quality` on backends without one, and an aspect ratio outside MiniMax's shorter list; `hd`/`standard` translate onto OpenAI's own quality scale rather than being rejected. What stays a refusal is anything that cannot be substituted without changing what gets generated: an unknown model, or a value outside the shared vocabulary.

### App evidence

GPT-6 Astra, `work` project, desktop build of this branch:

```
ARGS   {"prompt":"One plain grey cube …","n":1,"aspect_ratio":"1:1","resolution":"1k", …}
RESULT {"backend":"openai","model":"gpt-image-2","n":1,
        "path":"…/work/.agenc/imagine/imagine-cc2240f9….png",
        "ignoredControls":["resolution"]}
```

772,787 bytes, magic `89504e470d0a1a0a`, rendered inline in the transcript. One call, not twenty-five.

MiniMax M2.5 session, same build: `{"backend":"minimax","model":"image-01",…}` saved as `.jpg` and rendered inline.

`tests/tools/system/imagine-image.test.ts` is now **44 passed**, including a case that pins every pre-request refusal to `effectDisposition.disposition === "confirmed_no_effect"` so this cannot regress into a session gate again.

One pre-existing test changed: `rejects unsupported Z.ai image requests…` asserted that Z.AI refuses `resolution`. Z.AI now drops it and names it, for the same reason, and the test asserts the request went out without it and with the aspect-derived size.
