### PR TITLE
fix(permissions): use live FileRead examples in user guidance

### DIFF
--- a/runtime/src/permissions/permission-cli.ts
+++ b/runtime/src/permissions/permission-cli.ts
@@ -126,7 +126,7 @@ export function formatAgenCPermissionsCliHelpText(): string {
     "",
     "Examples:",
     "  agenc permissions list",
-    "  agenc permissions approve --persist user 'Read(./src/**)'",
+    "  agenc permissions approve --persist user 'FileRead(./src/**)'",
     "  agenc permissions approve --session session_123 call_456",
     "  agenc permissions revoke --session session_123 call_456",
   ].join("\n");

--- a/runtime/src/utils/settings/validationTips.ts
+++ b/runtime/src/utils/settings/validationTips.ts
@@ -47,7 +47,7 @@ const TIP_MATCHERS: TipMatcher[] = [
       ctx.expected === 'array',
     tip: {
       suggestion:
-        'Permission rules must be in an array. Format: ["Tool(specifier)"]. Examples: ["Bash(npm run build)", "Edit(docs/**)", "Read(~/.zshrc)"]. Use * for wildcards.',
+        'Permission rules must be in an array. Format: ["Tool(specifier)"]. Examples: ["exec_command(npm run build)", "Edit(docs/**)", "FileRead(~/.zshrc)"]. Use * for wildcards.',
     },
   },
   {

--- a/runtime/tests/permissions/tool-name-authority.test.ts
+++ b/runtime/tests/permissions/tool-name-authority.test.ts
@@ -11,8 +11,26 @@ import { matchesPattern } from "../../src/utils/hooks.js";
 import {
   permissionRuleValueFromString,
 } from "../../src/utils/permissions/permissionRuleParser.js";
+import { formatAgenCPermissionsCliHelpText } from "../../src/permissions/permission-cli.js";
 import { isRemovedLiveToolName } from "../../src/permissions/tool-names.js";
 import { validatePermissionRule } from "../../src/utils/settings/permissionValidation.js";
+import { getValidationTip } from "../../src/utils/settings/validationTips.js";
+
+/** Pull `Tool(...)` examples out of quoted help/tip text. Skip the schema placeholder. */
+function extractQuotedPermissionRules(text: string): string[] {
+  const rules: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(/['"]([^'"]+)['"]/g)) {
+    const value = match[1];
+    if (value === "Tool(specifier)") continue;
+    if (!/^[A-Za-z][\w.]*\(.+\)$/.test(value)) continue;
+    if (seen.has(value)) continue;
+    seen.add(value);
+    rules.push(value);
+  }
+  return rules;
+}
+
 
 const REMOVED_NAMES = [
   "WebFetch",
@@ -100,5 +118,31 @@ describe("live tool-name authority", () => {
     { task_id: "task-1", wait_up_to: 1 },
   ])("TaskOutput rejects removed input aliases %#", (input) => {
     expect(TaskOutputTool.inputSchema.safeParse(input).success).toBe(false);
+  });
+
+  test("permissions CLI help examples are live rules the validator accepts", () => {
+    const help = formatAgenCPermissionsCliHelpText();
+    const examples = extractQuotedPermissionRules(help);
+    expect(examples.length).toBeGreaterThan(0);
+    for (const example of examples) {
+      const parsed = permissionRuleValueFromString(example);
+      expect(isRemovedLiveToolName(parsed.toolName)).toBe(false);
+      expect(validatePermissionRule(example)).toEqual({ valid: true });
+    }
+  });
+
+  test("permission-array validation tips quote live rules the validator accepts", () => {
+    const tip = getValidationTip({
+      path: "permissions.allow",
+      code: "invalid_type",
+      expected: "array",
+    });
+    const examples = extractQuotedPermissionRules(tip?.suggestion ?? "");
+    expect(examples.length).toBeGreaterThan(0);
+    for (const example of examples) {
+      const parsed = permissionRuleValueFromString(example);
+      expect(isRemovedLiveToolName(parsed.toolName)).toBe(false);
+      expect(validatePermissionRule(example)).toEqual({ valid: true });
+    }
   });
 });


### PR DESCRIPTION
## Changes

Closes #2130.

CLI help and settings validation tips still printed removed `Read(...)` (and `Bash(...)`) rules that the permission validator rejects. Following those examples cannot grant the live `FileRead` tool.

- Quote `FileRead(./src/**)` in `formatAgenCPermissionsCliHelpText`.
- Quote `exec_command(npm run build)`, `Edit(docs/**)`, and `FileRead(~/.zshrc)` in the permissions-array validation tip.
- Tests extract those quoted examples from the real help/tip strings and assert `validatePermissionRule` accepts them and `isRemovedLiveToolName` is false.

## Verification

- `runtime/tests/permissions/tool-name-authority.test.ts` 26/26 (hermetic vitest, Node 26.7.0).
- `npm run typecheck` on the runtime workspace.

## Notes

One issue. Does not touch hook transcript grants (#2132) or session-clear permissions (#2127 / open PR #2352).