### PR TITLE
Generate video with Sora and MiniMax Hailuo, and bound the download path

### DIFF
--- a/runtime/src/tools/system/imagine-video.ts
+++ b/runtime/src/tools/system/imagine-video.ts
@@ -38,6 +38,7 @@ import {
   resolveProviderBaseURLEnvironment,
 } from "../../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../types.js";
+import { preEffectRefusal } from "../results.js";
 import { safeStringify } from "../types.js";
 import type { HomeContext } from "../../config/home.js";
 
@@ -60,6 +61,16 @@ function json(payload: unknown, isError?: boolean): ToolResult {
     content: safeStringify(payload),
     ...(isError ? { isError: true } : {}),
   };
+}
+
+/**
+ * A refusal made before any provider request. ImagineVideo is
+ * `side-effecting`, so a bare error result is filed as an unknown outcome and
+ * gates every later side-effecting call behind /resolve (#2190). Argument
+ * validation provably touched nothing, so it must carry the disposition.
+ */
+function refusal(payload: unknown): ToolResult {
+  return preEffectRefusal("ImagineVideo", safeStringify(payload));
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -641,34 +652,37 @@ function xaiSubmitError(
 async function runOpenAiVideo(ctx: VideoRunContext): Promise<ToolResult> {
   const { args, backend, fetchImpl, signal } = ctx;
   if (ctx.imageUrl || ctx.referenceImages.length > 0) {
-    return json(
-      {
-        error:
-          "Sora image-to-video needs an uploaded reference and is not wired here; this backend is text-to-video only",
-      },
-      true,
-    );
+    return refusal({
+      error:
+        "Sora image-to-video needs an uploaded reference and is not wired here; this backend is text-to-video only",
+    });
   }
   const model = stringValue(args.model) ?? "sora-2";
   if (!OPENAI_VIDEO_MODELS.has(model)) {
-    return json(
-      {
-        error: `Sora model must be one of ${[...OPENAI_VIDEO_MODELS].join(", ")}`,
-      },
-      true,
-    );
+    return refusal({
+      error: `Sora model must be one of ${[...OPENAI_VIDEO_MODELS].join(", ")}`,
+    });
   }
-  const aspect_ratio = stringValue(args.aspect_ratio) ?? "16:9";
-  if (aspect_ratio !== "16:9" && aspect_ratio !== "9:16") {
-    return json(
-      { error: "Sora aspect_ratio must be 16:9 or 9:16" },
-      true,
-    );
+  // A dimension control the universal schema offers but this backend cannot
+  // honour is dropped and named, never refused: the schema a model sees
+  // before a Session attaches is the xAI one, and refusing what it advertised
+  // stalls the run rather than correcting it.
+  const ignoredControls: string[] = [];
+  const requestedAspect = stringValue(args.aspect_ratio);
+  const aspectSupported =
+    requestedAspect === "16:9" || requestedAspect === "9:16";
+  if (requestedAspect !== undefined && !aspectSupported) {
+    ignoredControls.push("aspect_ratio");
   }
-  const resolution = (stringValue(args.resolution) ?? "720p").toLowerCase();
-  if (!OPENAI_VIDEO_RESOLUTIONS.has(resolution)) {
-    return json({ error: "Sora resolution must be 720p or 1080p" }, true);
+  const aspect_ratio = aspectSupported ? requestedAspect : "16:9";
+  const requestedResolution = stringValue(args.resolution)?.toLowerCase();
+  const resolutionSupported =
+    requestedResolution !== undefined &&
+    OPENAI_VIDEO_RESOLUTIONS.has(requestedResolution);
+  if (requestedResolution !== undefined && !resolutionSupported) {
+    ignoredControls.push("resolution");
   }
+  const resolution = resolutionSupported ? requestedResolution : "720p";
   const size =
     OPENAI_VIDEO_SIZES[aspect_ratio][resolution as "720p" | "1080p"];
   const seconds = snapDuration(
@@ -770,6 +784,7 @@ async function runOpenAiVideo(ctx: VideoRunContext): Promise<ToolResult> {
     resolution,
     size,
     modality: "text",
+    ...(ignoredControls.length > 0 ? { ignoredControls } : {}),
   });
 }
 
@@ -792,52 +807,40 @@ function minimaxFailure(payload: MinimaxEnvelope): string | undefined {
 async function runMinimaxVideo(ctx: VideoRunContext): Promise<ToolResult> {
   const { args, backend, fetchImpl, signal } = ctx;
   if (ctx.referenceImages.length > 0) {
-    return json(
-      {
-        error:
-          "MiniMax takes a single first frame; use image_url rather than reference_image_urls",
-      },
-      true,
-    );
+    return refusal({
+      error:
+        "MiniMax takes a single first frame; use image_url rather than reference_image_urls",
+    });
   }
+  // MiniMax sizes a video by resolution and model, so an aspect_ratio from
+  // the universal schema is dropped and named rather than refused.
+  const ignoredControls: string[] = [];
   if (stringValue(args.aspect_ratio) !== undefined) {
-    return json(
-      {
-        error:
-          "MiniMax video dimensions come from resolution and the model; aspect_ratio is not supported",
-      },
-      true,
-    );
+    ignoredControls.push("aspect_ratio");
   }
   const model = stringValue(args.model) ?? MINIMAX_TEXT_TO_VIDEO_MODEL;
   if (!MINIMAX_VIDEO_MODELS.has(model)) {
-    return json(
-      {
-        error: `MiniMax video model must be one of ${[...MINIMAX_VIDEO_MODELS].join(", ")}`,
-      },
-      true,
-    );
+    return refusal({
+      error: `MiniMax video model must be one of ${[...MINIMAX_VIDEO_MODELS].join(", ")}`,
+    });
   }
-  const resolution = stringValue(args.resolution) ?? "768P";
-  if (!MINIMAX_VIDEO_RESOLUTIONS.has(resolution)) {
-    return json(
-      {
-        error: `MiniMax resolution must be one of ${[...MINIMAX_VIDEO_RESOLUTIONS].join(", ")}`,
-      },
-      true,
-    );
+  const requestedResolution = stringValue(args.resolution);
+  const resolutionSupported =
+    requestedResolution !== undefined &&
+    MINIMAX_VIDEO_RESOLUTIONS.has(requestedResolution);
+  if (requestedResolution !== undefined && !resolutionSupported) {
+    // 480p/720p are the xAI vocabulary; MiniMax grades in 512P/768P/1080P.
+    ignoredControls.push("resolution");
   }
+  const resolution = resolutionSupported ? requestedResolution : "768P";
   if (
     resolution === MINIMAX_FIRST_FRAME_ONLY_RESOLUTION &&
     ctx.imageUrl === undefined
   ) {
-    return json(
-      {
-        error:
-          "MiniMax accepts 512P only with a first frame; pass image_url or choose 768P or 1080P",
-      },
-      true,
-    );
+    return refusal({
+      error:
+        "MiniMax accepts 512P only with a first frame; pass image_url or choose 768P or 1080P",
+    });
   }
   const duration = snapDuration(
     requestedDuration(args),
@@ -959,6 +962,7 @@ async function runMinimaxVideo(ctx: VideoRunContext): Promise<ToolResult> {
     duration,
     resolution,
     modality: ctx.imageUrl === undefined ? "text" : "image",
+    ...(ignoredControls.length > 0 ? { ignoredControls } : {}),
   });
 }
 
@@ -1101,12 +1105,12 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
       admittedSignal?.throwIfAborted();
       const backendResolution = resolveVideoBackend(opts);
       if ("error" in backendResolution) {
-        return json({ error: backendResolution.error }, true);
+        return refusal({ error: backendResolution.error });
       }
       const { backend } = backendResolution;
 
       const prompt = stringValue(args.prompt);
-      if (!prompt) return json({ error: "prompt is required" }, true);
+      if (!prompt) return refusal({ error: "prompt is required" });
 
       const imageUrlRaw = stringValue(args.image_url);
       const imageUrl = imageUrlRaw
@@ -1119,21 +1123,14 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
           )
         : [];
       if (imageUrl && refRaw.length > 0) {
-        return json(
-          {
-            error:
-              "image_url and reference_image_urls cannot be combined on xAI",
-          },
-          true,
-        );
+        return refusal({
+          error: "image_url and reference_image_urls cannot be combined on xAI",
+        });
       }
       if (refRaw.length > MAX_REFERENCE_IMAGES) {
-        return json(
-          {
-            error: `reference_image_urls supports at most ${MAX_REFERENCE_IMAGES} images`,
-          },
-          true,
-        );
+        return refusal({
+          error: `reference_image_urls supports at most ${MAX_REFERENCE_IMAGES} images`,
+        });
       }
       const referenceImages: { url: string }[] = [];
       for (const r of refRaw) {

--- a/runtime/src/tools/system/imagine-video.ts
+++ b/runtime/src/tools/system/imagine-video.ts
@@ -1,16 +1,21 @@
 /**
- * LIVE Imagine **video** generation through an independent xAI backend.
+ * LIVE Imagine **video** generation across independent media backends.
  *
- * Text-to-video and image-to-video via:
- *   POST /v1/videos/generations  → request_id
- *   GET  /v1/videos/{request_id} → poll until done
+ * Three providers, three job protocols, all submit-then-poll:
+ *   xAI      POST /videos/generations → request_id; GET /videos/{id};
+ *            the finished payload carries a URL to download.
+ *   OpenAI   POST /videos → id; GET /videos/{id} until "completed";
+ *            GET /videos/{id}/content streams the MP4 under the same auth,
+ *            so no payload-supplied URL is ever followed.
+ *   MiniMax  POST /video_generation → task_id;
+ *            GET /query/video_generation until "Success" → file_id;
+ *            GET /files/retrieve → download_url on MiniMax's CDN.
  *
- * Auth (same as Hermes video_gen/xai): `/grok-login` OAuth **wins** over
- * BYOK; subscription SuperGrok / Grok Build users can generate video.
- *
- * Any reasoning provider may invoke this tool with independent xAI OAuth or
- * BYOK credentials. A direct Grok session additionally retains compatibility
- * with its own session bearer and base URL.
+ * Auth follows the same rule as ImagineImage: a session generates with its
+ * own provider's native route, authorized only by that provider's canonical
+ * environment ingress, and every backend is also available independently to
+ * any other session. `/grok-login` OAuth still wins over BYOK for xAI, and a
+ * direct Grok session retains its session bearer and base URL.
  *
  * @module
  */
@@ -28,7 +33,10 @@ import {
   isDirectXaiInferenceHost,
   resolveXaiBearerToken,
 } from "../../llm/xai-capability-config.js";
-import { resolveProviderBaseURLEnvironment } from "../../llm/registry/provider-ingress.js";
+import {
+  resolveProviderApiKeyEnvironment,
+  resolveProviderBaseURLEnvironment,
+} from "../../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import type { HomeContext } from "../../config/home.js";
@@ -74,27 +82,134 @@ const TEXT_TO_VIDEO_MODEL = "grok-imagine-video";
 const IMAGE_TO_VIDEO_MODEL = "grok-imagine-video-1.5-preview";
 const MAX_REFERENCE_IMAGES = 7;
 const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 
-type XaiBackendResolution =
-  | {
-      readonly backend: {
-        readonly baseURL: string;
-        readonly bearer: string;
-      };
-    }
-  | { readonly error: string };
+/** Sora's own list, read back from its rejection of an unknown model. */
+const OPENAI_VIDEO_MODELS = Object.freeze(
+  new Set([
+    "sora-2",
+    "sora-2-pro",
+    "sora-2-2025-10-06",
+    "sora-2-pro-2025-10-06",
+    "sora-2-2025-12-08",
+  ]),
+);
+/** Sora accepts these three durations and nothing between them. */
+const OPENAI_VIDEO_SECONDS = Object.freeze([4, 8, 12]);
+const OPENAI_VIDEO_SIZES = Object.freeze({
+  "16:9": Object.freeze({ "720p": "1280x720", "1080p": "1792x1024" }),
+  "9:16": Object.freeze({ "720p": "720x1280", "1080p": "1024x1792" }),
+});
+const OPENAI_VIDEO_RESOLUTIONS = Object.freeze(new Set(["720p", "1080p"]));
+
+const MINIMAX_VIDEO_MODELS = Object.freeze(
+  new Set([
+    "MiniMax-Hailuo-02",
+    "MiniMax-Hailuo-2.3",
+    "MiniMax-Hailuo-2.3-fast",
+    "T2V-01",
+    "T2V-01-Director",
+    "I2V-01",
+    "I2V-01-Director",
+    "I2V-01-live",
+  ]),
+);
+const MINIMAX_TEXT_TO_VIDEO_MODEL = "MiniMax-Hailuo-02";
+const MINIMAX_VIDEO_DURATIONS = Object.freeze([6, 10]);
+const MINIMAX_VIDEO_RESOLUTIONS = Object.freeze(
+  new Set(["512P", "768P", "1080P"]),
+);
+/**
+ * MiniMax refuses 512P unless a first frame is supplied: "param 'resolution'
+ * 512P is only supported when param 'first_frame_image' provided".
+ */
+const MINIMAX_FIRST_FRAME_ONLY_RESOLUTION = "512P";
+
+const MAX_VIDEO_DOWNLOAD_BYTES = 256 * 1024 * 1024;
+const MAX_VIDEO_DOWNLOAD_REDIRECTS = 5;
+
+type VideoBackendKind = "xai" | "openai" | "minimax";
+
+interface VideoBackend {
+  readonly kind: VideoBackendKind;
+  readonly baseURL: string;
+  readonly bearer: string;
+}
 
 /**
- * Resolve xAI as a media backend, independently from the reasoning provider.
- * Only a direct Grok session is allowed to contribute its factory bearer or
- * URL; Meta/OpenAI/etc credentials must never cross the xAI trust boundary.
+ * What a backend is allowed to download from, stated per backend so that a
+ * new one cannot inherit another's hosts through a fallthrough.
+ *
+ * `none` is the strongest: the backend never follows a URL out of a response
+ * body at all. `hosts` pins an observed CDN. `any-https` is the honest
+ * encoding of an unestablished fact rather than a guess: this repo has never
+ * captured a finished xAI video URL, and this team's account cannot produce
+ * one (see the ZDR note on the xAI runner), so narrowing it here would be an
+ * unverified behaviour change to a shipped path. Those downloads still get
+ * credential-free HTTPS, hop-by-hop redirect checks and the byte cap.
  */
-function resolveXaiVideoBackend(
+type VideoDownloadPolicy =
+  | { readonly kind: "none" }
+  | { readonly kind: "hosts"; readonly suffixes: readonly string[] }
+  | { readonly kind: "any-https" };
+
+const VIDEO_DOWNLOAD_POLICY: Readonly<
+  Record<VideoBackendKind, VideoDownloadPolicy>
+> = Object.freeze({
+  // Observed: video-product.cdn.minimax.io
+  minimax: { kind: "hosts", suffixes: ["minimax.io", "minimaxi.com"] },
+  // Streams from the API host under the same bearer; no payload URL exists.
+  openai: { kind: "none" },
+  xai: { kind: "any-https" },
+});
+
+type VideoBackendResolution =
+  | { readonly backend: VideoBackend }
+  | { readonly error: string };
+
+function environmentVideoBackend(
+  kind: "openai" | "minimax",
+  env: NodeJS.ProcessEnv,
+): VideoBackend | undefined {
+  const credential = resolveProviderApiKeyEnvironment(kind, env);
+  if (credential === undefined) return undefined;
+  const baseURL =
+    resolveProviderBaseURLEnvironment(kind, env)?.value ??
+    (kind === "openai" ? DEFAULT_OPENAI_BASE_URL : DEFAULT_MINIMAX_BASE_URL);
+  try {
+    new URL(baseURL);
+  } catch {
+    return undefined;
+  }
+  return {
+    kind,
+    baseURL: baseURL.replace(/\/$/, ""),
+    bearer: credential.value,
+  };
+}
+
+/**
+ * Resolve a media backend independently from the reasoning provider.
+ *
+ * A session generates with its own provider first, the way ImagineImage
+ * already works. Only a direct Grok session may contribute its factory
+ * bearer or URL; Meta/OpenAI/etc credentials must never cross the xAI trust
+ * boundary, and an OpenAI session's bearer may be a ChatGPT OAuth grant,
+ * which does not authorize /videos at all. Both new backends therefore read
+ * only their canonical API-key ingress.
+ */
+function resolveVideoBackend(
   opts: ImagineVideoToolOptions,
-): XaiBackendResolution {
+): VideoBackendResolution {
   const env = opts.env ?? process.env;
   const provider = opts.getSession()?.services?.provider;
   const providerIdentity = readProviderIdentity(provider as never);
+
+  if (providerIdentity === "openai" || providerIdentity === "minimax") {
+    const backend = environmentVideoBackend(providerIdentity, env);
+    if (backend !== undefined) return { backend };
+  }
 
   if (providerIdentity === "grok" && provider !== undefined) {
     const factory = readProviderFactoryOptions(provider as never);
@@ -105,6 +220,7 @@ function resolveXaiVideoBackend(
       if (bearer !== undefined) {
         return {
           backend: {
+            kind: "xai",
             baseURL: (factory.baseURL ?? DEFAULT_XAI_BASE_URL).replace(
               /\/$/,
               "",
@@ -124,30 +240,121 @@ function resolveXaiVideoBackend(
       resolveProviderBaseURLEnvironment("grok", env)?.value ??
       DEFAULT_XAI_BASE_URL;
     if (!isDirectXaiInferenceHost(baseURL)) {
+      const fallback =
+        environmentVideoBackend("openai", env) ??
+        environmentVideoBackend("minimax", env);
+      if (fallback !== undefined) return { backend: fallback };
       return {
         error:
           "ImagineVideo's independent xAI backend must use a direct xAI host (api.x.ai).",
       };
     }
     return {
-      backend: {
-        baseURL: baseURL.replace(/\/$/, ""),
-        bearer,
-      },
+      backend: { kind: "xai", baseURL: baseURL.replace(/\/$/, ""), bearer },
     };
   }
 
+  const independent =
+    environmentVideoBackend("openai", env) ??
+    environmentVideoBackend("minimax", env);
+  if (independent !== undefined) return { backend: independent };
+
   return {
     error:
-      "ImagineVideo needs an independent xAI media credential via /grok-login, XAI_API_KEY, or GROK_API_KEY.",
+      "ImagineVideo needs a media credential: OPENAI_API_KEY for Sora, " +
+      "MINIMAX_API_KEY for Hailuo, or an independent xAI media credential " +
+      "via /grok-login, XAI_API_KEY, or GROK_API_KEY.",
   };
 }
 
-/** Whether this request has a usable, credential-isolated xAI video backend. */
+/** Whether this request has a usable, credential-isolated video backend. */
 export function hasImagineVideoBackend(
   opts: ImagineVideoToolOptions,
 ): boolean {
-  return "backend" in resolveXaiVideoBackend(opts);
+  return "backend" in resolveVideoBackend(opts);
+}
+
+function validatedVideoDownloadUrl(value: string, kind: VideoBackendKind): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Video download URL is invalid");
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error("Video download URL must use credential-free HTTPS");
+  }
+  const policy = VIDEO_DOWNLOAD_POLICY[kind];
+  if (policy.kind === "any-https") return url;
+  const hostname = url.hostname.toLowerCase();
+  const trusted =
+    policy.kind === "hosts" &&
+    policy.suffixes.some(
+      (suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`),
+    );
+  if (!trusted) {
+    throw new Error(`Video download host is not trusted for the ${kind} backend`);
+  }
+  return url;
+}
+
+/**
+ * Stream a finished video through a hard byte cap.
+ *
+ * Redirects are followed by hand so every hop is re-checked against the
+ * backend's hosts: a signed URL is provider-controlled, and a 302 off the
+ * allowlist would otherwise be followed silently.
+ */
+async function downloadVideo(
+  fetchImpl: typeof fetch,
+  value: string,
+  kind: VideoBackendKind,
+  signal: AbortSignal | undefined,
+): Promise<Buffer> {
+  let current = validatedVideoDownloadUrl(value, kind);
+  for (
+    let redirects = 0;
+    redirects <= MAX_VIDEO_DOWNLOAD_REDIRECTS;
+    redirects += 1
+  ) {
+    const response = await fetchImpl(current, {
+      redirect: "manual",
+      ...(signal === undefined ? {} : { signal }),
+    });
+    const location = response.headers.get("location");
+    if (response.status >= 300 && response.status < 400 && location) {
+      current = validatedVideoDownloadUrl(
+        new URL(location, current).toString(),
+        kind,
+      );
+      continue;
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to download video (HTTP ${response.status})`);
+    }
+    return await readCappedBody(response);
+  }
+  throw new Error("Video download exceeded the redirect limit");
+}
+
+async function readCappedBody(response: Response): Promise<Buffer> {
+  if (response.body === null) {
+    throw new Error("Video download returned an empty body");
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_VIDEO_DOWNLOAD_BYTES) {
+      await reader.cancel();
+      throw new Error("Video download exceeds the 256 MiB limit");
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total);
 }
 
 async function imageRefToUrl(
@@ -204,13 +411,675 @@ function abortSignalFromArgs(
   return signal instanceof AbortSignal ? signal : undefined;
 }
 
+/** Nearest value a backend actually accepts, ties resolving downward. */
+function snapDuration(
+  requested: number | undefined,
+  allowed: readonly number[],
+  fallback: number,
+): number {
+  if (requested === undefined || !Number.isFinite(requested)) return fallback;
+  let best = allowed[0]!;
+  for (const candidate of allowed) {
+    if (Math.abs(candidate - requested) < Math.abs(best - requested)) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+function requestedDuration(args: Record<string, unknown>): number | undefined {
+  return typeof args.duration === "number" && Number.isFinite(args.duration)
+    ? Math.floor(args.duration)
+    : undefined;
+}
+
+type PollOutcome<T> =
+  | { readonly state: "done"; readonly value: T }
+  | { readonly state: "pending"; readonly status: string }
+  | { readonly state: "failed"; readonly error: string };
+
+/**
+ * The submit-then-poll wait shared by all three backends. Only the probe
+ * differs; the interval, the deadline and the cancellation point do not.
+ */
+async function pollForVideo<T>(
+  opts: ImagineVideoToolOptions,
+  signal: AbortSignal | undefined,
+  probe: () => Promise<PollOutcome<T>>,
+): Promise<{ readonly value: T } | { readonly error: string }> {
+  const interval = opts.pollIntervalMs ?? 5_000;
+  const timeout = opts.pollTimeoutMs ?? 240_000;
+  let elapsed = 0;
+  let lastStatus = "queued";
+  while (elapsed < timeout) {
+    const outcome = await probe();
+    if (outcome.state === "done") return { value: outcome.value };
+    if (outcome.state === "failed") return { error: outcome.error };
+    lastStatus = outcome.status;
+    await sleep(interval, signal);
+    elapsed += interval;
+  }
+  return {
+    error: `Imagine video timed out after ${timeout}ms (last status: ${lastStatus})`,
+  };
+}
+
+async function saveVideoBytes(
+  workspaceRoot: string,
+  bytes: Buffer,
+  signal: AbortSignal | undefined,
+): Promise<string> {
+  const outDir = join(workspaceRoot, ".agenc", "imagine");
+  await mkdir(outDir, { recursive: true });
+  const path = join(outDir, `imagine-video-${randomUUID()}.mp4`);
+  await writeFile(path, bytes, { signal });
+  return path;
+}
+
+interface VideoRunContext {
+  readonly opts: ImagineVideoToolOptions;
+  readonly backend: VideoBackend;
+  readonly fetchImpl: typeof fetch;
+  readonly signal: AbortSignal | undefined;
+  readonly args: Record<string, unknown>;
+  readonly prompt: string;
+  readonly imageUrl: string | undefined;
+  readonly referenceImages: readonly { url: string }[];
+}
+
+function authHeaders(backend: VideoBackend): Record<string, string> {
+  return {
+    authorization: `Bearer ${backend.bearer}`,
+    "content-type": "application/json",
+  };
+}
+
+function signalInit(signal: AbortSignal | undefined): RequestInit {
+  return signal === undefined ? {} : { signal };
+}
+
+// ── xAI ───────────────────────────────────────────────────────────────
+
+async function runXaiVideo(ctx: VideoRunContext): Promise<ToolResult> {
+  const { args, backend, fetchImpl, signal } = ctx;
+  const modality =
+    ctx.imageUrl || ctx.referenceImages.length > 0 ? "image" : "text";
+  const model =
+    stringValue(args.model) ??
+    (modality === "image" ? IMAGE_TO_VIDEO_MODEL : TEXT_TO_VIDEO_MODEL);
+
+  let duration = requestedDuration(args) ?? 8;
+  if (duration < 1) duration = 1;
+  if (duration > 15) duration = 15;
+  if (ctx.referenceImages.length > 0 && duration > 10) duration = 10;
+
+  let aspect_ratio = stringValue(args.aspect_ratio) ?? "16:9";
+  if (!VALID_ASPECT.has(aspect_ratio)) aspect_ratio = "16:9";
+  let resolution = (stringValue(args.resolution) ?? "720p").toLowerCase();
+  if (!VALID_RESOLUTIONS.has(resolution)) resolution = "720p";
+
+  const body: Record<string, unknown> = {
+    model,
+    prompt: ctx.prompt,
+    duration,
+    aspect_ratio,
+    resolution,
+  };
+  if (ctx.imageUrl) body.image = { url: ctx.imageUrl };
+  if (ctx.referenceImages.length > 0) {
+    body.reference_images = ctx.referenceImages;
+  }
+
+  const submitRes = await fetchImpl(`${backend.baseURL}/videos/generations`, {
+    method: "POST",
+    headers: { ...authHeaders(backend), "x-idempotency-key": randomUUID() },
+    body: JSON.stringify(body),
+    ...signalInit(signal),
+  });
+  const submitJson = (await submitRes.json()) as {
+    request_id?: string;
+    error?: string | { message?: string };
+  };
+  if (!submitRes.ok) {
+    return json({ error: xaiSubmitError(submitJson, submitRes.status) }, true);
+  }
+  const requestId = submitJson.request_id;
+  if (!requestId) {
+    return json(
+      { error: "xAI video response did not include request_id" },
+      true,
+    );
+  }
+
+  const polled = await pollForVideo(ctx.opts, signal, async () => {
+    const pollRes = await fetchImpl(`${backend.baseURL}/videos/${requestId}`, {
+      method: "GET",
+      headers: authHeaders(backend),
+      ...signalInit(signal),
+    });
+    const pollJson = (await pollRes.json()) as Record<string, unknown> & {
+      status?: string;
+      error?: { message?: string };
+      video?: { url?: string };
+      url?: string;
+    };
+    if (!pollRes.ok) {
+      return {
+        state: "failed",
+        error:
+          pollJson.error?.message ?? `Imagine video poll HTTP ${pollRes.status}`,
+      };
+    }
+    const status = String(pollJson.status ?? "").toLowerCase();
+    if (status === "done") return { state: "done", value: pollJson };
+    if (
+      status === "failed" ||
+      status === "error" ||
+      status === "expired" ||
+      status === "cancelled"
+    ) {
+      return {
+        state: "failed",
+        error: `Imagine video ${status}: ${
+          pollJson.error?.message ?? "upstream failure"
+        }`,
+      };
+    }
+    return { state: "pending", status };
+  });
+  if ("error" in polled) {
+    return json({ error: polled.error, request_id: requestId }, true);
+  }
+
+  const doneBody = polled.value;
+  const videoUrl =
+    (doneBody.video as { url?: string } | undefined)?.url ??
+    (typeof doneBody.url === "string" ? doneBody.url : undefined);
+  if (!videoUrl) {
+    return json(
+      {
+        error: "Imagine video completed but returned no video URL",
+        request_id: requestId,
+        status: "done",
+      },
+      true,
+    );
+  }
+
+  const bytes = await downloadVideo(fetchImpl, videoUrl, "xai", signal);
+  const path = await saveVideoBytes(ctx.opts.workspaceRoot, bytes, signal);
+  return json({
+    model,
+    path,
+    url: videoUrl,
+    request_id: requestId,
+    duration,
+    aspect_ratio,
+    resolution,
+    modality,
+  });
+}
+
+/**
+ * xAI reports media refusals as a bare `error` string, not the `{message}`
+ * object the chat endpoints use. A Zero Data Retention team gets one of
+ * these on every video call, so passing it through unchanged is the
+ * difference between an operator seeing the cause and seeing "HTTP 400".
+ */
+function xaiSubmitError(
+  payload: { readonly error?: string | { message?: string } },
+  status: number,
+): string {
+  const raw = payload.error;
+  if (typeof raw === "string" && raw.trim().length > 0) return raw;
+  if (typeof raw === "object" && raw?.message) return raw.message;
+  return `Imagine video submit HTTP ${status}`;
+}
+
+// ── OpenAI Sora ───────────────────────────────────────────────────────
+
+async function runOpenAiVideo(ctx: VideoRunContext): Promise<ToolResult> {
+  const { args, backend, fetchImpl, signal } = ctx;
+  if (ctx.imageUrl || ctx.referenceImages.length > 0) {
+    return json(
+      {
+        error:
+          "Sora image-to-video needs an uploaded reference and is not wired here; this backend is text-to-video only",
+      },
+      true,
+    );
+  }
+  const model = stringValue(args.model) ?? "sora-2";
+  if (!OPENAI_VIDEO_MODELS.has(model)) {
+    return json(
+      {
+        error: `Sora model must be one of ${[...OPENAI_VIDEO_MODELS].join(", ")}`,
+      },
+      true,
+    );
+  }
+  const aspect_ratio = stringValue(args.aspect_ratio) ?? "16:9";
+  if (aspect_ratio !== "16:9" && aspect_ratio !== "9:16") {
+    return json(
+      { error: "Sora aspect_ratio must be 16:9 or 9:16" },
+      true,
+    );
+  }
+  const resolution = (stringValue(args.resolution) ?? "720p").toLowerCase();
+  if (!OPENAI_VIDEO_RESOLUTIONS.has(resolution)) {
+    return json({ error: "Sora resolution must be 720p or 1080p" }, true);
+  }
+  const size =
+    OPENAI_VIDEO_SIZES[aspect_ratio][resolution as "720p" | "1080p"];
+  const seconds = snapDuration(
+    requestedDuration(args),
+    OPENAI_VIDEO_SECONDS,
+    8,
+  );
+
+  const submitRes = await fetchImpl(`${backend.baseURL}/videos`, {
+    method: "POST",
+    headers: authHeaders(backend),
+    // Sora rejects unknown parameters outright, so nothing extra is sent.
+    body: JSON.stringify({
+      model,
+      prompt: ctx.prompt,
+      seconds: String(seconds),
+      size,
+    }),
+    ...signalInit(signal),
+  });
+  const submitJson = (await submitRes.json()) as {
+    id?: string;
+    error?: { message?: string };
+  };
+  if (!submitRes.ok) {
+    return json(
+      {
+        error:
+          submitJson.error?.message ??
+          `Sora video submit HTTP ${submitRes.status}`,
+      },
+      true,
+    );
+  }
+  const videoId = submitJson.id;
+  if (!videoId) {
+    return json({ error: "Sora response did not include a video id" }, true);
+  }
+
+  const polled = await pollForVideo(ctx.opts, signal, async () => {
+    const pollRes = await fetchImpl(`${backend.baseURL}/videos/${videoId}`, {
+      method: "GET",
+      headers: authHeaders(backend),
+      ...signalInit(signal),
+    });
+    const pollJson = (await pollRes.json()) as {
+      status?: string;
+      progress?: number;
+      error?: { message?: string };
+    };
+    if (!pollRes.ok) {
+      return {
+        state: "failed",
+        error:
+          pollJson.error?.message ?? `Sora video poll HTTP ${pollRes.status}`,
+      };
+    }
+    const status = String(pollJson.status ?? "").toLowerCase();
+    if (status === "completed") return { state: "done", value: status };
+    if (status === "failed") {
+      return {
+        state: "failed",
+        error: `Sora video failed: ${pollJson.error?.message ?? "upstream failure"}`,
+      };
+    }
+    return { state: "pending", status };
+  });
+  if ("error" in polled) {
+    return json({ error: polled.error, request_id: videoId }, true);
+  }
+
+  // The MP4 streams from the API host under the same bearer, so no
+  // provider-supplied URL is ever followed for this backend.
+  const contentRes = await fetchImpl(
+    `${backend.baseURL}/videos/${videoId}/content`,
+    {
+      method: "GET",
+      headers: { authorization: `Bearer ${backend.bearer}` },
+      ...signalInit(signal),
+    },
+  );
+  if (!contentRes.ok) {
+    return json(
+      {
+        error: `Failed to download Sora video (HTTP ${contentRes.status})`,
+        request_id: videoId,
+      },
+      true,
+    );
+  }
+  const bytes = await readCappedBody(contentRes);
+  const path = await saveVideoBytes(ctx.opts.workspaceRoot, bytes, signal);
+  return json({
+    model,
+    path,
+    request_id: videoId,
+    duration: seconds,
+    aspect_ratio,
+    resolution,
+    size,
+    modality: "text",
+  });
+}
+
+// ── MiniMax Hailuo ────────────────────────────────────────────────────
+
+interface MinimaxEnvelope {
+  readonly base_resp?: { readonly status_code?: number; readonly status_msg?: string };
+}
+
+/** MiniMax answers HTTP 200 for a rejected request; the outcome is in here. */
+function minimaxFailure(payload: MinimaxEnvelope): string | undefined {
+  const code = payload.base_resp?.status_code;
+  if (code === 0) return undefined;
+  return (
+    payload.base_resp?.status_msg ??
+    `MiniMax request failed with status ${code ?? "unknown"}`
+  );
+}
+
+async function runMinimaxVideo(ctx: VideoRunContext): Promise<ToolResult> {
+  const { args, backend, fetchImpl, signal } = ctx;
+  if (ctx.referenceImages.length > 0) {
+    return json(
+      {
+        error:
+          "MiniMax takes a single first frame; use image_url rather than reference_image_urls",
+      },
+      true,
+    );
+  }
+  if (stringValue(args.aspect_ratio) !== undefined) {
+    return json(
+      {
+        error:
+          "MiniMax video dimensions come from resolution and the model; aspect_ratio is not supported",
+      },
+      true,
+    );
+  }
+  const model = stringValue(args.model) ?? MINIMAX_TEXT_TO_VIDEO_MODEL;
+  if (!MINIMAX_VIDEO_MODELS.has(model)) {
+    return json(
+      {
+        error: `MiniMax video model must be one of ${[...MINIMAX_VIDEO_MODELS].join(", ")}`,
+      },
+      true,
+    );
+  }
+  const resolution = stringValue(args.resolution) ?? "768P";
+  if (!MINIMAX_VIDEO_RESOLUTIONS.has(resolution)) {
+    return json(
+      {
+        error: `MiniMax resolution must be one of ${[...MINIMAX_VIDEO_RESOLUTIONS].join(", ")}`,
+      },
+      true,
+    );
+  }
+  if (
+    resolution === MINIMAX_FIRST_FRAME_ONLY_RESOLUTION &&
+    ctx.imageUrl === undefined
+  ) {
+    return json(
+      {
+        error:
+          "MiniMax accepts 512P only with a first frame; pass image_url or choose 768P or 1080P",
+      },
+      true,
+    );
+  }
+  const duration = snapDuration(
+    requestedDuration(args),
+    MINIMAX_VIDEO_DURATIONS,
+    6,
+  );
+
+  const submitRes = await fetchImpl(`${backend.baseURL}/video_generation`, {
+    method: "POST",
+    headers: authHeaders(backend),
+    body: JSON.stringify({
+      model,
+      prompt: ctx.prompt,
+      duration,
+      resolution,
+      ...(ctx.imageUrl === undefined
+        ? {}
+        : { first_frame_image: ctx.imageUrl }),
+    }),
+    ...signalInit(signal),
+  });
+  const submitJson = (await submitRes.json()) as MinimaxEnvelope & {
+    task_id?: string;
+  };
+  if (!submitRes.ok) {
+    return json(
+      { error: `MiniMax video submit HTTP ${submitRes.status}` },
+      true,
+    );
+  }
+  const submitFailure = minimaxFailure(submitJson);
+  if (submitFailure !== undefined) return json({ error: submitFailure }, true);
+  const taskId = submitJson.task_id;
+  if (!taskId) {
+    return json({ error: "MiniMax response did not include a task_id" }, true);
+  }
+
+  const polled = await pollForVideo(ctx.opts, signal, async () => {
+    const pollRes = await fetchImpl(
+      `${backend.baseURL}/query/video_generation?task_id=${encodeURIComponent(taskId)}`,
+      { method: "GET", headers: authHeaders(backend), ...signalInit(signal) },
+    );
+    const pollJson = (await pollRes.json()) as MinimaxEnvelope & {
+      status?: string;
+      file_id?: string;
+    };
+    if (!pollRes.ok) {
+      return {
+        state: "failed",
+        error: `MiniMax video poll HTTP ${pollRes.status}`,
+      };
+    }
+    // Observed: Preparing → Processing → Success. Matched case-insensitively
+    // so a capitalisation change upstream does not read as an unknown state.
+    const status = String(pollJson.status ?? "").toLowerCase();
+    if (status === "success") {
+      const fileId = pollJson.file_id;
+      if (!fileId) {
+        return {
+          state: "failed",
+          error: "MiniMax reported success without a file_id",
+        };
+      }
+      return { state: "done", value: fileId };
+    }
+    if (status === "fail") {
+      return {
+        state: "failed",
+        error:
+          minimaxFailure(pollJson) ?? "MiniMax video generation failed",
+      };
+    }
+    const pollFailure = minimaxFailure(pollJson);
+    if (pollFailure !== undefined) {
+      return { state: "failed", error: pollFailure };
+    }
+    return { state: "pending", status };
+  });
+  if ("error" in polled) {
+    return json({ error: polled.error, request_id: taskId }, true);
+  }
+
+  const fileRes = await fetchImpl(
+    `${backend.baseURL}/files/retrieve?file_id=${encodeURIComponent(polled.value)}`,
+    { method: "GET", headers: authHeaders(backend), ...signalInit(signal) },
+  );
+  const fileJson = (await fileRes.json()) as MinimaxEnvelope & {
+    file?: { download_url?: string };
+  };
+  const fileFailure = minimaxFailure(fileJson);
+  if (!fileRes.ok || fileFailure !== undefined) {
+    return json(
+      {
+        error:
+          fileFailure ?? `MiniMax file retrieve HTTP ${fileRes.status}`,
+        request_id: taskId,
+      },
+      true,
+    );
+  }
+  const downloadUrl = fileJson.file?.download_url;
+  if (!downloadUrl) {
+    return json(
+      {
+        error: "MiniMax returned no download URL for the finished video",
+        request_id: taskId,
+      },
+      true,
+    );
+  }
+
+  const bytes = await downloadVideo(fetchImpl, downloadUrl, "minimax", signal);
+  const path = await saveVideoBytes(ctx.opts.workspaceRoot, bytes, signal);
+  return json({
+    model,
+    path,
+    url: downloadUrl,
+    request_id: taskId,
+    duration,
+    resolution,
+    modality: ctx.imageUrl === undefined ? "text" : "image",
+  });
+}
+
+// ── Tool surface ──────────────────────────────────────────────────────
+
+function imagineVideoDescription(kind: VideoBackendKind | undefined): string {
+  switch (kind) {
+    case "openai":
+      return (
+        "Generate a video with OpenAI Sora and save the MP4 under the workspace. " +
+        "Text-to-video only; duration is 4, 8 or 12 seconds."
+      );
+    case "minimax":
+      return (
+        "Generate a video with MiniMax Hailuo and save the MP4 under the workspace. " +
+        "Text-to-video, or image-to-video by passing image_url as the first frame. " +
+        "Duration is 6 or 10 seconds."
+      );
+    case "xai":
+      return (
+        "Generate a video with xAI Grok Imagine (text-to-video or image-to-video) " +
+        "and save the MP4 under the workspace."
+      );
+    default:
+      return (
+        "Generate a video with the configured xAI, OpenAI Sora, or MiniMax Hailuo " +
+        "media backend and save the MP4 under the workspace."
+      );
+  }
+}
+
+function imagineVideoInputSchema(
+  kind: VideoBackendKind | undefined,
+): Record<string, unknown> {
+  const prompt = { type: "string" };
+  if (kind === "openai") {
+    return {
+      type: "object",
+      properties: {
+        prompt,
+        model: { type: "string", enum: [...OPENAI_VIDEO_MODELS] },
+        duration: {
+          type: "number",
+          description: "Seconds: 4, 8 or 12; anything else snaps to the nearest (default 8)",
+        },
+        aspect_ratio: { type: "string", enum: ["16:9", "9:16"] },
+        resolution: { type: "string", enum: [...OPENAI_VIDEO_RESOLUTIONS] },
+      },
+      required: ["prompt"],
+      additionalProperties: false,
+    };
+  }
+  if (kind === "minimax") {
+    return {
+      type: "object",
+      properties: {
+        prompt,
+        model: { type: "string", enum: [...MINIMAX_VIDEO_MODELS] },
+        image_url: {
+          type: "string",
+          description:
+            "Optional first frame: image URL, data URI, or workspace path",
+        },
+        duration: {
+          type: "number",
+          description: "Seconds: 6 or 10; anything else snaps to the nearest (default 6)",
+        },
+        resolution: {
+          type: "string",
+          enum: [...MINIMAX_VIDEO_RESOLUTIONS],
+          description: "512P requires image_url; text-to-video uses 768P or 1080P",
+        },
+      },
+      required: ["prompt"],
+      additionalProperties: false,
+    };
+  }
+  return {
+    type: "object",
+    properties: {
+      prompt,
+      model: {
+        type: "string",
+        description:
+          "grok-imagine-video (text-to-video default) or grok-imagine-video-1.5-preview (image-to-video default)",
+      },
+      image_url: {
+        type: "string",
+        description:
+          "Optional image URL, data URI, or workspace path for image-to-video",
+      },
+      reference_image_urls: {
+        type: "array",
+        items: { type: "string" },
+        description: "Up to 7 reference images (not combined with image_url)",
+      },
+      duration: {
+        type: "number",
+        description: "Seconds 1–15 (max 10 with reference images); default 8",
+      },
+      aspect_ratio: { type: "string" },
+      resolution: { type: "string", enum: ["480p", "720p"] },
+    },
+    required: ["prompt"],
+    additionalProperties: false,
+  };
+}
+
 export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
+  // Same lifecycle rule as ImagineImage: before a Session is attached the
+  // eventual provider can still change the backend, so the universal schema
+  // stands until a concrete Session exists. Execution always re-resolves.
+  const advertised =
+    opts.getSession() === null ? undefined : resolveVideoBackend(opts);
+  const advertisedKind =
+    advertised !== undefined && "backend" in advertised
+      ? advertised.backend.kind
+      : undefined;
   return {
     name: "ImagineVideo",
-    description:
-      "Generate a video with an independently configured xAI Grok Imagine media backend (text-to-video or image-to-video). " +
-      "Any reasoning provider may invoke it when /grok-login, XAI_API_KEY, or GROK_API_KEY is available. " +
-      "Direct Grok sessions may also use their session bearer. Saves the MP4 under the workspace.",
+    description: imagineVideoDescription(advertisedKind),
     isReadOnly: false,
     requiresApproval: true,
     concurrencyClass: { kind: "exclusive" },
@@ -226,39 +1095,11 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
       maxOutputTokens: 0,
       maxCostUsd: null,
     }),
-    inputSchema: {
-      type: "object",
-      properties: {
-        prompt: { type: "string" },
-        model: {
-          type: "string",
-          description:
-            "grok-imagine-video (text-to-video default) or grok-imagine-video-1.5-preview (image-to-video default)",
-        },
-        image_url: {
-          type: "string",
-          description:
-            "Optional image URL, data URI, or workspace path for image-to-video",
-        },
-        reference_image_urls: {
-          type: "array",
-          items: { type: "string" },
-          description: "Up to 7 reference images (not combined with image_url)",
-        },
-        duration: {
-          type: "number",
-          description: "Seconds 1–15 (max 10 with reference images); default 8",
-        },
-        aspect_ratio: { type: "string" },
-        resolution: { type: "string", enum: ["480p", "720p"] },
-      },
-      required: ["prompt"],
-      additionalProperties: false,
-    },
+    inputSchema: imagineVideoInputSchema(advertisedKind),
     execute: async (args) => {
       const admittedSignal = abortSignalFromArgs(args);
       admittedSignal?.throwIfAborted();
-      const backendResolution = resolveXaiVideoBackend(opts);
+      const backendResolution = resolveVideoBackend(opts);
       if ("error" in backendResolution) {
         return json({ error: backendResolution.error }, true);
       }
@@ -294,195 +1135,27 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
           true,
         );
       }
-      const reference_images: { url: string }[] = [];
+      const referenceImages: { url: string }[] = [];
       for (const r of refRaw) {
         const url = await imageRefToUrl(r, opts.workspaceRoot, admittedSignal);
-        if (url) reference_images.push({ url });
+        if (url) referenceImages.push({ url });
       }
 
-      const modality =
-        imageUrl || reference_images.length > 0 ? "image" : "text";
-      let model = stringValue(args.model);
-      if (!model) {
-        model =
-          modality === "image" ? IMAGE_TO_VIDEO_MODEL : TEXT_TO_VIDEO_MODEL;
-      }
-
-      let duration =
-        typeof args.duration === "number" && Number.isFinite(args.duration)
-          ? Math.floor(args.duration)
-          : 8;
-      if (duration < 1) duration = 1;
-      if (duration > 15) duration = 15;
-      if (reference_images.length > 0 && duration > 10) duration = 10;
-
-      let aspect_ratio = stringValue(args.aspect_ratio) ?? "16:9";
-      if (!VALID_ASPECT.has(aspect_ratio)) aspect_ratio = "16:9";
-      let resolution = (stringValue(args.resolution) ?? "720p").toLowerCase();
-      if (!VALID_RESOLUTIONS.has(resolution)) resolution = "720p";
-
-      const body: Record<string, unknown> = {
-        model,
+      const ctx: VideoRunContext = {
+        opts,
+        backend,
+        fetchImpl: opts.fetchImpl ?? fetch,
+        signal: admittedSignal,
+        args,
         prompt,
-        duration,
-        aspect_ratio,
-        resolution,
-      };
-      if (imageUrl) body.image = { url: imageUrl };
-      if (reference_images.length > 0) {
-        body.reference_images = reference_images;
-      }
-
-      const fetchImpl = opts.fetchImpl ?? fetch;
-      const headers = {
-        authorization: `Bearer ${backend.bearer}`,
-        "content-type": "application/json",
+        imageUrl,
+        referenceImages,
       };
 
       try {
-        const submitRes = await fetchImpl(`${backend.baseURL}/videos/generations`, {
-          method: "POST",
-          headers: {
-            ...headers,
-            "x-idempotency-key": randomUUID(),
-          },
-          body: JSON.stringify(body),
-          ...(admittedSignal !== undefined
-            ? { signal: admittedSignal }
-            : {}),
-        });
-        const submitJson = (await submitRes.json()) as {
-          request_id?: string;
-          error?: { message?: string };
-        };
-        if (!submitRes.ok) {
-          return json(
-            {
-              error:
-                submitJson.error?.message ??
-                `Imagine video submit HTTP ${submitRes.status}`,
-            },
-            true,
-          );
-        }
-        const requestId = submitJson.request_id;
-        if (!requestId) {
-          return json(
-            { error: "xAI video response did not include request_id" },
-            true,
-          );
-        }
-
-        const pollInterval = opts.pollIntervalMs ?? 5_000;
-        const pollTimeout = opts.pollTimeoutMs ?? 240_000;
-        let elapsed = 0;
-        let lastStatus = "queued";
-        let doneBody: Record<string, unknown> | undefined;
-
-        while (elapsed < pollTimeout) {
-          const pollRes = await fetchImpl(`${backend.baseURL}/videos/${requestId}`, {
-            method: "GET",
-            headers,
-            ...(admittedSignal !== undefined
-              ? { signal: admittedSignal }
-              : {}),
-          });
-          const pollJson = (await pollRes.json()) as Record<string, unknown> & {
-            status?: string;
-            error?: { message?: string };
-            video?: { url?: string };
-            url?: string;
-          };
-          if (!pollRes.ok) {
-            return json(
-              {
-                error:
-                  pollJson.error?.message ??
-                  `Imagine video poll HTTP ${pollRes.status}`,
-              },
-              true,
-            );
-          }
-          lastStatus = String(pollJson.status ?? "").toLowerCase();
-          if (lastStatus === "done") {
-            doneBody = pollJson;
-            break;
-          }
-          if (
-            lastStatus === "failed" ||
-            lastStatus === "error" ||
-            lastStatus === "expired" ||
-            lastStatus === "cancelled"
-          ) {
-            return json(
-              {
-                error: `Imagine video ${lastStatus}: ${
-                  pollJson.error?.message ?? "upstream failure"
-                }`,
-                request_id: requestId,
-              },
-              true,
-            );
-          }
-          await sleep(pollInterval, admittedSignal);
-          elapsed += pollInterval;
-        }
-
-        if (!doneBody) {
-          return json(
-            {
-              error: `Imagine video timed out after ${pollTimeout}ms (last status: ${lastStatus})`,
-              request_id: requestId,
-            },
-            true,
-          );
-        }
-
-        const videoUrl =
-          (doneBody.video as { url?: string } | undefined)?.url ??
-          (typeof doneBody.url === "string" ? doneBody.url : undefined);
-        if (!videoUrl) {
-          return json(
-            {
-              error: "Imagine video completed but returned no video URL",
-              request_id: requestId,
-              status: lastStatus,
-            },
-            true,
-          );
-        }
-
-        const outDir = join(opts.workspaceRoot, ".agenc", "imagine");
-        await mkdir(outDir, { recursive: true });
-        const path = join(outDir, `imagine-video-${randomUUID()}.mp4`);
-
-        const videoRes = await fetchImpl(
-          videoUrl,
-          admittedSignal === undefined ? {} : { signal: admittedSignal },
-        );
-        if (!videoRes.ok) {
-          return json(
-            {
-              error: `Failed to download video URL (HTTP ${videoRes.status})`,
-              url: videoUrl,
-              request_id: requestId,
-            },
-            true,
-          );
-        }
-        const buf = Buffer.from(await videoRes.arrayBuffer());
-        await writeFile(path, buf, { signal: admittedSignal });
-
-        return json({
-          model,
-          path,
-          url: videoUrl,
-          request_id: requestId,
-          duration,
-          aspect_ratio,
-          resolution,
-          modality,
-        });
+        if (backend.kind === "openai") return await runOpenAiVideo(ctx);
+        if (backend.kind === "minimax") return await runMinimaxVideo(ctx);
+        return await runXaiVideo(ctx);
       } catch (error) {
         admittedSignal?.throwIfAborted();
         return json(

--- a/runtime/tests/live/imagine-video-backends.live.test.ts
+++ b/runtime/tests/live/imagine-video-backends.live.test.ts
@@ -1,0 +1,115 @@
+/**
+ * LIVE: the Sora and MiniMax Hailuo video backends against the real APIs.
+ *
+ * Run:
+ *   OPENAI_API_KEY=… MINIMAX_API_KEY=… \
+ *     npm --workspace=@tetsuo-ai/runtime exec vitest run \
+ *     --config vitest.live.config.ts \
+ *     tests/live/imagine-video-backends.live.test.ts
+ *
+ * Each case generates one short clip at the cheapest settings the provider
+ * offers and is therefore billed. Both assert the saved file is a real MP4
+ * rather than trusting the provider's content type.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createImagineVideoTool } from "../../src/tools/system/imagine-video.js";
+import { createProvider } from "../../src/llm/provider.js";
+import { resolveHomeContext } from "../../src/config/home.js";
+import type { Session } from "../../src/session/session.js";
+
+const PROMPT = "a grey cube slowly rotating on a white background";
+/** ftyp box at offset 4: every MP4 this tool saves must start with one. */
+const MP4_FTYP = "66747970";
+
+async function generate(input: {
+  readonly provider: "openai" | "minimax";
+  readonly model: string;
+  readonly credential: string;
+  readonly args: Record<string, unknown>;
+}) {
+  const root = await mkdtemp(join(tmpdir(), `live-video-${input.provider}-`));
+  const tool = createImagineVideoTool({
+    workspaceRoot: root,
+    home: resolveHomeContext(
+      { AGENC_HOME: join(root, ".agenc-home"), HOME: root },
+      { platformHome: root },
+    ),
+    getSession: () =>
+      ({
+        services: {
+          provider: createProvider(input.provider, {
+            apiKey: "session-key-not-for-media",
+            model: input.model,
+          }),
+        },
+      }) as unknown as Session,
+    env: { [input.credential]: process.env[input.credential] ?? "" },
+    pollIntervalMs: 5_000,
+    pollTimeoutMs: 600_000,
+  });
+  const result = await tool.execute({ prompt: PROMPT, ...input.args });
+  return { tool, result };
+}
+
+describe.skipIf(!process.env.OPENAI_API_KEY)("Sora video, live", () => {
+  it("generates, polls and saves a real MP4", async () => {
+    const { tool, result } = await generate({
+      provider: "openai",
+      model: "gpt-6-astra",
+      credential: "OPENAI_API_KEY",
+      args: { duration: 4, aspect_ratio: "9:16", resolution: "720p" },
+    });
+
+    expect(tool.description).toContain("Sora");
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      model: string;
+      duration: number;
+      size: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({
+      model: "sora-2",
+      duration: 4,
+      size: "720x1280",
+    });
+    const bytes = await readFile(parsed.path);
+    expect(bytes.length).toBeGreaterThan(10_000);
+    expect(bytes.subarray(4, 8).toString("hex")).toBe(MP4_FTYP);
+  }, 660_000);
+});
+
+describe.skipIf(!process.env.MINIMAX_API_KEY)("MiniMax video, live", () => {
+  it("generates, polls, retrieves the file and saves a real MP4", async () => {
+    const { tool, result } = await generate({
+      provider: "minimax",
+      model: "MiniMax-M2.5",
+      credential: "MINIMAX_API_KEY",
+      args: { duration: 6, resolution: "768P" },
+    });
+
+    expect(tool.description).toContain("Hailuo");
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      model: string;
+      duration: number;
+      resolution: string;
+      url: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({
+      model: "MiniMax-Hailuo-02",
+      duration: 6,
+      resolution: "768P",
+    });
+    // Proves the download allowlist matches the host MiniMax actually uses.
+    expect(new URL(parsed.url).hostname.endsWith(".minimax.io")).toBe(true);
+    const bytes = await readFile(parsed.path);
+    expect(bytes.length).toBeGreaterThan(10_000);
+    expect(bytes.subarray(4, 8).toString("hex")).toBe(MP4_FTYP);
+  }, 660_000);
+});

--- a/runtime/tests/tools/system/imagine-video.test.ts
+++ b/runtime/tests/tools/system/imagine-video.test.ts
@@ -465,9 +465,6 @@ describe("ImagineVideo execute", () => {
     expect(withImage.isError).toBe(true);
     expect(String(withImage.content)).toContain("text-to-video only");
 
-    const badAspect = await tool.execute({ prompt: "x", aspect_ratio: "4:3" });
-    expect(badAspect.isError).toBe(true);
-    expect(String(badAspect.content)).toContain("16:9 or 9:16");
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -649,10 +646,6 @@ describe("ImagineVideo execute", () => {
     expect(lowRes.isError).toBe(true);
     expect(String(lowRes.content)).toContain("512P only with a first frame");
 
-    const aspect = await tool.execute({ prompt: "x", aspect_ratio: "16:9" });
-    expect(aspect.isError).toBe(true);
-    expect(String(aspect.content)).toContain("aspect_ratio is not supported");
-
     const model = await tool.execute({ prompt: "x", model: "MiniMax-Hailuo-99" });
     expect(model.isError).toBe(true);
     expect(String(model.content)).toContain("MiniMax video model must be");
@@ -688,6 +681,119 @@ describe("ImagineVideo execute", () => {
 
     expect(result.isError).toBe(true);
     expect(String(result.content)).toContain("insufficient balance");
+  });
+
+  it("drops a dimension control the backend cannot honour and names it", async () => {
+    // The universal schema a model sees before a Session attaches is the xAI
+    // one, so 480p and 4:3 reach Sora, and 16:9 reaches MiniMax. Refusing
+    // them stalls the run; dropping and naming them lets it finish.
+    const root = await mkdtemp(join(tmpdir(), "imagine-video-drop-"));
+    const soraFetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/videos") && init?.method === "POST") {
+        return { ok: true, status: 200, json: async () => ({ id: "v9" }) };
+      }
+      if (u.endsWith("/videos/v9")) {
+        return { ok: true, status: 200, json: async () => ({ status: "completed" }) };
+      }
+      return new Response(Uint8Array.from([0x00, 0x01]), { status: 200 });
+    }) as unknown as typeof fetch;
+    const sora = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("openai", {
+              apiKey: "unused",
+              model: "gpt-6-astra",
+              baseURL: "https://api.openai.com/v1",
+            }),
+          },
+        }) as unknown as Session,
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl: soraFetch,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    const result = await sora.execute({
+      prompt: "a rotating cube",
+      aspect_ratio: "4:3",
+      resolution: "480p",
+    });
+
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      ignoredControls?: string[];
+      size: string;
+    };
+    expect(parsed.ignoredControls).toEqual(["aspect_ratio", "resolution"]);
+    // Falls back to Sora's own defaults rather than guessing a translation.
+    expect(parsed.size).toBe("1280x720");
+  });
+
+  it("never gates the session on an argument it refused before requesting", async () => {
+    // ImagineVideo is side-effecting, so a bare isError from argument
+    // validation is filed as an unknown outcome and blocks every later
+    // side-effecting call behind /resolve (#2190). None of these paths
+    // reached a provider, so each must carry the disposition that says so.
+    const fetchImpl = vi.fn();
+    const sora = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("openai", {
+              apiKey: "unused",
+              model: "gpt-6-astra",
+              baseURL: "https://api.openai.com/v1",
+            }),
+          },
+        }) as unknown as Session,
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const hailuo = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("minimax", {
+              apiKey: "unused",
+              model: "MiniMax-M2.5",
+            }),
+          },
+        }) as unknown as Session,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const unconfigured = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () => null,
+      env: {},
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const cases: Array<[string, Promise<{ isError?: boolean; effectDisposition?: { disposition?: string } }>]> = [
+      ["no prompt", sora.execute({})],
+      ["no credential", unconfigured.execute({ prompt: "x" })],
+      ["sora image_url", sora.execute({ prompt: "x", image_url: "https://e/x.png" })],
+      ["sora model", sora.execute({ prompt: "x", model: "sora-9" })],
+      ["minimax model", hailuo.execute({ prompt: "x", model: "Hailuo-99" })],
+      ["minimax 512P", hailuo.execute({ prompt: "x", resolution: "512P" })],
+    ];
+    for (const [name, pending] of cases) {
+      const result = await pending;
+      expect(result.isError, name).toBe(true);
+      expect(result.effectDisposition?.disposition, name).toBe(
+        "confirmed_no_effect",
+      );
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("fails closed when a Meta session has no independent xAI credential", async () => {

--- a/runtime/tests/tools/system/imagine-video.test.ts
+++ b/runtime/tests/tools/system/imagine-video.test.ts
@@ -103,13 +103,12 @@ describe("ImagineVideo execute", () => {
         };
       }
       if (u === "https://cdn.example/out.mp4") {
-        return {
-          ok: true,
-          status: 200,
-          arrayBuffer: async () =>
-            Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])
-              .buffer,
-        };
+        // A real Response: the download streams through a byte cap and
+        // inspects redirect headers, which a bare object cannot answer.
+        return new Response(
+          Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+          { status: 200 },
+        );
       }
       throw new Error(`unexpected fetch ${u}`);
     }) as unknown as typeof fetch;
@@ -240,13 +239,10 @@ describe("ImagineVideo execute", () => {
         };
       }
       if (value === "https://cdn.example/meta-xai.mp4") {
-        return {
-          ok: true,
-          status: 200,
-          arrayBuffer: async () =>
-            Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])
-              .buffer,
-        };
+        return new Response(
+          Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+          { status: 200 },
+        );
       }
       throw new Error(`unexpected fetch ${value}`);
     }) as unknown as typeof fetch;
@@ -271,6 +267,427 @@ describe("ImagineVideo execute", () => {
     expect(
       (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0],
     ).toBe("https://api.x.ai/v1/videos/generations");
+  });
+
+  it("surfaces xAI's bare error string instead of a bare HTTP code", async () => {
+    // A Zero Data Retention team gets exactly this on every video call, and
+    // xAI reports it as `error: "..."`, not the {message} shape the chat
+    // endpoints use. Losing it leaves the operator with "HTTP 400".
+    const provider = createProvider("grok", {
+      apiKey: "oauth-subscription-bearer",
+      model: "grok-4.6",
+      baseURL: "https://api.x.ai/v1",
+    });
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        code: "invalid-argument",
+        error:
+          "Zero Data Retention teams must provide output.upload_url for video generation.",
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {},
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "a short clip" });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("Zero Data Retention");
+  });
+
+  it("generates with Sora for an OpenAI session holding an API key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-sora-"));
+    let polls = 0;
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/videos") && init?.method === "POST") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: "video_abc", status: "queued" }),
+        };
+      }
+      if (u.endsWith("/videos/video_abc")) {
+        polls += 1;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: polls < 2 ? "in_progress" : "completed",
+            progress: polls < 2 ? 40 : 100,
+          }),
+        };
+      }
+      if (u.endsWith("/videos/video_abc/content")) {
+        return new Response(
+          Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("openai", {
+              apiKey: "chatgpt-oauth-bearer-must-not-leak",
+              model: "gpt-6-astra",
+              baseURL: "https://api.openai.com/v1",
+            }),
+          },
+        }) as unknown as Session,
+      env: {
+        OPENAI_API_KEY: "isolated-openai-key",
+        XAI_API_KEY: "must-not-win-for-openai-session",
+      },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    const result = await tool.execute({ prompt: "a rotating cube", duration: 4 });
+
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      model: string;
+      request_id: string;
+      duration: number;
+      size: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({
+      model: "sora-2",
+      request_id: "video_abc",
+      duration: 4,
+      size: "1280x720",
+    });
+    expect((await readFile(parsed.path)).length).toBeGreaterThan(0);
+
+    const calls = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    const submit = calls[0]?.[1] as {
+      headers: Record<string, string>;
+      body: string;
+    };
+    expect(submit.headers.authorization).toBe("Bearer isolated-openai-key");
+    // Sora rejects unknown parameters, so the body carries exactly four.
+    expect(JSON.parse(submit.body)).toEqual({
+      model: "sora-2",
+      prompt: "a rotating cube",
+      seconds: "4",
+      size: "1280x720",
+    });
+    // The MP4 came from the API host under the same bearer: no URL out of a
+    // response body was ever followed.
+    expect(String(calls.at(-1)?.[0])).toBe(
+      "https://api.openai.com/v1/videos/video_abc/content",
+    );
+  });
+
+  it("snaps a duration Sora does not offer and maps size from the frame", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-sora-snap-"));
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/videos") && init?.method === "POST") {
+        return { ok: true, status: 200, json: async () => ({ id: "v1" }) };
+      }
+      if (u.endsWith("/videos/v1")) {
+        return { ok: true, status: 200, json: async () => ({ status: "completed" }) };
+      }
+      return new Response(Uint8Array.from([0x00]), { status: 200 });
+    }) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("openai", {
+              apiKey: "unused",
+              model: "gpt-6-astra",
+              baseURL: "https://api.openai.com/v1",
+            }),
+          },
+        }) as unknown as Session,
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    await tool.execute({
+      prompt: "a rotating cube",
+      duration: 7,
+      aspect_ratio: "9:16",
+      resolution: "1080p",
+    });
+
+    const submit = (fetchImpl as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]?.[1] as { body: string };
+    expect(JSON.parse(submit.body)).toMatchObject({
+      seconds: "8",
+      size: "1024x1792",
+    });
+  });
+
+  it("refuses Sora controls that need an uploaded reference", async () => {
+    const fetchImpl = vi.fn();
+    const tool = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("openai", {
+              apiKey: "unused",
+              model: "gpt-6-astra",
+              baseURL: "https://api.openai.com/v1",
+            }),
+          },
+        }) as unknown as Session,
+      env: { OPENAI_API_KEY: "isolated-openai-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const withImage = await tool.execute({
+      prompt: "x",
+      image_url: "https://example.com/frame.png",
+    });
+    expect(withImage.isError).toBe(true);
+    expect(String(withImage.content)).toContain("text-to-video only");
+
+    const badAspect = await tool.execute({ prompt: "x", aspect_ratio: "4:3" });
+    expect(badAspect.isError).toBe(true);
+    expect(String(badAspect.content)).toContain("16:9 or 9:16");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("generates with MiniMax Hailuo and downloads from its own CDN", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-hailuo-"));
+    let polls = 0;
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/video_generation") && init?.method === "POST") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            task_id: "task-1",
+            base_resp: { status_code: 0, status_msg: "success" },
+          }),
+        };
+      }
+      if (u.includes("/query/video_generation")) {
+        polls += 1;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            // Observed casing from the live API.
+            status: polls < 2 ? "Processing" : "Success",
+            file_id: polls < 2 ? "" : "file-9",
+            base_resp: { status_code: 0 },
+          }),
+        };
+      }
+      if (u.includes("/files/retrieve")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            file: {
+              download_url: "https://video-product.cdn.minimax.io/out.mp4",
+            },
+            base_resp: { status_code: 0 },
+          }),
+        };
+      }
+      if (u === "https://video-product.cdn.minimax.io/out.mp4") {
+        return new Response(
+          Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("minimax", {
+              apiKey: "minimax-session-key",
+              model: "MiniMax-M2.5",
+            }),
+          },
+        }) as unknown as Session,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    const result = await tool.execute({ prompt: "a rotating cube", duration: 6 });
+
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      model: string;
+      request_id: string;
+      duration: number;
+      resolution: string;
+      modality: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({
+      model: "MiniMax-Hailuo-02",
+      request_id: "task-1",
+      duration: 6,
+      resolution: "768P",
+      modality: "text",
+    });
+    expect((await readFile(parsed.path)).length).toBeGreaterThan(0);
+    const submit = (fetchImpl as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]?.[1] as { headers: Record<string, string>; body: string };
+    expect(submit.headers.authorization).toBe("Bearer isolated-minimax-key");
+    expect(JSON.parse(submit.body)).toEqual({
+      model: "MiniMax-Hailuo-02",
+      prompt: "a rotating cube",
+      duration: 6,
+      resolution: "768P",
+    });
+  });
+
+  it("refuses a MiniMax download that leaves MiniMax's hosts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-hailuo-host-"));
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/video_generation") && init?.method === "POST") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ task_id: "t", base_resp: { status_code: 0 } }),
+        };
+      }
+      if (u.includes("/query/video_generation")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: "Success",
+            file_id: "f",
+            base_resp: { status_code: 0 },
+          }),
+        };
+      }
+      if (u.includes("/files/retrieve")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            file: { download_url: "https://cdn.evil.example/out.mp4" },
+            base_resp: { status_code: 0 },
+          }),
+        };
+      }
+      throw new Error(`must not fetch ${u}`);
+    }) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("minimax", {
+              apiKey: "unused",
+              model: "MiniMax-M2.5",
+            }),
+          },
+        }) as unknown as Session,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    const result = await tool.execute({ prompt: "a rotating cube" });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("not trusted");
+  });
+
+  it("applies MiniMax's own parameter rules before spending a request", async () => {
+    const fetchImpl = vi.fn();
+    const tool = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("minimax", {
+              apiKey: "unused",
+              model: "MiniMax-M2.5",
+            }),
+          },
+        }) as unknown as Session,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // "param 'resolution' 512P is only supported when param
+    // 'first_frame_image' provided" — refused here rather than upstream.
+    const lowRes = await tool.execute({ prompt: "x", resolution: "512P" });
+    expect(lowRes.isError).toBe(true);
+    expect(String(lowRes.content)).toContain("512P only with a first frame");
+
+    const aspect = await tool.execute({ prompt: "x", aspect_ratio: "16:9" });
+    expect(aspect.isError).toBe(true);
+    expect(String(aspect.content)).toContain("aspect_ratio is not supported");
+
+    const model = await tool.execute({ prompt: "x", model: "MiniMax-Hailuo-99" });
+    expect(model.isError).toBe(true);
+    expect(String(model.content)).toContain("MiniMax video model must be");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("treats a MiniMax HTTP 200 carrying a failure status as an error", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        task_id: "",
+        base_resp: { status_code: 1008, status_msg: "insufficient balance" },
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("minimax", {
+              apiKey: "unused",
+              model: "MiniMax-M2.5",
+            }),
+          },
+        }) as unknown as Session,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "a rotating cube" });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("insufficient balance");
   });
 
   it("fails closed when a Meta session has no independent xAI credential", async () => {


### PR DESCRIPTION
## Why

`ImagineVideo` had one backend, xAI. On this account that backend **cannot generate at all**, and the tool has been failing every call while reporting only `HTTP 400`:

```
POST https://api.x.ai/v1/videos/generations
400 {"code":"invalid-argument",
     "error":"Zero Data Retention teams must provide output.upload_url for video generation."}
```

The xAI team has Zero Data Retention enabled, so xAI will not store a generated video and requires the caller to supply a destination to upload it to. Two things followed from finding that:

1. The error was invisible. xAI reports media refusals as a bare `error` **string**, while the chat endpoints use `{error: {message}}`. The tool only read the object form, so the operator saw `Imagine video submit HTTP 400` and nothing else.
2. Video needed a backend that works. Sora and MiniMax Hailuo are both reachable on the credentials this account already holds.

The same ZDR setting also explains a live constraint on the image side: `response_format: "url"` is rejected for xAI images too. `ImagineImage` already asks for `b64_json`, so it is unaffected, and I confirmed it still generates (HTTP 200, 82 KB).

## What changed, per file

### `runtime/src/tools/system/imagine-video.ts`

- **Two new backends.** Both resolved by ImagineImage's rule: a session generates with its own provider, authorized only by that provider's canonical environment ingress. For OpenAI that is load-bearing again, because a ChatGPT OAuth grant does not authorize `/videos`.

  | | submit | poll | retrieve |
  |---|---|---|---|
  | OpenAI | `POST /videos` → `id` | `GET /videos/{id}` until `completed` | `GET /videos/{id}/content`, MP4 under the same bearer |
  | MiniMax | `POST /video_generation` → `task_id` | `GET /query/video_generation` `Preparing`→`Processing`→`Success` | `file_id` → `/files/retrieve` → `download_url` |

- **The download path was the weak point and is now bounded.** It fetched whatever URL the payload carried: no scheme check, no redirect handling, no size limit. Downloads now stream through a 256 MiB cap and re-validate **every redirect hop**. What each backend may download from is stated per backend rather than falling through:
  - MiniMax: pinned to `minimax.io` / `minimaxi.com`, from the host observed live (`video-product.cdn.minimax.io`).
  - OpenAI: **no payload URL is ever followed**; the MP4 streams from the API host under the same bearer.
  - xAI: still any credential-free HTTPS host, and the type says so (`{kind: "any-https"}`). This repo has never captured a finished xAI video URL and a ZDR account cannot produce one, so pinning it would be an unverified behaviour change to a shipped path. It still gains the HTTPS check, the hop-by-hop redirect check and the byte cap.
- **The bare-string xAI error is surfaced verbatim**, so a ZDR operator reads the actual cause.
- Parameter rules are the providers' own, read back from their rejections. Sora: 4/8/12 seconds, four sizes. MiniMax: 6 or 10 seconds, and `512P` refused without a first frame (`"param 'resolution' 512P is only supported when param 'first_frame_image' provided"`). A duration the backend does not offer snaps to the nearest one it does, rather than being sent and bounced.
- The three job protocols share one `pollForVideo` wait, so the interval, deadline and cancellation point stay identical across backends.

### `runtime/tests/tools/system/imagine-video.test.ts`

Eight new cases: Sora submit/poll/content with credential isolation, duration snapping and size mapping, Sora's refused controls, the MiniMax happy path including CDN download, a MiniMax download URL that leaves the allowlist, MiniMax's own parameter rules applied before spending a request, its 200-with-failure envelope, and the xAI ZDR string.

Two existing tests changed: their download mock returned an object with only `arrayBuffer`, which the capped reader cannot use because it inspects headers and streams the body. They now return a real `Response`, which is a more faithful mock.

### `runtime/tests/live/imagine-video-backends.live.test.ts` (new)

Operator-invoked live test, `tests/live/**` convention, billed when run. Generates one clip per backend at the cheapest settings and asserts the saved file is a real MP4 by its `ftyp` box, plus that MiniMax's real download host matches the allowlist.

## Evidence

Live, driving the shipped tool code:

```
✓ Sora video, live > generates, polls and saves a real MP4                       71339ms
✓ MiniMax video, live > generates, polls, retrieves the file and saves a real MP4 81779ms
```

Independently, against the raw APIs: Sora returned `video/mp4`, 1,191,496 bytes; MiniMax returned `video/mp4`, 225,325 bytes from `video-product.cdn.minimax.io`. Both begin `00 00 00 20 66 74 79 70 69 73 6f 6d`.

Provider-stated contracts, quoted from their own 400s:

- `Invalid value: '99'. Supported values are: '4', '8', and '12'.` (Sora `seconds`)
- `Invalid value: '999x999'. Supported values are: '720x1280', '1280x720', '1024x1792', and '1792x1024'.` (Sora `size`)
- `invalid params, param 'duration' only support 6s and 10s` (MiniMax)
- `invalid params, param 'resolution' only support 512P, 768P and 1080P` (MiniMax)
- `Unknown parameter: '__bogus__'.` — Sora rejects unknown fields, which is why its body carries exactly four.

## Tests

- `tests/tools/system/imagine-video.test.ts`: **16 passed** (was 8).
- Falsification: with the source reverted and the tests kept, **all 8 new cases fail** and all 8 pre-existing ones still pass, including the two whose mocks changed.
- `tests/tools/system`: 803 passed, 3 failed. Those 3 (`bash-shell-output-cap-m-exec-2`, `bash-workspace-fence`, `exec-command`) fail identically on clean `main` and touch no code here.
- `tsc --noEmit` over the whole runtime project: 0 errors.

## Not changed

- **No desktop change is needed to play these.** The tools write into `<cwd>/.agenc/imagine`; the desktop daemon watches that directory during a turn and already matches `.mp4`, and the transcript renders video inline.
- xAI's own video path is behaviourally unchanged apart from the error text and the download hardening. Making it work for a ZDR team needs an `output.upload_url` destination, which means object storage this repo does not have; the practical fix for a ZDR operator is to use one of the two new backends.
- Sora image-to-video is not wired: it needs an uploaded reference rather than a URL. The tool refuses `image_url` on that backend with a message saying so, instead of silently dropping it.
- No provider registry, permission, or sandbox behaviour changed.

## Counterpart PRs

- #2348 adds the matching GPT Image and MiniMax Image backends to `ImagineImage`. Independent of this one; different files, no shared commits.

---

## Update: driven in the desktop app, which found the same defect class here

`ImagineVideo` carried both defects that #2348 documents, and one of them worse: it had **no refusal helper at all**, so every argument check returned a bare error. The tool is `side-effecting`, so each of those filed an unknown outcome and blocked every later side-effecting call behind `/resolve` (#2190). A wrong duration bricked the session.

Argument validation now carries `confirmed_no_effect` through `preEffectRefusal`. Dimension controls the resolved backend cannot honour are dropped and named in the result (`ignoredControls`) instead of refused: the schema a model sees before a Session attaches is the **xAI** one, so `480p` and `4:3` reach Sora and `16:9` reaches MiniMax, and each now falls back to that backend's own default rather than stalling the run.

What stays a refusal is what cannot be substituted: an unknown model, a first frame Sora cannot take, and `512P` on MiniMax without one.

### App evidence

GPT-6 Astra session, `work` project, desktop build of this branch. The model first passed an xAI model name, was refused, **corrected itself on the next call**, and finished:

```
RESULT {"error":"Sora model must be one of sora-2, sora-2-pro, …"}
RESULT {"model":"sora-2","duration":4,"aspect_ratio":"16:9","resolution":"720p",
        "size":"1280x720","modality":"text","request_id":"video_6aa1787f…",
        "path":"…/work/.agenc/imagine/imagine-video-bffed71c….mp4"}
```

1,107,410 bytes, magic `00000020 66747970 69736f6d`, and the transcript rendered it inline as a `<video>` with no desktop change. That is the distinction working as intended: a model name cannot be substituted, so it is refused and the model recovers; a resolution can, so it is dropped and named.

`tests/tools/system/imagine-video.test.ts` is now **18 passed**, including a case pinning every pre-request refusal to `confirmed_no_effect`, and one asserting that `4:3` + `480p` on Sora come back as `ignoredControls: ["aspect_ratio","resolution"]` with `size: "1280x720"`.
