### PR TITLE
fix(runtime): abort Grok streams when turns are interrupted

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/09-ctrl-c-mid-stream.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/09-ctrl-c-mid-stream.mjs
@@ -1,35 +1,151 @@
-/**
- * Mid-stream Ctrl+C scenario.
- *
- * Submits a prompt that yields a long reply, then sends Ctrl+C while the
- * assistant is still streaming. Expects the cancel to land cleanly: stream
- * stops, prompt returns idle, no crash, no orphaned subagent.
- *
- * Catches: cancel paths that throw, half-written transcript entries that
- * never close, subagents that keep streaming bytes after the parent client
- * detaches, daemon ↔ client state mismatch on cancel.
- *
- * The test waits ~2s after the assistant starts replying before sending
- * SIGINT, which is enough for the model to have generated some content but
- * (with a long-form prompt) far short of the natural turn end.
- */
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
 
 export const meta = {
-  description: "Ctrl+C mid-stream cancels cleanly without crashing the TUI.",
+  description: "Escape aborts a held Grok stream and records turn cancellation.",
   timeoutMs: 60_000,
+  args: ["--provider", "grok", "--model", "grok-4.6"],
 };
 
 export default async function (session) {
-  await session.start();
-  await session.waitForPrompt({ timeout: 15_000 });
-  await session.type(
-    "Write a 200-word essay about the history of the printing press.",
-  );
-  await session.submit();
-  // Let the model start producing tokens. Idle won't fire while bytes flow.
-  await sleep(3_000);
-  // Ctrl+C: this is "esc to interrupt" in the TUI footer.
-  session.send("\x1b"); // Esc is the documented mid-stream cancel
-  await session.waitForIdle({ idleWindow: 1_500, timeout: 15_000 });
+  const activeResponses = new Set();
+  let streamStarted = false;
+  let streamClosed = false;
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404);
+        response.end();
+        return;
+      }
+      const chunks = [];
+      for await (const chunk of request) chunks.push(chunk);
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      if (body.stream !== true) {
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({
+          id: "resp_escape_prewarm",
+          object: "response",
+          created_at: Math.floor(Date.now() / 1000),
+          status: "completed",
+          model: body.model,
+          output: [{
+            type: "message",
+            id: "msg_escape_prewarm",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "OK", annotations: [] }],
+          }],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        }));
+        return;
+      }
+      if (streamStarted) {
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.end(`data: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_escape_followup",
+            object: "response",
+            created_at: Math.floor(Date.now() / 1000),
+            status: "completed",
+            model: body.model,
+            output: [{
+              type: "message",
+              id: "msg_escape_followup",
+              role: "assistant",
+              status: "completed",
+              content: [{
+                type: "output_text",
+                text: "GROK_INTERRUPT_FOLLOWUP_OK",
+                annotations: [],
+              }],
+            }],
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+          },
+        })}\n\ndata: [DONE]\n\n`);
+        return;
+      }
+      streamStarted = true;
+      activeResponses.add(response);
+      response.on("close", () => {
+        streamClosed = true;
+        activeResponses.delete(response);
+      });
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      });
+      response.write(`data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        item_id: "item_escape",
+        output_index: 0,
+        content_index: 0,
+        delta: "GROK_INTERRUPT_STREAM_ACTIVE",
+      })}\n\n`);
+    } catch (error) {
+      response.destroy(error);
+    }
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    Object.assign(session.envOverrides, {
+      AGENC_PROVIDER: "grok",
+      AGENC_MODEL: "grok-4.6",
+      AGENC_MAX_OUTPUT_TOKENS: "4096",
+      GROK_AUTH_MODE: "api-key",
+      XAI_API_KEY: "local-inert-escape-key",
+      XAI_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
+      AGENC_AUTH_MANAGED_KEYS_ENABLED: "0",
+    });
+    await session.start();
+    await session.waitForPrompt({ timeout: 15_000 });
+    await session.submit("Produce a response for the interruption test.");
+    await session.waitFor(/GROK_INTERRUPT_STREAM_ACTIVE/u, { timeout: 15_000 });
+    assert.equal(streamStarted, true);
+    assert.equal(streamClosed, false);
+    session.send("\x1b");
+    const deadline = Date.now() + 4_000;
+    while (!streamClosed && Date.now() < deadline) {
+      session.throwIfAborted();
+      await delay(50);
+    }
+    assert.equal(streamClosed, true, "Escape did not close Grok's active HTTP stream");
+    const terminalDeadline = Date.now() + 4_000;
+    let aborted = [];
+    while (Date.now() < terminalDeadline) {
+      session.throwIfAborted();
+      const items = await session.readRolloutItems();
+      const events = items
+        .filter((item) => item.type === "event_msg")
+        .map((item) => item.payload.msg);
+      aborted = events.filter((event) => event.type === "turn_aborted");
+      if (aborted.length > 0) break;
+      await delay(50);
+    }
+    assert.equal(aborted.length, 1, "Escape must durably abort exactly one turn");
+    assert.equal(aborted[0].payload.reason, "interrupted");
+    await session.waitForIdle({ idleWindow: 1_500, timeout: 5_000 });
+    await session.submit("Reply to this follow-up after the interrupted turn.");
+    await session.waitFor(/GROK_INTERRUPT_FOLLOWUP_OK/u, { timeout: 15_000 });
+    await session.waitForIdle({ idleWindow: 1_500, timeout: 5_000 });
+    const finalEvents = (await session.readRolloutItems())
+      .filter((item) => item.type === "event_msg")
+      .map((item) => item.payload.msg);
+    assert.equal(finalEvents.filter((event) => event.type === "turn_started").length, 2);
+    assert.equal(finalEvents.filter((event) => event.type === "turn_aborted").length, 1);
+    assert.equal(finalEvents.filter((event) => event.type === "turn_complete").length, 1);
+  } finally {
+    for (const response of activeResponses) response.destroy();
+    server.closeAllConnections();
+    await new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
 }

--- a/runtime/src/llm/providers/grok/adapter.ts
+++ b/runtime/src/llm/providers/grok/adapter.ts
@@ -360,6 +360,7 @@ async function nextStreamChunkWithTimeout<T>(
   // gaphunt3 #21: the caller's AbortSignal must keep teeing the open stream;
   // withTimeout detaches at stream-open, so the chunk loop re-supplies it here.
   externalSignal?: AbortSignal,
+  abortStream?: (reason?: unknown) => void,
 ): Promise<IteratorResult<T>> {
   const effectiveTimeoutMs =
     typeof timeoutMs === "number" && timeoutMs > 0 ? timeoutMs : undefined;
@@ -370,8 +371,10 @@ async function nextStreamChunkWithTimeout<T>(
   // gaphunt3 #21: already-aborted signals must reject before awaiting the next
   // chunk so a mid-stream cancel cannot block on a slow iterator.next().
   if (externalSignal?.aborted) {
+    const error = createStreamAbortError(providerName, externalSignal);
+    abortStream?.(error);
     await closeAsyncIterator(iterator);
-    throw createStreamAbortError(providerName, externalSignal);
+    throw error;
   }
 
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -390,6 +393,7 @@ async function nextStreamChunkWithTimeout<T>(
   const interrupt = (error: Error): void => {
     if (interruption.error !== undefined) return;
     interruption.error = error;
+    abortStream?.(error);
     void (async () => {
       // `return()` requests teardown, but the AsyncIterator contract does not
       // guarantee that its resolution also settles an already-pending
@@ -1389,6 +1393,8 @@ export class GrokProvider implements LLMProvider {
       // forwarded under the call_id the tool-input session events key on.
       const functionCallItemIds = new Map<string, string>();
       let streamIterator: AsyncIterator<any> | null = null;
+      let abortStream: ((reason?: unknown) => void) | undefined;
+      let streamExhausted = false;
       let responseTracePayload: Record<string, unknown> | undefined;
       let streamResponseMeta: ProviderResponseTraceMeta | undefined;
       let completedResponseId: string | undefined;
@@ -1487,6 +1493,12 @@ export class GrokProvider implements LLMProvider {
         options?.tools,
       );
       const stream = result.data;
+      const streamController = (stream as { controller?: AbortController }).controller;
+      if (streamController !== undefined && typeof streamController.abort === "function") {
+        abortStream = (reason) => {
+          if (!streamController.signal.aborted) streamController.abort(reason);
+        };
+      }
       attemptPhaseTimeoutMs = streamTimeout.timeoutMs;
       streamResponseMeta = buildProviderResponseMeta({
         response: result.response,
@@ -1533,8 +1545,12 @@ export class GrokProvider implements LLMProvider {
           streamTimeout.timeoutMs,
           this.name,
           options?.signal,
+          abortStream,
         );
-        if (iterResult.done) break;
+        if (iterResult.done) {
+          streamExhausted = true;
+          break;
+        }
         const event = iterResult.value;
         streamEventIndex += 1;
         emitProviderTraceEvent(options, {
@@ -1969,6 +1985,7 @@ export class GrokProvider implements LLMProvider {
       }
       throw mappedError;
       } finally {
+      if (!streamExhausted) abortStream?.(options?.signal?.reason);
       if (streamIterator) await closeAsyncIterator(streamIterator);
       streamIterator = null;
     }

--- a/runtime/tests/llm/providers/grok/stream-cancellation.test.ts
+++ b/runtime/tests/llm/providers/grok/stream-cancellation.test.ts
@@ -1,0 +1,209 @@
+import { getEventListeners } from "node:events";
+import { Stream } from "openai/core/streaming";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GrokProvider } from "../../../../src/llm/providers/grok/adapter.js";
+import { LLMTimeoutError } from "../../../../src/llm/errors.js";
+import type { LLMChatOptions, LLMResponse, StreamProgressCallback } from "../../../../src/llm/types.js";
+
+const cleanupStreams: Array<() => void> = [];
+const pendingRequests: Promise<LLMResponse>[] = [];
+
+function sdkStreamFixture(options: { delayAbortSettlement?: boolean } = {}) {
+  const controller = new AbortController();
+  let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(current) { bodyController = current; },
+  });
+  const release = () => bodyController.error(new DOMException("Fixture socket aborted", "AbortError"));
+  controller.signal.addEventListener("abort", () => {
+    if (options.delayAbortSettlement !== true) release();
+  }, { once: true });
+  const response = new Response(body, {
+    headers: { "content-type": "text/event-stream" },
+  });
+  const stream = Stream.fromSSEResponse<Record<string, unknown>>(response, controller);
+  const iterator = stream[Symbol.asyncIterator]();
+  const next = vi.fn(() => iterator.next());
+  const close = vi.fn(() => iterator.return!());
+  stream[Symbol.asyncIterator] = () => ({ next, return: close });
+  cleanupStreams.push(() => {
+    controller.abort();
+    release();
+  });
+  const send = (event: Record<string, unknown>) => {
+    bodyController.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+  };
+  return {
+    stream,
+    controller,
+    next,
+    close,
+    release,
+    send,
+    end: () => bodyController.close(),
+    fail: (error: Error) => bodyController.error(error),
+    request: { withResponse: async () => ({ data: stream, response, request_id: "fixture" }) },
+  };
+}
+
+function providerFixture(streams: ReturnType<typeof sdkStreamFixture>[], timeoutMs?: number) {
+  const provider = new GrokProvider({
+    apiKey: "fixture-only",
+    model: "grok-4-fast",
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  });
+  let nextStream = 0;
+  const create = vi.fn(() => {
+    const stream = streams[nextStream++];
+    if (stream === undefined) throw new Error("Unexpected extra provider request");
+    return stream.request;
+  });
+  Object.assign(provider, { client: { responses: { create } } });
+  return { provider, create };
+}
+
+function startStream(
+  provider: GrokProvider,
+  options: LLMChatOptions = {},
+  onChunk: StreamProgressCallback = () => {},
+) {
+  const request = provider.chatStream(
+    [{ role: "user", content: "Fixture cancellation request" }],
+    onChunk,
+    { singleWireAttempt: true, ...options },
+  );
+  pendingRequests.push(request);
+  let settled = false;
+  void request.then(() => { settled = true; }, () => { settled = true; });
+  return { request, settled: () => settled };
+}
+
+function completedEvent() {
+  return {
+    type: "response.completed",
+    response: {
+      id: "fixture-response",
+      model: "grok-4-fast",
+      status: "completed",
+      output_text: "done",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    },
+  };
+}
+
+afterEach(async () => {
+  for (const cleanup of cleanupStreams.splice(0)) cleanup();
+  await Promise.allSettled(pendingRequests.splice(0));
+  vi.restoreAllMocks();
+});
+
+describe("Grok SDK stream cancellation", () => {
+  it.each([false, true])("aborts a pending physical SSE read after partial content=%s", async (partial) => {
+    const fixture = sdkStreamFixture();
+    const { provider } = providerFixture([fixture]);
+    const caller = new AbortController();
+    const running = startStream(provider, { signal: caller.signal });
+    await vi.waitFor(() => expect(fixture.next).toHaveBeenCalledOnce());
+    if (partial) {
+      fixture.send({ type: "response.output_text.delta", delta: "partial" });
+      await vi.waitFor(() => expect(fixture.next).toHaveBeenCalledTimes(2));
+    }
+    caller.abort("interrupted");
+    await vi.waitFor(() => expect(fixture.controller.signal.aborted).toBe(true));
+    if (partial) {
+      await expect(running.request).resolves.toMatchObject({ content: "partial", finishReason: "error" });
+    } else {
+      await expect(running.request).rejects.toThrow();
+    }
+    expect(fixture.close).toHaveBeenCalledOnce();
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+  });
+
+  it("retains settlement until the aborted SDK reader physically finishes", async () => {
+    const fixture = sdkStreamFixture({ delayAbortSettlement: true });
+    const { provider } = providerFixture([fixture]);
+    const caller = new AbortController();
+    const running = startStream(provider, { signal: caller.signal });
+    await vi.waitFor(() => expect(fixture.next).toHaveBeenCalledOnce());
+    caller.abort("interrupted");
+    await vi.waitFor(() => expect(fixture.controller.signal.aborted).toBe(true));
+    expect(running.settled()).toBe(false);
+    fixture.release();
+    await expect(running.request).rejects.toThrow();
+    expect(fixture.close).toHaveBeenCalledOnce();
+  });
+
+  it("aborts the physical SSE stream on an explicit idle timeout", async () => {
+    const fixture = sdkStreamFixture();
+    const { provider } = providerFixture([fixture], 100);
+    const running = startStream(provider);
+    await vi.waitFor(() => expect(fixture.controller.signal.aborted).toBe(true));
+    await expect(running.request).rejects.toBeInstanceOf(LLMTimeoutError);
+    expect(fixture.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes an opened transport when cancelled before its first next call", async () => {
+    const fixture = sdkStreamFixture();
+    const { provider } = providerFixture([fixture]);
+    const caller = new AbortController();
+    fixture.stream[Symbol.asyncIterator] = () => {
+      caller.abort("interrupted");
+      return { next: fixture.next, return: fixture.close };
+    };
+    const running = startStream(provider, { signal: caller.signal });
+    await expect(running.request).rejects.toThrow();
+    expect(fixture.next).not.toHaveBeenCalled();
+    expect(fixture.controller.signal.aborted).toBe(true);
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+  });
+
+  it("does not abort an independent concurrent stream", async () => {
+    const first = sdkStreamFixture();
+    const second = sdkStreamFixture();
+    const { provider, create } = providerFixture([first, second]);
+    const caller = new AbortController();
+    const interrupted = startStream(provider, { signal: caller.signal });
+    const continued = startStream(provider);
+    await vi.waitFor(() => {
+      expect(first.next).toHaveBeenCalledOnce();
+      expect(second.next).toHaveBeenCalledOnce();
+    });
+    caller.abort("interrupted");
+    await vi.waitFor(() => expect(first.controller.signal.aborted).toBe(true));
+    await expect(interrupted.request).rejects.toThrow();
+    expect(second.controller.signal.aborted).toBe(false);
+    expect(continued.settled()).toBe(false);
+    second.send(completedEvent());
+    await expect(continued.request).resolves.toMatchObject({ content: "done", finishReason: "stop" });
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps natural EOF distinct from cancellation and releases listeners", async () => {
+    const fixture = sdkStreamFixture();
+    const { provider } = providerFixture([fixture]);
+    const caller = new AbortController();
+    const running = startStream(provider, { signal: caller.signal });
+    await vi.waitFor(() => expect(fixture.next).toHaveBeenCalledOnce());
+    fixture.end();
+    await expect(running.request).resolves.toMatchObject({ finishReason: "error" });
+    expect(fixture.controller.signal.aborted).toBe(false);
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+    caller.abort("late interrupt");
+    expect(fixture.controller.signal.aborted).toBe(false);
+  });
+
+  it("cleans up after a physical transport error", async () => {
+    const fixture = sdkStreamFixture();
+    const { provider } = providerFixture([fixture]);
+    const caller = new AbortController();
+    const running = startStream(provider, { signal: caller.signal });
+    await vi.waitFor(() => expect(fixture.next).toHaveBeenCalledOnce());
+    fixture.fail(new Error("Fixture transport failure"));
+    await expect(running.request).rejects.toThrow("Fixture transport failure");
+    expect(fixture.controller.signal.aborted).toBe(true);
+    expect(fixture.close).toHaveBeenCalledOnce();
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Fix

Escape could stop the TUI while Grok's HTTP stream remained open. The SDK iterator's return operation waited behind a pending read, and the abort link used when opening the request was already detached.

Abort the current SDK stream controller before waiting for reader cleanup. Keep the physical-settlement checks, isolate concurrent streams, and close unfinished transport on early failure. Grok OAuth uses this same provider adapter.

## Tests

- Add eight SDK-stream regression cases. Six fail on the original code, and all eight pass with the fix.
- Replace the previous instant-response interruption scenario with a held loopback Grok stream. Assert that Escape closes HTTP before cleanup, records one aborted turn, and permits a completed follow-up in the same session.
- The real PTY scenario fails before the fix and passes after rebuilding.
- Runtime and test-support typechecks, runtime build, generated SDK checks, startup PTYs at three viewport sizes, 57 hermetic tests, and 80 adjacent tests pass.
- Independent local agent review approves all three files. GitNexus reports the expected low mapped scope; the new test file was reviewed separately.

The checks use local mocks and inert test credentials, with no paid inference. No full-suite or native platform matrix was rerun for this narrow change. Automatic GitHub Actions workflows remain disabled. This PR does not publish a release or change workflow configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mid-stream cancellation and HTTP teardown in the Grok provider path used by interactive turns; behavior is well covered by new unit and e2e tests but still touches core LLM streaming.
> 
> **Overview**
> **Escape mid-stream could leave Grok’s HTTP/SSE connection open** even after the TUI stopped the turn, because chunk-loop cancellation only closed the async iterator and did not abort the OpenAI SDK stream controller.
> 
> The Grok adapter now **hooks the SDK stream’s `AbortController`** and passes an `abortStream` callback into `nextStreamChunkWithTimeout`, so caller abort, idle timeout, and pre-aborted signals **abort the wire transport immediately** while still waiting for iterator teardown. A `streamExhausted` flag avoids aborting streams that finish normally.
> 
> **Tests:** new Vitest suite covers pending reads, delayed settlement, idle timeout, pre-first-chunk cancel, concurrent streams, natural EOF, and transport errors. The TUI e2e scenario **09** is rewritten to use a **loopback mock xAI server** that holds the first stream open; it asserts Escape closes HTTP, records exactly one `turn_aborted` (`interrupted`), and allows a follow-up turn to complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b674ad8453f9792526eb2af5970d8a64f7a46dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->