### PR TITLE
Let an unattended read-only run reach the folder, the catalog, and an end

### DIFF
--- a/runtime/src/permissions/read-only-grant.ts
+++ b/runtime/src/permissions/read-only-grant.ts
@@ -13,7 +13,10 @@
  * (tools/router.ts, `ledgerTurnBlocksTool`), and then removes three families
  * that satisfy it on paper and not in fact.
  */
+import { resolve } from "node:path";
+
 import { isBashTool } from "../tools/concurrency.js";
+import { SYSTEM_SEARCH_TOOLS_NAME } from "../tools/system/tool-search-name.js";
 import type { ToolPermissionContext } from "./types.js";
 
 /** The shape the evaluator sees. Kept structural so tests need no registry. */
@@ -52,6 +55,20 @@ const NEVER_GRANTED = Object.freeze(
     "AskUserQuestion",
   ]),
 );
+
+/**
+ * Tool discovery, which declares itself side-effecting but changes nothing.
+ *
+ * `system.searchTools` widens the turn's own advertised tool list and writes
+ * nothing (its metadata says `virtualNoFsWrites`). It is marked
+ * side-effecting for recovery purposes, so the read-only conjunction below
+ * refuses it, and an unattended run is then unable to find the very tools it
+ * is allowed to use: observed live, a routine burned its turn being refused
+ * discovery and never produced a report. Loading a schema does not widen what
+ * may actually run, because every non-builtin source is still refused when
+ * the tool is called.
+ */
+const DISCOVERY_TOOLS = Object.freeze(new Set([SYSTEM_SEARCH_TOOLS_NAME]));
 
 /**
  * Shell that may run: read-only by command, and confined to the workspace.
@@ -117,8 +134,14 @@ export function shellCallIsGranted(
     return { ok: false, reason: "the command could not be read" };
   }
   // A working directory of its own would move the ground the path check
-  // measures against, so only the run's own folder is accepted.
-  if (parsed.workdir !== undefined && parsed.workdir !== cwd) {
+  // measures against, so only the run's own folder is accepted. Compared
+  // after resolution, not as strings: a relative workdir is relative to the
+  // run's cwd, so "." is that folder, and refusing it stranded routines whose
+  // agent quite reasonably passed one.
+  if (
+    parsed.workdir !== undefined &&
+    resolve(cwd, parsed.workdir) !== resolve(cwd)
+  ) {
     return { ok: false, reason: "it runs in a different folder" };
   }
   if (deps.checkReadOnly({ command: parsed.command }).behavior !== "allow") {
@@ -171,6 +194,9 @@ export function readOnlyGrantVerdict(
   }
   if (NEVER_GRANTED.has(tool.name) || tool.requiresUserInteraction?.() === true) {
     return { granted: false, refusal: { kind: "interactive" } };
+  }
+  if (DISCOVERY_TOOLS.has(tool.name) && tool.metadata?.source === "builtin") {
+    return GRANTED;
   }
   // An MCP or plugin tool describes itself, and that description arrives from
   // the server. `readOnlyHint` is advisory everywhere else in this codebase

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -1485,6 +1485,35 @@ function sessionTransactionGuardConfig(
 /** After this many unproductive calls in a row, say so in the result. */
 const UNATTENDED_UNPRODUCTIVE_LIMIT = 3;
 
+/**
+ * Where advice becomes a stop.
+ *
+ * Past `UNATTENDED_UNPRODUCTIVE_LIMIT` the run is told to stop calling tools,
+ * but telling is not bounding: observed live, a routine was refused eleven
+ * times in a row and spent three and a half minutes re-asking for the same
+ * tool before the turn ended with nothing written. After this many
+ * consecutive dead calls the next one is refused without being dispatched,
+ * which leaves the model nothing to do except write its answer. The counter
+ * resets on any call that gets somewhere, so a run making progress never
+ * reaches it.
+ */
+const UNATTENDED_UNPRODUCTIVE_STOP = 6;
+
+/** What a dead-call streak of this length earns. */
+export type UnattendedStreakOutcome = "count" | "advise" | "stop";
+
+/**
+ * Escalation for an unattended read-only run's consecutive dead calls.
+ * Exported so the thresholds are pinned by a test rather than by reading.
+ */
+export function unattendedStreakOutcome(
+  consecutiveDenials: number,
+): UnattendedStreakOutcome {
+  if (consecutiveDenials >= UNATTENDED_UNPRODUCTIVE_STOP) return "stop";
+  if (consecutiveDenials >= UNATTENDED_UNPRODUCTIVE_LIMIT) return "advise";
+  return "count";
+}
+
 const STOP_AND_REPORT =
   "This run has nobody attached, so nothing here will be approved or " +
   "unblocked by asking again. Stop calling tools and write what you have " +
@@ -1522,11 +1551,21 @@ function noteUnproductiveCall(
   }
   const next = recordDenial(state);
   persistDenialState(context, next);
-  if (next.consecutiveDenials < UNATTENDED_UNPRODUCTIVE_LIMIT) return output;
+  const outcome = unattendedStreakOutcome(next.consecutiveDenials);
+  if (outcome === "count") return output;
   const content = typeof output.content === "string" ? output.content : "";
-  return content.includes(STOP_AND_REPORT)
+  const advised = content.includes(STOP_AND_REPORT)
     ? output
     : { ...output, content: `${content}\n\n${STOP_AND_REPORT}` };
+  // Telling the run to stop is not the same as stopping it: observed live, a
+  // routine was refused eleven times in a row and spent three and a half
+  // minutes re-asking before the turn ended with nothing written. Past the
+  // stop threshold the tool loop is ended the same way a denied approval ends
+  // it, which leaves the model nothing to do but write its answer. The
+  // counter resets on any call that gets somewhere, so a run making progress
+  // never reaches this.
+  if (outcome === "stop") PREVENT_CONTINUATION_OUTPUTS.add(advised);
+  return advised;
 }
 
 export async function runToolUse(

--- a/runtime/tests/permissions/read-only-grant.test.ts
+++ b/runtime/tests/permissions/read-only-grant.test.ts
@@ -116,6 +116,41 @@ describe("unattended read-only grant", () => {
     expect(verdict(tool("system.background.bash"), { command: "ls" }).granted).toBe(false);
   });
 
+  it("accepts a workdir that names this folder in another form", () => {
+    // Observed live: a routine's own agent passed `workdir: "."`, which is
+    // the run's folder, and the string comparison called it a different one.
+    // The run then had no way to read the project it was created for.
+    for (const workdir of [".", "./", `${CWD}/`, `${CWD}/.`, "./sub/.."]) {
+      expect(
+        verdict(tool("exec_command"), { cmd: "git status", workdir }).granted,
+        workdir,
+      ).toBe(true);
+    }
+  });
+
+  it("still refuses a workdir that genuinely leaves the folder", () => {
+    for (const workdir of ["..", "/tmp", `${CWD}/../sibling`, "sub"]) {
+      const result = verdict(tool("exec_command"), { cmd: "ls", workdir });
+      expect(result.granted, workdir).toBe(false);
+      if (!result.granted && result.refusal.kind === "shell") {
+        expect(result.refusal.reason).toContain("different folder");
+      }
+    }
+  });
+
+  it("admits tool discovery, which declares itself side-effecting", () => {
+    // system.searchTools carries recoveryCategory "side-effecting" for
+    // recovery purposes and writes nothing (virtualNoFsWrites). Refusing it
+    // left an unattended run unable to find the tools it is allowed to use.
+    expect(verdict(tool("system.searchTools")).granted).toBe(true);
+    // Loading a schema does not widen what may run: a non-builtin tool is
+    // still refused when it is actually called.
+    expect(
+      verdict({ name: "system.searchTools", metadata: { source: "mcp" } })
+        .granted,
+    ).toBe(false);
+  });
+
   it("refuses a command that moves its own working directory", () => {
     expect(verdict(tool("exec_command"), { cmd: "ls", workdir: "/elsewhere" }).granted).toBe(false);
     expect(verdict(tool("exec_command"), { cmd: "ls", workdir: CWD }).granted).toBe(true);

--- a/runtime/tests/tools/unattended-streak.test.ts
+++ b/runtime/tests/tools/unattended-streak.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The bound on an unattended run's dead calls.
+ *
+ * A routine run has nobody to approve anything, so a refused tool will be
+ * refused again. Advice alone did not stop it: observed live, a routine was
+ * refused eleven times in a row and spent three and a half minutes re-asking
+ * for the same tool before the turn ended having written nothing.
+ */
+import { describe, expect, it } from "vitest";
+
+import { unattendedStreakOutcome } from "../../src/tools/execution.js";
+
+describe("unattended dead-call streak", () => {
+  it("says nothing while the run is only briefly stuck", () => {
+    expect(unattendedStreakOutcome(0)).toBe("count");
+    expect(unattendedStreakOutcome(1)).toBe("count");
+    expect(unattendedStreakOutcome(2)).toBe("count");
+  });
+
+  it("advises before it stops, so a recoverable run gets a chance", () => {
+    expect(unattendedStreakOutcome(3)).toBe("advise");
+    expect(unattendedStreakOutcome(4)).toBe("advise");
+    expect(unattendedStreakOutcome(5)).toBe("advise");
+  });
+
+  it("ends the tool loop once advice has plainly been ignored", () => {
+    expect(unattendedStreakOutcome(6)).toBe("stop");
+    expect(unattendedStreakOutcome(11)).toBe("stop");
+    expect(unattendedStreakOutcome(100)).toBe("stop");
+  });
+
+  it("escalates monotonically, so no streak length skips a rung", () => {
+    const rank = { count: 0, advise: 1, stop: 2 } as const;
+    let previous = 0;
+    for (let streak = 0; streak <= 20; streak += 1) {
+      const current = rank[unattendedStreakOutcome(streak)];
+      expect(current, `streak ${streak}`).toBeGreaterThanOrEqual(previous);
+      previous = current;
+    }
+  });
+
+  it("stops strictly after it advises, never at the same count", () => {
+    const firstAdvise = [...Array(30).keys()].find(
+      (n) => unattendedStreakOutcome(n) === "advise",
+    );
+    const firstStop = [...Array(30).keys()].find(
+      (n) => unattendedStreakOutcome(n) === "stop",
+    );
+    expect(firstAdvise).toBeDefined();
+    expect(firstStop).toBeDefined();
+    expect(firstStop!).toBeGreaterThan(firstAdvise!);
+  });
+});


### PR DESCRIPTION
## Why

You reported: *"type in prompt `create a routine for me` to the agent, then go to Routines and start the routine, it fails."* Reproduced on a clean profile against merged `main`. The routine started, ran **3 minutes**, and ended `failed` having written nothing.

Its error log names the causes exactly:

| refused | count |
|---|---|
| `ExitPlanMode` | 6 |
| `"...runs in a different folder"` | 2 |
| `Skill` / `AskUserQuestion` / `SendUserMessage` | 1 each |
| `system.searchTools` | 1 |

Three of those are defects in the read-only grant this repo ships. The fourth (`ExitPlanMode`, the primary cause) is the Desktop counterpart PR.

## What changed, per file

### `runtime/src/permissions/read-only-grant.ts`

**1. A workdir naming this folder was called a different one.** The gate compared strings:

```ts
if (parsed.workdir !== undefined && parsed.workdir !== cwd) { … }
```

The routine's own agent issued `{"cmd":"git status …","workdir":"."}`. `.` *is* the cwd, and the run was refused access to the project it was created for. Now compared after `resolve(cwd, workdir)`, which also settles a trailing slash and `./sub/..`. A workdir that genuinely leaves the folder is still refused, and `checkPathConstraints` behind it is untouched.

**2. Tool discovery was refused.** `system.searchTools` declares `recoveryCategory: "side-effecting"` for recovery purposes while writing nothing — its own metadata carries `virtualNoFsWrites: true`. The read-only conjunction therefore refused it, and an unattended run could not discover the tools it was allowed to use. It is now granted explicitly, next to `NEVER_GRANTED`, with the reason recorded.

This does not widen what may actually run: loading a schema is not calling it, and a non-builtin source is still refused at the call. The test asserts exactly that (`{name: "system.searchTools", metadata: {source: "mcp"}}` stays refused).

### `runtime/src/tools/execution.ts`

**3. The retry bound did not bind.** Past `UNATTENDED_UNPRODUCTIVE_LIMIT` (3) the run is told to stop calling tools, but that was advice appended to the error text and nothing more. The live run ignored it and was refused **eleven times in a row**. Six consecutive dead calls now end the tool loop through the same `preventContinuation` path a denied approval already uses, so the model has nothing left to do but write its answer. The counter resets on any call that gets somewhere, so a run making progress never reaches it.

The escalation is exported as `unattendedStreakOutcome(streak) → "count" | "advise" | "stop"` so the thresholds are pinned by a test instead of by reading.

## Evidence

From the failed run's own error log (`errors/2026-09-09.jsonl`), verbatim:

```
"cause":"permission_denied:permission_mode",
"message":"That command was refused because it runs in a different folder. …"

"message":"system.searchTools can change things outside this report. …"

"message":"ExitPlanMode … This run has now been refused 11 times.
           Stop calling tools and write your findings as your final answer."
```

and the call that produced the first of those, from the rollout:

```json
{"cmd":"git status --short; git log --since='24 hours ago' …","workdir":"."}
```

## Tests

- `tests/permissions/read-only-grant.test.ts`: **17 passed** (3 new cases).
- `tests/tools/unattended-streak.test.ts` (new): **5 passed**, pinning count → advise → stop, monotonic escalation, and that stop is strictly after advise.
- Falsification: with the source reverted and the tests kept, *accepts a workdir that names this folder in another form* and *admits tool discovery* both fail. The guard *still refuses a workdir that genuinely leaves the folder* passes either way, which is the point of a regression guard.
- `tests/permissions` + `tests/tools`: 2925 passed, 6 failed. Those 6 (`permission-audit-log`, `streaming-executor`, `request-permissions`, `bash-shell-output-cap-m-exec-2`, `bash-workspace-fence`, `exec-command`) fail **identically on clean `main`** with this branch's files reverted — a pre-existing local baseline, unrelated to this change.
- `tsc --noEmit` over the runtime project: 0 errors.

## Not changed

- `Skill`, `AskUserQuestion` and `SendUserMessage` stay refused. Each of them needs a person and an unattended run has none; those refusals are the design working.
- No change to `checkReadOnlyConstraints` or `checkPathConstraints`. The shell gate is still the conjunction of both.
- No change to which sources may be granted: non-builtin is still refused everywhere.

## Counterpart PRs

- tetsuo-ai/agenc-desktop#223 — the primary cause: the agent-facing routine tool created routines in **plan** mode, whose only exit is `ExitPlanMode`, which always needs a person.
