### PR TITLE
fix(memory): keep the saved-memory notice out of the conversation

### DIFF
--- a/runtime/src/phases/commit.ts
+++ b/runtime/src/phases/commit.ts
@@ -31,6 +31,8 @@
  * @module
  */
 
+import { basename } from "node:path";
+
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
 import type {
@@ -96,20 +98,40 @@ function cloneCompletedToolResult(
   };
 }
 
-function emitSavedMemoryMessage(
+/**
+ * Memory extraction is housekeeping, so it reports on the diagnostic
+ * channel the rest of the memory subsystem already uses
+ * (`emitExtractionWarning` in services/extractMemories, cause
+ * `memory_extraction_skipped`).
+ *
+ * It used to emit an `agent_message`, which is the channel the model's own
+ * text arrives on. A line reading `Saved memory: /private/tmp/…/projects/
+ * v2--Users-…/memory/user_language.md` therefore appeared in the chat as
+ * something the assistant had said, directly under its real answer. Being an
+ * assistant message it was also persisted into the transcript and replayed as
+ * conversation history, and the desktop builds turn notifications from that
+ * same event type.
+ *
+ * The file name says which memory was written; the absolute path was internal
+ * detail that only ever reached the user by mistake.
+ */
+function emitSavedMemoryNotice(
   session: Session,
   paths: readonly string[],
 ): void {
   if (paths.length === 0) return;
-  const message =
-    paths.length === 1
-      ? `Saved memory: ${paths[0]}`
-      : `Saved memories: ${paths.join(", ")}`;
+  const names = paths.map((path) => basename(path));
   session.emit({
     id: session.nextInternalSubId(),
     msg: {
-      type: "agent_message",
-      payload: { message },
+      type: "warning",
+      payload: {
+        cause: "memory_saved",
+        message:
+          names.length === 1
+            ? `Saved memory: ${names[0]}`
+            : `Saved memories: ${names.join(", ")}`,
+      },
     },
   });
 }
@@ -533,7 +555,7 @@ export async function commit(
             session,
             signal,
           },
-          (paths) => emitSavedMemoryMessage(session, paths),
+          (paths) => emitSavedMemoryNotice(session, paths),
         ).catch(() => {});
       }
     }

--- a/runtime/tests/phases/commit.test.ts
+++ b/runtime/tests/phases/commit.test.ts
@@ -207,6 +207,51 @@ describe("commit", () => {
     });
   });
 
+  test("reports a saved memory off the conversation, by file name", async () => {
+    // It used to arrive as an `agent_message`, so a line reading
+    // "Saved memory: /private/tmp/.../memory/user_language.md" appeared in the
+    // chat as something the assistant had said, and was replayed as history.
+    const session = mkSession();
+    await commit(
+      mkState({
+        needsFollowUp: false,
+        toolUseBlocks: [],
+        messages: [
+          { role: "user", content: "answer in Spanish" },
+          { role: "assistant", content: "ok" },
+        ],
+      }),
+      mkCtx(),
+      session,
+    );
+
+    const extract = vi.mocked(executeExtractMemories);
+    expect(extract).toHaveBeenCalled();
+    const report = extract.mock.calls.at(-1)?.[1];
+    expect(report).toBeTypeOf("function");
+    report?.(["/private/tmp/home/projects/v2--Users-x/memory/user_language.md"]);
+
+    const emitted = vi
+      .mocked(session.emit)
+      .mock.calls.map((call) => call[0] as { msg: { type: string; payload: Record<string, unknown> } });
+    const notice = emitted.find((event) =>
+      String(event.msg.payload["message"] ?? "").startsWith("Saved memor"),
+    );
+    expect(notice?.msg.type).toBe("warning");
+    expect(notice?.msg.payload).toEqual({
+      cause: "memory_saved",
+      message: "Saved memory: user_language.md",
+    });
+    // Nothing about a saved memory reaches the channel the model speaks on.
+    expect(
+      emitted.some(
+        (event) =>
+          event.msg.type === "agent_message" &&
+          String(event.msg.payload["message"] ?? "").includes("Saved memor"),
+      ),
+    ).toBe(false);
+  });
+
   test("summary promise rejection is non-fatal and still clears the pending slot", async () => {
     const state = mkState({
       pendingToolUseSummary: Promise.reject(new Error("summary_boom")),


### PR DESCRIPTION
## Why

A turn that saved a memory printed this into the chat, directly under the assistant's real answer:

```
No veo en navegador información sobre el último iPhone.

Saved memory: /private/tmp/agenc-clean/home/projects/v2--Users-tetsuoarena-Documents-code-gam-1d38f4e047b651e5b7162bb75dbe0142b1978e6480da1000f6adbe04d65afbdb/memory/user_language.md
```

`emitSavedMemoryMessage` emitted an `agent_message`. That is the channel the model's own text arrives on, so an internal housekeeping notice read as something the assistant had said. Three consequences, not one:

- it is shown to the user as assistant speech, carrying an absolute internal path;
- being an assistant message it is persisted into the transcript and replayed as conversation history, so the model is taught internal filesystem paths it never needs;
- the desktop derives turn notifications from that same event type (`src/main/turn-notification.ts`).

Memory extraction already has a channel for exactly this kind of report: `emitExtractionWarning` in `services/extractMemories/extractMemories.ts` emits `{type: "warning", payload: {cause, message}}`, which is how `memory_extraction_skipped` is reported today and why the user has never seen *that* in a chat.

## What, per file

- **`runtime/src/phases/commit.ts`** — `emitSavedMemoryMessage` becomes `emitSavedMemoryNotice` and emits a `warning` with cause `memory_saved` instead of an `agent_message`. The message names the memory by `basename(path)` rather than its absolute path. Adds the `node:path` import and updates the single call site.
- **`runtime/tests/phases/commit.test.ts`** — new case.

## Evidence

The desktop surfaces only named warning causes: `provider_outage_wait`, `durable_resume_side_effect_halt`, `stream_model_failed`, `mode_changed_to_plan` / `mode_exited_plan` (`src/main/turn-notification.ts`). An unrecognised cause returns `null` and is not rendered, so `memory_saved` cannot reach the chat the way the old event did. `memory_extraction_skipped` already travels this path and has never appeared in a transcript.

## Tests

- New case in `tests/phases/commit.test.ts`: drives `commit` through a natural terminal turn, captures the reporting callback that `executeExtractMemories` is handed, invokes it with an absolute memory path, and asserts the emitted event is a `warning` with `{cause: "memory_saved", message: "Saved memory: user_language.md"}` — and that no `agent_message` mentioning a saved memory is emitted at all.
- Fails on this PR's parent with `expected 'agent_message' to be 'warning'`.
- `tests/phases/commit.test.ts`: 15 passed.
- `tsc --noEmit` clean.

## Not changed

- Memory extraction itself, its cadence, and what it writes are untouched; only how the result is announced changes.
- `emitExtractionWarning` and the existing `memory_extraction_skipped` reporting are untouched.
- No desktop change. The desktop already ignores unrecognised warning causes, so it needs no counterpart; giving `memory_saved` a visible home in the UI would be a separate feature.

## Counterpart PRs

None.