### PR TITLE
fix(runtime): repair Grok approval and resume workflows

### DIFF
--- a/packages/agenc-sdk/src/protocol-wire.generated.ts
+++ b/packages/agenc-sdk/src/protocol-wire.generated.ts
@@ -1619,6 +1619,27 @@ export interface SessionTranscriptV2TurnResult extends JsonObject {
     readonly provider?: string;
 }
 
+export interface SessionTranscriptV2Event extends JsonObject {
+    readonly eventId: string;
+    readonly committedSequence: number;
+    readonly type: "token_count" | "turn_failed" | "turn_aborted";
+    readonly payload: {
+        readonly promptTokens?: number;
+        readonly completionTokens?: number;
+        readonly totalTokens?: number;
+        readonly cachedInputTokens?: number;
+        readonly cacheCreationInputTokens?: number;
+        readonly reasoningOutputTokens?: number;
+        readonly webSearchRequests?: number;
+        readonly model?: string;
+        readonly provider?: string;
+        readonly turnId?: string;
+        readonly code?: string;
+        readonly message?: string;
+        readonly reason?: string;
+    };
+}
+
 export interface SessionTranscriptV2Result extends JsonObject {
     readonly schemaVersion: 2;
     readonly sessionId: string;
@@ -1628,6 +1649,7 @@ export interface SessionTranscriptV2Result extends JsonObject {
     readonly messages: readonly SessionTranscriptV2Message[];
     readonly activeTurn?: SessionTranscriptV2ActiveTurn;
     readonly turnResults?: readonly SessionTranscriptV2TurnResult[];
+    readonly events?: readonly SessionTranscriptV2Event[];
 }
 
 export interface SessionCancelTurnResult extends JsonObject {

--- a/packages/agenc-sdk/src/transcript-v2.generated.ts
+++ b/packages/agenc-sdk/src/transcript-v2.generated.ts
@@ -40,6 +40,27 @@ export interface SessionTranscriptV2TurnResult extends TranscriptV2JsonObject {
   readonly provider?: string;
 }
 
+export interface SessionTranscriptV2Event extends TranscriptV2JsonObject {
+  readonly eventId: string;
+  readonly committedSequence: number;
+  readonly type: "token_count" | "turn_failed" | "turn_aborted";
+  readonly payload: {
+    readonly promptTokens?: number;
+    readonly completionTokens?: number;
+    readonly totalTokens?: number;
+    readonly cachedInputTokens?: number;
+    readonly cacheCreationInputTokens?: number;
+    readonly reasoningOutputTokens?: number;
+    readonly webSearchRequests?: number;
+    readonly model?: string;
+    readonly provider?: string;
+    readonly turnId?: string;
+    readonly code?: string;
+    readonly message?: string;
+    readonly reason?: string;
+  };
+}
+
 export interface SessionTranscriptV2Result extends TranscriptV2JsonObject {
   readonly schemaVersion: 2;
   readonly sessionId: string;
@@ -49,4 +70,5 @@ export interface SessionTranscriptV2Result extends TranscriptV2JsonObject {
   readonly messages: readonly SessionTranscriptV2Message[];
   readonly activeTurn?: SessionTranscriptV2ActiveTurn;
   readonly turnResults?: readonly SessionTranscriptV2TurnResult[];
+  readonly events?: readonly SessionTranscriptV2Event[];
 }

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -66,6 +66,7 @@ const transcriptV2InterfaceNames = [
   "SessionTranscriptV2Message",
   "SessionTranscriptV2ActiveTurn",
   "SessionTranscriptV2TurnResult",
+  "SessionTranscriptV2Event",
   "SessionTranscriptV2Result",
 ];
 

--- a/runtime/src/agents/child-approval-context.ts
+++ b/runtime/src/agents/child-approval-context.ts
@@ -1,0 +1,76 @@
+import type { Session } from "../session/session.js";
+
+type ChildApprovalObserver = (child: Session) => () => void;
+
+interface ChildApprovalOwnership {
+  readonly parent: Session;
+  readonly cancellation: AbortController;
+}
+
+const approvalParents = new WeakMap<Session, ChildApprovalOwnership>();
+const approvalObservers = new WeakMap<Session, Set<ChildApprovalObserver>>();
+
+export function isApprovalSessionOwnedBy(session: Session, owner: Session): boolean {
+  let current: Session | undefined = session;
+  while (current !== undefined) {
+    if (current === owner) return true;
+    const ownership = approvalParents.get(current);
+    if (ownership?.cancellation.signal.aborted) return false;
+    current = ownership?.parent;
+  }
+  return false;
+}
+
+export function observeChildApprovalSessions(
+  parent: Session,
+  observer: ChildApprovalObserver,
+): () => void {
+  let observers = approvalObservers.get(parent);
+  if (observers === undefined) {
+    observers = new Set();
+    approvalObservers.set(parent, observers);
+  }
+  observers.add(observer);
+  return () => {
+    observers.delete(observer);
+    if (observers.size === 0) approvalObservers.delete(parent);
+  };
+}
+
+export function registerChildApprovalSession(child: Session, parent: Session): void {
+  if (approvalParents.has(child) || isApprovalSessionOwnedBy(parent, child)) {
+    throw new Error("Child approval ownership is already assigned or cyclic");
+  }
+  const cancellation = new AbortController();
+  const revoke = () => cancellation.abort("child approval ownership revoked");
+  const parentSignal = approvalParents.get(parent)?.cancellation.signal ?? parent.abortController.signal;
+  const childSignal = child.abortController.signal;
+  parentSignal.addEventListener("abort", revoke, { once: true });
+  childSignal.addEventListener("abort", revoke, { once: true });
+  const cleanups: Array<() => void> = [];
+  const unregisterClose = child.onBeforeDurableClose(() => {
+    revoke();
+    approvalParents.delete(child);
+    parentSignal.removeEventListener("abort", revoke);
+    childSignal.removeEventListener("abort", revoke);
+    for (const cleanup of cleanups) cleanup();
+    unregisterClose();
+  });
+  approvalParents.set(child, { parent, cancellation });
+  if (parentSignal.aborted || childSignal.aborted) revoke();
+  let ancestor: Session | undefined = parent;
+  while (ancestor !== undefined) {
+    for (const observer of approvalObservers.get(ancestor) ?? []) {
+      cleanups.push(observer(child));
+    }
+    ancestor = approvalParents.get(ancestor)?.parent;
+  }
+}
+
+export function childApprovalRevocationSignal(child: Session): AbortSignal | undefined {
+  return approvalParents.get(child)?.cancellation.signal;
+}
+
+export function revokeChildApprovalSession(child: Session): void {
+  approvalParents.get(child)?.cancellation.abort("child approval session is shutting down");
+}

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -19,6 +19,7 @@
 
 import { normalize } from "node:path";
 import { LRUCache } from "lru-cache";
+import { registerChildApprovalSession, revokeChildApprovalSession } from "./child-approval-context.js";
 import { createInertMcpManager } from "../mcp-client/inert-manager.js";
 import { createChildAbortController } from "../utils/abortController.js";
 import type {
@@ -3050,6 +3051,7 @@ function buildChildSession(
     }
   }
 
+  registerChildApprovalSession(childSession, params.parent);
   return childSession;
 }
 
@@ -4284,6 +4286,7 @@ export async function* runAgent(
     }
     if (childSession !== null) {
       try {
+        revokeChildApprovalSession(childSession);
         await childSession.shutdown();
       } catch (error) {
         durableCloseError = error;

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -37,6 +37,7 @@ import {
 } from "../state/runtime-settings-snapshot.js";
 
 import { AsyncLock } from "../utils/async-lock.js";
+import { captureRecoverableCommandEnvironment } from "./client-env-snapshot.js";
 import { withTimeout } from "../utils/sleep.js";
 import {
   DaemonOperationScope,
@@ -947,6 +948,7 @@ export class AgenCDaemonAgentManager {
         ...(permissionMode !== undefined ? { permissionMode } : {}),
         unattendedAllow,
         unattendedDeny,
+        commandEnvironment: captureRecoverableCommandEnvironment(params.envOverrides),
         // Session operator inputs are part of the durable run identity. A
         // daemon restart must restore the exact values captured at create
         // time, never reinterpret the daemon's current process environment.
@@ -1048,8 +1050,23 @@ export class AgenCDaemonAgentManager {
         );
       }
 
+      const recovery = metadata.recovery;
+      const retainedRecovery =
+        typeof recovery === "object" && recovery !== null && !Array.isArray(recovery)
+          ? recovery
+          : undefined;
       const agentMetadata: JsonObject = {
         ...metadata,
+        ...(resumeSessionId !== undefined &&
+        (retainedRecovery !== undefined || metadata.recovered === true)
+          ? {
+              recovery: {
+                ...retainedRecovery,
+                runnable: true,
+                runtimeRestore: "available",
+              },
+            }
+          : {}),
         ...(started.rolloutPath !== undefined
           ? { canonicalRolloutPath: started.rolloutPath }
           : {}),
@@ -1060,7 +1077,6 @@ export class AgenCDaemonAgentManager {
           ? { canonicalRolloutIno: started.rolloutIno }
           : {}),
       };
-
       const agent: MutableAgent = {
         agentId: started.agentId,
         ...(started.agentPath !== undefined
@@ -3987,7 +4003,13 @@ export class AgenCDaemonAgentManager {
       );
     }
     if (sessionId !== undefined) {
-      return this.#resolveActiveAgentIdForSession(sessionId, {
+      const daemonSessionId = await this.#state.with((state) => {
+        const canonicalAgent = state.agents.get(sessionId);
+        return canonicalAgent === undefined
+          ? sessionId
+          : latestSessionIdForAgentRun(canonicalAgent) ?? sessionId;
+      });
+      return this.#resolveActiveAgentIdForSession(daemonSessionId, {
         allowListPermissions: true,
       });
     }

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -83,6 +83,11 @@ import {
   resolveProviderModelSelection,
 } from "../session/provider-model-selection.js";
 import { applyProviderSwitch } from "../commands/provider.js";
+import {
+  isApprovalSessionOwnedBy,
+  observeChildApprovalSessions,
+  childApprovalRevocationSignal,
+} from "../agents/child-approval-context.js";
 import { resolveProfile } from "../config/profiles.js";
 import {
   resolveLiveEffectPoison,
@@ -290,7 +295,6 @@ import {
   replayRecoveredToolCalls,
   hydrateRecoveredSessionHistory,
   resolvePermissionDecisionTimeoutMs,
-  readApprovalAgentId,
 } from "./background-agent-runner/tool-recovery.js";
 import {
   configuredHookExecutionState,
@@ -4515,11 +4519,59 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     ).services;
     if (services === undefined) return () => {};
     const previousResolver = services.approvalResolver;
+    const childSubscriptions = new Set<() => void>();
+    const childRequestIds = new WeakMap<LocalRuntimeBootstrap["session"], Map<string, string>>();
+    const unsubscribeChildren = observeChildApprovalSessions(session, (child) => {
+      const requestIds = new Map<string, string>();
+      childRequestIds.set(child, requestIds);
+      const unsubscribe = child.eventLog.subscribe((event) => {
+        if (
+          event.msg.type !== "request_permissions" &&
+          event.msg.type !== "permission_decision"
+        ) return;
+        const active = this.#active.get(session.conversationId);
+        if (active?.bootstrap.session !== session || !isRunnableActiveAgent(active)) return;
+        const projected = daemonEventFromUnboundSessionEvent(event);
+        if (projected === null) return;
+        const callId = projected.payload?.callId;
+        if (typeof callId !== "string") return;
+        let requestId = requestIds.get(callId);
+        if (event.msg.type === "request_permissions") {
+          if (!isApprovalSessionOwnedBy(child, session)) return;
+          requestId = `child-approval:${randomUUID()}`;
+          requestIds.set(callId, requestId);
+        } else {
+          if (requestId === undefined) return;
+          requestIds.delete(callId);
+        }
+        void this.#emitOrBufferEvent(active, {
+          id: `${requestId}:${projected.type}`,
+          type: projected.type,
+          payload: { ...projected.payload, callId: requestId },
+          statusProjection: "session_only",
+        }).catch(() => {});
+      });
+      childSubscriptions.add(unsubscribe);
+      return () => {
+        unsubscribe();
+        childRequestIds.delete(child);
+        childSubscriptions.delete(unsubscribe);
+      };
+    });
     const resolver: ApprovalResolver = {
-      request: (ctx) => this.#requestDaemonToolDecision(ctx),
+      request: (ctx) => this.#requestDaemonToolDecision(
+        ctx,
+        session,
+        ctx.invocation.session === session
+          ? ctx.callId
+          : childRequestIds.get(ctx.invocation.session)?.get(ctx.callId),
+      ),
     };
     services.approvalResolver = resolver;
     return () => {
+      unsubscribeChildren();
+      for (const unsubscribe of childSubscriptions) unsubscribe();
+      childSubscriptions.clear();
       if (services.approvalResolver === resolver) {
         if (previousResolver === undefined) {
           delete services.approvalResolver;
@@ -4678,12 +4730,20 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     }
   }
 
-  async #requestDaemonToolDecision(ctx: ApprovalCtx): Promise<ReviewDecision> {
-    const agentId = readApprovalAgentId(ctx);
-    if (agentId === null) return DENIED;
+  async #requestDaemonToolDecision(
+    ctx: ApprovalCtx,
+    owner: LocalRuntimeBootstrap["session"],
+    requestId: string | undefined,
+  ): Promise<ReviewDecision> {
+    const requestingSession = ctx.invocation.session;
+    if (!isApprovalSessionOwnedBy(requestingSession, owner)) return DENIED;
+    const agentId = owner.conversationId;
     const active = this.#active.get(agentId);
-    if (active === undefined || !isRunnableActiveAgent(active)) return DENIED;
-    const requestId = ctx.callId;
+    if (active?.bootstrap.session !== owner || !isRunnableActiveAgent(active)) return DENIED;
+    const ownershipSignal = childApprovalRevocationSignal(requestingSession);
+    if (ctx.signal?.aborted || ownershipSignal?.aborted) return ABORT;
+    if (requestId === undefined) return DENIED;
+    if (this.#pendingToolDecisions.get(agentId)?.has(requestId)) return DENIED;
     const timeoutMs = resolvePermissionDecisionTimeoutMs();
     const decision = new Promise<ReviewDecision>((resolve) => {
       let pendingForAgent = this.#pendingToolDecisions.get(agentId);
@@ -4697,17 +4757,20 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         if (settled) return;
         settled = true;
         if (timer !== undefined) clearTimeout(timer);
+        ctx.signal?.removeEventListener("abort", abort);
+        ownershipSignal?.removeEventListener("abort", abort);
         pendingForAgent!.delete(requestId);
         if (pendingForAgent!.size === 0) {
           this.#pendingToolDecisions.delete(agentId);
         }
-        resolve(value);
+        resolve(isApprovalSessionOwnedBy(requestingSession, owner) ? value : ABORT);
       };
       pendingForAgent.set(requestId, (value) => settle(value));
       const abort = (): void => {
         settle(ABORT);
       };
       ctx.signal?.addEventListener("abort", abort, { once: true });
+      ownershipSignal?.addEventListener("abort", abort, { once: true });
       if (timeoutMs !== undefined) {
         timer = setTimeout(() => {
           settle(TIMED_OUT);

--- a/runtime/src/app-server/background-agent-runner/daemon-events.ts
+++ b/runtime/src/app-server/background-agent-runner/daemon-events.ts
@@ -303,6 +303,9 @@ export function notificationFromDaemonEvent(
         ...(typeof payload.planFilePath === "string"
           ? { planFilePath: payload.planFilePath }
           : {}),
+        ...(payload.fileWritePreview !== undefined
+          ? { fileWritePreview: payload.fileWritePreview }
+          : {}),
       },
     };
   }

--- a/runtime/src/app-server/background-agent-runner/journal-reconstruction.ts
+++ b/runtime/src/app-server/background-agent-runner/journal-reconstruction.ts
@@ -13,6 +13,7 @@ import {
 } from "../../session/rollout-reconstruction.js";
 import type {
   JsonObject,
+  SessionTranscriptV2Event,
   SessionTranscriptV2Result,
   SessionTranscriptV2TurnResult,
 } from "../protocol/index.js";
@@ -201,6 +202,56 @@ function closedTurnResult(
     ...(open.model !== undefined ? { model: open.model } : {}),
     ...(open.provider !== undefined ? { provider: open.provider } : {}),
   };
+}
+
+function transcriptNoticesFromRollout(
+  items: readonly RolloutItem[],
+  boundaryIndex: number,
+): readonly SessionTranscriptV2Event[] {
+  const notices: SessionTranscriptV2Event[] = [];
+  const seenEventIds = new Set<string>();
+  const closedTurnIds = new Set<string>();
+  let currentTurnId: string | undefined;
+  for (const [index, item] of items.entries()) {
+    if (item.type !== "event_msg") continue;
+    const event = item.payload;
+    const committedSequence = positiveSequence(event.seq) ?? 0;
+    const eventId = event.eventId ?? (committedSequence > 0
+      ? canonicalEventId(event)
+      : `legacy-notice:${index}:${event.id}`);
+    if (seenEventIds.has(eventId)) continue;
+    seenEventIds.add(eventId);
+    if (event.msg.type === "token_count") {
+      notices.push({ eventId, committedSequence, type: "token_count", payload: { ...event.msg.payload } });
+      continue;
+    }
+    if (index <= boundaryIndex) continue;
+    if (event.msg.type === "turn_started") {
+      currentTurnId = event.msg.payload.turnId;
+      continue;
+    }
+    const terminal = classifyTurnTerminal(event.msg, {
+      expectedTurnId: currentTurnId,
+      legacyJournal: true,
+    });
+    if (terminal === undefined) continue;
+    const turnId = terminal.turnId ?? currentTurnId;
+    if (turnId !== undefined && closedTurnIds.has(turnId)) continue;
+    if (turnId !== undefined) closedTurnIds.add(turnId);
+    currentTurnId = undefined;
+    if (terminal.outcome === "errored") {
+      notices.push({
+        eventId, committedSequence, type: "turn_failed",
+        payload: { turnId, code: terminal.failureCode, message: terminal.message ?? "" },
+      });
+    } else if (terminal.outcome === "aborted") {
+      notices.push({
+        eventId, committedSequence, type: "turn_aborted",
+        payload: { ...(turnId !== undefined ? { turnId } : {}), ...(terminal.message !== undefined ? { reason: terminal.message } : {}) },
+      });
+    }
+  }
+  return notices;
 }
 
 export function sessionTranscriptV2FromRollout(
@@ -416,6 +467,7 @@ export function sessionTranscriptV2FromRollout(
     historyEpoch: historyEpochForBoundary(runId, boundaryId),
     asOfSequence,
     messages,
+    events: transcriptNoticesFromRollout(items, boundaryIndex),
     ...(activeTurn !== undefined ? { activeTurn } : {}),
     ...(turnResults.length > 0 ? { turnResults } : {}),
   };

--- a/runtime/src/app-server/client-env-snapshot.ts
+++ b/runtime/src/app-server/client-env-snapshot.ts
@@ -91,3 +91,24 @@ export function mergeDaemonClientEnvironment(
   }
   return merged
 }
+
+export function captureRecoverableCommandEnvironment(
+  overrides: Readonly<Record<string, string>> | undefined,
+): { readonly PATH: string } {
+  return { PATH: overrides?.PATH?.trim() ? overrides.PATH : "" }
+}
+
+export function readRecoverableCommandEnvironment(
+  value: unknown,
+): { readonly PATH: string } | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.keys(value).length !== 1 ||
+    !("PATH" in value) ||
+    typeof value.PATH !== "string" ||
+    value.PATH.includes("\0")
+  ) return undefined
+  return { PATH: value.PATH }
+}

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -157,6 +157,7 @@ import {
   type AgenCDaemonStartupGuardReceiver,
 } from "./daemon-startup-guard.js";
 import { createPermissionAuditFileLogger } from "../permissions/permission-audit-log.js";
+import { readRecoverableCommandEnvironment } from "./client-env-snapshot.js";
 import { loadCanonicalDaemonConfig } from "../config/repository.js";
 import { resolveProviderBaseURL } from "../config/env.js";
 import {
@@ -5442,7 +5443,10 @@ export async function restoreRecoveredAgentRuntime(
     resumeSource?.close();
     return { available: false };
   }
-  if (runtimeOptions === null) {
+  const commandEnvironment = readRecoverableCommandEnvironment(
+    run.metadata?.commandEnvironment,
+  );
+  if (runtimeOptions === null || commandEnvironment === undefined) {
     resumeSource.close();
     return { available: false };
   }
@@ -5465,6 +5469,7 @@ export async function restoreRecoveredAgentRuntime(
       explicitColdResume: true,
       restoreAttemptId,
       runtimeOptions,
+      envOverrides: commandEnvironment,
       ...(resumeSource.activeStartupActivationResumeEventId !== undefined
         ? { resumeStartupActivationPending: true }
         : {}),

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -3208,6 +3208,27 @@ export interface SessionTranscriptV2TurnResult extends JsonObject {
   readonly provider?: string;
 }
 
+export interface SessionTranscriptV2Event extends JsonObject {
+  readonly eventId: string;
+  readonly committedSequence: number;
+  readonly type: "token_count" | "turn_failed" | "turn_aborted";
+  readonly payload: {
+    readonly promptTokens?: number;
+    readonly completionTokens?: number;
+    readonly totalTokens?: number;
+    readonly cachedInputTokens?: number;
+    readonly cacheCreationInputTokens?: number;
+    readonly reasoningOutputTokens?: number;
+    readonly webSearchRequests?: number;
+    readonly model?: string;
+    readonly provider?: string;
+    readonly turnId?: string;
+    readonly code?: string;
+    readonly message?: string;
+    readonly reason?: string;
+  };
+}
+
 export interface SessionTranscriptV2Result extends JsonObject {
   readonly schemaVersion: 2;
   readonly sessionId: string;
@@ -3217,6 +3238,7 @@ export interface SessionTranscriptV2Result extends JsonObject {
   readonly messages: readonly SessionTranscriptV2Message[];
   readonly activeTurn?: SessionTranscriptV2ActiveTurn;
   readonly turnResults?: readonly SessionTranscriptV2TurnResult[];
+  readonly events?: readonly SessionTranscriptV2Event[];
 }
 
 export interface SessionCancelTurnResult extends JsonObject {

--- a/runtime/src/permissions/file-write-preview.ts
+++ b/runtime/src/permissions/file-write-preview.ts
@@ -1,0 +1,88 @@
+import { stat } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import type { FileWriteApprovalPreview } from "../session/event-log.js";
+import type { ToolInvocation } from "../tools/context.js";
+import { getSessionReadSnapshot, safePath } from "../tools/system/filesystem.js";
+import { workspaceAuthoritativeRead } from "../workspace/mutation-coordinator.js";
+import { checkToolPathPermission } from "./path-validation.js";
+
+export async function buildFileWriteApprovalPreview(
+  invocation: ToolInvocation,
+  input: Readonly<Record<string, unknown>>,
+): Promise<FileWriteApprovalPreview> {
+  const unavailable = (reason: string): FileWriteApprovalPreview => ({
+    kind: "unavailable",
+    reason,
+  });
+  const cwd = invocation.turn?.cwd;
+  const sessionId = invocation.session?.conversationId;
+  const context = invocation.session?.services.permissionModeRegistry?.current();
+  const filePath = input.file_path;
+  if (
+    typeof cwd !== "string" ||
+    !isAbsolute(cwd) ||
+    typeof sessionId !== "string" ||
+    sessionId.length === 0 ||
+    context === undefined ||
+    typeof filePath !== "string" ||
+    filePath.trim().length === 0 ||
+    filePath.includes("\0")
+  ) {
+    return unavailable("File preview authority is unavailable.");
+  }
+  try {
+    const allowedRoots = [cwd, ...context.additionalWorkingDirectories.keys()];
+    const safe = await safePath(resolve(cwd, filePath), allowedRoots);
+    if (!safe.safe) {
+      return unavailable("The target is outside the authorized workspace.");
+    }
+    const permission = checkToolPathPermission({
+      toolName: "FileRead",
+      input: { file_path: safe.resolved },
+      path: safe.resolved,
+      cwd,
+      context,
+      operationType: "read",
+      extraWorkingDirectories: allowedRoots,
+    });
+    if (permission.behavior !== "allow") {
+      return unavailable("Reading the target requires permission.");
+    }
+    const editorRead = workspaceAuthoritativeRead(safe.resolved);
+    let metadata;
+    try {
+      metadata = await stat(safe.resolved);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "ENOENT" && editorRead === null) {
+        return { kind: "missing" };
+      }
+      return unavailable("The target's current state could not be verified.");
+    }
+    if (!metadata.isFile()) {
+      return unavailable("The target is not a regular file.");
+    }
+    const snapshot = getSessionReadSnapshot(sessionId, safe.resolved);
+    const content = snapshot?.rawContent;
+    if (
+      snapshot?.viewKind !== "full" ||
+      snapshot.isPartialView === true ||
+      typeof snapshot.content !== "string" ||
+      typeof content !== "string"
+    ) {
+      return unavailable("Read the full existing file before reviewing its replacement.");
+    }
+    if (
+      editorRead !== null
+        ? editorRead.content !== content
+        : snapshot.timestamp !== metadata.mtimeMs
+    ) {
+      return unavailable("The file changed since its last full read.");
+    }
+    if (content.includes("\0") || Buffer.byteLength(content, "utf8") > 256 * 1024) {
+      return unavailable("The existing content exceeds the text preview limit.");
+    }
+    return { kind: "existing", content };
+  } catch {
+    return unavailable("The target's current state could not be verified.");
+  }
+}

--- a/runtime/src/permissions/guardian/arbiter.ts
+++ b/runtime/src/permissions/guardian/arbiter.ts
@@ -12,7 +12,11 @@
  * @module
  */
 
-import type { Event, EventLog } from "../../session/event-log.js";
+import type {
+  Event,
+  EventLog,
+  FileWriteApprovalPreview,
+} from "../../session/event-log.js";
 import { isHookExecutionSuppressed } from "../../hooks/runtime-policy.js";
 import { asRecord } from "../../utils/record.js";
 import { nonEmptyString as stringValue } from "../../utils/stringUtils.js";
@@ -262,6 +266,7 @@ export interface ApprovalCtx {
   readonly availableDecisions?: readonly AvailableApprovalDecision[];
   readonly planContent?: string;
   readonly planFilePath?: string;
+  readonly fileWritePreview?: FileWriteApprovalPreview;
 }
 
 export interface ApprovalResolver {
@@ -452,6 +457,15 @@ export function requestApproval(
 async function resolveAndJournalApproval(
   opts: RequestApprovalOpts,
 ): Promise<RequestApprovalResult> {
+  if (opts.ctx.toolName === "Write") {
+    const { buildFileWriteApprovalPreview } =
+      await import("../file-write-preview.js");
+    const fileWritePreview = await buildFileWriteApprovalPreview(
+      opts.ctx.invocation,
+      opts.args ?? approvalInputFromInvocation(opts.ctx.invocation),
+    );
+    opts = { ...opts, ctx: { ...opts.ctx, fileWritePreview } };
+  }
   const journal = beginDurableApprovalJournal(opts);
   const result = await resolveApproval(opts);
   if (journal !== null) {
@@ -692,6 +706,9 @@ function beginDurableApprovalJournal(
           input,
           ...(planContent !== undefined ? { planContent } : {}),
           ...(planFilePath !== undefined ? { planFilePath } : {}),
+          ...(opts.ctx.fileWritePreview !== undefined
+            ? { fileWritePreview: opts.ctx.fileWritePreview }
+            : {}),
           recordedAt: new Date().toISOString(),
         },
       },

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -369,6 +369,11 @@ export interface ExecApprovalRequestEvent {
   readonly reason?: string;
 }
 
+export type FileWriteApprovalPreview =
+  | { readonly kind: "existing"; readonly content: string }
+  | { readonly kind: "missing" }
+  | { readonly kind: "unavailable"; readonly reason: string };
+
 export interface RequestPermissionsEvent {
   readonly callId: string;
   readonly toolName: string;
@@ -378,6 +383,7 @@ export interface RequestPermissionsEvent {
   readonly input?: Readonly<Record<string, unknown>>;
   readonly planContent?: string;
   readonly planFilePath?: string;
+  readonly fileWritePreview?: FileWriteApprovalPreview;
   readonly recordedAt?: string;
 }
 

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -861,6 +861,11 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
       input: isRecord,
       planContent: isString,
       planFilePath: isString,
+      fileWritePreview: either(
+        objectShape({ kind: literal("existing"), content: isString }),
+        objectShape({ kind: literal("missing") }),
+        objectShape({ kind: literal("unavailable"), reason: isString }),
+      ),
       recordedAt: isString,
     },
   ),

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -391,26 +391,17 @@ export interface ToolExecutionOverrides {
 // I-79: large-int JSON reviver
 // ─────────────────────────────────────────────────────────────────────
 
-const LARGE_INT_LITERAL_RE = /(:|,|\[|\{|\s)\s*(-?\d{16,})(\s*)(?=,|\}|\])/g;
-
-function wrapLargeInts(raw: string): string {
-  return raw.replace(
-    LARGE_INT_LITERAL_RE,
-    (_m, pre: string, digits: string, post: string) =>
-      `${pre}"__bigint__${digits}"${post}`,
-  );
-}
-
-const BIGINT_PREFIX = "__bigint__";
-
-function bigIntReviver(_key: string, value: unknown): unknown {
-  if (typeof value === "string" && value.startsWith(BIGINT_PREFIX)) {
-    const digits = value.slice(BIGINT_PREFIX.length);
-    try {
-      return BigInt(digits);
-    } catch {
-      return digits;
-    }
+function bigIntReviver(
+  _key: string,
+  value: unknown,
+  context?: { readonly source?: string },
+): unknown {
+  if (
+    typeof value === "number" &&
+    context?.source !== undefined &&
+    /^-?\d{16,}$/.test(context.source)
+  ) {
+    return BigInt(context.source);
   }
   return value;
 }
@@ -421,8 +412,7 @@ export function parseToolArgsWithBigInt(
   const trimmed = raw?.trim();
   if (!trimmed) return {};
   try {
-    const wrapped = wrapLargeInts(trimmed);
-    const parsed = JSON.parse(wrapped, bigIntReviver);
+    const parsed = JSON.parse(trimmed, bigIntReviver);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : null;
@@ -1327,6 +1317,7 @@ export type ToolProgressCallback = (event: ToolProgressEvent) => void;
 // ─────────────────────────────────────────────────────────────────────
 
 export interface RunToolUseOptions {
+  readonly parsedArgs?: Readonly<Record<string, unknown>>;
   readonly signal?: AbortSignal;
   readonly currentTurnId: string;
   readonly getActiveTurnId?: () => string | null;
@@ -1578,7 +1569,9 @@ export async function runToolUse(
   const startedAt = performance.now();
 
   // Step 1: I-79 arg parse.
-  const parsedArgs = parseToolArgsWithBigInt(rawArgs);
+  const parsedArgs = opts.parsedArgs === undefined
+    ? parseToolArgsWithBigInt(rawArgs)
+    : { ...opts.parsedArgs };
   if (parsedArgs === null) {
     const message = `invalid JSON arguments for tool ${toolNameDisplay(invocation.toolName)}`;
     if (opts.eventLog) {

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -745,6 +745,7 @@ export class ToolRouter {
               invoke: ({ signal, abortController, crossEffectBoundary }) =>
                 executeToolDispatch({
                   rawArgs: dispatchRawArgs,
+                  parsedArgs: dispatchArgs,
                   signal,
                   currentTurnId: directDispatchTurnId(invocation),
                   eventLog: invocation.session.eventLog,
@@ -1326,6 +1327,7 @@ export class ToolRouter {
                       : opts,
                   ),
                   tool: spec.tool,
+                  parsedArgs: dispatchArgs,
                   invocation: dispatchInvocation,
                   preHooks: [],
                   ...(preHookPermissionDecision !== undefined
@@ -1607,8 +1609,11 @@ function buildPayloadForArgs(
 }
 
 function stringifyToolArgsWithBigInt(args: Record<string, unknown>): string {
-  return JSON.stringify(args, (_key, value) =>
-    typeof value === "bigint" ? `__bigint__${value.toString()}` : value,
+  const { rawJSON } = JSON as typeof JSON & {
+    rawJSON: (text: string) => unknown;
+  };
+  return JSON.stringify(args, (_key, value: unknown) =>
+    typeof value === "bigint" ? rawJSON(value.toString()) : value,
   );
 }
 
@@ -1740,6 +1745,7 @@ function rawDispatchOptions(
   rawArgs: string,
   opts: LiveToolDispatchOptions & {
     readonly tool: Tool;
+    readonly parsedArgs: Readonly<Record<string, unknown>>;
     readonly invocation: ToolInvocation;
     readonly abortController: AbortController;
     readonly subId: string;
@@ -1753,6 +1759,7 @@ function rawDispatchOptions(
   const contextWindowTokens = effectiveContextWindowTokens(opts.turn);
   return {
     rawArgs,
+    parsedArgs: opts.parsedArgs,
     signal: opts.abortController.signal,
     currentTurnId: opts.turn.subId,
     eventLog: opts.session.eventLog,

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -2546,6 +2546,7 @@ function subscribeToDaemonEvents(
   transcriptSnapshot?: SessionTranscriptV2Result,
 ): () => void {
   let replayingInitialEvents = true;
+  const pendingApprovals = new Map<string, AbortController>();
   const deliver = (event: JsonObject): void => {
     cb(event);
     void maybeBridgeDaemonApproval(
@@ -2554,6 +2555,7 @@ function subscribeToDaemonEvents(
       session,
       event,
       cb,
+      pendingApprovals,
     );
     void maybeBridgeDaemonElicitation(
       client,
@@ -2609,6 +2611,8 @@ function subscribeToDaemonEvents(
     }
   });
   return () => {
+    for (const controller of pendingApprovals.values()) controller.abort();
+    pendingApprovals.clear();
     unsubscribeSession();
     unsubscribeRealtime?.();
     unsubscribeConnection?.();
@@ -2651,17 +2655,28 @@ async function maybeBridgeDaemonApproval(
   session: AgenCTuiBridgeSession,
   event: unknown,
   cb: (event: unknown) => void,
+  pendingApprovals: Map<string, AbortController>,
 ): Promise<void> {
-  if (!isJsonObject(event) || event.type !== "request_permissions") return;
+  if (!isJsonObject(event)) return;
   const payload = event.payload;
   if (!isJsonObject(payload) || typeof payload.callId !== "string") return;
+  if (event.type === "permission_decision" || event.type === "tool_call_completed") {
+    pendingApprovals.get(payload.callId)?.abort();
+    pendingApprovals.delete(payload.callId);
+    return;
+  }
+  if (event.type !== "request_permissions" || pendingApprovals.has(payload.callId)) return;
   const resolver = session.services.approvalResolver;
   if (resolver === undefined) return;
+  const controller = new AbortController();
+  pendingApprovals.set(payload.callId, controller);
   const toolName =
     typeof payload.toolName === "string" ? payload.toolName : "tool";
   const decision = await resolver
-    .request(buildDaemonApprovalCtx(session, payload, toolName))
+    .request(buildDaemonApprovalCtx(session, payload, toolName, controller.signal))
     .catch((): ReviewDecision => ({ kind: "denied" }));
+  if (controller.signal.aborted) return;
+  pendingApprovals.delete(payload.callId);
   // A transient daemon RPC failure here silently drops the user's
   // approve/deny decision and the tool call hangs forever. Catch and surface
   // it so the user gets feedback instead of an indefinite hang.
@@ -2817,13 +2832,28 @@ async function maybeBridgeDaemonElicitation(
   }
 }
 
+function daemonFileWritePreview(value: unknown): NonNullable<ApprovalCtx["fileWritePreview"]> | undefined {
+  if (!isJsonObject(value)) return undefined;
+  if (value.kind === "missing") return { kind: "missing" };
+  if (value.kind === "existing" && typeof value.content === "string" &&
+    Buffer.byteLength(value.content, "utf8") <= 256 * 1024) {
+    return { kind: "existing", content: value.content };
+  }
+  if (value.kind === "unavailable" && typeof value.reason === "string") {
+    return { kind: "unavailable", reason: value.reason.slice(0, 200) };
+  }
+  return undefined;
+}
+
 function buildDaemonApprovalCtx(
   session: AgenCTuiBridgeSession,
   payload: JsonObject,
   toolName: string,
+  signal: AbortSignal,
 ): ApprovalCtx {
   const callId = payload.callId as string;
   const input = isJsonObject(payload.input) ? payload.input : {};
+  const fileWritePreview = daemonFileWritePreview(payload.fileWritePreview);
   return {
     invocation: {
       session,
@@ -2845,6 +2875,8 @@ function buildDaemonApprovalCtx(
     } as unknown as ApprovalCtx["invocation"],
     callId,
     toolName,
+    signal,
+    ...(fileWritePreview === undefined ? {} : { fileWritePreview }),
     turnId: typeof payload.turnId === "string" ? payload.turnId : callId,
     ...(typeof payload.reason === "string"
       ? { retryReason: payload.reason }
@@ -2870,6 +2902,7 @@ function baseInitialTranscriptEvents(
 
 function transcriptEventFromPermissionRequest(params: JsonObject): JsonObject | null {
   if (typeof params.requestId !== "string") return null;
+  const fileWritePreview = daemonFileWritePreview(params.fileWritePreview);
   return {
     id: daemonTranscriptEventId(
       params,
@@ -2878,6 +2911,7 @@ function transcriptEventFromPermissionRequest(params: JsonObject): JsonObject | 
     type: "request_permissions",
     payload: {
       callId: params.requestId,
+      ...(fileWritePreview === undefined ? {} : { fileWritePreview }),
       ...(typeof params.toolName === "string"
         ? { toolName: params.toolName }
         : {}),

--- a/runtime/src/tui/daemon-transcript-snapshot.ts
+++ b/runtime/src/tui/daemon-transcript-snapshot.ts
@@ -3,6 +3,7 @@ import type {
   SessionTranscriptV2Result,
 } from "../app-server/protocol/index.js";
 import { isRecord } from "../utils/record.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 
 export function daemonTranscriptSnapshotEvents(
   snapshot: SessionTranscriptV2Result,
@@ -19,7 +20,7 @@ export function daemonTranscriptSnapshotEvents(
   ) {
     throw new Error("Daemon returned an invalid transcript snapshot");
   }
-  const events = snapshot.messages.map((message) => {
+  const events: { readonly sequence: number; readonly event: JsonObject }[] = snapshot.messages.map((message) => {
     if (
       (message.role !== "user" && message.role !== "assistant") ||
       typeof message.text !== "string" ||
@@ -40,6 +41,33 @@ export function daemonTranscriptSnapshotEvents(
       } satisfies JsonObject,
     };
   });
+  if (snapshot.events !== undefined && !Array.isArray(snapshot.events)) {
+    throw new Error("Daemon returned invalid transcript notices");
+  }
+  const seenEventIds = new Set<string>();
+  for (const notice of snapshot.events ?? []) {
+    if (
+      typeof notice.eventId !== "string" || notice.eventId.length === 0 ||
+      !Number.isSafeInteger(notice.committedSequence) ||
+      notice.committedSequence < 0 || notice.committedSequence > snapshot.asOfSequence ||
+      !isRecord(notice.payload) ||
+      (notice.type !== "token_count" && notice.type !== "turn_failed" && notice.type !== "turn_aborted") ||
+      (notice.type !== "token_count" && classifyTurnTerminal(notice) === undefined)
+    ) {
+      throw new Error("Daemon returned an invalid transcript notice");
+    }
+    if (seenEventIds.has(notice.eventId)) continue;
+    seenEventIds.add(notice.eventId);
+    events.push({
+      sequence: notice.committedSequence,
+      event: {
+        id: `snapshot:${snapshot.historyEpoch}:event:${notice.eventId}`,
+        eventId: notice.eventId,
+        type: notice.type,
+        payload: notice.payload,
+      },
+    });
+  }
   events.sort((left, right) => left.sequence - right.sequence);
   const transcript: JsonObject[] = events.map((entry) => entry.event);
   if (snapshot.activeTurn !== undefined) {
@@ -71,6 +99,27 @@ export function daemonTranscriptSnapshotCoversEvent(
   if (!isRecord(params)) return false;
   if (params.runId !== undefined && params.runId !== snapshot.runId) return false;
   const sequence = params.sequence;
+  if (
+    transcriptEvent.type === "token_count" || transcriptEvent.type === "turn_failed" ||
+    transcriptEvent.type === "turn_aborted" || transcriptEvent.type === "error"
+  ) {
+    if (sequence !== undefined && (
+      typeof sequence !== "number" || !Number.isSafeInteger(sequence) || sequence < 0 ||
+      sequence > snapshot.asOfSequence
+    )) return false;
+    const eventId = params.eventId ?? transcriptEvent.eventId;
+    if (snapshot.events?.some((notice) =>
+      (typeof eventId === "string" && notice.eventId === eventId) ||
+      (typeof sequence === "number" && sequence > 0 && notice.committedSequence === sequence),
+    )) return true;
+    if (snapshot.events === undefined || typeof sequence !== "number") return false;
+    const terminal = typeof transcriptEvent.type === "string"
+      ? classifyTurnTerminal({ type: transcriptEvent.type, payload: transcriptEvent.payload }, { legacyJournal: true })
+      : undefined;
+    return terminal !== undefined && (
+      snapshot.activeTurn === undefined || terminal.turnId !== snapshot.activeTurn.turnId
+    );
+  }
   if (typeof sequence !== "number" || !Number.isSafeInteger(sequence)) return false;
   if (sequence > snapshot.asOfSequence) return false;
   const payload = transcriptEvent.payload;

--- a/runtime/src/tui/keybindings/defaultBindings.ts
+++ b/runtime/src/tui/keybindings/defaultBindings.ts
@@ -140,7 +140,7 @@ export const DEFAULT_BINDINGS: KeybindingBlock[] = [
       down: "confirm:next",
       tab: "confirm:nextField",
       space: "confirm:toggle",
-      d: "workbench:openDiff",
+      "ctrl+w d": "workbench:openDiff",
       // Toggle permission explanation in permission dialogs
       "ctrl+e": "confirm:toggleExplanation",
       // Toggle permission debug info

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -507,21 +507,29 @@ function AgenCApprovalOverlay({
   readonly toolUseConfirm: ProjectedToolUseConfirm;
 }) {
   const command = approvalInputText(toolUseConfirm.input, { prettyJson: true });
-  // Build a bounded diff/content preview so a Write/Edit is not approved blind.
-  // Reuses the same diff engine + helper the post-approval DIFF card uses; it
-  // returns null for non-file-write tools (e.g. Bash), so those show no diff.
+  const fileWritePreview = request.ctx.fileWritePreview;
+  const writePreviewUnavailable = toolUseConfirm.tool.name === "Write" &&
+    (fileWritePreview === undefined || fileWritePreview.kind === "unavailable");
   const diffPreview = useMemo<ApprovalDiffPreview | undefined>(() => {
     try {
+      if (writePreviewUnavailable) return undefined;
+      const writeInput = toolUseConfirm.tool.name === "Write" &&
+        fileWritePreview?.kind === "existing" &&
+        toolUseConfirm.input !== null && typeof toolUseConfirm.input === "object"
+        ? {
+            ...toolUseConfirm.input,
+            old_string: fileWritePreview.content,
+            new_string: (toolUseConfirm.input as Record<string, unknown>).content,
+          }
+        : undefined;
       const built = buildEditDiffPreview(
-        toolUseConfirm.tool.name,
-        toolUseConfirm.input,
+        writeInput === undefined ? toolUseConfirm.tool.name : "Edit",
+        writeInput ?? toolUseConfirm.input,
       );
       if (built === null) return undefined;
-      // Label the inline diff the same way the post-approval TRANSCRIPT card
-      // does: a Write produces a brand-new file → CREATE; Edit/MultiEdit change
-      // an existing one → EDIT. Keeps the approval preview and the transcript in
-      // sync instead of showing a neutral DIFF here.
-      const op = toolUseConfirm.tool.name === "Write" ? "CREATE" : "EDIT";
+      const op = toolUseConfirm.tool.name === "Write" && fileWritePreview?.kind === "missing"
+        ? "CREATE"
+        : "EDIT";
       return {
         file: built.file,
         stats: built.stats,
@@ -534,7 +542,7 @@ function AgenCApprovalOverlay({
       // command-only card rather than throwing inside render.
       return undefined;
     }
-  }, [toolUseConfirm.tool.name, toolUseConfirm.input]);
+  }, [toolUseConfirm.tool.name, toolUseConfirm.input, fileWritePreview, writePreviewUnavailable]);
   const risk = classifyApprovalRisk({
     request,
     toolName: toolUseConfirm.tool.name,
@@ -588,7 +596,10 @@ function AgenCApprovalOverlay({
         if (destructive) return false;
         approve();
       },
-      "confirm:no": reject,
+      "confirm:no": () => {
+        if (destructive) return false;
+        reject();
+      },
       "app:interrupt": abort,
     },
     { context: "Confirmation" },
@@ -648,8 +659,8 @@ function AgenCApprovalOverlay({
         setTyped((value) => value.slice(0, -1));
         return;
       }
-      if (input.length === 1 && !key.ctrl && !key.meta) {
-        setTyped((value) => (value + input).slice(0, requiredWord.length));
+      if (input.length > 0 && !key.ctrl && !key.meta && !/[\u0000-\u001f\u007f]/u.test(input)) {
+        setTyped((value) => (value + input).slice(0, requiredWord.length + 1));
       }
     },
     { isActive: destructive },
@@ -686,7 +697,9 @@ function AgenCApprovalOverlay({
             value: destructive ? `type ${requiredWord}` : "enter",
           },
         ]}
-        note={toolUseConfirm.description}
+        note={writePreviewUnavailable
+          ? `Existing content unavailable; this write may overwrite a file. ${fileWritePreview?.kind === "unavailable" ? fileWritePreview.reason : ""}`.trim()
+          : toolUseConfirm.description}
         {...(diffPreview !== undefined ? { diffPreview } : {})}
         requestId={request.id}
         requireTypedConfirmation={destructive}

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1560,6 +1560,20 @@ export function formatStructuredToolResult(
   }
 
   if (toolName === "FileRead") {
+    if (typeof result === "string") {
+      const metadata = metadataRecord(payload);
+      const count = metadata.numLines;
+      const numberedLines = result.split("\n").filter((line) => /^\s*\d+→/u.test(line)).length;
+      const lineCount = typeof count === "number" && Number.isSafeInteger(count) && count >= 0
+        ? count
+        : numberedLines;
+      if (lineCount > 0) {
+        return [{ type: "text", text: `<read-lines>1-${lineCount}</read-lines>` }];
+      }
+      if (count === 0 || result.length === 0) {
+        return [{ type: "text", text: "<read-content></read-content>" }];
+      }
+    }
     if (
       result &&
       typeof result === "object" &&

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -23,6 +23,7 @@ import { execFileSync } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AsyncQueue } from "../utils/async-queue.js";
 import { AgentControl } from "./control.js";
+import { childApprovalRevocationSignal, isApprovalSessionOwnedBy, observeChildApprovalSessions } from "../../src/agents/child-approval-context.js";
 import { AgentRegistry } from "./registry.js";
 import {
   buildFilteredRegistry,
@@ -1491,6 +1492,36 @@ describe("runAgent", () => {
     expect(result.outcome).toBe("errored");
     expect(provider.chatStream).not.toHaveBeenCalled();
     expect(events.some((e) => e.kind === "run_error")).toBe(true);
+  });
+
+  it("registers silent child approval ownership before sampling and revokes it at shutdown", async () => {
+    const provider = makeProvider([{ content: "Memory extraction complete." }]);
+    const parent = makeStubSession({ services: { provider } });
+    const { live } = await spawnLive(parent);
+    let child: Session | undefined;
+    const unsubscribe = observeChildApprovalSessions(parent, (registered) => {
+      child = registered;
+      expect(isApprovalSessionOwnedBy(registered, parent)).toBe(true);
+      expect(provider.chatStream).not.toHaveBeenCalled();
+      registered.trackDurableOperation(new Promise<void>((resolve) => {
+        childApprovalRevocationSignal(registered)!.addEventListener("abort", () => resolve(), { once: true });
+      }));
+      return () => {};
+    });
+    try {
+      const { result } = await collectRun(runAgent({
+        live,
+        parent,
+        initialMessages: [{ role: "user", content: "Extract useful memory" }],
+        taskPrompt: "Extract useful memory",
+        silent: true,
+      }));
+      expect(result.outcome).toBe("completed");
+      expect(child?.conversationId).toBe(live.agentId);
+      expect(isApprovalSessionOwnedBy(child!, parent)).toBe(false);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("marks completed on success", async () => {

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -35,6 +35,7 @@ import {
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
 import { DAEMON_CLIENT_ENV_SNAPSHOT_KEYS } from "./client-env-snapshot.js";
+import { findAgenCDaemonAgentBySessionId } from "../../src/app-server-client/index.js";
 import {
   AGENC_DAEMON_PROTOCOL_VERSION,
   AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
@@ -2528,6 +2529,7 @@ describe("AgenC background agent lifecycle", () => {
         addDirs: ["../shared workspace", "/tmp/shared"],
         unattendedAllow: [],
         unattendedDeny: [],
+        commandEnvironment: { PATH: "" },
         runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
       },
       sessionId: "session_1",
@@ -2543,6 +2545,7 @@ describe("AgenC background agent lifecycle", () => {
           addDirs: ["../shared workspace", "/tmp/shared"],
           unattendedAllow: [],
           unattendedDeny: [],
+          commandEnvironment: { PATH: "" },
           runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
         },
         unattendedAllow: [],
@@ -2566,6 +2569,7 @@ describe("AgenC background agent lifecycle", () => {
         source: "agent.start",
         unattendedAllow: [],
         unattendedDeny: [],
+        commandEnvironment: { PATH: "" },
         runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
       },
     });
@@ -2586,6 +2590,7 @@ describe("AgenC background agent lifecycle", () => {
             addDirs: ["../shared workspace", "/tmp/shared"],
             unattendedAllow: [],
             unattendedDeny: [],
+            commandEnvironment: { PATH: "" },
             runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
           },
         },
@@ -2618,6 +2623,7 @@ describe("AgenC background agent lifecycle", () => {
             source: "agent.start",
             unattendedAllow: [],
             unattendedDeny: [],
+            commandEnvironment: { PATH: "" },
             runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
           },
           activeAttachmentIds: ["attachment_1"],
@@ -2921,6 +2927,7 @@ describe("AgenC background agent lifecycle", () => {
         permissionMode: "acceptEdits",
         unattendedAllow: [],
         unattendedDeny: [],
+        commandEnvironment: { PATH: "" },
         runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
       },
       restoreAttemptId: expect.any(String),
@@ -2942,6 +2949,95 @@ describe("AgenC background agent lifecycle", () => {
         },
       },
     );
+  });
+
+  it.each(["/client/bin:/usr/bin", ""])("durably records fresh command authority when explicitly resuming a legacy run: %j", async (path) => {
+    const fixture = createResumeFixture("conv-legacy-command-authority");
+    const driver = openStateDatabases({ cwd: fixture.cwd, agencHome: process.env.AGENC_HOME });
+    const restoreAgent = vi.fn(async () => true);
+    const agents = new AgenCDaemonAgentManager({
+      runner: { startAgent: vi.fn(), restoreAgent },
+      recordAgentRun: (record) => { upsertAgentRun(driver, record); },
+    });
+    try {
+      await agents.restoreAgent({
+        agentId: "conv-legacy-command-authority",
+        objective: "retained canonical objective",
+        status: "idle",
+        createdAt: "2026-05-01T12:30:00.000Z",
+        startedAt: "2026-05-01T12:30:00.000Z",
+        lastActiveAt: "2026-05-01T12:31:00.000Z",
+        cwd: fixture.cwd,
+        sessionIds: [],
+        runtimeAvailable: false,
+        metadata: { agentPath: "/root", runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS },
+      });
+      await createTestAgent(agents, {
+        resumeSessionId: "conv-legacy-command-authority",
+        resumeRolloutPath: fixture.rolloutPath,
+        resumeSourceProof: fixture.sourceProof,
+        cwd: fixture.cwd,
+        envOverrides: { PATH: path, XAI_API_KEY: "fresh-client-secret" },
+      });
+      const row = driver.prepareState<[], { metadata_json: string }>(
+        "SELECT metadata_json FROM agent_runs WHERE id = 'conv-legacy-command-authority'",
+      ).get();
+      expect(row).toBeDefined();
+      expect(JSON.parse(row!.metadata_json)).toMatchObject({ commandEnvironment: { PATH: path } });
+      expect(row!.metadata_json).not.toContain("fresh-client-secret");
+      expect(restoreAgent).toHaveBeenCalledWith(expect.objectContaining({
+        envOverrides: { PATH: path, XAI_API_KEY: "fresh-client-secret" },
+        metadata: expect.objectContaining({ commandEnvironment: { PATH: path } }),
+      }));
+    } finally {
+      driver.close();
+    }
+  });
+
+  it.each([
+    { recovered: true },
+    { recovery: { runtimeRestore: "unavailable", runnable: false } },
+  ])("finds a warm attachment after explicitly resuming unavailable metadata %j", async (recoveryMetadata) => {
+    const sessionId = "conv-resume-then-reattach";
+    const fixture = createResumeFixture(sessionId);
+    const agents = new AgenCDaemonAgentManager({
+      sessionManager: new AgenCDaemonSessionManager(),
+      runner: { startAgent: vi.fn(), restoreAgent: vi.fn(async () => true) },
+    });
+    await agents.restoreAgent({
+      agentId: sessionId,
+      objective: "retained canonical objective",
+      status: "idle",
+      createdAt: "2026-05-01T12:30:00.000Z",
+      startedAt: "2026-05-01T12:30:00.000Z",
+      lastActiveAt: "2026-05-01T12:31:00.000Z",
+      cwd: fixture.cwd,
+      sessionIds: [],
+      runtimeAvailable: false,
+      metadata: { agentPath: "/root", runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS, ...recoveryMetadata },
+    });
+    const client = {
+      request: async () => agents.listAgents(),
+    } as Parameters<typeof findAgenCDaemonAgentBySessionId>[0];
+    await expect(findAgenCDaemonAgentBySessionId(client, sessionId)).resolves.toBeNull();
+    await createTestAgent(agents, {
+      resumeSessionId: sessionId,
+      resumeRolloutPath: fixture.rolloutPath,
+      resumeSourceProof: fixture.sourceProof,
+      cwd: fixture.cwd,
+      envOverrides: { PATH: "/resumed-client/bin:/usr/bin" },
+    });
+    await expect(findAgenCDaemonAgentBySessionId(client, sessionId)).resolves.toMatchObject({
+      agentId: sessionId,
+      status: "running",
+      metadata: { commandEnvironment: { PATH: "/resumed-client/bin:/usr/bin" } },
+    });
+    await expect(createTestAgent(agents, {
+      resumeSessionId: sessionId,
+      resumeRolloutPath: fixture.rolloutPath,
+      resumeSourceProof: fixture.sourceProof,
+      cwd: fixture.cwd,
+    })).rejects.toMatchObject({ code: "CANONICAL_SESSION_ALREADY_ACTIVE" });
   });
 
   it("restores retained additional directories on a flagless cold resume", async () => {
@@ -4521,6 +4617,7 @@ describe("AgenC background agent lifecycle", () => {
       metadata: {
         unattendedAllow: [],
         unattendedDeny: [],
+        commandEnvironment: { PATH: "" },
         runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
       },
     });
@@ -4856,6 +4953,7 @@ describe("AgenC background agent lifecycle", () => {
             metadata: {
               unattendedAllow: [],
               unattendedDeny: [],
+              commandEnvironment: { PATH: "" },
               runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
             },
           },
@@ -5045,6 +5143,7 @@ describe("AgenC background agent lifecycle", () => {
           metadata: {
             unattendedAllow: [],
             unattendedDeny: [],
+            commandEnvironment: { PATH: "" },
             runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
           },
         },
@@ -5059,6 +5158,7 @@ describe("AgenC background agent lifecycle", () => {
           metadata: {
             unattendedAllow: [],
             unattendedDeny: [],
+            commandEnvironment: { PATH: "" },
             runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
           },
         },
@@ -6201,6 +6301,7 @@ describe("AgenC background agent lifecycle", () => {
           addDirs: ["../shared workspace", "/tmp/shared"],
           unattendedAllow: [],
           unattendedDeny: [],
+          commandEnvironment: { PATH: "" },
           runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
         },
       },
@@ -6246,6 +6347,7 @@ describe("AgenC background agent lifecycle", () => {
               addDirs: ["../shared workspace", "/tmp/shared"],
               unattendedAllow: [],
               unattendedDeny: [],
+              commandEnvironment: { PATH: "" },
               runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
             },
           },
@@ -6876,6 +6978,7 @@ describe("AgenC background agent lifecycle", () => {
           source: "portal.dashboard",
           unattendedAllow: ["FileRead"],
           unattendedDeny: [],
+          commandEnvironment: { PATH: "" },
           runtimeOptions: TEST_AGENT_RUNTIME_OPTIONS,
         },
         unattendedAllow: ["FileRead"],

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -70,6 +70,9 @@ import {
   setCurrentRuntimeSession,
 } from "../session/current-session.js";
 import type { Session } from "../session/session.js";
+import { EventLog } from "../../src/session/event-log.js";
+import { registerChildApprovalSession, revokeChildApprovalSession } from "../../src/agents/child-approval-context.js";
+import type { ApprovalResolver } from "../../src/permissions/guardian/arbiter.js";
 import type { TurnContext } from "../session/turn-context.js";
 import type { Tool, ToolResult } from "../tools/types.js";
 import { readToolRuntimeContext } from "../tools/runtimes/context.js";
@@ -4170,6 +4173,151 @@ describe("AgenC delegate background-agent runner", () => {
     ]);
     expect(bootstrapShutdown).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["approved", "denied"] as const)(
+    "routes silent nested child approvals to the parent without granting them automatically: %s",
+    async (decisionKind) => {
+      const agentId = `parent-memory-${decisionKind}`;
+      const { runner, session } = makeTopLevelRunner({ conversationId: agentId });
+      const notifications: unknown[] = [];
+      await runner.startAgent({ objective: "memory approval", unattendedAllow: [], unattendedDeny: [] });
+      await runner.attachAgentSessionEvents(agentId, {
+        sessionId: "attached-parent",
+        emit: (notification) => { notifications.push(notification); },
+      });
+      const parent = session as unknown as Session;
+      const makeChild = (conversationId: string) => {
+        const eventLog = new EventLog();
+        const finalizers = new Set<() => void | Promise<void>>();
+        const durableOperations = new Set<Promise<unknown>>();
+        const child = {
+          ...session,
+          conversationId,
+          abortController: new AbortController(),
+          eventLog,
+          emit: (event: Parameters<EventLog["emit"]>[0]) => eventLog.emit(event),
+          trackDurableOperation: <Result>(operation: Promise<Result>) => {
+            durableOperations.add(operation);
+            void operation.then(() => durableOperations.delete(operation), () => durableOperations.delete(operation));
+            return operation;
+          },
+          onBeforeDurableClose: (callback: () => void | Promise<void>) => {
+            finalizers.add(callback);
+            return () => { finalizers.delete(callback); };
+          },
+        } as unknown as Session;
+        return { child, close: async () => {
+          revokeChildApprovalSession(child);
+          await Promise.all([...durableOperations]);
+          for (const callback of [...finalizers]) await callback();
+        } };
+      };
+      const intermediate = makeChild("child-intermediate");
+      registerChildApprovalSession(intermediate.child, parent);
+      const memory = makeChild("child-memory");
+      registerChildApprovalSession(memory.child, intermediate.child);
+      notifications.length = 0;
+      const childEvents: string[] = [];
+      memory.child.eventLog.subscribe((event) => childEvents.push(event.msg.type));
+      const resolver = (session.services as { approvalResolver: ApprovalResolver }).approvalResolver;
+      const makeRequest = (requestingSession: Session, callId: string, signal?: AbortSignal) => requestApproval({
+        ctx: {
+          invocation: {
+            session: requestingSession,
+            turn: { subId: "child-memory-turn" },
+            callId,
+            toolName: { name: "Glob" },
+            payload: { kind: "function", arguments: JSON.stringify({ pattern: callId, scope: requestingSession.conversationId }) },
+            source: "direct",
+          } as never,
+          callId,
+          toolName: "Glob",
+          turnId: "child-memory-turn",
+          ...(signal !== undefined ? { signal } : {}),
+        },
+        resolver,
+      });
+      const requestIdFor = (conversationId: string, callId: string): string => {
+        const prompt = notifications.find((notification) => {
+          const candidate = notification as { method?: string; params?: { input?: { pattern?: string; scope?: string } } };
+          return candidate.method === "event.permission_request" && candidate.params?.input?.pattern === callId && candidate.params.input.scope === conversationId;
+        }) as { params?: { requestId?: string } } | undefined;
+        expect(prompt?.params?.requestId).toEqual(expect.any(String));
+        return prompt!.params!.requestId!;
+      };
+      const expectDecision = async (requestId: string, decision: string) => {
+        await vi.waitFor(() => expect(notifications).toContainEqual(expect.objectContaining({
+          method: "event.session_event",
+          params: expect.objectContaining({ event: expect.objectContaining({
+            type: "permission_decision",
+            payload: expect.objectContaining({ callId: requestId, decision }),
+          }) }),
+        })));
+      };
+      let settled = false;
+      const pending = makeRequest(memory.child, "memory-glob").then((result) => {
+        settled = true;
+        return result;
+      });
+      await vi.waitFor(() => expect(notifications).toContainEqual(expect.objectContaining({
+        method: "event.permission_request",
+        params: expect.objectContaining({ sessionId: "attached-parent", toolName: "Glob" }),
+      })));
+      expect(settled).toBe(false);
+      const prompt = notifications.find((notification) => (notification as { method?: string }).method === "event.permission_request") as { params: Record<string, unknown> };
+      expect(prompt.params).not.toHaveProperty("sequence");
+      const memoryRequestId = requestIdFor(memory.child.conversationId, "memory-glob");
+      expect(memoryRequestId).not.toBe("memory-glob");
+      expect(await runner.resolveToolDecision(agentId, { requestId: memoryRequestId, decision: { kind: decisionKind } })).toBe(true);
+      await expect(pending).resolves.toMatchObject({ decision: { kind: decisionKind }, source: "resolver" });
+      await expectDecision(memoryRequestId, decisionKind);
+      expect(childEvents).toEqual(["request_permissions", "permission_decision"]);
+      expect(await runner.getAgentSnapshot(agentId)).toMatchObject({ status: "running" });
+
+      const forged = makeChild(agentId);
+      await expect(makeRequest(forged.child, "forged")).resolves.toMatchObject({ decision: { kind: "denied" } });
+      expect(await runner.resolveToolDecision(agentId, { requestId: "forged", decision: { kind: "approved" } })).toBe(false);
+
+      const closing = makeRequest(memory.child, "closing-child");
+      await vi.waitFor(() => requestIdFor(memory.child.conversationId, "closing-child"));
+      const closingRequestId = requestIdFor(memory.child.conversationId, "closing-child");
+      await memory.close();
+      await expect(closing).resolves.toMatchObject({ decision: { kind: "abort" } });
+      await expectDecision(closingRequestId, "abort");
+      await expect(makeRequest(memory.child, "stale-child")).resolves.toMatchObject({ decision: { kind: "denied" } });
+
+      const sibling = makeChild("child-sibling");
+      const grandchild = makeChild("child-grandchild");
+      registerChildApprovalSession(sibling.child, parent);
+      registerChildApprovalSession(grandchild.child, intermediate.child);
+      const siblingPending = makeRequest(sibling.child, "call_1");
+      const grandchildPending = makeRequest(grandchild.child, "call_1");
+      await vi.waitFor(() => {
+        requestIdFor(sibling.child.conversationId, "call_1");
+        requestIdFor(grandchild.child.conversationId, "call_1");
+      });
+      const siblingRequestId = requestIdFor(sibling.child.conversationId, "call_1");
+      const grandchildRequestId = requestIdFor(grandchild.child.conversationId, "call_1");
+      expect(siblingRequestId).not.toBe(grandchildRequestId);
+      expect(await runner.resolveToolDecision(agentId, { requestId: siblingRequestId, decision: { kind: "approved" } })).toBe(true);
+      await expect(siblingPending).resolves.toMatchObject({ decision: { kind: "approved" } });
+      await expectDecision(siblingRequestId, "approved");
+      await intermediate.close();
+      await expect(grandchildPending).resolves.toMatchObject({ decision: { kind: "abort" } });
+      await expectDecision(grandchildRequestId, "abort");
+      expect(await runner.resolveToolDecision(agentId, { requestId: grandchildRequestId, decision: { kind: "approved" } })).toBe(false);
+      await grandchild.close();
+
+      const abortController = new AbortController();
+      const aborting = makeRequest(sibling.child, "aborting-child", abortController.signal);
+      abortController.abort();
+      await expect(aborting).resolves.toMatchObject({ decision: { kind: "abort" } });
+      const stopping = makeRequest(sibling.child, "stopping-parent");
+      await runner.stopAgent(agentId, "test_cleanup");
+      await expect(stopping).resolves.toMatchObject({ decision: { kind: "abort" } });
+      await sibling.close();
+    },
+  );
 
   it("fsync-journals daemon permission requests and decisions before execution resumes", async () => {
     const { runner, session, rolloutItems } = makeTopLevelRunner({

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -5648,7 +5648,7 @@ snapshot_max_bytes = 64
     await rm(agencHome, { recursive: true, force: true });
   });
 
-  it("refuses to reinterpret daemon environment for a run without durable runtime options", async () => {
+  it.each(["runtime options", "command environment"] as const)("refuses to reinterpret daemon environment for a run without durable %s", async (missingAuthority) => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);
     const io = createIo();
@@ -5659,7 +5659,8 @@ snapshot_max_bytes = 64
       cwd: process.cwd(),
       runId,
       sessionId,
-      includeRuntimeOptions: false,
+      includeRuntimeOptions: missingAuthority !== "runtime options",
+      includeCommandEnvironment: missingAuthority !== "command environment",
     });
     const restoreAgent = vi.fn(async () => true);
     const runner: AgenCBackgroundAgentRunner = {
@@ -6973,6 +6974,7 @@ function seedRecoverableDaemonState(
     readonly status?: string;
     /** Set false only when exercising the fail-closed pre-contract recovery path. */
     readonly includeRuntimeOptions?: boolean;
+    readonly includeCommandEnvironment?: boolean;
   },
 ): string {
   const driver = openStateDatabases({
@@ -7008,6 +7010,9 @@ function seedRecoverableDaemonState(
           ...(params.includeRuntimeOptions === false
             ? {}
             : { runtimeOptions: TEST_RUNTIME_OPTIONS }),
+          ...(params.includeCommandEnvironment === false
+            ? {}
+            : { commandEnvironment: { PATH: "/usr/bin:/bin" } }),
         }),
       );
     driver
@@ -7226,6 +7231,7 @@ function seedRecoverableCompletedToolState(
         JSON.stringify({
           agentPath: `/root/${params.runId}`,
           runtimeOptions: TEST_RUNTIME_OPTIONS,
+          commandEnvironment: { PATH: "/usr/bin:/bin" },
         }),
       );
     driver

--- a/runtime/tests/app-server/daemon-workflow-authority.test.ts
+++ b/runtime/tests/app-server/daemon-workflow-authority.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { mergeDaemonClientEnvironment } from "../../src/app-server/client-env-snapshot.js";
+import { restoreRecoveredAgentRuntime } from "../../src/app-server/daemon-cli.js";
+import type { AgenCBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import type { RecoveredAgentRun } from "../../src/state/recovery.js";
+
+const runtimeOptions = resolveAgentRuntimeOptions({});
+
+function recoveredRun(commandEnvironment?: unknown): RecoveredAgentRun {
+  const timestamp = "2026-09-10T01:00:00.000Z";
+  return {
+    id: "conv-recovered-path",
+    objective: "Continue the sandboxed coding task",
+    status: "suspended",
+    projectDir: "/tmp/agenc-recovered-project",
+    currentSessionId: "daemon-session-recovered",
+    startedAt: timestamp,
+    lastActiveAt: timestamp,
+    metadata: {
+      agentPath: "/root",
+      runtimeOptions,
+      ...(commandEnvironment !== undefined ? { commandEnvironment } : {}),
+    },
+    latestSnapshot: {
+      projectDir: "/tmp/agenc-recovered-project",
+      sessionId: "daemon-session-recovered",
+      snapshotAt: timestamp,
+      conversation: [],
+      toolState: {},
+      mcpConnectionState: {},
+      recoveredToolCalls: [],
+    },
+    resumeSource: {
+      runId: "conv-recovered-path",
+      sessionId: "conv-recovered-path",
+      cwd: "/tmp/agenc-recovered-project",
+      rolloutPath: "/tmp/agenc-recovered-project/rollout.jsonl",
+      lifecycleState: "suspended",
+      close: vi.fn(),
+    } as RecoveredAgentRun["resumeSource"],
+  } as RecoveredAgentRun;
+}
+
+describe("daemon workflow authority", () => {
+  it("persists only the explicit client PATH for command recovery", async () => {
+    const startAgent = vi.fn(async () => ({
+      agentId: "conv-path-authority",
+      agentPath: "/root",
+      startedAt: "2026-09-10T01:00:00.000Z",
+      status: "running" as const,
+    }));
+    const manager = new AgenCDaemonAgentManager({
+      runner: { startAgent },
+      sessionManager: new AgenCDaemonSessionManager(),
+    });
+    await manager.createAgent({
+      objective: "Capture command authority",
+      cwd: "/tmp",
+      runtimeOptions,
+      envOverrides: { PATH: "/client/bin:/usr/bin", XAI_API_KEY: "fixture-secret" },
+      metadata: { commandEnvironment: { PATH: "/forged/bin", XAI_API_KEY: "forged" } },
+    });
+    expect(startAgent.mock.calls[0]?.[0].metadata?.commandEnvironment).toEqual({
+      PATH: "/client/bin:/usr/bin",
+    });
+    const listed = await manager.listAgents();
+    expect(listed.agents[0]?.metadata?.commandEnvironment).toEqual({
+      PATH: "/client/bin:/usr/bin",
+    });
+    expect(JSON.stringify(listed)).not.toContain("fixture-secret");
+    expect(JSON.stringify(listed)).not.toContain("forged");
+  });
+
+  it.each(["/client/bin:/usr/bin", ""])(
+    "restores the retained PATH authority %j without provider credentials",
+    async (retainedPath) => {
+      let restoredEnvironment: NodeJS.ProcessEnv | undefined;
+      const restoreAgent = vi.fn(async (params) => {
+        restoredEnvironment = mergeDaemonClientEnvironment(
+          { PATH: "/different-daemon/bin", XAI_API_KEY: "daemon-secret" },
+          params.envOverrides,
+        );
+        return true;
+      });
+      const runner: AgenCBackgroundAgentRunner = {
+        startAgent: vi.fn(),
+        restoreAgent,
+      };
+      await expect(
+        restoreRecoveredAgentRuntime(runner, recoveredRun({ PATH: retainedPath })),
+      ).resolves.toMatchObject({ available: true });
+      expect(restoreAgent.mock.calls[0]?.[0].envOverrides).toEqual({ PATH: retainedPath });
+      expect(restoredEnvironment?.PATH).toBe(retainedPath || undefined);
+      expect(restoredEnvironment).not.toHaveProperty("XAI_API_KEY");
+    },
+  );
+
+  it.each([undefined, {}, { PATH: 42 }, { PATH: "/client/bin", XAI_API_KEY: "secret" }])(
+    "defers recovery without valid credential-free command authority %j",
+    async (commandEnvironment) => {
+      const restoreAgent = vi.fn(async () => true);
+      const run = recoveredRun(commandEnvironment);
+      await expect(
+        restoreRecoveredAgentRuntime({ startAgent: vi.fn(), restoreAgent }, run),
+      ).resolves.toEqual({ available: false });
+      expect(restoreAgent).not.toHaveBeenCalled();
+      expect(run.resumeSource?.close).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("lists the same live permissions by canonical TUI and daemon session IDs", async () => {
+    const sessions = new AgenCDaemonSessionManager({
+      createSessionId: () => "daemon-session-permissions",
+    });
+    const listPermissions = vi.fn(async () => ({ permissions: [] }));
+    const manager = new AgenCDaemonAgentManager({
+      sessionManager: sessions,
+      runner: {
+        startAgent: async () => ({
+          agentId: "conv-canonical-permissions",
+          agentPath: "/root",
+          startedAt: "2026-09-10T01:00:00.000Z",
+          status: "running",
+        }),
+        listPermissions,
+      },
+    });
+    await manager.createAgent({ objective: "Inspect permissions", cwd: "/tmp", runtimeOptions });
+    await sessions.restoreSession({
+      sessionId: "conv-canonical-permissions",
+      agentId: "agent_default",
+      status: "waiting",
+      metadata: { recovered: true },
+    });
+    await expect(
+      manager.listPermissions({ sessionId: "conv-canonical-permissions" }),
+    ).resolves.toEqual({ permissions: [] });
+    await expect(
+      manager.listPermissions({ sessionId: "daemon-session-permissions" }),
+    ).resolves.toEqual({ permissions: [] });
+    expect(listPermissions.mock.calls).toEqual([
+      ["conv-canonical-permissions"],
+      ["conv-canonical-permissions"],
+    ]);
+    await sessions.terminateSession({ sessionId: "daemon-session-permissions" });
+    await expect(
+      manager.listPermissions({ sessionId: "conv-canonical-permissions" }),
+    ).rejects.toThrow("not found or closed");
+    expect(listPermissions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
+++ b/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
@@ -664,7 +664,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
         }
       ).approvalResolver?.request({
         callId: APPROVAL_REQUEST_ID,
-        invocation: { session: { conversationId: CONVERSATION_ID } },
+        invocation: { session },
       });
       resumeDriven.resolve();
     });

--- a/runtime/tests/permissions/file-write-preview.test.ts
+++ b/runtime/tests/permissions/file-write-preview.test.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { Event } from "../session/event-log.js";
+import {
+  daemonEventFromUnboundSessionEvent,
+  notificationFromDaemonEvent,
+} from "../app-server/background-agent-runner/daemon-events.js";
+import { isCanonicalEventPayload } from "../state/recovery-journal-schema.js";
+import type { ToolInvocation } from "../tools/context.js";
+import { createFileReadTool } from "../tools/system/file-read.js";
+import {
+  clearSessionReadState,
+  recordSessionRead,
+} from "../tools/system/filesystem.js";
+import { buildFileWriteApprovalPreview } from "./file-write-preview.js";
+import { requestApproval, type ApprovalCtx } from "./guardian/arbiter.js";
+import { createEmptyToolPermissionContext } from "./types.js";
+
+describe("file write approval preview", () => {
+  let root: string;
+  let sessionId: string;
+  let invocation: ToolInvocation;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-write-preview-"));
+    sessionId = randomUUID();
+    invocation = {
+      session: {
+        conversationId: sessionId,
+        services: {
+          permissionModeRegistry: {
+            current: () => createEmptyToolPermissionContext(),
+          },
+        },
+      },
+      turn: { cwd: root, subId: "turn-preview" },
+      callId: "call-preview",
+      toolName: { name: "Write" },
+      payload: { kind: "function", arguments: "{}" },
+      source: "direct",
+    } as ToolInvocation;
+  });
+
+  afterEach(async () => {
+    clearSessionReadState(sessionId, tmpdir());
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function seedRead(filePath: string, content: string): Promise<void> {
+    await writeFile(filePath, content);
+    const metadata = await stat(filePath);
+    recordSessionRead(sessionId, filePath, {
+      viewKind: "full",
+      content: "formatted display content",
+      rawContent: content,
+      timestamp: metadata.mtimeMs,
+    });
+  }
+
+  test.each(["original\nremoved\n", ""])(
+    "uses previously authorized raw contents, including an empty file",
+    async (content) => {
+      const target = join(root, "existing.txt");
+      await seedRead(target, content);
+      await expect(
+        buildFileWriteApprovalPreview(invocation, { file_path: "existing.txt" }),
+      ).resolves.toEqual({ kind: "existing", content });
+    },
+  );
+
+  test("marks only a verified missing path as a creation", async () => {
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: "new.txt" }),
+    ).resolves.toEqual({ kind: "missing" });
+  });
+
+  test("uses the snapshot produced by an actual full FileRead", async () => {
+    const target = join(root, "read-through-tool.txt");
+    const content = "original\nremoved\n";
+    await writeFile(target, content);
+    const tool = createFileReadTool({ allowedPaths: [root] });
+    const result = await tool.execute({ file_path: target, __agencSessionId: sessionId });
+    expect(result.isError).not.toBe(true);
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: target }),
+    ).resolves.toEqual({ kind: "existing", content });
+  });
+
+  test("does not read an existing file without a full session snapshot", async () => {
+    const target = join(root, "unread.txt");
+    await writeFile(target, "unapproved contents");
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: target }),
+    ).resolves.toMatchObject({ kind: "unavailable" });
+    recordSessionRead(sessionId, target, {
+      viewKind: "partial",
+      content: "unapproved contents",
+    });
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: target }),
+    ).resolves.toMatchObject({ kind: "unavailable" });
+  });
+
+  test("does not present stale, binary, oversized, or non-file content", async () => {
+    const target = join(root, "existing.txt");
+    await seedRead(target, "original");
+    recordSessionRead(sessionId, target, { timestamp: 0 });
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: target }),
+    ).resolves.toMatchObject({ kind: "unavailable" });
+    for (const content of ["binary\0content", "x".repeat(256 * 1024 + 1)]) {
+      await seedRead(target, content);
+      await expect(
+        buildFileWriteApprovalPreview(invocation, { file_path: target }),
+      ).resolves.toMatchObject({ kind: "unavailable" });
+    }
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: root }),
+    ).resolves.toMatchObject({ kind: "unavailable" });
+  });
+
+  test("does not treat a full image snapshot's base64 as file text", async () => {
+    const target = join(root, "image.png");
+    await seedRead(target, "image bytes");
+    recordSessionRead(sessionId, target, {
+      viewKind: "full",
+      content: null,
+      rawContent: Buffer.from("image bytes").toString("base64"),
+    });
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: target }),
+    ).resolves.toMatchObject({ kind: "unavailable" });
+  });
+
+  test("rejects outside paths and symlinks even when their contents were cached", async () => {
+    const workspace = join(root, "workspace");
+    const outside = join(root, "outside.txt");
+    await mkdir(workspace);
+    await seedRead(outside, "outside contents");
+    await symlink(outside, join(workspace, "link.txt"));
+    invocation = { ...invocation, turn: { ...invocation.turn, cwd: workspace } };
+    for (const filePath of [outside, "link.txt", "../outside.txt"]) {
+      await expect(
+        buildFileWriteApprovalPreview(invocation, { file_path: filePath }),
+      ).resolves.toMatchObject({ kind: "unavailable" });
+    }
+  });
+
+  test("respects current read denials even for previously read files", async () => {
+    const target = join(root, "denied.txt");
+    await seedRead(target, "previously authorized");
+    invocation = {
+      ...invocation,
+      session: {
+        ...invocation.session,
+        services: {
+          ...invocation.session.services,
+          permissionModeRegistry: {
+            current: () => ({
+              ...createEmptyToolPermissionContext(),
+              alwaysDenyRules: { localSettings: ["FileRead(**)"] },
+            }),
+          },
+        },
+      },
+    } as ToolInvocation;
+    await expect(
+      buildFileWriteApprovalPreview(invocation, { file_path: target }),
+    ).resolves.toMatchObject({ kind: "unavailable" });
+  });
+
+  test("supplies the same authoritative preview to the resolver and durable request", async () => {
+    const target = join(root, "existing.txt");
+    await seedRead(target, "old\nremoved\n");
+    const events: Event[] = [];
+    const session = {
+      ...invocation.session,
+      rolloutStore: {},
+      emit: (event: Event): Event => {
+        const stamped = { ...event, seq: events.length + 1, eventId: randomUUID() };
+        events.push(stamped);
+        return stamped;
+      },
+    } as ToolInvocation["session"];
+    const resolver = vi.fn(async (_context: ApprovalCtx) => ({ kind: "denied" as const }));
+    const preview = { kind: "existing", content: "old\nremoved\n" };
+    await requestApproval({
+      ctx: {
+        invocation: { ...invocation, session },
+        callId: invocation.callId,
+        toolName: "Write",
+        turnId: "turn-preview",
+        fileWritePreview: { kind: "missing" },
+      },
+      args: { file_path: target, content: "new\n" },
+      resolver: { request: resolver },
+    });
+    expect(resolver).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ fileWritePreview: preview }),
+    );
+    expect(events[0]?.msg).toMatchObject({
+      type: "request_permissions",
+      payload: { fileWritePreview: preview },
+    });
+    expect(isCanonicalEventPayload("request_permissions", events[0]?.msg.payload)).toBe(true);
+    const projected = daemonEventFromUnboundSessionEvent(events[0]!);
+    expect(projected).not.toBeNull();
+    expect(notificationFromDaemonEvent("session-preview", sessionId, projected!)).toMatchObject({
+      method: "event.permission_request",
+      params: { fileWritePreview: preview },
+    });
+  });
+
+  test("validates optional durable preview variants without accepting malformed content", () => {
+    const payload = { callId: "call-preview", toolName: "Write", permissions: ["tool.use"] };
+    for (const fileWritePreview of [
+      undefined,
+      { kind: "missing" },
+      { kind: "existing", content: "old\n" },
+      { kind: "unavailable", reason: "Read required" },
+    ]) {
+      expect(isCanonicalEventPayload("request_permissions", {
+        ...payload,
+        ...(fileWritePreview === undefined ? {} : { fileWritePreview }),
+      })).toBe(true);
+    }
+    for (const fileWritePreview of [
+      { kind: "existing", content: 123 },
+      { kind: "unavailable" },
+      { kind: "unknown" },
+    ]) {
+      expect(isCanonicalEventPayload("request_permissions", {
+        ...payload,
+        fileWritePreview,
+      })).toBe(false);
+    }
+  });
+});

--- a/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
+++ b/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
@@ -86,6 +86,11 @@ export interface SessionTranscriptV2TurnResult extends JsonObject {
   readonly outcome: "completed" | "aborted";
 }
 
+export interface SessionTranscriptV2Event extends JsonObject {
+  readonly eventId: string;
+  readonly type: "token_count" | "turn_failed" | "turn_aborted";
+}
+
 export interface SessionTranscriptV2Result extends JsonObject {
   readonly messages: readonly SessionTranscriptV2Message[];
 }

--- a/runtime/tests/tools/execution.test.ts
+++ b/runtime/tests/tools/execution.test.ts
@@ -85,6 +85,59 @@ describe("I-79 parseToolArgsWithBigInt", () => {
     expect(parsed!.n).toBe(12345);
   });
 
+  test.each([
+    'const record = {nextId:9007199254740992,bookmarks:[]};',
+    'const values = [9007199254740992, -9007199254740993];',
+    'const nested = "\\\"quoted\\\""; const record = {id:9007199254740992};',
+    '__bigint__9007199254740992',
+    '__bigint__not-a-number',
+  ])("preserves edit text without interpreting its contents: %s", (newString) => {
+    const input = {
+      file_path: "bookmarks.test.mjs",
+      old_string: "old",
+      new_string: newString,
+    };
+    expect(parseToolArgsWithBigInt(JSON.stringify(input))).toEqual(input);
+  });
+
+  test("preserves nested large integer tokens and literal marker strings", () => {
+    expect(
+      parseToolArgsWithBigInt(
+        '{"values":[9007199254740992,-9007199254740993,{"id":123456789012345678901234567890}],"__bigint__9007199254740992":"__bigint__9007199254740992","text":"{id:9007199254740992}"}',
+      ),
+    ).toEqual({
+      values: [
+        9007199254740992n,
+        -9007199254740993n,
+        { id: 123456789012345678901234567890n },
+      ],
+      __bigint__9007199254740992: "__bigint__9007199254740992",
+      text: "{id:9007199254740992}",
+    });
+  });
+
+  test("keeps decimal and exponent tokens as numbers", () => {
+    expect(
+      parseToolArgsWithBigInt(
+        '{"decimal":1234567890123456.5,"exponent":1234567890123456e2,"negativeZero":-0}',
+      ),
+    ).toEqual({
+      decimal: 1234567890123456.5,
+      exponent: 1234567890123456e2,
+      negativeZero: -0,
+    });
+  });
+
+  test.each([
+    '{"value":01234567890123456}',
+    '{"value":-01234567890123456}',
+    '{"value":+1234567890123456}',
+    '{"value":1234567890123456,}',
+    '{"value":1234567890123456e}',
+  ])("rejects malformed numeric JSON without repairing it: %s", (input) => {
+    expect(parseToolArgsWithBigInt(input)).toBeNull();
+  });
+
   test("malformed JSON returns null", () => {
     expect(parseToolArgsWithBigInt("{not json")).toBeNull();
   });
@@ -92,6 +145,53 @@ describe("I-79 parseToolArgsWithBigInt", () => {
   test("empty string returns empty object", () => {
     expect(parseToolArgsWithBigInt("")).toEqual({});
     expect(parseToolArgsWithBigInt("  ")).toEqual({});
+  });
+});
+
+describe("trusted parsed arguments", () => {
+  test("still validates runtime-supplied arguments before executing", async () => {
+    const execute = vi.fn(async () => ({ content: "unexpected" }));
+    const result = await runToolUse('{"count":1}', {
+      currentTurnId: "turn-typed-args",
+      invocation: makeInvocation("call-typed-args", "ArgumentEcho"),
+      parsedArgs: { count: "invalid" },
+      tool: {
+        name: "ArgumentEcho",
+        description: "",
+        isReadOnly: true,
+        inputSchema: {
+          type: "object",
+          properties: { count: { type: "number" } },
+          required: ["count"],
+          additionalProperties: false,
+        },
+        execute,
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("does not treat a model argument named parsedArgs as runtime authority", async () => {
+    const execute = vi.fn(async () => ({ content: "unexpected" }));
+    const result = await runToolUse('{"parsedArgs":{"count":1}}', {
+      currentTurnId: "turn-model-args",
+      invocation: makeInvocation("call-model-args", "ArgumentEcho"),
+      tool: {
+        name: "ArgumentEcho",
+        description: "",
+        isReadOnly: true,
+        inputSchema: {
+          type: "object",
+          properties: { count: { type: "number" } },
+          required: ["count"],
+          additionalProperties: false,
+        },
+        execute,
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
   });
 });
 

--- a/runtime/tests/tools/router.test.ts
+++ b/runtime/tests/tools/router.test.ts
@@ -1357,7 +1357,7 @@ describe("ToolRouter.dispatchToolCallWithCodeMode", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  test("dispatchModelToolCall preserves BigInt args after pre-hook rewrites", async () => {
+  test.each([0n, 123n, -123n, 900719925474099312345n])("dispatchModelToolCall preserves BigInt %s after pre-hook rewrites", async (rewrittenValue) => {
     let observedArgs: Record<string, unknown> | undefined;
     const execute = vi.fn(async (args: Record<string, unknown>) => {
       observedArgs = args;
@@ -1403,7 +1403,7 @@ describe("ToolRouter.dispatchToolCallWithCodeMode", () => {
         preHooks: [
           ({ args }) => ({
             kind: "continue" as const,
-            args: { ...args, path: "rewritten" },
+            args: { ...args, path: "rewritten", lamports: rewrittenValue },
           }),
         ],
       },
@@ -1412,7 +1412,62 @@ describe("ToolRouter.dispatchToolCallWithCodeMode", () => {
     expect(result.isError).toBeFalsy();
     expect(execute).toHaveBeenCalledOnce();
     expect(observedArgs).toMatchObject({ path: "rewritten" });
-    expect(observedArgs?.["lamports"]).toBe(900719925474099312345n);
+    expect(observedArgs?.["lamports"]).toBe(rewrittenValue);
+  });
+
+  test("dispatchModelToolCall preserves large integer literals inside edit arguments", async () => {
+    const input = {
+      file_path: "bookmarks.test.mjs",
+      edits: [
+        {
+          old_string: "old",
+          new_string: "const record = {nextId:9007199254740992,bookmarks:[]};",
+        },
+      ],
+    };
+    const execute = vi.fn(async () => ({ content: "ok" }));
+    const router = new ToolRouter([
+      {
+        tool: {
+          name: "ArgumentEcho",
+          description: "",
+          inputSchema: {},
+          isReadOnly: true,
+          execute,
+        },
+        supportsParallelToolCalls: true,
+      },
+    ]);
+
+    const result = await router.dispatchModelToolCall(
+      {
+        id: "call-model-edit-literal",
+        name: "ArgumentEcho",
+        arguments: JSON.stringify(input),
+      },
+      {
+        session: {
+          eventLog: new EventLog(),
+          services: { admissionRequired: false, runtimeOptions: TEST_RUNTIME_OPTIONS },
+        } as never,
+        turn: {
+          subId: "turn-model-edit-literal",
+          cwd: "/repo",
+          approvalPolicy: { value: "never" },
+          sandboxPolicy: { value: "read_only" },
+        } as never,
+        tracker: {
+          appendFileDiff: () => {},
+          snapshot: () => [],
+          clear: () => {},
+        },
+        approvalPolicy: "never",
+        sandboxMode: "read_only",
+      },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(execute).toHaveBeenCalledExactlyOnceWith(input);
   });
 
   test("dispatchModelToolCall audits terminal pre-hook denials once", async () => {

--- a/runtime/tests/tui/approval-confirmation-routing.test.tsx
+++ b/runtime/tests/tui/approval-confirmation-routing.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { ApprovalCtx } from "../../src/tools/orchestrator.js";
+import type { ReviewDecision } from "../../src/permissions/review-decision.js";
+import { AgenCPermissionOverlay, type PendingRequest } from "../../src/tui/permission-requests.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+const bindings = vi.hoisted(() => ({ handlers: {} as Record<string, () => unknown> }));
+
+vi.mock("../../src/tui/ink.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/tui/ink.js")>(),
+  useInput: () => {},
+}));
+vi.mock("../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybindings: (handlers: Record<string, () => unknown>) => { bindings.handlers = handlers; },
+}));
+
+describe("typed confirmation shortcut ownership", () => {
+  it("does not interpret the n in transfer as a denial shortcut", async () => {
+    const decisions: ReviewDecision[] = [];
+    const input = { command: "agenc transfer --mainnet --amount 5" };
+    const request: PendingRequest = {
+      id: "transfer-confirmation",
+      ctx: { callId: "transfer-confirmation", toolName: "Bash", turnId: "turn-1" } as ApprovalCtx,
+      input,
+      description: "Confirm transfer",
+      resolve: decision => decisions.push(decision),
+    };
+    const output = await renderToString(<AgenCPermissionOverlay request={request} tools={[{ name: "Bash" }]} />, { rows: 40, columns: 120 });
+    expect(output).toContain("transfer");
+    expect(bindings.handlers["confirm:no"]?.()).toBe(false);
+    expect(bindings.handlers["confirm:yes"]?.()).toBe(false);
+    expect(decisions).toEqual([]);
+    bindings.handlers["app:interrupt"]?.();
+    expect(decisions).toEqual([{ kind: "abort" }]);
+  });
+});

--- a/runtime/tests/tui/approval-write-preview.test.tsx
+++ b/runtime/tests/tui/approval-write-preview.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { ApprovalCtx } from "../../src/tools/orchestrator.js";
+import { AgenCPermissionOverlay, type PendingRequest } from "../../src/tui/permission-requests.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+vi.mock("../../src/tui/ink.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/tui/ink.js")>(),
+  useInput: () => {},
+}));
+
+function writeRequest(fileWritePreview?: ApprovalCtx["fileWritePreview"]): PendingRequest {
+  const input = { file_path: "bookmarks.mjs", content: "replacement\n" };
+  return {
+    id: "overwrite-request",
+    ctx: {
+      callId: "overwrite-request",
+      toolName: "Write",
+      turnId: "turn-1",
+      fileWritePreview,
+      invocation: { payload: { kind: "function", arguments: JSON.stringify(input) } },
+    } as unknown as ApprovalCtx,
+    input,
+    description: "Permission required to write bookmarks.mjs",
+    resolve() {},
+  };
+}
+
+async function renderWrite(request: PendingRequest): Promise<string> {
+  return renderToString(<AgenCPermissionOverlay request={request} tools={[{ name: "Write" }]} />, {
+    columns: 120,
+    rows: 45,
+  });
+}
+
+describe("authoritative Write approval preview", () => {
+  it("shows removed content and labels an overwrite EDIT", async () => {
+    const rendered = await renderWrite(writeRequest({ kind: "existing", content: "original first\noriginal second\n" }));
+    expect(rendered).toContain("EDIT");
+    expect(rendered).not.toContain("CREATE");
+    expect(rendered).toContain("+1 -2");
+    expect(rendered).toContain("original first");
+    expect(rendered).toContain("original second");
+    expect(rendered).toContain("replacement");
+  });
+
+  it("labels an empty existing file EDIT rather than CREATE", async () => {
+    const rendered = await renderWrite(writeRequest({ kind: "existing", content: "" }));
+    expect(rendered).toContain("EDIT");
+    expect(rendered).not.toContain("CREATE");
+  });
+
+  it("labels a daemon-confirmed missing file CREATE", async () => {
+    const rendered = await renderWrite(writeRequest({ kind: "missing" }));
+    expect(rendered).toContain("CREATE");
+    expect(rendered).toContain("+1 -0");
+  });
+
+  it.each([undefined, { kind: "unavailable" as const, reason: "Read access requires approval." }])("never fabricates a new-file diff when old content is unavailable", async (preview) => {
+    const rendered = await renderWrite(writeRequest(preview));
+    expect(rendered).toContain("Existing content unavailable");
+    expect(rendered).not.toContain("CREATE");
+    expect(rendered).not.toContain("+1 -0");
+    expect(rendered).toContain("approve once");
+  });
+});

--- a/runtime/tests/tui/daemon-session.dropped-approvals.test.ts
+++ b/runtime/tests/tui/daemon-session.dropped-approvals.test.ts
@@ -93,6 +93,107 @@ const flush = (): Promise<void> =>
   });
 
 describe("daemon approval/elicitation delivery never silently drops decisions", () => {
+  it.each([
+    { kind: "existing", content: "old contents\n" },
+    { kind: "missing" },
+    { kind: "unavailable", reason: "Read access requires approval." },
+  ])("forwards authoritative Write preview metadata through the approval context", async (fileWritePreview) => {
+    const client = createClient();
+    const contexts: import("../../src/tools/orchestrator.js").ApprovalCtx[] = [];
+    const session = createDaemonTuiSession({
+      baseSession: {
+        ...createBaseSession(),
+        services: {
+          ...createBaseSession().services,
+          approvalResolver: { request: async ctx => { contexts.push(ctx); return DENIED; } },
+        },
+      },
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    const unsubscribe = session.subscribeToEvents(() => {});
+    client.emit("session_1", {
+      type: "daemon.event",
+      msg: { type: "request_permissions", payload: { callId: "write_call", toolName: "Write", fileWritePreview } },
+    });
+    await flush();
+    expect(contexts[0]?.fileWritePreview).toEqual(fileWritePreview);
+    unsubscribe();
+  });
+
+  it("rejects oversized preview metadata without trusting tool-input hints", async () => {
+    const client = createClient();
+    const contexts: import("../../src/tools/orchestrator.js").ApprovalCtx[] = [];
+    const session = createDaemonTuiSession({
+      baseSession: {
+        ...createBaseSession(),
+        services: {
+          ...createBaseSession().services,
+          approvalResolver: { request: async ctx => { contexts.push(ctx); return DENIED; } },
+        },
+      },
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    const unsubscribe = session.subscribeToEvents(() => {});
+    client.emit("session_1", {
+      method: "event.permission_request",
+      params: {
+        requestId: "write_call",
+        toolName: "Write",
+        fileWritePreview: { kind: "existing", content: "x".repeat(256 * 1024 + 1) },
+        input: { file_path: "existing.txt", content: "replacement", fileWritePreview: { kind: "missing" } },
+      },
+    });
+    await flush();
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.fileWritePreview).toBeUndefined();
+    unsubscribe();
+  });
+
+  it.each(["permission_decision", "tool_call_completed"])("dismisses only the settled prompt on %s without sending another decision", async (type) => {
+    const client = createClient();
+    const contexts: import("../../src/tools/orchestrator.js").ApprovalCtx[] = [];
+    const session = createDaemonTuiSession({
+      baseSession: {
+        ...createBaseSession(),
+        services: {
+          ...createBaseSession().services,
+          approvalResolver: {
+            request: ctx => {
+              contexts.push(ctx);
+              return new Promise(resolve => {
+                ctx.signal?.addEventListener("abort", () => resolve(DENIED), { once: true });
+              });
+            },
+          },
+        },
+      },
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    const unsubscribe = session.subscribeToEvents(() => {});
+    for (const callId of ["cached_call", "pending_call"]) {
+      client.emit("session_1", {
+        type: "daemon.event",
+        msg: { type: "request_permissions", payload: { callId, toolName: "FileRead" } },
+      });
+    }
+    expect(contexts).toHaveLength(2);
+    client.emit("session_1", {
+      type: "daemon.event",
+      msg: { type, payload: { callId: "cached_call", decision: "approved_for_session", source: "cache" } },
+    });
+    await flush();
+    expect(contexts[0]?.signal?.aborted).toBe(true);
+    expect(contexts[1]?.signal?.aborted).toBe(false);
+    expect(client.requests).toEqual([]);
+    unsubscribe();
+  });
+
   it("surfaces a warning notice when tool.approve delivery fails", async () => {
     const client = createClient();
     client.failMethods.add("tool.approve");

--- a/runtime/tests/tui/daemon-transcript-snapshot-notices.test.ts
+++ b/runtime/tests/tui/daemon-transcript-snapshot-notices.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import { sessionTranscriptV2FromRollout } from "../../src/app-server/background-agent-runner.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+import type { EventMsg } from "../../src/session/event-log.js";
+import type { RolloutItem } from "../../src/session/rollout-item.js";
+import {
+  daemonTranscriptSnapshotCoversEvent,
+  daemonTranscriptSnapshotEvents,
+} from "../../src/tui/daemon-transcript-snapshot.js";
+import { adaptTranscriptEvents } from "../../src/tui/session-transcript.js";
+
+function event(sequence: number | undefined, eventId: string, msg: EventMsg): RolloutItem {
+  return { type: "event_msg", payload: { id: eventId, eventId, seq: sequence, msg } };
+}
+
+function transcriptEvent(item: RolloutItem): JsonObject {
+  if (item.type !== "event_msg") throw new Error("Expected a public event");
+  return { id: item.payload.id, ...item.payload.msg } as JsonObject;
+}
+
+function notification(item: RolloutItem): JsonObject {
+  if (item.type !== "event_msg") throw new Error("Expected a public event");
+  return {
+    method: "event.session_event",
+    params: {
+      sessionId: "session-1",
+      runId: "run-1",
+      eventId: item.payload.eventId,
+      sequence: item.payload.seq,
+      event: transcriptEvent(item),
+    },
+  };
+}
+
+function failedTurn(): RolloutItem[] {
+  return [
+    event(1, "user", { type: "user_message", payload: { message: "Finish the tests" } }),
+    event(2, "start", { type: "turn_started", payload: { turnId: "turn-1" } }),
+    event(3, "usage-1", { type: "token_count", payload: {
+      promptTokens: 10_000, completionTokens: 700, cachedInputTokens: 8_000,
+      reasoningOutputTokens: 100, webSearchRequests: 2, model: "grok-4.5", provider: "grok",
+    } }),
+    event(4, "answer", { type: "agent_message", payload: { message: "I will run the tests now." } }),
+    event(5, "usage-2", { type: "token_count", payload: {
+      promptTokens: 2_000, completionTokens: 250, cacheCreationInputTokens: 300,
+      model: "claude-sonnet-4-20250514", provider: "anthropic",
+    } }),
+    event(6, "failure", { type: "turn_failed", payload: {
+      turnId: "turn-1", code: "max_cost_exceeded", message: "Stopped: session cost limit reached.",
+    } }),
+  ];
+}
+
+describe("durable resume notices", () => {
+  it("restores failure explanations and exact per-sample spend through the production adapter", () => {
+    const items = failedTurn();
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    const resumed = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, "session-1"));
+    const live = adaptTranscriptEvents(items.map(transcriptEvent));
+    expect(JSON.stringify(resumed.messages)).toContain("Stopped: session cost limit reached.");
+    expect(snapshot.events?.find((entry) => entry.eventId === "failure")).toMatchObject({
+      type: "turn_failed", payload: { code: "max_cost_exceeded" }, committedSequence: 6,
+    });
+    expect(resumed.sessionCostUsd).toBeGreaterThan(0);
+    expect(resumed.sessionCostUsd).toBe(live.sessionCostUsd);
+    expect(resumed.latestUsage).toEqual(live.latestUsage);
+    expect(resumed.isStreaming).toBe(false);
+    const replay = items.filter((item) => !daemonTranscriptSnapshotCoversEvent(
+      snapshot, notification(item), transcriptEvent(item),
+    ));
+    expect(replay).toEqual([]);
+    const twice = adaptTranscriptEvents([
+      ...daemonTranscriptSnapshotEvents(snapshot, "session-1"), ...replay.map(transcriptEvent),
+    ]);
+    expect(twice.sessionCostUsd).toBe(live.sessionCostUsd);
+    expect(JSON.stringify(twice.messages).match(/Stopped: session cost limit reached\./gu)).toHaveLength(1);
+  });
+
+  it("retains active usage once and admits later samples and terminals", () => {
+    const items = failedTurn().slice(0, 5);
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1", {
+      turnId: "turn-1", clientMessageId: "client-1",
+    });
+    const later = event(7, "usage-later", { type: "token_count", payload: {
+      promptTokens: 5_000, completionTokens: 1_000, model: "grok-4.5", provider: "grok",
+    } });
+    const terminal = event(8, "failure-later", { type: "turn_failed", payload: {
+      turnId: "turn-1", code: "provider_error", message: "Provider stopped responding.",
+    } });
+    for (const item of [items[2]!, items[4]!]) {
+      expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(item), transcriptEvent(item))).toBe(true);
+    }
+    for (const item of [later, terminal]) {
+      expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(item), transcriptEvent(item))).toBe(false);
+    }
+    const resumed = adaptTranscriptEvents([
+      ...daemonTranscriptSnapshotEvents(snapshot, "session-1"), transcriptEvent(later), transcriptEvent(terminal),
+    ]);
+    expect(resumed.sessionCostUsd).toBe(adaptTranscriptEvents([...items, later].map(transcriptEvent)).sessionCostUsd);
+    expect(JSON.stringify(resumed.messages)).toContain("Provider stopped responding.");
+    expect(resumed.isStreaming).toBe(false);
+  });
+
+  it("preserves mixed unsequenced legacy notices and canonical turns without double counting", () => {
+    const legacyUsage = event(undefined, "legacy-usage", { type: "token_count", payload: {
+      promptTokens: 1_000, completionTokens: 20, model: "grok-4.5", provider: "grok",
+    } });
+    const legacyFailure = event(undefined, "legacy-failure", { type: "error", payload: {
+      turnId: "legacy-turn", cause: "background_agent_error", message: "Legacy permission denied.",
+    } });
+    const items: RolloutItem[] = [
+      { type: "response_item", payload: { role: "user", content: "Legacy request" } },
+      { type: "response_item", payload: { role: "assistant", content: "Legacy partial answer" } },
+      event(undefined, "legacy-start", { type: "turn_started", payload: { turnId: "legacy-turn" } }),
+      legacyUsage, legacyUsage, legacyFailure, ...failedTurn(),
+    ];
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    const resumed = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, "session-1"));
+    expect(JSON.stringify(resumed.messages)).toContain("Legacy permission denied.");
+    expect(JSON.stringify(resumed.messages)).toContain("Stopped: session cost limit reached.");
+    expect(resumed.sessionCostUsd).toBe(adaptTranscriptEvents([legacyUsage, ...failedTurn()].map(transcriptEvent)).sessionCostUsd);
+    for (const item of [legacyUsage, legacyFailure]) {
+      expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(item), transcriptEvent(item))).toBe(true);
+    }
+  });
+
+  it("does not suppress notices absent from older daemon snapshots", () => {
+    const snapshot = sessionTranscriptV2FromRollout(failedTurn(), "session-1", "run-1");
+    const older = { ...snapshot, events: undefined };
+    for (const item of failedTurn().filter((entry) => entry.type === "event_msg" &&
+      ["token_count", "turn_failed"].includes(entry.payload.msg.type))) {
+      expect(daemonTranscriptSnapshotCoversEvent(older, notification(item), transcriptEvent(item))).toBe(false);
+    }
+  });
+
+  it("retains session spend across a history reset without resurrecting cleared failure text", () => {
+    const items = [
+      ...failedTurn(),
+      event(7, "clear", { type: "history_cleared", payload: {} }),
+      event(8, "new-user", { type: "user_message", payload: { message: "A fresh request" } }),
+    ];
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    const resumed = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, "session-1"));
+    expect(resumed.sessionCostUsd).toBe(adaptTranscriptEvents(items.map(transcriptEvent)).sessionCostUsd);
+    expect(resumed.sessionCostUsd).toBeGreaterThan(0);
+    expect(JSON.stringify(resumed.messages)).not.toContain("Stopped: session cost limit reached.");
+    expect(JSON.stringify(resumed.messages)).toContain("A fresh request");
+    expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(items[5]!), transcriptEvent(items[5]!))).toBe(true);
+  });
+
+  it("restores abort reasons and rejects stale or duplicate failure identities", () => {
+    const items = [
+      ...failedTurn().slice(0, 5),
+      event(6, "stale", { type: "turn_failed", payload: {
+        turnId: "old-turn", code: "provider_error", message: "Stale failure",
+      } }),
+      event(7, "abort", { type: "turn_aborted", payload: { turnId: "turn-1", reason: "Permission denied" } }),
+      event(8, "duplicate", { type: "turn_failed", payload: {
+        turnId: "turn-1", code: "provider_error", message: "Duplicate failure",
+      } }),
+    ];
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    const resumed = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, "session-1"));
+    const text = JSON.stringify(resumed.messages);
+    expect(text).toContain("Turn aborted: Permission denied");
+    expect(text).not.toContain("Stale failure");
+    expect(text).not.toContain("Duplicate failure");
+    expect(resumed.isStreaming).toBe(false);
+    for (const item of items.slice(5)) {
+      expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(item), transcriptEvent(item))).toBe(true);
+    }
+  });
+
+  it("does not collapse legacy usage rows whose subscription envelope IDs were reused", () => {
+    const items: RolloutItem[] = [100, 200].map((promptTokens) => ({
+      type: "event_msg",
+      payload: { id: "reused-subscription", msg: { type: "token_count", payload: {
+        promptTokens, completionTokens: 20, model: "grok-4.5", provider: "grok",
+      } } },
+    }));
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    const resumed = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, "session-1"));
+    expect(snapshot.events).toHaveLength(2);
+    expect(resumed.sessionCostUsd).toBe(items.reduce((cost, item) =>
+      cost + adaptTranscriptEvents([transcriptEvent(item)]).sessionCostUsd, 0));
+  });
+
+  it("rejects malformed notices and deduplicates repeated snapshot event IDs", () => {
+    const snapshot = sessionTranscriptV2FromRollout(failedTurn(), "session-1", "run-1");
+    const notice = snapshot.events![0]!;
+    expect(() => daemonTranscriptSnapshotEvents({ ...snapshot, events: [{
+      ...notice, committedSequence: snapshot.asOfSequence + 1,
+    }] }, "session-1")).toThrow(/invalid transcript notice/u);
+    expect(() => daemonTranscriptSnapshotEvents({ ...snapshot, events: [{
+      ...notice, type: "request_permissions" as never,
+    }] }, "session-1")).toThrow(/invalid transcript notice/u);
+    const once = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, "session-1"));
+    const repeated = adaptTranscriptEvents(daemonTranscriptSnapshotEvents({
+      ...snapshot, events: [...snapshot.events!, notice],
+    }, "session-1"));
+    expect(repeated.sessionCostUsd).toBe(once.sessionCostUsd);
+  });
+});

--- a/runtime/tests/tui/file-read-count-regression.test.tsx
+++ b/runtime/tests/tui/file-read-count-regression.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { formatStructuredToolResult } from "../../src/tui/session-transcript.js";
+import { FileReadView } from "../../src/tui/tool-rendering.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+describe("live FileRead line counts", () => {
+  it.each([403, 50, 1, 0])("preserves %i returned lines before transcript clamping", async (numLines) => {
+    const result = Array.from({ length: numLines }, (_, index) => ` ${index + 101}→line ${index}`).join("\n");
+    const blocks = formatStructuredToolResult("FileRead", "tool_call_completed", {
+      result,
+      metadata: { numLines, totalLines: 500, startLine: 101 },
+    });
+    const rendered = await renderToString(<FileReadView content={blocks.map(block => block.text).join("\n")} />);
+    expect(rendered).toContain(numLines === 0 ? "(empty file)" : `Read ${numLines} ${numLines === 1 ? "line" : "lines"}`);
+    expect(blocks.map(block => block.text).join("\n").length).toBeLessThan(100);
+  });
+
+  it("counts all numbered rows when older results lack metadata", async () => {
+    const blocks = formatStructuredToolResult("FileRead", "tool_call_completed", {
+      result: " 21→first\n 22→second\n 23→third",
+    });
+    const rendered = await renderToString(<FileReadView content={blocks.map(block => block.text).join("\n")} />);
+    expect(rendered).toContain("Read 3 lines");
+  });
+});

--- a/runtime/tests/tui/keybindings/KeybindingProviderSetup.test.tsx
+++ b/runtime/tests/tui/keybindings/KeybindingProviderSetup.test.tsx
@@ -81,6 +81,20 @@ function parseInputEvent(sequence: string): InputEvent {
 }
 
 describe("KeybindingProviderSetup", () => {
+  test("leaves destructive confirmation letters alone while keeping the explicit diff chord", () => {
+    const bindings = parseBindings(DEFAULT_BINDINGS);
+    for (const character of "delete") {
+      expect(resolveKeyWithChordState(character, key(), ["Confirmation"], bindings, null).type).toBe("none");
+    }
+    const prefix = resolveKeyWithChordState("w", key({ ctrl: true }), ["Confirmation"], bindings, null);
+    expect(prefix.type).toBe("chord_started");
+    if (prefix.type !== "chord_started") throw new Error("expected the full-diff chord prefix");
+    expect(resolveKeyWithChordState("d", key(), ["Confirmation"], bindings, prefix.pending)).toEqual({
+      type: "match",
+      action: "workbench:openDiff",
+    });
+  });
+
   test("summarizes warning counts without upstream utility dependencies", () => {
     expect(
       formatKeybindingWarningSummary([

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -109,6 +109,36 @@ function createPendingRequest(
 }
 
 describe("permission request overlay coverage", () => {
+  test.each(["delete", "del", "delete extra"])("handles a confirmation input chunk %s without premature approval", async (chunk) => {
+    const resolved: ReviewDecision[] = [];
+    const request = createPendingRequest(decision => resolved.push(decision), {
+      input: { command: "rm -rf /tmp/agenc-confirmation-fixture" },
+      description: "Remove a disposable fixture",
+    });
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    try {
+      root.render(<AgenCPermissionOverlay request={request} tools={[{ name: "Bash" }]} />);
+      await sleep();
+      stdin.write(chunk);
+      await sleep();
+      expect(stripAnsi(output())).toContain(chunk === "del" ? "del" : "delete");
+      expect(resolved).toEqual([]);
+      stdin.write("\r");
+      await sleep();
+      expect(resolved).toEqual(chunk === "delete" ? [APPROVED] : []);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
   test("requires the typed high-risk confirmation word before approving", async () => {
     const resolved: ReviewDecision[] = [];
     const request = createPendingRequest(decision => {

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -223,8 +223,9 @@ describe("workbench keybinding contract", () => {
       x: "agents:stop",
     });
     expect(byContext.get("Confirmation")).toMatchObject({
-      d: "workbench:openDiff",
+      "ctrl+w d": "workbench:openDiff",
     });
+    expect(byContext.get("Confirmation")).not.toHaveProperty("d");
   });
 
   it("keeps TEST surface footer hints aligned with surface navigation bindings", () => {


### PR DESCRIPTION
## Changes

- Preserve explicit client PATH during daemon recovery and make later warm attachment find the restored live session.
- Route memory-child approvals through the live parent Session with cancellation, identity checks, and separate request IDs.
- Show authorized overwrite diffs, accept exact destructive-confirmation text, keep the diff shortcut out of text input, and remove settled approval prompts.
- Resolve ordinary TUI session IDs for permission inspection and show correct FileRead line counts.
- Preserve quoted code and bigint values through tool argument parsing without bypassing validation or permissions.
- Restore failure explanations, usage, and spending when resuming a transcript. Keep older snapshots compatible and update the generated SDK types.
- Add regression tests for all ten audit findings and the related warm-attachment failure.

## Validation

- Runtime and test-support typechecks, runtime and SDK builds, generated SDK checks, and whitespace checks pass.
- Final hermetic lifecycle and durable-approval tests pass, 156 tests. Other targeted regression suites pass, with before-and-after failure checks for the repaired behavior.
- Real PTY startup passes at three viewport sizes in both startup modes. Five mock-provider TUI permission scenarios and all 51 PowerShell tests pass.
- Cold, warm, and repeated cold attachment of the original Grok session restore spending and failure explanations. Journal counts remain unchanged, with no additional inference or budget change.
- Independent local agent review approves the approval boundary, parser, write preview, recovery authority, and transcript replay. GitNexus reports the expected high aggregate scope, 69 mapped symbols and 13 affected flows. New files were reviewed separately.

## Known Test Limits

The full hermetic suite completed with 24,697 passes and eight failures. One failure was a fixture using a fake Session identity; the corrected fixture and affected suites pass on the final source. Six failures reproduce unchanged on main: two stale CLI expectations, live-test discovery, two architecture checks, and a saved benchmark digest. The remaining failure is the fuzzy benchmark's deliberate dirty-checkout guard; its clean-baseline run passes.

After committing the reviewed source, the clean-commit fuzzy benchmark suite passes all eight tests. Its hermetic run also repeats runtime and test-support typechecks.

The complete suite preceded the final warm-attachment adjustment. Its affected tests, typechecks, builds, and real attachment checks were rerun afterward. The local kernel lane passed 14 tests and failed one AppArmor host-profile assertion. No host policy, test constraint, or baseline evidence was weakened.

Automatic CI workflows remain disabled as requested. This PR does not change workflow files, enable Actions workflows, publish packages, or release artifacts.
