### PR TITLE
fix(runtime): address Grok workflow regressions

### DIFF
--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -449,7 +449,15 @@ Standard process and desktop discovery inputs:
 | --- | --- |
 | Home, user, temp, and application data | `APPDATA`, `FULLNAME`, `HOME`, `LOCALAPPDATA`, `LOGNAME`, `NAME`, `ProgramData`, `REALNAME`, `TEMP`, `TMPDIR`, `USER`, `USERNAME`, `USERPROFILE` |
 | Shell, editor, locale, and process execution | `BROWSER`, `ComSpec`, `EDITOR`, `LANG`, `LC_ALL`, `LC_TERMINAL`, `LC_TIME`, `MSYSTEM`, `NODE_ENV`, `NODE_EXTRA_CA_CERTS`, `NODE_OPTIONS`, `P4PORT`, `PATH`, `PATHEXT`, `SHELL`, `SystemRoot`, `VISUAL`, `VSCODE_GIT_ASKPASS_MAIN`, `VisualStudioVersion`, `WINDIR`, `XDG_CACHE_HOME`, `XDG_CONFIG_HOME` |
+| Local graphical desktop | `DISPLAY`, `WAYLAND_DISPLAY` |
 | Terminal detection and styling | `ALACRITTY_LOG`, `BAT_THEME`, `COLORTERM`, `ConEmuANSI`, `ConEmuPID`, `ConEmuTask`, `GNOME_TERMINAL_SERVICE`, `ITERM_SESSION_ID`, `KITTY_WINDOW_ID`, `KONSOLE_VERSION`, `PTYXIS_VERSION`, `SSH_CLIENT`, `SSH_CONNECTION`, `SSH_TTY`, `STY`, `TERMINAL_EMULATOR`, `TERMINATOR_UUID`, `TERM`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `TILIX_ID`, `TMUX`, `TMUX_PANE`, `VTE_VERSION`, `WSL_DISTRO_NAME`, `WT_SESSION`, `XTERM_VERSION`, `ZED_TERM`, `__CFBundleIdentifier` |
+
+OAuth browser opening uses a snapshot of the local TUI process environment,
+not a remote session's provider or home settings. On Linux, `DISPLAY` or
+`WAYLAND_DISPLAY` identifies a graphical desktop. When neither is set and
+`BROWSER` is empty, AgenC asks you to open the displayed sign-in URL manually.
+A failed browser launcher or a launch that takes more than five seconds also
+shows the manual-opening prompt.
 
 CI and hosting discovery inputs:
 

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -2470,6 +2470,7 @@ async function loadCreateDaemonTuiSession(): Promise<
     client: unknown;
     sessionId: string;
     conversationId?: string;
+    transcriptSnapshot?: import("../app-server/protocol/index.js").SessionTranscriptV2Result;
     clientId: string;
     runtimeSettingsCursor: { readonly eventId: string; readonly cwd: string };
   }) => Promise<unknown>
@@ -2480,6 +2481,7 @@ async function loadCreateDaemonTuiSession(): Promise<
       client: unknown;
       sessionId: string;
       conversationId?: string;
+      transcriptSnapshot?: import("../app-server/protocol/index.js").SessionTranscriptV2Result;
       clientId: string;
       runtimeSettingsCursor: {
         readonly eventId: string;
@@ -4932,6 +4934,7 @@ export async function attachAgentTuiEntry(
         `daemon agent runtime options disagree with the attaching client: ${args.agentId}`,
       );
     }
+    const attachedClient = daemonClient;
     return await runWithAgentRuntimeOptions(runtimeOptions, async () => {
       setIsRemoteMode(runtimeOptions.remoteMode);
       const sessionId = attachment.sessionIds[0];
@@ -5016,6 +5019,11 @@ export async function attachAgentTuiEntry(
       const attachProfile = liveSettings.profile ?? undefined;
       const attachConfigPath =
         startupLayers.flagConfigPath ?? retainedConfigPath;
+      const transcriptSnapshot = await attachedClient.request("session.transcript.v2", {
+        sessionId,
+      });
+      const { daemonTranscriptSnapshotEvents } = await import("../tui/daemon-transcript-snapshot.js");
+      daemonTranscriptSnapshotEvents(transcriptSnapshot, sessionId);
       const {
         workspaceRoot,
         baseSession,
@@ -5043,6 +5051,7 @@ export async function attachAgentTuiEntry(
         sessionId,
         conversationId: runtimeSessionId,
         clientId: args.clientId,
+        transcriptSnapshot,
         runtimeSettingsCursor: {
           eventId: attachment.runtimeSettingsEventId,
           cwd: bootstrapCwd,

--- a/runtime/src/commands/auth.tsx
+++ b/runtime/src/commands/auth.tsx
@@ -1,11 +1,10 @@
-import { spawn } from "node:child_process";
-
 import type { AuthBackend, AuthIdentity, AuthLlmUsage } from "../auth/backend.js";
 import { createAuthBackend } from "../auth/selection.js";
 import { defaultConfig } from "../config/schema.js";
 import { Box, Text } from "../tui/ink.js";
 import { openLocalJsxCommand } from "./local-jsx-command.js";
 import { readBuiltInSessionSelection } from "../session/provider-model-selection.js";
+import { openLocalBrowser } from "../utils/browser.js";
 import {
   providerEnvironmentFromCommandContext,
   remoteAuthContextFromCommandContext,
@@ -273,31 +272,7 @@ function clearLocalAuthNotice(ctx: SlashCommandContext): void {
 }
 
 export async function openUrlInBrowser(url: string): Promise<void> {
-  const { command, args } = browserOpenCommand(url);
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, {
-      detached: true,
-      stdio: "ignore",
-    });
-    child.once("error", reject);
-    child.once("spawn", () => {
-      child.unref();
-      resolve();
-    });
-  });
-}
-
-function browserOpenCommand(url: string): {
-  readonly command: string;
-  readonly args: readonly string[];
-} {
-  if (process.platform === "darwin") {
-    return { command: "open", args: [url] };
-  }
-  if (process.platform === "win32") {
-    return { command: "cmd", args: ["/c", "start", "", url] };
-  }
-  return { command: "xdg-open", args: [url] };
+  await openLocalBrowser(url);
 }
 
 function formatAgenCAuthIdentity(identity: AuthIdentity | undefined): string {

--- a/runtime/src/memory/extraction-triggers.ts
+++ b/runtime/src/memory/extraction-triggers.ts
@@ -20,6 +20,7 @@ export type MemoryExtractionEnv = Readonly<Record<string, string | undefined>>;
 export interface MemoryExtractionVisibleRange {
   readonly visibleMessages: readonly LLMMessage[];
   readonly unprocessedMessages: readonly LLMMessage[];
+  readonly unprocessedVisibleCount: number;
   readonly currentVisibleCount: number;
 }
 
@@ -38,18 +39,28 @@ export function createMemoryExtractionTriggerState(): MemoryExtractionTriggerSta
 export function memoryExtractionVisibleRange(
   messages: readonly LLMMessage[],
   processedVisibleCount: number,
+  maxVisibleMessages = Number.POSITIVE_INFINITY,
 ): MemoryExtractionVisibleRange {
   const visibleMessages = messages.filter(
-    (message) => message.role === "user" || message.role === "assistant",
+    (message) => message.role === "user" || message.role === "assistant" || message.role === "tool",
   );
-  const currentVisibleCount = visibleMessages.length;
-  const unprocessedMessages =
+  const visibleOffsets = visibleMessages.flatMap((message, index) =>
+    message.role === "tool" ? [] : [index],
+  );
+  const currentVisibleCount = visibleOffsets.length;
+  const batchStart =
     currentVisibleCount < processedVisibleCount
-      ? visibleMessages
-      : visibleMessages.slice(processedVisibleCount);
+      ? 0
+      : processedVisibleCount;
+  const batchEnd = Math.min(currentVisibleCount, batchStart + maxVisibleMessages);
+  const unprocessedMessages = visibleMessages.slice(
+    visibleOffsets[batchStart] ?? visibleMessages.length,
+    visibleOffsets[batchEnd] ?? visibleMessages.length,
+  );
   return {
     visibleMessages,
     unprocessedMessages,
+    unprocessedVisibleCount: batchEnd - batchStart,
     currentVisibleCount,
   };
 }

--- a/runtime/src/permissions/risk.ts
+++ b/runtime/src/permissions/risk.ts
@@ -2,6 +2,17 @@ import { matchedDangerousShellCommandLabel } from "./dangerous-patterns.js";
 
 export type ApprovalRiskTier = "low" | "medium" | "destructive";
 
+const DATA_BEARING_BUILTIN_TOOL_NAMES = new Set([
+  "spawn_agent",
+  "send_message",
+  "TodoWrite",
+  "TaskCreate",
+  "TaskUpdate",
+  "Write",
+  "Edit",
+  "NotebookEdit",
+]);
+
 const SHELL_COMMAND_FRAGMENT = String.raw`[^;&|\n]*`;
 const RECURSIVE_FORCE_RM_BUNDLED_FLAGS = new RegExp(
   [
@@ -20,22 +31,26 @@ export function classifyApprovalRisk(input: {
   readonly toolName?: string;
   readonly description?: string;
   readonly command?: string;
+  readonly toolInput?: unknown;
 }): ApprovalRiskTier {
   const requestToolName =
     typeof input.request?.ctx?.toolName === "string"
       ? input.request.ctx.toolName
       : undefined;
+  const command = input.toolInput === undefined
+    ? input.command
+    : approvalActionText(input.toolInput, input.toolName ?? requestToolName);
   const haystack = [
-    requestToolName,
-    input.toolName,
+    requestToolName?.replaceAll("_", " "),
+    input.toolName?.replaceAll("_", " "),
     input.description,
-    input.command,
+    command,
   ]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
 
-  if (commandLooksDestructive(input.command)) {
+  if (commandLooksDestructive(command)) {
     return "destructive";
   }
   // "slash" is deliberately NOT a destructive keyword: it collides with the
@@ -56,15 +71,52 @@ export function typedConfirmationWordForRisk(input: {
   readonly risk: ApprovalRiskTier;
   readonly command?: string;
   readonly description?: string;
+  readonly toolName?: string;
+  readonly toolInput?: unknown;
 }): string {
   if (input.risk !== "destructive") return "yes";
-  const haystack = [input.command, input.description].filter(Boolean).join(" ").toLowerCase();
+  const command = input.toolInput === undefined
+    ? input.command
+    : approvalActionText(input.toolInput, input.toolName);
+  const haystack = [command, input.description, input.toolName?.replaceAll("_", " ")].filter(Boolean).join(" ").toLowerCase();
   if (/\bsettle\b/u.test(haystack)) return "settle";
   if (/\bstake\b/u.test(haystack)) return "stake";
   if (/\btransfer\b/u.test(haystack)) return "transfer";
   if (/\b(delete|destroy|wipe)\b/u.test(haystack)) return "delete";
-  if (input.command && commandLooksLikeRemoval(input.command)) return "delete";
+  if (command && commandLooksLikeRemoval(command)) return "delete";
   return "approve";
+}
+
+function approvalActionText(input: unknown, toolName: string | undefined): string | undefined {
+  if (typeof input === "string") return input;
+  if (input === null || typeof input !== "object") return undefined;
+  const record = input as Record<string, unknown>;
+  const parts = Array.isArray(input)
+    ? input.filter((part) => typeof part === "string")
+    : ["command", "cmd", "script", "code", "action", "operation", "method", "edit_mode"]
+      .flatMap((key) => {
+        const value = record[key];
+        return typeof value === "string"
+          ? [value]
+          : Array.isArray(value)
+            ? value.filter((part) => typeof part === "string")
+            : [];
+      });
+  if (parts.length > 0 && Array.isArray(record.args)) {
+    parts.push(...record.args.filter((part) => typeof part === "string"));
+  }
+  if (toolName?.split(".").at(-1) === "write_stdin" && typeof record.chars === "string") {
+    parts.push(record.chars);
+  }
+  if (!DATA_BEARING_BUILTIN_TOOL_NAMES.has(toolName ?? "")) {
+    try {
+      const serialized = JSON.stringify(input);
+      if (serialized !== undefined) parts.push(serialized);
+    } catch {
+      parts.push(String(input));
+    }
+  }
+  return parts.join(" ");
 }
 
 function dangerousShellCommandLabel(command: string | undefined): string | null {

--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -458,7 +458,9 @@ function approvalRejectedResult(err: ApprovalRejectedError): ToolDispatchResultL
       approvalDecision: decision,
     }),
     isError: true,
-    ...(approvalDenialEndsTurn(err) ? { preventContinuation: true } : {}),
+    ...(approvalDenialEndsTurn(err)
+      ? { preventContinuation: true, metadata: { approvalDenied: true } }
+      : {}),
   };
 }
 
@@ -991,15 +993,12 @@ export class StreamingToolExecutor {
             },
           });
         } catch (err) {
-          dispatchResult = {
-            content:
-              err instanceof ApprovalRejectedError
-                ? approvalRejectedResult(err).content
-                : err instanceof Error
-                  ? err.message
-                  : String(err),
-            isError: true,
-          };
+          dispatchResult = err instanceof ApprovalRejectedError
+            ? approvalRejectedResult(err)
+            : {
+                content: err instanceof Error ? err.message : String(err),
+                isError: true,
+              };
         }
       }
 

--- a/runtime/src/phases/continuation-nudge.ts
+++ b/runtime/src/phases/continuation-nudge.ts
@@ -41,7 +41,7 @@ const CONTINUATION_SIGNALS: RegExp[] = [
   /\blet me (go ahead and |now )?(do|create|write|edit|update|fix|implement|add|run|check|make|build|set up|proceed)\b/,
   /\btime to (do|create|write|edit|update|fix|implement|add|run|check|make|build|get started|begin)\b/,
   /\b(continuing|proceeding|executing|starting|moving on to)\b.{0,120}\b(do|create|write|edit|update|fix|implement|add|run|check|make|build|test|verify|wire|parse|dispatch|execute)\b/,
-  /\b(source|eval|tests?|edits?|tool calls?|verification)\b.{0,80}\b(incoming|next|queued|sequential)\b/,
+  /\b(source|eval|tests?|edits?|tool calls?|verification)\b.{0,80}\b(incoming|queued|sequential)\b/,
 ];
 
 const SHORT_TEXT_SIGNALS: RegExp[] = [
@@ -52,9 +52,12 @@ const SHORT_TEXT_SIGNALS: RegExp[] = [
 const COMPLETION_MARKERS =
   /\b(done|finished|completed|complete|summary|that's all|that is all|all set|hope this helps|let me know if)\b/;
 
+const CONSENT_MARKERS =
+  /\b(?:if|when|once|after|until|unless) you(?:['’]d| would)? (?:want|like|approve|agree|confirm|prefer|allow|authorize|permit|give)\b|\b(?:your|user) (?:approval|permission|confirmation|consent|go[- ]ahead)\b|\b(?:would|do) you (?:like|want)\b|\b(?:may|shall|should|can|could) i\b|\blet me know\b/;
+
 function matchesContinuationSignal(text: string): boolean {
   const lowered = text.toLowerCase();
-  if (COMPLETION_MARKERS.test(lowered)) return false;
+  if (COMPLETION_MARKERS.test(lowered) || CONSENT_MARKERS.test(lowered)) return false;
   if (CONTINUATION_SIGNALS.some((re) => re.test(lowered))) return true;
   if (lowered.length < 80 && SHORT_TEXT_SIGNALS.some((re) => re.test(lowered))) {
     return true;

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -220,6 +220,7 @@ interface QueuedExtraction {
 interface VisibleRange {
   readonly visibleMessages: readonly LLMMessage[];
   readonly unprocessedMessages: readonly LLMMessage[];
+  readonly unprocessedVisibleCount: number;
   readonly currentVisibleCount: number;
 }
 
@@ -825,18 +826,16 @@ export function initExtractMemories(
     const range: VisibleRange = memoryExtractionVisibleRange(
       queued.context.messages,
       lane.trigger.processedVisibleCount,
+      MAX_EXTRACTION_BATCH_MESSAGES,
     );
     // The cursor restarts at zero when the visible history shrank (a reset).
     const batchStart =
       range.currentVisibleCount < lane.trigger.processedVisibleCount
         ? 0
         : lane.trigger.processedVisibleCount;
-    const batch = range.unprocessedMessages.slice(
-      0,
-      MAX_EXTRACTION_BATCH_MESSAGES,
-    );
-    const batchEnd = batchStart + batch.length;
-    const newMessageCount = batch.length;
+    const batch = range.unprocessedMessages;
+    const newMessageCount = range.unprocessedVisibleCount;
+    const batchEnd = batchStart + newMessageCount;
     if (newMessageCount === 0) {
       emitExtractionWarning(
         session,

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -3108,6 +3108,19 @@ async function* runTurnKernelInner(
     }
     if (state.preventContinuation) {
       state.toolUseBlocks = [];
+      const approvalDeniedTools = state.completedToolResults.filter(
+        (result) => result.isError === true && result.metadata?.approvalDenied === true,
+      );
+      if (approvalDeniedTools.length > 0) {
+        const toolNames = [...new Set(approvalDeniedTools.map((result) => result.toolName))];
+        lastContent = `Approval was denied for ${toolNames.join(", ")}. The turn stopped without running the denied action.`;
+        const error = new Error(lastContent);
+        state.messages.push({ role: "assistant", content: lastContent });
+        await syncSessionState();
+        emitTurnComplete(lastContent, "error", error);
+        yield { type: "turn_complete", content: lastContent, usage, stopReason: "error", error };
+        return { reason: "aborted_tools", error };
+      }
       await commit(state, ctx, session, signal, {
         querySource: turnQuerySource,
       });

--- a/runtime/src/tools/orchestrator.ts
+++ b/runtime/src/tools/orchestrator.ts
@@ -812,13 +812,16 @@ export async function orchestrateToolCall<T>(
   }
 
   if (requirement.kind === "needs_approval") {
+    const approvalReason = requirement === toolRequirement
+      ? opts.approvalCtx.retryReason ?? requirement.reason
+      : requirement.reason;
     const approvalCtx: ApprovalCtx = {
       ...opts.approvalCtx,
       ...(opts.tool.requiresUserInteraction?.() === true
         ? { requiresUserInteraction: true }
         : {}),
-      ...(requirement.reason !== undefined
-        ? { retryReason: requirement.reason }
+      ...(approvalReason !== undefined
+        ? { retryReason: approvalReason }
         : {}),
       ...approvalContextForSandboxPermissions(normalizedSandboxPermissions),
     };

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -1904,7 +1904,9 @@ function toolDispatchErrorResult(err: unknown): ToolDispatchResult {
       // A resolver denial ends the turn after this batch so the model
       // cannot re-issue the same call (observed: 8 identical retries until
       // the no-progress backstop).
-      ...(approvalDenialEndsTurn(err) ? { preventContinuation: true } : {}),
+      ...(approvalDenialEndsTurn(err)
+        ? { preventContinuation: true, metadata: { approvalDenied: true } }
+        : {}),
     };
   }
   return {

--- a/runtime/src/tools/system/planning.ts
+++ b/runtime/src/tools/system/planning.ts
@@ -372,10 +372,8 @@ export function createPlanningTools(options: PlanningToolOptions = {}): readonly
    *
    * Tool result content is AgenC
    * `mapToolResultToToolResultBlockParam`'s `base` sentence
-   * (`TodoWriteTool.ts`). When the AgenC verification-agent
-   * contract is enabled, the close-out nudge below mirrors the donor:
-   * finishing 3+ tasks without a verification item reminds the model
-   * to spawn the verification agent before final response.
+   * (`TodoWriteTool.ts`). Finishing 3+ tasks without a verification
+   * item adds a reminder to verify within the user's task constraints.
    */
   const todoWriteTool: Tool = {
     name: "TodoWrite",
@@ -431,9 +429,9 @@ export function createPlanningTools(options: PlanningToolOptions = {}): readonly
       await persistTodosToTaskBoard(nextTodos);
       const verificationNudgeNeeded = allDone &&
         todos.length >= 3 &&
-        !todos.some((todo) => /verif/i.test(todo.content));
+        !todos.some((todo) => /\b(?:verif\w*|tests?|testing|checks?|checking|reviews?|reviewing)\b/i.test(todo.content));
       const nudge = verificationNudgeNeeded
-        ? '\n\nNOTE: You just closed out 3+ tasks and none of them was a verification step. Before writing your final summary, spawn the sentinel agent (agent_type="sentinel"). You cannot self-assign PARTIAL by listing caveats in your summary; only the sentinel issues a verdict.'
+        ? "\n\nVerify the changes with the checks allowed by the user's instructions, then report the actual results and any checks you could not perform."
         : "";
       return textResult(`${TODO_WRITE_RESULT_MESSAGE}${nudge}`, {
         verificationNudgeNeeded,

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -9,6 +9,10 @@ import { randomUUID } from "node:crypto";
 import { isAbsolute } from "node:path";
 import { AgenCDaemonResponseError, MAX_BUFFERED_SESSION_EVENTS_PER_SESSION } from "../app-server/agent-cli.js";
 import { DaemonEventReplay } from "./daemon-event-replay.js";
+import {
+  daemonTranscriptSnapshotCoversEvent,
+  daemonTranscriptSnapshotEvents,
+} from "./daemon-transcript-snapshot.js";
 import { classifyTurnTerminal, createTurnFailedEvent } from "../contracts/turn-terminal.js";
 import type {
   AgentAttachParams,
@@ -50,6 +54,7 @@ import type {
   SessionApplyConfigParams,
   SessionApplyConfigResult,
   SessionSnapshotResult,
+  SessionTranscriptV2Result,
   SessionShellExecuteParams,
   SessionShellExecuteResult,
   SessionResolveToolCallResult,
@@ -663,6 +668,7 @@ export interface AgenCDaemonTuiSessionOptions<
   readonly realtimeWebrtcSessionFactory?: CreateRealtimeTuiControlsOptions["startWebrtcSession"];
   readonly realtimeAudioCaptureFactory?: StartRealtimeAudioCapture;
   readonly realtimeAudioPlayer?: RealtimeAudioPlayer;
+  readonly transcriptSnapshot?: SessionTranscriptV2Result;
   /** Snapshot cursor captured only after this socket's session route exists. */
   readonly runtimeSettingsCursor: {
     readonly eventId: string;
@@ -725,11 +731,16 @@ export async function attachDaemonAgentTuiSession<
     authorityCwd,
     attachment.runtimeSettings,
   );
+  const transcriptSnapshot = await options.client.request("session.transcript.v2", {
+    sessionId,
+  });
+  daemonTranscriptSnapshotEvents(transcriptSnapshot, sessionId);
   return createDaemonTuiSession({
     ...options,
     sessionId,
     conversationId: attachment.runtimeSessionId ?? options.agentId,
     realtimeThreadId: options.agentId,
+    transcriptSnapshot,
     runtimeSettingsCursor: {
       eventId: attachment.runtimeSettingsEventId,
       cwd: authorityCwd,
@@ -743,6 +754,9 @@ export function createDaemonTuiSession<
   options: AgenCDaemonTuiSessionOptions<Session>,
 ): AgenCDaemonBackedTuiSession<Session> {
   const { baseSession, client, sessionId, clientId } = options;
+  const restoredTranscriptEvents = options.transcriptSnapshot === undefined
+    ? undefined
+    : daemonTranscriptSnapshotEvents(options.transcriptSnapshot, sessionId);
   // These authenticated TUI-only methods are intentionally absent from the
   // public daemon method union. The transport accepts known internal methods;
   // keep the widening narrow so ordinary TUI calls remain contract-checked.
@@ -775,7 +789,8 @@ export function createDaemonTuiSession<
   };
   const queuedInputs: DaemonQueuedInput[] = [];
   const eventReplay = new DaemonEventReplay(MAX_BUFFERED_SESSION_EVENTS_PER_SESSION);
-  let activeTurnSnapshot: { readonly turnId: string } | null = null;
+  let activeTurnSnapshot: { readonly turnId: string } | null =
+    options.transcriptSnapshot?.activeTurn ?? null;
   let lastObservedTurnId: string | undefined;
   let daemonTurnStartGeneration = 0;
   let inFlightShellExecutionCount = 0;
@@ -1014,6 +1029,7 @@ export function createDaemonTuiSession<
       () => activeTurnSnapshot?.turnId === "daemon-turn"
         ? lastObservedTurnId
         : activeTurnSnapshot?.turnId ?? lastObservedTurnId,
+      options.transcriptSnapshot,
     );
     const currentConnectionState = client.getConnectionState?.();
     if (
@@ -1751,7 +1767,7 @@ export function createDaemonTuiSession<
       };
     },
     getInitialTranscriptEvents: () => [
-      ...baseInitialTranscriptEvents(baseSession),
+      ...(restoredTranscriptEvents ?? baseInitialTranscriptEvents(baseSession)),
       ...connectionNoticeEvents(client.getConnectionState?.() ?? null),
     ],
   } as AgenCDaemonBackedTuiSession<Session>;
@@ -2527,6 +2543,7 @@ function subscribeToDaemonEvents(
   cb: (event: unknown) => void,
   runtimeSettingsReconciler?: RuntimeSettingsReconciler,
   activeTurnId?: () => string | undefined,
+  transcriptSnapshot?: SessionTranscriptV2Result,
 ): () => void {
   let replayingInitialEvents = true;
   const deliver = (event: JsonObject): void => {
@@ -2559,6 +2576,10 @@ function subscribeToDaemonEvents(
         return;
       }
       const transcriptEvent = toTranscriptEvent(event, activeTurnId?.());
+      if (
+        transcriptSnapshot !== undefined &&
+        daemonTranscriptSnapshotCoversEvent(transcriptSnapshot, event, transcriptEvent)
+      ) return;
       if (runtimeSettingsReconciler === undefined) {
         deliver(transcriptEvent);
       } else if (replayingInitialEvents) {

--- a/runtime/src/tui/daemon-transcript-snapshot.ts
+++ b/runtime/src/tui/daemon-transcript-snapshot.ts
@@ -1,0 +1,96 @@
+import type {
+  JsonObject,
+  SessionTranscriptV2Result,
+} from "../app-server/protocol/index.js";
+import { isRecord } from "../utils/record.js";
+
+export function daemonTranscriptSnapshotEvents(
+  snapshot: SessionTranscriptV2Result,
+  sessionId: string,
+): readonly JsonObject[] {
+  if (
+    snapshot.schemaVersion !== 2 ||
+    snapshot.sessionId !== sessionId ||
+    typeof snapshot.runId !== "string" ||
+    typeof snapshot.historyEpoch !== "string" ||
+    !Number.isSafeInteger(snapshot.asOfSequence) ||
+    snapshot.asOfSequence < 0 ||
+    !Array.isArray(snapshot.messages)
+  ) {
+    throw new Error("Daemon returned an invalid transcript snapshot");
+  }
+  const events = snapshot.messages.map((message) => {
+    if (
+      (message.role !== "user" && message.role !== "assistant") ||
+      typeof message.text !== "string" ||
+      typeof message.messageId !== "string" ||
+      typeof message.commitEventId !== "string" ||
+      !Number.isSafeInteger(message.committedSequence) ||
+      message.committedSequence < 0 ||
+      message.committedSequence > snapshot.asOfSequence
+    ) {
+      throw new Error("Daemon returned an invalid transcript message");
+    }
+    return {
+      sequence: message.committedSequence,
+      event: {
+        id: `snapshot:${snapshot.historyEpoch}:${message.messageId}`,
+        type: message.role === "user" ? "user_message" : "agent_message",
+        payload: { message: message.text },
+      } satisfies JsonObject,
+    };
+  });
+  events.sort((left, right) => left.sequence - right.sequence);
+  const transcript: JsonObject[] = events.map((entry) => entry.event);
+  if (snapshot.activeTurn !== undefined) {
+    const firstActiveMessage = snapshot.messages.find((message) =>
+      message.turnId === snapshot.activeTurn?.turnId,
+    );
+    const activeIndex = firstActiveMessage === undefined ? -1 : transcript.findIndex((event) =>
+      event.id === `snapshot:${snapshot.historyEpoch}:${firstActiveMessage.messageId}`,
+    );
+    transcript.splice(activeIndex < 0 ? transcript.length : activeIndex, 0, {
+      id: `snapshot:active:${snapshot.activeTurn.turnId}`,
+      type: "turn_started",
+      payload: { turnId: snapshot.activeTurn.turnId },
+    });
+  }
+  return transcript;
+}
+
+export function daemonTranscriptSnapshotCoversEvent(
+  snapshot: SessionTranscriptV2Result,
+  event: JsonObject,
+  transcriptEvent: JsonObject,
+): boolean {
+  if (
+    transcriptEvent.type === "run_runtime_settings_changed" ||
+    transcriptEvent.type === "runtime_settings_authority_gap"
+  ) return false;
+  const params = event.params;
+  if (!isRecord(params)) return false;
+  if (params.runId !== undefined && params.runId !== snapshot.runId) return false;
+  const sequence = params.sequence;
+  if (typeof sequence !== "number" || !Number.isSafeInteger(sequence)) return false;
+  if (sequence > snapshot.asOfSequence) return false;
+  const payload = transcriptEvent.payload;
+  const turnId = params.turnId ?? (
+    isRecord(payload) ? payload.turnId : undefined
+  );
+  if (snapshot.activeTurn === undefined || turnId !== snapshot.activeTurn.turnId) {
+    return true;
+  }
+  if (transcriptEvent.type === "turn_started" || transcriptEvent.type === "turn_start") {
+    return true;
+  }
+  if (
+    transcriptEvent.type === "user_message" ||
+    transcriptEvent.type === "agent_message" ||
+    transcriptEvent.type === "agent_message_delta"
+  ) {
+    return snapshot.messages.some((message) =>
+      message.turnId === turnId && message.committedSequence >= sequence,
+    );
+  }
+  return false;
+}

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -540,12 +540,15 @@ function AgenCApprovalOverlay({
     toolName: toolUseConfirm.tool.name,
     description: toolUseConfirm.description,
     command,
+    toolInput: toolUseConfirm.input,
   });
   const destructive = risk === "destructive";
   const requiredWord = typedConfirmationWordForRisk({
     risk,
     command,
     description: toolUseConfirm.description,
+    toolName: toolUseConfirm.tool.name,
+    toolInput: toolUseConfirm.input,
   });
   const [typed, setTyped] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -36,6 +36,7 @@ export function DiffSurface({
         request: pendingApproval,
         description: pendingApproval.description,
         command: approvalInputText(pendingApproval.input),
+        toolInput: pendingApproval.input,
       })
     : null;
 

--- a/runtime/src/utils/browser.ts
+++ b/runtime/src/utils/browser.ts
@@ -1,3 +1,5 @@
+import { spawn } from 'node:child_process'
+
 import { execFileNoThrow } from './execFileNoThrow.js'
 
 function validateUrl(url: string): void {
@@ -65,4 +67,57 @@ export async function openBrowser(url: string): Promise<boolean> {
   } catch (_) {
     return false
   }
+}
+
+export async function openLocalBrowser(url: string): Promise<void> {
+  const environment = { ...process.env }
+  const manualOpening = 'Open the displayed sign-in URL manually.'
+  if (
+    process.platform === 'linux' &&
+    !environment.DISPLAY?.trim() &&
+    !environment.WAYLAND_DISPLAY?.trim() &&
+    !environment.BROWSER?.trim()
+  ) {
+    throw new Error(`No graphical browser environment is available. ${manualOpening}`)
+  }
+  const { command, args } = browserOpenCommand(url)
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+      env: environment,
+    })
+    const timeout = setTimeout(() => {
+      reject(new Error(`Browser launcher did not confirm opening within 5 seconds. ${manualOpening}`))
+    }, 5_000)
+    child.once('error', () => {
+      clearTimeout(timeout)
+      reject(new Error(`Browser launcher could not start. ${manualOpening}`))
+    })
+    child.once('spawn', () => {
+      child.unref()
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve()
+      } else {
+        const cause = signal === null ? `exit code ${code}` : `signal ${signal}`
+        reject(new Error(`Browser launcher failed with ${cause}. ${manualOpening}`))
+      }
+    })
+  })
+}
+
+function browserOpenCommand(url: string): {
+  readonly command: string
+  readonly args: readonly string[]
+} {
+  if (process.platform === 'darwin') {
+    return { command: 'open', args: [url] }
+  }
+  if (process.platform === 'win32') {
+    return { command: 'cmd', args: ['/c', 'start', '', url] }
+  }
+  return { command: 'xdg-open', args: [url] }
 }

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -378,6 +378,19 @@ function installDaemonCliDepsForTest(
           },
         };
       }
+      if (method === "session.transcript.v2") {
+        return {
+          schemaVersion: 2,
+          sessionId,
+          runId: runtimeSessionId,
+          historyEpoch: "test_epoch",
+          asOfSequence: 2,
+          messages: [
+            { messageId: "prior_user", commitEventId: "event:1", role: "user", text: "Earlier request", committedSequence: 1 },
+            { messageId: "prior_assistant", commitEventId: "event:2", role: "assistant", text: "Earlier answer", committedSequence: 2 },
+          ],
+        };
+      }
       if (method === "agent.stop") {
         return { agentId, stopped: true };
       }
@@ -2907,6 +2920,7 @@ describe("main() smoke", () => {
       expect(daemon.requests.map((request) => request.method)).toEqual([
         "agent.list",
         "agent.attach",
+        "session.transcript.v2",
       ]);
     } finally {
       vi.doUnmock("../tui/main.js");
@@ -3238,6 +3252,34 @@ describe("main() smoke", () => {
     },
   );
 
+  it("fails transcript restoration before allocating local TUI resources", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-transcript-failure-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-transcript-failure-cwd-"));
+    const daemon = installDaemonCliDepsForTest({
+      agentId: "agent_transcript_failure",
+      sessionId: "session_transcript_failure",
+      cwd: tmpCwd,
+      requestErrors: { "session.transcript.v2": new Error("transcript unavailable") },
+    });
+    const bootTUI = vi.fn(async () => ({ unmount: vi.fn(), waitUntilExit: async () => undefined }));
+    vi.doMock("../tui/main.js", () => ({ bootTUI }));
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      await expect(attachAgentTuiEntry({
+        agentId: "agent_transcript_failure",
+        clientId: "client_transcript_failure",
+        env: { AGENC_HOME: tmpHome, AGENC_WORKSPACE: tmpCwd, HOME: tmpHome },
+      })).rejects.toThrow("transcript unavailable");
+      expect(daemon.createTuiContext).not.toHaveBeenCalled();
+      expect(daemon.client.close).toHaveBeenCalledOnce();
+      expect(bootTUI).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("../tui/main.js");
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
   it("attach binds local TUI work to the daemon session runtime options", async () => {
     const tmpHome = await mkdtemp(join(tmpdir(), "agenc-bare-attach-home-"));
     const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-bare-attach-cwd-"));
@@ -3250,9 +3292,11 @@ describe("main() smoke", () => {
       runtimeOptions,
     });
     const observedBareMode: boolean[] = [];
+    const observedTranscript: unknown[] = [];
     vi.doMock("../tui/main.js", () => ({
-      bootTUI: vi.fn(async () => {
+      bootTUI: vi.fn(async (options: { session: { getInitialTranscriptEvents(): readonly unknown[] } }) => {
         observedBareMode.push(isBareMode());
+        observedTranscript.push(...options.session.getInitialTranscriptEvents());
         return {
           unmount: vi.fn(),
           waitUntilExit: async () => {
@@ -3286,6 +3330,10 @@ describe("main() smoke", () => {
         }),
       );
       expect(observedBareMode).toEqual([true, true]);
+      expect(observedTranscript).toEqual([
+        { id: "snapshot:test_epoch:prior_user", type: "user_message", payload: { message: "Earlier request" } },
+        { id: "snapshot:test_epoch:prior_assistant", type: "agent_message", payload: { message: "Earlier answer" } },
+      ]);
       await expect(
         attachAgentTuiEntry({
           agentId: "agent_bare_attach",

--- a/runtime/tests/commands/browser-open.test.ts
+++ b/runtime/tests/commands/browser-open.test.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn() }));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...await importOriginal<typeof import("node:child_process")>(),
+  spawn: mocks.spawn,
+}));
+
+import { openUrlInBrowser } from "../../src/commands/auth.js";
+
+describe("OAuth browser opener", () => {
+  let child: EventEmitter & { unref: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("DISPLAY", ":99");
+    child = Object.assign(new EventEmitter(), { unref: vi.fn() });
+    mocks.spawn.mockReset().mockReturnValue(child);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  test("waits for the launcher result instead of treating spawn as success", async () => {
+    let settled = false;
+    const opened = openUrlInBrowser("https://example.test/authorize").finally(() => {
+      settled = true;
+    });
+    child.emit("spawn");
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    child.emit("exit", 0, null);
+    await expect(opened).resolves.toBeUndefined();
+    expect(child.unref).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("reports an early nonzero exit without including the authorization URL", async () => {
+    const opened = openUrlInBrowser("https://example.test/authorize?state=private-state");
+    const rejected = expect(opened).rejects.toThrow(/exit code 3/);
+    child.emit("spawn");
+    child.emit("exit", 3, null);
+    await rejected;
+    await expect(opened).rejects.not.toThrow("private-state");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("reports signal termination", async () => {
+    const opened = openUrlInBrowser("https://example.test/authorize");
+    const rejected = expect(opened).rejects.toThrow(/signal SIGTERM/);
+    child.emit("spawn");
+    child.emit("exit", null, "SIGTERM");
+    await rejected;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("rejects a missing launcher", async () => {
+    const opened = openUrlInBrowser("https://example.test/authorize");
+    const rejected = expect(opened).rejects.toThrow(/Open the displayed sign-in URL manually/);
+    child.emit("error", new Error("spawn failed"));
+    await rejected;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("bounds waiting for a launcher that stays open", async () => {
+    const opened = openUrlInBrowser("https://example.test/authorize");
+    const rejected = expect(opened).rejects.toThrow(/did not confirm/);
+    child.emit("spawn");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejected;
+    expect(child.unref).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("passes one local desktop environment snapshot to the launcher", async () => {
+    vi.stubEnv("HOME", "/tmp/local-browser-home");
+    const opened = openUrlInBrowser("https://example.test/authorize");
+    vi.stubEnv("DISPLAY", ":changed");
+    vi.stubEnv("HOME", "/tmp/changed-browser-home");
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ DISPLAY: ":99", HOME: "/tmp/local-browser-home" }),
+      }),
+    );
+    child.emit("spawn");
+    child.emit("exit", 0, null);
+    await expect(opened).resolves.toBeUndefined();
+  });
+
+  test.runIf(process.platform === "linux")("uses manual opening when no desktop or browser is configured", async () => {
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+    vi.stubEnv("BROWSER", "");
+    await expect(openUrlInBrowser("https://example.test/authorize")).rejects.toThrow(/Open the displayed sign-in URL manually/);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  test.runIf(process.platform === "linux")("honors an explicitly configured browser without display variables", async () => {
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+    vi.stubEnv("BROWSER", "configured-browser");
+    const opened = openUrlInBrowser("https://example.test/authorize");
+    child.emit("spawn");
+    child.emit("exit", 0, null);
+    await expect(opened).resolves.toBeUndefined();
+    expect(mocks.spawn).toHaveBeenCalledOnce();
+  });
+});

--- a/runtime/tests/commands/xai-auth.test.ts
+++ b/runtime/tests/commands/xai-auth.test.ts
@@ -141,4 +141,26 @@ describe("xAI auth command authority", () => {
       expect(result.text).toContain("API key is also set");
     }
   });
+
+  test("keeps the authorization URL visible when the browser launcher fails", async () => {
+    const setToolJSX = vi.fn();
+    const context = commandContext(Object.freeze({}));
+    context.appState = { setToolJSX };
+    mocks.openUrlInBrowser.mockRejectedValueOnce(new Error("Browser launcher failed"));
+    mocks.runXaiBrowserLogin.mockImplementationOnce(async (options?: {
+      onAuthorizeUrl?: (url: string) => Promise<void>;
+    }) => {
+      await options?.onAuthorizeUrl?.("https://example.test/authorize");
+      const notices = JSON.stringify(setToolJSX.mock.calls);
+      expect(notices).toContain("Open this URL in your browser to sign in:");
+      expect(notices).toContain("https://example.test/authorize");
+      return {
+        identity: { sub: "xai-user" },
+        tokenEndpoint: "https://example.test/token",
+        tokens: { accessToken: "oauth-token" },
+      };
+    });
+    await expect(grokLoginCommand.execute(context)).resolves.toMatchObject({ kind: "text" });
+    expect(mocks.openUrlInBrowser).toHaveBeenCalledWith("https://example.test/authorize");
+  });
 });

--- a/runtime/tests/phases/continuation-nudge.offers.test.ts
+++ b/runtime/tests/phases/continuation-nudge.offers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { continuationNudge } from "../../src/phases/continuation-nudge.js";
+import { buildInitialTurnState } from "../../src/session/turn-state.js";
+import { mkCtx, mkSession } from "../fixtures.js";
+
+describe("continuation consent boundary", () => {
+  test.each([
+    "I'm AgenC, an autonomous coding agent for software engineering in this workspace.\n\nThis directory is essentially empty except for TASK.md: a notes CLI exercise. I can implement notes.mjs (add/list/show/delete, notes.json storage, black-box node:test tests, and a short README) if you want that next.",
+    "I can run the tests next if you'd like.",
+    "Would you like me to run the tests next?",
+    "If you want, I'll create the file.",
+    "Let me run the tests if you approve.",
+    "Let me know whether I should run the tests next.",
+    "Suggested next step: review the source and tests next.",
+    "I'll run the tests after you approve.",
+    "With your permission, I'll update the file.",
+    "I'll wait until you confirm, then I'll create the file.",
+    "Once you give me the go-ahead, I'll run the tests.",
+    "I'll update the file pending your approval.",
+    "I'll run the tests after your confirmation.",
+  ])("does not turn an offer or suggestion into execution: %s", async (text) => {
+    const ctx = mkCtx();
+    const state = buildInitialTurnState(ctx, { role: "user", content: "Inspect the directory and suggest one useful next step." });
+    state.assistantMessages = [{ uuid: "offer", role: "assistant", text, toolCalls: [] }];
+    const { session } = mkSession();
+
+    await continuationNudge(state, ctx, session);
+
+    expect(state.transition).toBeUndefined();
+    expect(state.continuationNudgeCount).toBe(0);
+    expect(state.messages).toHaveLength(1);
+  });
+
+  test.each([
+    "Now I'll create the file.",
+    "I'll run the tests next.",
+    "Let me verify the result. Now I'll run the tests.",
+    "Source/eval/shopt/tests incoming sequential tool calls.",
+  ])("retains an explicit execution continuation: %s", async (text) => {
+    const ctx = mkCtx();
+    const state = buildInitialTurnState(ctx, { role: "user", content: "Implement and test the feature." });
+    state.assistantMessages = [{ uuid: "execution", role: "assistant", text, toolCalls: [] }];
+    const { session } = mkSession();
+
+    await continuationNudge(state, ctx, session);
+
+    expect(state.transition?.reason).toBe("continuation_nudge");
+    expect(state.continuationNudgeCount).toBe(1);
+  });
+});

--- a/runtime/tests/phases/tool-runtime-deps.test.ts
+++ b/runtime/tests/phases/tool-runtime-deps.test.ts
@@ -4,8 +4,47 @@ import type { LLMToolCall } from "../llm/types.js";
 import type { ToolDispatchResult, ToolRegistry } from "../tool-registry.js";
 import type { PreToolUseHook } from "../tools/hooks.js";
 import type { Tool } from "../tools/types.js";
+import { mkCtx, mkSession } from "../fixtures.js";
 
 describe("phase tool-runtime dependency executor", () => {
+  test.each([false, true])("preserves resolver denial status and metadata when audit logging throws=%s", async (throwAudit) => {
+    let executed = 0;
+    const tool: Tool = {
+      name: "legacy_approval",
+      description: "approval-gated legacy tool",
+      inputSchema: { type: "object" },
+      requiresApproval: true,
+      execute: async () => {
+        executed += 1;
+        return { content: "must not execute" };
+      },
+    };
+    const registry: ToolRegistry = { tools: [tool], toLLMTools: () => [], dispatch: async () => tool.execute({}) };
+    const { session } = mkSession({ registry });
+    const executor = new StreamingToolExecutor({
+      registry,
+      liveToolDispatch: {
+        router: { registry },
+        options: {
+          session: { services: session.services },
+          turn: mkCtx(),
+          approvalPolicy: "on_request",
+          approvalResolver: { request: async () => ({ kind: "denied" }) },
+          permissionAuditLogger: async () => { if (throwAudit) throw new Error("audit failed"); },
+          onPermissionAuditError: () => {},
+        },
+      },
+    });
+    executor.addTool({}, { id: "denied-legacy", name: tool.name, arguments: "{}" });
+    executor.close();
+    const results: ToolDispatchResult[] = [];
+
+    for await (const completed of executor.getRemainingResults()) results.push(completed.result);
+
+    expect(executed).toBe(0);
+    expect(results).toEqual([expect.objectContaining({ isError: true, preventContinuation: true, metadata: { approvalDenied: true } })]);
+  });
+
   test("normalizes array-shaped parsed arguments before pre-hooks", async () => {
     let observedArgs: Record<string, unknown> | undefined;
     const preHook: PreToolUseHook = ({ args }) => {

--- a/runtime/tests/planning/todo-write-board-bridge.test.ts
+++ b/runtime/tests/planning/todo-write-board-bridge.test.ts
@@ -107,4 +107,20 @@ describe('TodoWrite → task board bridge', () => {
     const text = JSON.stringify(result)
     expect(text).toContain('Todos have been modified successfully')
   })
+
+  it.each([
+    { contents: ['Implement the CLI', 'Write the README', 'Clean up files'], needsVerification: true },
+    { contents: ['Implement the CLI', 'Write the README', 'Run the tests'], needsVerification: false },
+    { contents: ['Implement the CLI', 'Write the README', 'Verify the behavior'], needsVerification: false },
+  ])('keeps verification guidance compatible with a no-delegation task: $contents', async ({ contents, needsVerification }) => {
+    const tool = findTodoWrite()
+    const result = await withHomeAuthority(() => tool.execute({
+      todos: contents.map(content => ({ content, status: 'completed', activeForm: content })),
+    }))
+
+    expect(result.isError).not.toBe(true)
+    expect(result.metadata?.verificationNudgeNeeded).toBe(needsVerification)
+    expect(result.content).not.toMatch(/spawn|sentinel|delegate|only .*verdict/i)
+    if (needsVerification) expect(result.content).toContain('Verify the changes')
+  })
 })

--- a/runtime/tests/services/extractMemories/tool-history-batches.test.ts
+++ b/runtime/tests/services/extractMemories/tool-history-batches.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { LLMMessage } from "../../../src/llm/types.js";
+import { findToolTurnValidationIssue } from "../../../src/llm/tool-turn-validator.js";
+import { memoryExtractionVisibleRange } from "../../../src/memory/extraction-triggers.js";
+import { readMemoryExtractionState } from "../../../src/session/memory-extraction-state.js";
+import {
+  executeExtractMemories,
+  initExtractMemories,
+  type ExtractMemoriesChildRequest,
+} from "../../../src/services/extractMemories/extractMemories.js";
+import { mkCtx, mkSession } from "../../fixtures.js";
+
+function conversationWithParallelTools(visibleCount: number): LLMMessage[] {
+  return Array.from({ length: visibleCount }, (_, index): LLMMessage[] => {
+    if (index % 12 !== 11) {
+      return [{ role: index % 2 === 0 ? "user" : "assistant", content: `visible ${index}` }];
+    }
+    const calls = Array.from({ length: index === 11 ? 2 : 3 }, (_, parallel) => ({
+      id: `read-${index}-${parallel}`,
+      name: "FileRead",
+      arguments: JSON.stringify({ file_path: `/project/file-${parallel}.ts` }),
+    }));
+    return [{ role: "assistant", content: `Inspecting files at ${index}`, toolCalls: calls },
+      ...calls.toReversed().map((call): LLMMessage => ({
+        role: "tool",
+        toolCallId: call.id,
+        toolName: call.name,
+        content: `Observed contents for ${call.id}`,
+      })),
+    ];
+  }).flat();
+}
+
+describe("memory extraction tool history", () => {
+  let root = "";
+  let memoryDir = "";
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-memory-tool-history-"));
+    memoryDir = join(root, "memory");
+    await mkdir(memoryDir);
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("retains complete parallel results at the twelfth visible-message boundary", () => {
+    const messages = conversationWithParallelTools(26);
+    expect(findToolTurnValidationIssue(messages)).toBeNull();
+    const range = memoryExtractionVisibleRange(messages, 0, 12);
+    expect(findToolTurnValidationIssue(range.unprocessedMessages)).toBeNull();
+    expect(range.unprocessedMessages).toEqual(messages.slice(0, 14));
+    expect(range.currentVisibleCount).toBe(26);
+    expect(range.unprocessedVisibleCount).toBe(12);
+  });
+
+  test("resumes legacy visible-message cursors without orphaning or replaying results", () => {
+    const messages = conversationWithParallelTools(26);
+    const range = memoryExtractionVisibleRange(messages, 12, 12);
+    expect(findToolTurnValidationIssue(range.unprocessedMessages)).toBeNull();
+    expect(range.unprocessedMessages).toEqual(messages.slice(14, 29));
+    expect(range.unprocessedVisibleCount).toBe(12);
+    const compacted = memoryExtractionVisibleRange(messages.slice(14), 99, 12);
+    expect(findToolTurnValidationIssue(compacted.unprocessedMessages)).toBeNull();
+    expect(compacted.unprocessedMessages).toEqual(messages.slice(14, 29));
+    expect(compacted.currentVisibleCount).toBe(14);
+  });
+
+  test("batches and persisted cursor survive lane reinitialization without losing tool outcomes", async () => {
+    const { session } = mkSession();
+    const messages = conversationWithParallelTools(26);
+    const runChild = vi.fn(async (request: ExtractMemoriesChildRequest) => {
+      expect(findToolTurnValidationIssue(request.messages)).toBeNull();
+      return { outcome: "completed" as const };
+    });
+    const dependencies = {
+      env: {}, minEligibleTurns: 1, runChild,
+      resolveMemoryDirectory: async () => ({ enabled: true as const, path: memoryDir }),
+    };
+    const context = { session, messages, completedToolResults: [], ctx: mkCtx({ cwd: root }) };
+    for (const cursor of [12, 24, 26]) {
+      initExtractMemories(dependencies);
+      await executeExtractMemories(context);
+      expect((await readMemoryExtractionState(session, memoryDir))?.processedVisibleCount).toBe(cursor);
+    }
+    expect(runChild.mock.calls.map(([request]) => request.messages.length)).toEqual([14, 15, 2]);
+    expect(runChild.mock.calls.flatMap(([request]) => request.messages)).toEqual(messages);
+    await executeExtractMemories(context);
+    expect(runChild).toHaveBeenCalledTimes(3);
+  });
+
+  test("retries then drops the same complete failed batch without consuming the next exchange", async () => {
+    const { session } = mkSession();
+    const messages = conversationWithParallelTools(26);
+    const runChild = vi.fn(async (request: ExtractMemoriesChildRequest) => {
+      expect(findToolTurnValidationIssue(request.messages)).toBeNull();
+      return { outcome: "errored" as const, error: new Error("temporary child failure") };
+    });
+    initExtractMemories({
+      env: {}, minEligibleTurns: 1, runChild,
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+    });
+    const context = { session, messages, completedToolResults: [], ctx: mkCtx({ cwd: root }) };
+    await executeExtractMemories(context);
+    expect((await readMemoryExtractionState(session, memoryDir))?.processedVisibleCount).toBe(0);
+    await executeExtractMemories(context);
+    expect((await readMemoryExtractionState(session, memoryDir))?.processedVisibleCount).toBe(12);
+    await executeExtractMemories(context);
+    expect(runChild.mock.calls.map(([request]) => request.messages)).toEqual([
+      messages.slice(0, 14), messages.slice(0, 14), messages.slice(14, 29),
+    ]);
+  });
+});

--- a/runtime/tests/session/run-turn.workflow-regressions.test.ts
+++ b/runtime/tests/session/run-turn.workflow-regressions.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, vi } from "vitest";
+import { classifyTurnTerminal } from "../../src/contracts/turn-terminal.js";
+import { findToolTurnValidationIssue } from "../../src/llm/tool-turn-validator.js";
+import type { PhaseEvent } from "../../src/phases/events.js";
+import { runTurn } from "../../src/session/run-turn.js";
+import type { ToolRegistry } from "../../src/tool-registry.js";
+import type { Tool } from "../../src/tools/types.js";
+import { drain, mkCtx, mkProvider, mkSession } from "../fixtures.js";
+
+function registryFor(tool: Tool): ToolRegistry {
+  return {
+    tools: [tool],
+    toLLMTools: () => [{
+      type: "function",
+      function: { name: tool.name, description: tool.description, parameters: tool.inputSchema },
+    }],
+    dispatch: async () => ({ content: "unexpected legacy dispatch", isError: true }),
+  } as ToolRegistry;
+}
+
+describe("workflow turn boundaries", () => {
+  test("ends an inspection turn after its conditional offer without executing the proposed work", async () => {
+    const execute = vi.fn(async () => ({ content: "must not write" }));
+    const registry = registryFor({ name: "write_notes", description: "Write the notes CLI", inputSchema: { type: "object" }, execute });
+    const provider = mkProvider();
+    let samples = 0;
+    provider.chatStream = async () => {
+      samples += 1;
+      return {
+        content: samples === 1 ? "I can implement the notes CLI, tests, and README if you want that next." : "Created the notes CLI.",
+        toolCalls: samples === 2 ? [{ id: "unrequested-write", name: "write_notes", arguments: "{}" }] : [],
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+        model: "test-model",
+        finishReason: samples === 2 ? "tool_calls" : "stop",
+      };
+    };
+    const { session, events } = mkSession({ provider, registry });
+
+    await drain(runTurn(session, mkCtx(), "Inspect this directory and suggest a useful next step."));
+
+    expect(samples).toBe(1);
+    expect(execute).not.toHaveBeenCalled();
+    expect(events.filter((event) => event.msg.type === "turn_complete")).toHaveLength(1);
+  });
+
+  test("fails a resolver-denied action with truthful text while keeping the session reusable", async () => {
+    const execute = vi.fn(async () => ({ content: "must not execute" }));
+    const registry = registryFor({ name: "spawn_agent", description: "Spawn a verifier", inputSchema: { type: "object" }, requiresApproval: true, execute });
+    const provider = mkProvider({
+      content: "I'll have a verification agent check the implementation.",
+      toolCalls: [{ id: "denied-spawn", name: "spawn_agent", arguments: "{}" }],
+      finishReason: "tool_calls",
+    });
+    const sample = vi.fn(provider.chatStream);
+    provider.chatStream = sample;
+    const request = vi.fn(async () => ({ kind: "denied" as const }));
+    const stop = vi.fn(async () => ({}));
+    const { session, events } = mkSession({
+      provider,
+      registry,
+      services: { approvalResolver: { request }, hooks: { executeStop: stop } },
+    });
+    const ctx = mkCtx({ approvalPolicy: { value: "on_request" }, sandboxPolicy: { value: "workspace_write" } });
+    const phases: PhaseEvent[] = [];
+
+    for await (const phase of runTurn(session, ctx, "Check the implementation.")) phases.push(phase);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(sample).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+    expect(events.flatMap((event) => {
+      const terminal = classifyTurnTerminal(event.msg);
+      return terminal === undefined ? [] : [terminal];
+    })).toEqual([expect.objectContaining({ outcome: "errored", code: 1, message: expect.stringMatching(/approval.*denied/i) })]);
+    const closures = events.filter((event) => event.msg.type === "tool_call_completed" && event.msg.payload.callId === "denied-spawn");
+    expect(closures).toHaveLength(1);
+    expect(closures[0]?.msg).toMatchObject({ payload: { isError: true, metadata: { approvalDenied: true } } });
+    expect(events.indexOf(closures[0]!)).toBeLessThan(events.findIndex((event) => event.msg.type === "turn_failed"));
+    expect(phases.at(-1)).toMatchObject({ type: "turn_complete", stopReason: "error", content: expect.stringMatching(/approval.*denied/i) });
+    expect(session.snapshotHistoryMessages().at(-1)).toMatchObject({ role: "assistant", content: expect.stringMatching(/approval.*denied/i) });
+    expect(findToolTurnValidationIssue(session.snapshotHistoryMessages())).toBeNull();
+    expect(session.abortController.signal.aborted).toBe(false);
+
+    provider.chatStream = mkProvider({ content: "Finished the allowed follow-up." }).chatStream;
+    const previousEvents = events.length;
+    await drain(runTurn(session, { ...ctx, subId: "allowed-followup" }, "Explain the code instead."));
+    expect(events.slice(previousEvents).map((event) => classifyTurnTerminal(event.msg)))
+      .toContainEqual(expect.objectContaining({ outcome: "completed", code: 0 }));
+  });
+
+  test("lets the model explain an unavailable approval resolver rather than marking a user denial", async () => {
+    const execute = vi.fn(async () => ({ content: "must not execute" }));
+    const registry = registryFor({ name: "approval_required", description: "Requires approval", inputSchema: { type: "object" }, requiresApproval: true, execute });
+    const provider = mkProvider();
+    let samples = 0;
+    provider.chatStream = async () => {
+      samples += 1;
+      return {
+        content: samples === 1 ? "Checking whether this action is permitted." : "No approval resolver is available, so I made no changes.",
+        toolCalls: samples === 1 ? [{ id: "default-denial", name: "approval_required", arguments: "{}" }] : [],
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+        model: "test-model",
+        finishReason: samples === 1 ? "tool_calls" : "stop",
+      };
+    };
+    const { session, events } = mkSession({ provider, registry });
+
+    await drain(runTurn(session, mkCtx({ approvalPolicy: { value: "on_request" }, sandboxPolicy: { value: "workspace_write" } }), "Explain whether this action can run."));
+
+    expect(samples).toBe(2);
+    expect(execute).not.toHaveBeenCalled();
+    const closure = events.find((event) => event.msg.type === "tool_call_completed" && event.msg.payload.callId === "default-denial");
+    expect(closure?.msg).toMatchObject({ payload: { isError: true } });
+    if (closure?.msg.type === "tool_call_completed") expect(closure.msg.payload.metadata?.approvalDenied).toBeUndefined();
+    expect(events.some((event) => event.msg.type === "turn_failed")).toBe(false);
+    expect(events.map((event) => classifyTurnTerminal(event.msg)))
+      .toContainEqual(expect.objectContaining({ outcome: "completed", message: "No approval resolver is available, so I made no changes." }));
+  });
+});

--- a/runtime/tests/tool-registry.test.ts
+++ b/runtime/tests/tool-registry.test.ts
@@ -1648,7 +1648,7 @@ describe("tool-registry dynamic and deferred catalog", () => {
     expect(emittedPlans).toHaveLength(1);
   });
 
-  test("TodoWrite adds the verification-agent nudge when closing 3+ tasks without verification", async () => {
+  test("TodoWrite does not demand delegation after completed verification tasks", async () => {
     const emittedPlans: unknown[] = [];
     const registry = buildToolRegistry({
       workspaceRoot: "/tmp",
@@ -1684,10 +1684,8 @@ describe("tool-registry dynamic and deferred catalog", () => {
     });
 
     expect(result.isError).toBeUndefined();
-    expect(result.content).toContain(
-      'spawn the sentinel agent (agent_type="sentinel")',
-    );
-    expect(result.metadata).toMatchObject({ verificationNudgeNeeded: true });
+    expect(result.content).not.toMatch(/spawn|sentinel|delegate/i);
+    expect(result.metadata).toMatchObject({ verificationNudgeNeeded: false });
     expect(emittedPlans).toHaveLength(1);
     expect(emittedPlans[0]).toMatchObject({
       todos: [],

--- a/runtime/tests/tools/orchestrator.test.ts
+++ b/runtime/tests/tools/orchestrator.test.ts
@@ -848,6 +848,43 @@ describe("orchestrateToolCall lifecycle (orchestrator behavior)", () => {
     expect(ran).toBe(1);
   });
 
+  test("preserves the permission evaluator reason for a forced approval", async () => {
+    const request = vi.fn(async () => ({ kind: "denied" as const }));
+    const dispatch = vi.fn(async () => "unexpected");
+    await expect(orchestrateToolCall({
+      tool: mkTool({ name: "spawn_agent", requiresApproval: true }),
+      approvalCtx: {
+        ...mkCtx(),
+        toolName: "spawn_agent",
+        retryReason: "Permission to use spawn_agent is required",
+      },
+      approvalPolicy: "untrusted",
+      sandboxMode: "workspace_write",
+      dispatch,
+      approvalResolver: { request },
+    })).rejects.toBeInstanceOf(ApprovalRejectedError);
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      retryReason: "Permission to use spawn_agent is required",
+    }));
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("keeps sandbox escalation reasons ahead of a permission evaluator reason", async () => {
+    const request = vi.fn(async () => ({ kind: "denied" as const }));
+    await expect(orchestrateToolCall({
+      tool: mkTool(),
+      approvalCtx: { ...mkCtx(), retryReason: "Tool requires approval" },
+      approvalPolicy: "untrusted",
+      sandboxMode: "workspace_write",
+      approvalArgs: { sandbox_permissions: "require_escalated" },
+      dispatch: async () => "unexpected",
+      approvalResolver: { request },
+    })).rejects.toBeInstanceOf(ApprovalRejectedError);
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      retryReason: expect.stringContaining("sandbox"),
+    }));
+  });
+
   test("sandbox_permissions=require_escalated: approval drives first attempt with sandbox off", async () => {
     const dispatches: string[] = [];
     const result = await orchestrateToolCall<string>({

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -811,6 +811,19 @@ describe("AgenC TUI daemon session adapter", () => {
           runtimeSettingsEventId: "settings:agent_1:initial",
         } as never;
       }
+      if (method === "session.transcript.v2") {
+        return {
+          schemaVersion: 2,
+          sessionId: "session_1",
+          runId: "agent_runtime",
+          historyEpoch: "epoch_1",
+          asOfSequence: 20,
+          messages: [
+            { messageId: "user_1", commitEventId: "event:1", role: "user", text: "Build a notes CLI", committedSequence: 1 },
+            { messageId: "assistant_1", commitEventId: "event:19", role: "assistant", text: "The notes CLI passes its tests", committedSequence: 19 },
+          ],
+        } as never;
+      }
       return {} as never;
     };
 
@@ -835,11 +848,16 @@ describe("AgenC TUI daemon session adapter", () => {
     unsubscribe();
 
     expect(session.conversationId).toBe("agent_runtime");
+    expect(session.getInitialTranscriptEvents()).toEqual([
+      { id: "snapshot:epoch_1:user_1", type: "user_message", payload: { message: "Build a notes CLI" } },
+      { id: "snapshot:epoch_1:assistant_1", type: "agent_message", payload: { message: "The notes CLI passes its tests" } },
+    ]);
     expect(client.requests).toEqual([
       {
         method: "agent.attach",
         params: { agentId: "agent_1", clientId: "tui_1" },
       },
+      { method: "session.transcript.v2", params: { sessionId: "session_1" } },
     ]);
     expect(received).toEqual([{ type: "turn_delta", id: "turn_1" }]);
   });

--- a/runtime/tests/tui/daemon-transcript-snapshot.test.ts
+++ b/runtime/tests/tui/daemon-transcript-snapshot.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { JsonObject, SessionTranscriptV2Result } from "../../src/app-server/protocol/index.js";
+import {
+  daemonTranscriptSnapshotCoversEvent,
+  daemonTranscriptSnapshotEvents,
+} from "../../src/tui/daemon-transcript-snapshot.js";
+import { adaptTranscriptEvents } from "../../src/tui/session-transcript.js";
+
+function snapshot(overrides: Partial<SessionTranscriptV2Result> = {}): SessionTranscriptV2Result {
+  return {
+    schemaVersion: 2,
+    sessionId: "session_1",
+    runId: "run_1",
+    historyEpoch: "epoch_1",
+    asOfSequence: 12,
+    messages: [
+      { messageId: "user_1", commitEventId: "event:1", role: "user", text: "Build notes", turnId: "turn_1", committedSequence: 1 },
+      { messageId: "assistant_1", commitEventId: "event:10", role: "assistant", text: "Notes are ready", turnId: "turn_1", committedSequence: 10 },
+    ],
+    ...overrides,
+  };
+}
+
+function notification(sequence: number, type: string, turnId = "turn_1"): JsonObject {
+  return {
+    method: "event.session_event",
+    params: {
+      sessionId: "session_1",
+      runId: "run_1",
+      sequence,
+      turnId,
+      event: { type, payload: { turnId } },
+    },
+  };
+}
+
+function covers(state: SessionTranscriptV2Result, sequence: number, type: string, turnId?: string): boolean {
+  return daemonTranscriptSnapshotCoversEvent(state, notification(sequence, type, turnId), {
+    type,
+    payload: { turnId: turnId ?? "turn_1" },
+  });
+}
+
+describe("daemon transcript snapshot", () => {
+  it("restores visible messages without leaving an idle session streaming", () => {
+    const events = daemonTranscriptSnapshotEvents(snapshot(), "session_1");
+    const transcript = adaptTranscriptEvents(events);
+    expect(transcript.messages).toHaveLength(2);
+    expect(JSON.stringify(transcript.messages)).toContain("Build notes");
+    expect(JSON.stringify(transcript.messages)).toContain("Notes are ready");
+    expect(transcript.isStreaming).toBe(false);
+  });
+
+  it("does not collapse migrated messages that share a sequence", () => {
+    const state = snapshot();
+    const events = daemonTranscriptSnapshotEvents({
+      ...state,
+      messages: state.messages.map((message) => ({ ...message, committedSequence: 0 })),
+    }, "session_1");
+    expect(adaptTranscriptEvents(events).messages).toHaveLength(2);
+  });
+
+  it("rejects an invalid or cross-session snapshot", () => {
+    expect(() => daemonTranscriptSnapshotEvents(snapshot(), "other")).toThrow(/invalid transcript snapshot/u);
+    expect(() => daemonTranscriptSnapshotEvents(snapshot({ asOfSequence: -1 }), "session_1")).toThrow();
+    expect(() => daemonTranscriptSnapshotEvents(snapshot({ messages: [{ role: "tool" } as never] }), "session_1")).toThrow(/invalid transcript message/u);
+  });
+
+  it("drops covered replay messages and closed lifecycle events, not newer events", () => {
+    for (const type of ["user_message", "agent_message", "agent_message_delta", "turn_started", "turn_complete", "request_permissions"]) {
+      expect(covers(snapshot(), 10, type)).toBe(true);
+      expect(covers(snapshot(), 13, type)).toBe(false);
+    }
+  });
+
+  it("never drops runtime-settings authority events", () => {
+    expect(covers(snapshot(), 2, "run_runtime_settings_changed")).toBe(false);
+    expect(covers(snapshot(), 2, "runtime_settings_authority_gap")).toBe(false);
+  });
+
+  it("keeps active tools, approvals, and uncommitted deltas while deduplicating committed text", () => {
+    const active = snapshot({ activeTurn: { turnId: "turn_1" } });
+    expect(adaptTranscriptEvents(daemonTranscriptSnapshotEvents(active, "session_1")).isStreaming).toBe(true);
+    expect(covers(active, 1, "user_message")).toBe(true);
+    expect(covers(active, 2, "turn_started")).toBe(true);
+    expect(covers(active, 9, "agent_message_delta")).toBe(true);
+    expect(covers(active, 10, "agent_message")).toBe(true);
+    expect(covers(active, 11, "agent_message_delta")).toBe(false);
+    expect(covers(active, 11, "request_permissions")).toBe(false);
+    expect(covers(active, 11, "tool_call_started")).toBe(false);
+  });
+
+  it("keeps unsequenced notifications and events from another run", () => {
+    expect(daemonTranscriptSnapshotCoversEvent(snapshot(), {}, { type: "warning" })).toBe(false);
+    expect(daemonTranscriptSnapshotCoversEvent(snapshot(), {
+      params: { runId: "other", sequence: 1 },
+    }, { type: "user_message" })).toBe(false);
+  });
+
+  it("does not repeat an active turn answer when its terminal arrives after attach", () => {
+    const events = daemonTranscriptSnapshotEvents(snapshot({ activeTurn: { turnId: "turn_1" } }), "session_1");
+    const transcript = adaptTranscriptEvents([
+      ...events,
+      { id: "event:13", type: "turn_complete", payload: { turnId: "turn_1", lastAgentMessage: "Notes are ready" } },
+    ]);
+    expect(transcript.messages).toHaveLength(2);
+    expect(transcript.isStreaming).toBe(false);
+  });
+});

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -365,4 +365,69 @@ describe("permission request overlay coverage", () => {
       await sleep();
     }
   });
+
+  test("keeps verification prose out of destructive action classification", async () => {
+    const resolved: ReviewDecision[] = [];
+    const base = createPendingRequest((decision) => resolved.push(decision), {
+      input: {
+        task_name: "verify_notes",
+        message: "Verify notes CLI add/list/show/delete and its storage format. Do not delete project files.",
+        agent_type: "verification",
+      },
+      description: "Permission to use spawn_agent is required",
+    });
+    const request = { ...base, ctx: { ...base.ctx, toolName: "spawn_agent" } };
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    try {
+      root.render(<AgenCPermissionOverlay request={request} tools={[{ name: "spawn_agent" }]} />);
+      await sleep();
+      const frame = stripAnsi(extractLastFrame(output())).replace(/\s+/gu, "");
+      expect(frame).not.toContain("high-riskapproval");
+      expect(frame).not.toContain("type'delete'");
+      expect(resolved).toEqual([]);
+      stdin.write("3");
+      await sleep();
+      expect(resolved).toEqual([DENIED]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("requires typed confirmation for destructive interactive stdin", async () => {
+    const resolved: ReviewDecision[] = [];
+    const base = createPendingRequest((decision) => resolved.push(decision), {
+      input: { session_id: 1, chars: "rm -rf /tmp/agenc-danger\n" },
+      description: "Send input to an interactive command",
+    });
+    const request = { ...base, ctx: { ...base.ctx, toolName: "write_stdin" } };
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    try {
+      root.render(<AgenCPermissionOverlay request={request} tools={[{ name: "write_stdin" }]} />);
+      await sleep();
+      const frame = stripAnsi(extractLastFrame(output())).replace(/\s+/gu, "");
+      expect(frame).toContain("high-riskapproval");
+      expect(frame).toContain("type'delete'toapprove");
+      stdin.write("\r");
+      await sleep();
+      expect(resolved).toEqual([]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
 });

--- a/runtime/tests/tui/workbench/risk.test.ts
+++ b/runtime/tests/tui/workbench/risk.test.ts
@@ -29,4 +29,61 @@ describe("approval risk helpers", () => {
     expect(typedConfirmationWordForRisk({ risk: "destructive", command: `bash {"script":"rm -rf /tmp/project"}` })).toBe("delete");
     expect(typedConfirmationWordForRisk({ risk: "medium", command: "npm install" })).toBe("yes");
   });
+
+  it.each([
+    ["spawn_agent", { message: "Verify the notes CLI delete command and storage format. Try rm -rf only in disposable test data." }],
+    ["TodoWrite", { todos: [{ content: "Test delete and transfer command formatting", status: "completed" }] }],
+    ["Write", { file_path: "README.md", content: "Example: delete a note with rm -rf" }],
+  ])("does not treat %s prose as an executable action", (toolName, toolInput) => {
+    expect(classifyApprovalRisk({
+      toolName,
+      description: "Tool requires approval",
+      command: JSON.stringify(toolInput),
+      toolInput,
+    })).not.toBe("destructive");
+  });
+
+  it.each([
+    ["exec_command", { cmd: "rm -rf /tmp/project" }],
+    ["Bash", { command: ["rm", "-rf"], args: ["/tmp/project"] }],
+    ["write_stdin", { session_id: 1, chars: "rm -rf /tmp/project\n" }],
+    ["resource", { action: "delete", id: "note-1" }],
+    ["transfer_tokens", { amount: 1, destination: "example" }],
+  ])("retains destructive classification for actionable %s input", (toolName, toolInput) => {
+    expect(classifyApprovalRisk({ toolName, toolInput })).toBe("destructive");
+  });
+
+  it("requires delete confirmation for destructive interactive stdin", () => {
+    const toolInput = { session_id: 1, chars: "rm -rf /tmp/project\n" };
+    const risk = classifyApprovalRisk({ request: { ctx: { toolName: "write_stdin" } }, toolInput });
+    expect(risk).toBe("destructive");
+    expect(typedConfirmationWordForRisk({ risk, toolName: "write_stdin", toolInput })).toBe("delete");
+  });
+
+  it.each([
+    ["mcp.database.execute", { query: "DELETE FROM notes WHERE id = 1" }],
+    ["mcp.database.execute", { sql: "DELETE FROM notes WHERE id = 1" }],
+    ["mcp.database.execute", { batch: [{ statement: { sql: "DELETE FROM notes" } }] }],
+    ["mcp.shell.execute", { commands: [{ command: "rm -rf /tmp/project" }] }],
+    ["mcp.shell.execute", [{ command: "rm -rf /tmp/project" }]],
+    ["mcp.remote.Write", { content: "DELETE FROM notes" }],
+    ["mcp.remote.spawn_agent", { message: "delete notes" }],
+    ["unknown_tool", { payload: { instructions: "delete notes" } }],
+    [undefined, { sql: "DELETE FROM notes" }],
+  ])("preserves conservative destructive checks for unknown %s payloads", (toolName, toolInput) => {
+    const risk = classifyApprovalRisk({ toolName, toolInput });
+    expect(risk).toBe("destructive");
+    expect(typedConfirmationWordForRisk({ risk, toolName, toolInput })).toBe("delete");
+  });
+
+  it("keeps notebook cell deletion destructive while treating source as data", () => {
+    expect(classifyApprovalRisk({
+      toolName: "NotebookEdit",
+      toolInput: { edit_mode: "replace", new_source: "delete a note" },
+    })).not.toBe("destructive");
+    expect(classifyApprovalRisk({
+      toolName: "NotebookEdit",
+      toolInput: { edit_mode: "delete", cell_id: "cell-1" },
+    })).toBe("destructive");
+  });
 });


### PR DESCRIPTION
## Fixes

- Report browser-launch failures and offer manual login instructions instead of claiming the browser opened.
- Keep conditional suggestions from starting unrequested execution.
- Remove mandatory sentinel delegation from TodoWrite completion reminders and respect user constraints.
- Classify known tool actions without treating worker prompt text as a destructive command. Keep conservative checks for unknown and MCP tools, shell input, and action fields.
- Preserve approval-denial metadata and reasons, stop denied delegation, and report failure instead of a stale completion claim.
- Keep tool calls and results together during memory extraction without changing persisted cursor semantics.
- Restore transcript history in the public `--resume` path and daemon TUI attachment, including active-turn replay ordering and failed-attach cleanup.

## Verification

- Runtime and test-support typechecks pass. Production build, package entrypoint checks, and generated SDK checks pass.
- Targeted regression and adjacent suites pass, with failing-before-fix checks for all seven issues.
- Built TUI import and PTY startup checks pass at three viewport sizes in normal and bypass modes.
- Frozen full suite at `d83bfbc610cda660d365e4833cbe898b2225b8cb` reports 24,627 passing tests and six failures. All six reproduce on clean, unchanged main `a3b5c878cf44e35ca73674f3194cde172a6815f5` in the same hermetic container.
- Existing failures cover the live-test discovery allowlist, agent CLI `localMcpAccess` expectation, daemon CLI `readOnly` expectation, home-state authority boundary, FND package evidence hash, and permission compatibility-import boundary. The agent-surface contract also stops at the same existing agent CLI expectation. No unrelated fixes are included.
- Real Grok OAuth testing in an isolated TMP workspace confirms restored resume history and a read-only suggestion without edits or delegation. A shell-test attempt fails closed on a host sandbox capability check; it is not counted as successful command execution.
- Independent reviews cover auth, risk classification, denial handling, continuation, memory extraction, and resume. GitNexus comparison reports only the expected 31 files and eight affected turn execution flows.

## Operations

- No breaking interface changes or state migration.
- Automatic CI workflows remain disabled. No hosted jobs were dispatched and no release was published.
- Merge manually with squash after review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval denial handling, permission risk heuristics, turn continuation logic, and daemon attach transcript restoration—user-visible behavior changes with broad test coverage but no migrations.
> 
> **Overview**
> Fixes several Grok/workflow regressions across auth, turn boundaries, permissions, memory, and daemon attach.
> 
> **OAuth browser opening** now goes through shared `openLocalBrowser`: Linux without `DISPLAY`/`WAYLAND`/`BROWSER` fails with a manual sign-in prompt; launchers must exit successfully within five seconds or the user is told to open the URL manually. Auth commands use this instead of inline spawn logic; env docs call out desktop discovery vars.
> 
> **Daemon TUI attach / resume** fetches `session.transcript.v2` before spinning up local TUI resources, hydrates initial transcript events (including active-turn state), and skips live events already covered by the snapshot so history does not duplicate. Invalid or failed snapshots abort attach without allocating the TUI.
> 
> **Turn workflow:** continuation nudges ignore consent/offers (“if you want…”) so inspection turns do not auto-execute proposed work; resolver **approval denials** tag tool results with `approvalDenied` metadata and end the turn with an explicit error message instead of a silent or completed stop; approval UI reasons prefer permission-evaluator text unless sandbox escalation applies.
> 
> **Risk classification** derives destructive/medium signals from structured `toolInput` (shell stdin, action fields, MCP payloads) while avoiding false positives from verification prose in `spawn_agent`, `TodoWrite`, `Write`, etc. **TodoWrite** completion reminders no longer mandate spawning a sentinel agent— they nudge user-constrained verification instead.
> 
> **Memory extraction** batches by user/assistant “visible” cursor but slices raw messages so parallel tool calls and results stay intact at batch boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d83bfbc610cda660d365e4833cbe898b2225b8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->