### PR TITLE
fix(permissions): measure the unattended grant against the run's own folder

### DIFF
--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -41,6 +41,7 @@
  * @module
  */
 
+import { resolve } from "node:path";
 import {
   freshDenialTracking,
   handleDenialLimitExceeded,
@@ -475,15 +476,33 @@ const READ_ONLY_GRANT_DEPS: ShellGateDeps = {
 };
 
 /**
- * Where a relative path in a granted command resolves from. Containment itself
- * is decided by the context's working directories, not by this value; this only
- * has to name the folder the run was started in.
+ * The folder this run works in, or null when it cannot be named.
+ *
+ * This is the base every relative path argument resolves from and, via
+ * `withRunFolderAsRoot`, the folder the shell path gate contains to.
+ *
+ * It used to read the first key of `additionalWorkingDirectories`, falling
+ * back to `process.cwd()`. Neither is this run's folder. That Map holds only
+ * the extra directories settings and `--add-dir` declare (permissions/
+ * settings.ts), never the session's own; on the routine path it is reliably
+ * empty, because the executor passes a cwd and no addDirs (routines/
+ * daemon-executor.ts) so no `--add-dir` is emitted. The fallback then handed
+ * the gate the daemon's process directory, and a routine in its own project
+ * was refused its own folder.
+ *
+ * `sessionConfiguration.cwd` is the workspace root bootstrap started this
+ * session with (bin/bootstrap.ts, session/configuration.ts), it is per
+ * session rather than per process, and it follows the session into a
+ * worktree. Absent it there is no folder to measure against, so this returns
+ * null and the gate refuses rather than guessing.
  */
 function readOnlyGrantWorkingDirectory(
-  context: ToolPermissionContext,
-): string {
-  const [first] = context.additionalWorkingDirectories.keys();
-  return first ?? process.cwd();
+  context: ToolEvaluatorContext,
+): string | null {
+  const configured: unknown = context.session?.sessionConfiguration?.cwd;
+  return typeof configured === "string" && configured.length > 0
+    ? resolve(configured)
+    : null;
 }
 
 /**
@@ -520,7 +539,7 @@ async function decideReadOnlyGrant(
     const verdict = readOnlyGrantVerdict(
       tool,
       input,
-      readOnlyGrantWorkingDirectory(permissionContext),
+      readOnlyGrantWorkingDirectory(context),
       permissionContext,
       READ_ONLY_GRANT_DEPS,
     );

--- a/runtime/src/permissions/read-only-grant.ts
+++ b/runtime/src/permissions/read-only-grant.ts
@@ -13,7 +13,7 @@
  * (tools/router.ts, `ledgerTurnBlocksTool`), and then removes three families
  * that satisfy it on paper and not in fact.
  */
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 import { isBashTool } from "../tools/concurrency.js";
 import { SYSTEM_SEARCH_TOOLS_NAME } from "../tools/system/tool-search-name.js";
@@ -107,22 +107,72 @@ export function shellToolIsGrantable(name: string): boolean {
 export function readShellCommand(
   toolName: string,
   input: unknown,
-): { command: string; workdir?: string } | null {
+): { command: string; workdir?: string; unparsedOperands?: true } | null {
   if (typeof input !== "object" || input === null) return null;
-  const record = input as { command?: unknown; cmd?: unknown; workdir?: unknown };
+  const record = input as {
+    command?: unknown;
+    cmd?: unknown;
+    args?: unknown;
+    workdir?: unknown;
+    cwd?: unknown;
+  };
   // system.bash keys it `command`; exec_command keys it `cmd`.
-  const raw = toolName === "exec_command" ? record.cmd : record.command;
+  const isExec = toolName === "exec_command";
+  const raw = isExec ? record.cmd : record.command;
   if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  // Each tool names its per-call working directory differently: `workdir` on
+  // exec_command (tools/system/exec-command.ts), `cwd` on system.bash
+  // (tools/system/bash.ts, applied unless lockCwd). Reading only `workdir`
+  // left a system.bash override invisible to the folder check below.
+  const override = isExec ? record.workdir : record.cwd;
   return {
     command: raw,
-    ...(typeof record.workdir === "string" ? { workdir: record.workdir } : {}),
+    ...(typeof override === "string" ? { workdir: override } : {}),
+    // system.bash also has a direct mode that puts the operands in `args` and
+    // execFiles them, so `cat` + ["/etc/passwd"] reaches both gates as the
+    // bare word "cat": read-only, no path arguments, granted. The operands
+    // are not in the string either gate parses, so the call is refused here.
+    ...(!isExec && Array.isArray(record.args) && record.args.length > 0
+      ? { unparsedOperands: true as const }
+      : {}),
   };
+}
+
+/**
+ * The run's own folder, named as a containment root for this one check.
+ *
+ * `checkPathConstraints` does not measure containment against the cwd it is
+ * handed; that argument only says where a relative path argument resolves
+ * from. The allowed roots come from `allWorkingDirectories`
+ * (utils/permissions/filesystem.ts): the process-global `getOriginalCwd()`
+ * plus `additionalWorkingDirectories`. In a daemon that hosts many sessions,
+ * `getOriginalCwd()` is the folder the daemon itself was started in, never a
+ * routine's project, and on the routine path the Map is empty. The file tools
+ * do not have this problem, because their own path check
+ * (permissions/path-validation.ts) adds the cwd it is handed to the root set;
+ * this brings the shell gate to the same rule. Added to a copy, so the
+ * session's context is left untouched.
+ */
+function withRunFolderAsRoot(
+  cwd: string,
+  context: ToolPermissionContext,
+): ToolPermissionContext {
+  if (context.additionalWorkingDirectories.has(cwd)) return context;
+  const roots = new Map(context.additionalWorkingDirectories);
+  roots.set(cwd, { path: cwd, source: "session" });
+  return { ...context, additionalWorkingDirectories: roots };
+}
+
+/** `child` is `root` or sits under it. */
+function pathIsInside(child: string, root: string): boolean {
+  const rel = relative(resolve(root), resolve(child));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
 export function shellCallIsGranted(
   toolName: string,
   input: unknown,
-  cwd: string,
+  cwd: string | null,
   context: ToolPermissionContext,
   deps: ShellGateDeps,
 ): ShellGateResult {
@@ -133,23 +183,32 @@ export function shellCallIsGranted(
   if (parsed === null) {
     return { ok: false, reason: "the command could not be read" };
   }
-  // A working directory of its own would move the ground the path check
-  // measures against, so only the run's own folder is accepted. Compared
-  // after resolution, not as strings: a relative workdir is relative to the
-  // run's cwd, so "." is that folder, and refusing it stranded routines whose
-  // agent quite reasonably passed one.
-  if (
-    parsed.workdir !== undefined &&
-    resolve(cwd, parsed.workdir) !== resolve(cwd)
-  ) {
+  // A caller that cannot name the run's folder has nothing safe to put in its
+  // place: every check below measures against it.
+  if (cwd === null) {
+    return { ok: false, reason: "this run has no folder of its own" };
+  }
+  if (parsed.unparsedOperands === true) {
+    return { ok: false, reason: "its arguments are not part of the command" };
+  }
+  // A working directory of its own moves the ground the path check measures
+  // against, so it has to stay inside the run's folder. A subdirectory is
+  // legitimate and is where the command actually runs, so it becomes the base
+  // the path arguments resolve from; anything outside is refused.
+  const workdir =
+    parsed.workdir === undefined ? resolve(cwd) : resolve(cwd, parsed.workdir);
+  if (!pathIsInside(workdir, cwd)) {
     return { ok: false, reason: "it runs in a different folder" };
   }
   if (deps.checkReadOnly({ command: parsed.command }).behavior !== "allow") {
     return { ok: false, reason: "the command is not read-only" };
   }
   if (
-    deps.checkPaths({ command: parsed.command }, cwd, context).behavior !==
-    "passthrough"
+    deps.checkPaths(
+      { command: parsed.command },
+      workdir,
+      withRunFolderAsRoot(resolve(cwd), context),
+    ).behavior !== "passthrough"
   ) {
     return { ok: false, reason: "it reads outside this project folder" };
   }
@@ -185,7 +244,7 @@ function declaresItselfReadOnly(tool: ReadOnlyGrantTool): boolean {
 export function readOnlyGrantVerdict(
   tool: ReadOnlyGrantTool,
   input: unknown,
-  cwd: string,
+  cwd: string | null,
   context: ToolPermissionContext,
   deps: ShellGateDeps,
 ): ReadOnlyGrantVerdict {

--- a/runtime/tests/permissions/read-only-grant-daemon-cwd.test.ts
+++ b/runtime/tests/permissions/read-only-grant-daemon-cwd.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The daemon condition: the run's folder is not the process's folder.
+ *
+ * A daemon hosts many sessions and works from its own home (app-server/
+ * daemon-working-directory.ts), so for a routine in `~/Documents/project`
+ * nothing about the process names that project. Every case here therefore
+ * uses a real directory that is NOT `process.cwd()` and a permission context
+ * with no directory grants at all, which is what the routine path actually
+ * builds. The shipped tests seeded the run folder into
+ * `additionalWorkingDirectories`, an alignment production never provides, and
+ * that is why they passed while a real routine was refused its own folder.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  readShellCommand,
+  shellCallIsGranted,
+  type ShellGateDeps,
+} from "../../src/permissions/read-only-grant.js";
+import { checkReadOnlyConstraints } from "../../src/tools/BashTool/readOnlyValidation.js";
+import { checkPathConstraints } from "../../src/tools/BashTool/pathValidation.js";
+import { createEmptyToolPermissionContext } from "./types.js";
+
+/** The real gates, so this is checked against shipped behaviour. */
+const deps: ShellGateDeps = {
+  checkReadOnly: (input) =>
+    checkReadOnlyConstraints(input as never, false) as { behavior: string },
+  checkPaths: (input, cwd, ctx) =>
+    checkPathConstraints(input as never, cwd, ctx) as { behavior: string },
+};
+
+/** No directory grants: exactly what the routine path builds. */
+const context = createEmptyToolPermissionContext({ mode: "unattended" });
+
+let runFolder: string;
+let subFolder: string;
+
+beforeAll(() => {
+  runFolder = resolve(mkdtempSync(join(tmpdir(), "readonly-grant-run-")));
+  subFolder = join(runFolder, "src");
+  mkdirSync(subFolder);
+  writeFileSync(join(runFolder, "README.md"), "hello\n");
+});
+
+describe("read-only grant in a daemon-hosted run", () => {
+  it("is measured against a folder the process is not in", () => {
+    expect(runFolder).not.toBe(resolve(process.cwd()));
+  });
+
+  it("grants a read-only command in the run's own folder", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: "df -h /", workdir: runFolder },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("grants reading a file inside the run's folder", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: `cat "${join(runFolder, "README.md")}"` },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("grants a workdir that is a subdirectory of the run's folder", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: "ls", workdir: subFolder },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts a relative workdir of '.'", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: "ls", workdir: "." },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("still refuses reading outside the run's folder", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: "cat /etc/passwd" },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: false, reason: "it reads outside this project folder" });
+  });
+
+  it("still refuses a workdir outside the run's folder", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: "ls", workdir: "/etc" },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: false, reason: "it runs in a different folder" });
+  });
+
+  it("still refuses a command that writes", () => {
+    expect(
+      shellCallIsGranted(
+        "exec_command",
+        { cmd: `rm -rf "${runFolder}"` },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: false, reason: "the command is not read-only" });
+  });
+
+  it("refuses when the caller cannot name the run's folder", () => {
+    expect(
+      shellCallIsGranted("exec_command", { cmd: "ls" }, null, context, deps),
+    ).toEqual({ ok: false, reason: "this run has no folder of its own" });
+  });
+});
+
+describe("system.bash names its per-call folder and operands differently", () => {
+  it("reads system.bash's `cwd` as the per-call working directory", () => {
+    expect(readShellCommand("system.bash", { command: "ls", cwd: "/etc" })).toEqual(
+      { command: "ls", workdir: "/etc" },
+    );
+  });
+
+  it("refuses a system.bash call whose folder is outside the run's", () => {
+    expect(
+      shellCallIsGranted(
+        "system.bash",
+        { command: "ls", cwd: "/etc" },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: false, reason: "it runs in a different folder" });
+  });
+
+  it("refuses direct mode, whose operands never reach either gate", () => {
+    // Both gates only ever see the bare word "cat": read-only, no paths.
+    expect(
+      shellCallIsGranted(
+        "system.bash",
+        { command: "cat", args: ["/etc/passwd"] },
+        runFolder,
+        context,
+        deps,
+      ),
+    ).toEqual({ ok: false, reason: "its arguments are not part of the command" });
+  });
+});

--- a/runtime/tests/permissions/read-only-grant.test.ts
+++ b/runtime/tests/permissions/read-only-grant.test.ts
@@ -13,12 +13,10 @@ import { checkPathConstraints } from "../../src/tools/BashTool/pathValidation.js
 import { createEmptyToolPermissionContext } from "./types.js";
 
 const CWD = "/workspace/project";
-const context = createEmptyToolPermissionContext({
-  mode: "unattended",
-  additionalWorkingDirectories: new Map([
-    [CWD, { path: CWD, source: "session" as const }],
-  ]),
-});
+// No directory grants. The routine path builds an empty Map, so seeding the
+// run folder here would test an alignment production never provides — which
+// is exactly how a gate that refused a routine its own folder passed review.
+const context = createEmptyToolPermissionContext({ mode: "unattended" });
 
 /** The real gates, so the table is checked against shipped behaviour. */
 const deps: ShellGateDeps = {
@@ -128,8 +126,20 @@ describe("unattended read-only grant", () => {
     }
   });
 
+  it("accepts a workdir inside the run's own folder", () => {
+    // The run's folder is the boundary, not the exact directory: an agent
+    // that cds into its own `src` before listing has not left the project.
+    // The subdirectory becomes the base its path arguments resolve from.
+    for (const workdir of ["sub", `${CWD}/sub`, "."]) {
+      expect(
+        verdict(tool("exec_command"), { cmd: "ls", workdir }).granted,
+        workdir,
+      ).toBe(true);
+    }
+  });
+
   it("still refuses a workdir that genuinely leaves the folder", () => {
-    for (const workdir of ["..", "/tmp", `${CWD}/../sibling`, "sub"]) {
+    for (const workdir of ["..", "/tmp", `${CWD}/../sibling`]) {
       const result = verdict(tool("exec_command"), { cmd: "ls", workdir });
       expect(result.granted, workdir).toBe(false);
       if (!result.granted && result.refusal.kind === "shell") {


### PR DESCRIPTION
## Why

A routine was refused every shell call it made in its own project, then reported an apology instead of its findings:

```
CALL exec_command {"cmd":"df -h /","workdir":"/Users/…/Documents/code gam"}
RES  "That command was refused because it runs in a different folder."
FINAL: "I couldn't collect system metrics: the environment refused the local
         diagnostic commands because no approver was attached."
```

Three separate things were wrong, and fixing any one alone changes nothing.

**1. The grant never knew the run's folder.** `readOnlyGrantWorkingDirectory` read the first key of `additionalWorkingDirectories`, falling back to `process.cwd()`. That Map holds only the extra directories settings and `--add-dir` declare (`permissions/settings.ts`); nothing puts the session's own cwd in it, and on the routine path it is reliably empty, because the executor passes a `cwd` and no `addDirs` (`routines/daemon-executor.ts`) so no `--add-dir` is emitted (`app-server/session-bootstrap-argv.ts`). The fallback therefore won, and the folder handed to the gate was the daemon's own process directory. The daemon deliberately works from its home (`app-server/daemon-working-directory.ts`, #2149), so this was never the project.

**2. `checkPathConstraints` does not contain against the cwd it is handed.** That argument only says where a relative path argument resolves from. The allowed roots come from `allWorkingDirectories` (`utils/permissions/filesystem.ts`): the process-global `getOriginalCwd()` plus `additionalWorkingDirectories`. Measured directly against this checkout:

```
checkPathConstraints({command:'cat "/private/tmp/dbgproj-mine/README.md"'},
                     "/private/tmp/dbgproj-mine", emptyContext)
-> ask: "cat in '/private/tmp/dbgproj-mine/README.md' was blocked. … may only
    concatenate files from the allowed working directories for this session:
    '/Users/…/wt-prov-core/runtime'"      <- the process cwd, not the one passed
```

The file tools do not have this problem: their own check (`permissions/path-validation.ts`) adds the cwd it is handed to the root set. The shell gate now follows the same rule.

**3. The gate read the wrong keys off `system.bash`.** It read only `workdir`, which is exec_command's name for the per-call working directory. `system.bash` names it `cwd` (`tools/system/bash.ts`, applied unless `lockCwd`), so an override there was invisible to the folder check. Worse, `system.bash`'s direct mode carries operands in `args` and execFiles them, so `{command: "cat", args: ["/etc/passwd"]}` reached both gates as the bare word `cat`: read-only, no path arguments, granted.

## What, per file

- **`runtime/src/permissions/evaluator.ts`** — `readOnlyGrantWorkingDirectory` now takes the evaluator context and returns `session.sessionConfiguration.cwd`, the workspace root bootstrap started this session with. It is per session rather than per process and follows the session into a worktree. When it is absent the function returns `null` and the gate refuses rather than guessing.
- **`runtime/src/permissions/read-only-grant.ts`** —
  - `readShellCommand` reads `cwd` for `system.bash` and `workdir` for `exec_command`, and flags direct mode (`args` non-empty) as `unparsedOperands`.
  - `shellCallIsGranted` takes `string | null` and refuses a null folder; refuses direct mode rather than parsing it; replaces the workdir *equality* test with containment, so a subdirectory of the run's folder is accepted and becomes the base its path arguments resolve from; and runs the path gate against a copy of the context with the run's folder added as a root (`withRunFolderAsRoot`). The copy means the session's own context is untouched.
- **`runtime/tests/permissions/read-only-grant.test.ts`** — the fixture seeded the run folder into `additionalWorkingDirectories`. Production never provides that alignment, and it is why these tests passed while a live routine was refused its own folder. Removed. The subdirectory case moves from the refusal list to a new positive case.
- **`runtime/tests/permissions/read-only-grant-daemon-cwd.test.ts`** — new.

## Evidence

Verified in the desktop app on the rebuilt daemon, not only in unit tests. Same routine, same folder, run from the UI:

- Before: every `exec_command` refused with "it runs in a different folder"; final answer an apology.
- After: `df -h` runs and the routine reports a real actionable finding ("Disk space is low on the writable data volume: 19 GiB free of 460 GiB, 96% used"). Zero folder refusals in the rollout.

Then the full user flow — type a request, let the agent draft the routine, Run now — on a project routine:

```
TOOLS: ['FileRead', 'Glob']       REFUSALS: 0
FINAL: "**Code Gam** is a very small JavaScript game-scoring demo, version 0.2.0 …
        Still to do: wire the scoreboard; fix the pause menu; add tie-break
        handling to score(), currently equal scores are incorrectly awarded to b."
```

What still refuses, correctly and by a different gate: `memory_pressure`, `sysctl`, `pmset`, `launchctl`, and a compound piping `top`. Those are refused by `checkReadOnlyConstraints` because they are not on the read-only command list (`uptime` and `df` are). Widening that list is a security decision and is deliberately not part of this PR.

## Tests

- New `read-only-grant-daemon-cwd.test.ts`, 12 cases, all against a real directory that is **not** `process.cwd()` and a context with no directory grants — the daemon's actual condition. Grants: a read-only command in the run's folder, reading a file inside it, a subdirectory workdir, a relative `"."`. Refuses: reading outside, a workdir outside, a writing command, a null folder, a `system.bash` `cwd` override outside, and direct-mode operands. It also asserts the run folder differs from `process.cwd()`, so the rig cannot silently become the old one.
- That file fails **7 of 12** against this PR's parent, including both security holes and "grants reading a file inside the run's folder". It is a real regression test, not a restatement.
- `read-only-grant.test.ts` + `read-only-grant-wiring.test.ts` + the new file: 32 passed.
- Every test file mentioning the grant or unattended permissions (39 files, 1588 tests) under the hermetic runner: 14 failed. The identical 14 fail on clean `origin/main` in the same single file (`tests/unified-exec/process-ownership.test.ts`, PTY-dependent). This change adds no failures.
- `tsc --noEmit` clean.

Note on the local gate: `npm test` refuses to run here ("requires a Linux Docker host"), so the runs above use `run-hermetic-vitest.mjs`, the non-authoritative host lane.

## Not changed

- `checkPathConstraints` and `allWorkingDirectories` are untouched. The root set is widened only for the grant's own check, on a copy, and only with the folder the run was started in.
- `checkReadOnlyConstraints` and its command list are untouched.
- The grant's other clauses (plan handoff, interactive tools, non-builtin sources, mutating tools) are unchanged.
- A routine refused every tool still finishes as `completed`, because the outcome derives from the turn's exit code. With this fix that no longer hides a total failure, but it remains a real reporting gap and is not addressed here.

## Counterpart PRs

None. tetsuo-ai/agenc-desktop#226 is the session Delete fix found in the same session; it is independent of this one.