### PR TITLE
fix(runtime): repair daemon workflows and status command authority

### DIFF
--- a/docs/reference/autonomy.md
+++ b/docs/reference/autonomy.md
@@ -188,6 +188,25 @@ is skipped (`no_heartbeat_file`) — no model call.
 
 ---
 
+## Session cron
+
+`CronCreate` defaults to `durable: false`. Session-only jobs disappear when
+their owning session closes. Set `durable: true` to retain unaccepted jobs
+across restarts. Delivery-routed jobs are always durable.
+
+The daemon starts a due prompt through the owning session's serialized turn
+driver, including its normal permission and budget checks. Busy sessions
+queue the prompt. `CronDelete` cancels it if deletion wins before acceptance.
+Startup recovery waits for ordinary Agent startup and an installed turn driver.
+
+Acceptance claims the exact occurrence under the task-store lock. A one-shot
+is removed and a recurring job's fire time advances before model or tool work
+starts. Accepted occurrences are not replayed after failure, interruption, or
+restart. This is at-most-once acceptance, not lossless execution: a crash after
+the claim but before execution can consume an occurrence without running it.
+Deleting an already accepted job cannot undo its work. Delivery jobs use the
+separate receipt and retry policy below.
+
 ## Cron delivery (`runtime/src/gateway/cron-delivery.ts`)
 
 Runs **delivery-tagged** cron tasks (`CronTask.deliver` set) in isolated

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -443,12 +443,24 @@ names; `[]` denotes an array entry. Open maps accept keys at the indicated
 | `max_output_tokens` | Positive global model-output limit. |
 | `capped_default_max_output_tokens` | Boolean capped-default/retry behavior. |
 | `max_turns` | Positive loop backstop. |
-| `max_budget_usd` | Positive session cost cap. |
+| `max_budget_usd` | Positive shared cost cap for the session and its child agents. |
 | `autonomous_mode` | Boolean autonomous runtime mode. |
 | `coordinator_mode` | Boolean coordinator-only main-session behavior. |
 | `stream_watchdog_timeout_ms` | Non-negative inter-chunk idle timeout; default `600000`, `0` disables. |
 | `provider_outage_wait_ms` | Non-negative total time a turn keeps waiting for a provider outage to end once the reconnect ladder is spent; default `1800000` (30 minutes), `0` ends the turn as soon as the ladder is exhausted. |
 | `provider_outage_retry_ms` | Positive first slow-retry delay during a provider outage, doubling up to ten times this value; default `30000`. |
+
+`max_budget_usd` limits the canonical admission ledger for the whole session,
+including concurrent child agents. Completed usage and outstanding reservations
+count against the same cap before new work starts. A stricter
+`agent.budget.dollar_cap` or enabled calendar budget still applies.
+
+Resuming a session preserves its recorded usage, reservations, and lowest bound
+cost cap. A lower configured cap tightens that limit; a higher or omitted cap
+does not increase the existing session's allowance. Start a new session to use
+a higher cap. Older sessions without a recorded cap acquire the configured
+limit on resume without resetting their spend. If existing usage and
+reservations already exceed the limit, new work is denied.
 
 Project-root discovery happens before project and local configuration can be
 loaded. Its marker authority is therefore limited to the built-in/plugin/user
@@ -708,6 +720,29 @@ optional `headers`), `github` (`repo`, optional `ref`, `path`, `sparsePaths`),
 | `attribution`, `attribution.commit`, `attribution.pr` | Commit and pull-request attribution strings. |
 | `worktree`, `worktree.symlinkDirectories`, `worktree.sparsePaths` | Worktree directory/sparse-checkout arrays. |
 | `spinnerVerbs`, `spinnerVerbs.mode`, `spinnerVerbs.verbs` | `append`/`replace` verb customization. |
+
+Daemon-backed TUI status commands execute in the owning daemon session, using
+its operator configuration, workspace, shell environment, sandbox, and execution
+admission. The TUI cannot supply a command or override those permissions.
+Workspace trust, managed hook policy, disabled hooks, and `--bare` still apply.
+Commands have a five-second deadline including admission wait, accept at most
+64 KiB of input, and return at most 16 KiB of text. A session runs only one status
+command at a time. Cancelling a refresh or closing the session stops its process
+tree before releasing execution capacity. Before a live session exists, the
+custom status line remains unavailable; rendering never starts a model turn.
+Protected Editor workspaces block status commands. An executing command also
+blocks Editor acquisition until its process cleanup finishes.
+
+The daemon reports current context usage from its own token records. If no
+recent record is available, `context_window.current_usage`, both context
+percentages, and `exceeds_200k_tokens` are `null`. Clearing or replacing history
+invalidates that context sample without resetting cumulative spending.
+
+In the TUI, status-line commands receive shared session spending, including
+child agents, in `cost.total_cost_usd`. When `cost.has_unknown_cost` is true,
+that number is only the known subtotal; a pending initial snapshot also sets
+the flag. Child spending refreshes the status line without waiting for a new
+parent response.
 
 ```toml
 [tui]

--- a/packages/agenc-sdk/src/protocol-wire.generated.ts
+++ b/packages/agenc-sdk/src/protocol-wire.generated.ts
@@ -25,7 +25,7 @@ export const JSON_RPC_VERSION = "2.0" as const;
  * Clients that need any of these additive surfaces must not negotiate an older
  * daemon.
  */
-export const AGENC_DAEMON_PROTOCOL_VERSION = "1.10.0" as const;
+export const AGENC_DAEMON_PROTOCOL_VERSION = "1.11.0" as const;
 
 export const AGENC_DAEMON_METHODS = [
     "remote.capabilities",
@@ -821,6 +821,7 @@ export const AGENC_DAEMON_INTERNAL_METHODS = [
     "session.permissions.mutateRule",
     "session.hooks.status",
     "session.hooks.setDisabled",
+    "session.statusLine.execute",
     "session.applyConfig",
     "session.mcp.reconnectServer",
     "session.mcp.enableServer",
@@ -1622,8 +1623,37 @@ export interface SessionTranscriptV2TurnResult extends JsonObject {
 export interface SessionTranscriptV2Event extends JsonObject {
     readonly eventId: string;
     readonly committedSequence: number;
-    readonly type: "token_count" | "turn_failed" | "turn_aborted";
+    readonly type: "token_count" | "session_usage" | "turn_failed" | "turn_aborted";
     readonly payload: {
+        readonly runId?: string;
+        readonly sequence?: number;
+        readonly costUsd?: number;
+        readonly heldCostUsd?: number;
+        readonly inputTokens?: number;
+        readonly outputTokens?: number;
+        readonly modelCalls?: number;
+        readonly hasUnknownCost?: boolean;
+        readonly models?: readonly {
+            readonly model: string;
+            readonly provider?: string;
+            readonly costUsd: number;
+            readonly heldCostUsd: number;
+            readonly inputTokens: number;
+            readonly outputTokens: number;
+            readonly totalTokens: number;
+            readonly modelCalls: number;
+            readonly hasUnknownCost: boolean;
+        }[];
+        readonly agents?: readonly {
+            readonly runId: string;
+            readonly costUsd: number;
+            readonly heldCostUsd: number;
+            readonly inputTokens: number;
+            readonly outputTokens: number;
+            readonly totalTokens: number;
+            readonly modelCalls: number;
+            readonly hasUnknownCost: boolean;
+        }[];
         readonly promptTokens?: number;
         readonly completionTokens?: number;
         readonly totalTokens?: number;

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -22,7 +22,7 @@ export type {
 /** JSON-RPC 2.0 envelope version sent on every request. */
 export const AGENC_SDK_JSON_RPC_VERSION = "2.0" as const;
 /** Protocol the SDK advertises on `initialize`. Handshake rules are in docs/sdk.md. */
-export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.10.0" as const;
+export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.11.0" as const;
 
 /** Preserve named wire fields while allowing helpers to supply cwd. */
 export type AgencDefaultCwdParams<Params extends { readonly cwd: string }> =

--- a/packages/agenc-sdk/src/transcript-v2.generated.ts
+++ b/packages/agenc-sdk/src/transcript-v2.generated.ts
@@ -43,8 +43,37 @@ export interface SessionTranscriptV2TurnResult extends TranscriptV2JsonObject {
 export interface SessionTranscriptV2Event extends TranscriptV2JsonObject {
   readonly eventId: string;
   readonly committedSequence: number;
-  readonly type: "token_count" | "turn_failed" | "turn_aborted";
+  readonly type: "token_count" | "session_usage" | "turn_failed" | "turn_aborted";
   readonly payload: {
+    readonly runId?: string;
+    readonly sequence?: number;
+    readonly costUsd?: number;
+    readonly heldCostUsd?: number;
+    readonly inputTokens?: number;
+    readonly outputTokens?: number;
+    readonly modelCalls?: number;
+    readonly hasUnknownCost?: boolean;
+    readonly models?: readonly {
+      readonly model: string;
+      readonly provider?: string;
+      readonly costUsd: number;
+      readonly heldCostUsd: number;
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly totalTokens: number;
+      readonly modelCalls: number;
+      readonly hasUnknownCost: boolean;
+    }[];
+    readonly agents?: readonly {
+      readonly runId: string;
+      readonly costUsd: number;
+      readonly heldCostUsd: number;
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly totalTokens: number;
+      readonly modelCalls: number;
+      readonly hasUnknownCost: boolean;
+    }[];
     readonly promptTokens?: number;
     readonly completionTokens?: number;
     readonly totalTokens?: number;

--- a/runtime/scripts/check-tui-e2e/scenarios/135-session-usage-legacy-footer.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/135-session-usage-legacy-footer.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { waitForFrameText } from "../helpers/workbench-buffer-neovim.mjs";
+
+export const meta = {
+  description: "The alternate footer, custom status-line command, and cost dialog receive canonical daemon usage.",
+  args: ["--dangerously-bypass-approvals-and-sandbox"],
+  env: { AGENC_TUI_WORKBENCH: "0" },
+  slimCwd: true,
+  timeoutMs: 90_000,
+};
+
+export default async function (session) {
+  const configPath = join(session.gateState.agencHome, "config.toml");
+  const scriptPath = join(session.gateState.agencHome, "status-line-135.mjs");
+  const receiptPath = join(session.gateState.agencHome, "status-line-135.jsonl");
+  const existingConfig = await readFile(configPath, "utf8");
+  assert.doesNotMatch(existingConfig, /^\[statusLine\]/mu);
+  await writeFile(scriptPath, [
+    'import { appendFileSync } from "node:fs";',
+    'let input = "";',
+    'for await (const chunk of process.stdin) input += chunk;',
+    'const status = JSON.parse(input);',
+    'const receipt = {',
+    '  sessionId: status.session_id,',
+    '  cwd: status.cwd,',
+    '  currentDir: status.workspace.current_dir,',
+    '  projectDir: status.workspace.project_dir,',
+    '  model: status.model.id,',
+    '  costUsd: status.cost.total_cost_usd,',
+    '  hasUnknownCost: status.cost.has_unknown_cost,',
+    '  inputTokens: status.context_window.total_input_tokens,',
+    '  outputTokens: status.context_window.total_output_tokens,',
+    '};',
+    `appendFileSync(${JSON.stringify(receiptPath)}, JSON.stringify(receipt) + "\\n");`,
+    'process.stdout.write(`STATUS_HOOK_135_OK_${receipt.outputTokens}`);',
+    '',
+  ].join("\n"));
+  const command = `"${process.execPath}" "${scriptPath}"`;
+  await writeFile(configPath, `${existingConfig}\n[statusLine]\ntype = "command"\ncommand = ${JSON.stringify(command)}\n`);
+  await session.start();
+  await session.waitForPrompt({ timeout: 20_000 });
+  await session.type("hi");
+  await session.submit();
+  await session.waitForAssistantReply({ timeout: 45_000 });
+  await session.waitForPrompt({ timeout: 20_000 });
+  await waitForFrameText(
+    session,
+    /spend \$0\.00/u,
+    "canonical local-model cost in the alternate footer",
+    15_000,
+  );
+  const rollout = await session.readRolloutItems();
+  const usage = rollout.filter((item) =>
+    item.type === "event_msg" && item.payload?.msg?.type === "session_usage",
+  ).at(-1)?.payload.msg.payload;
+  if (usage?.modelCalls !== 1 || usage.costUsd !== 0 || usage.hasUnknownCost !== false) {
+    throw new Error(`Unexpected canonical mock usage: ${JSON.stringify(usage)}`);
+  }
+  const sessionMeta = rollout.find((item) => item.type === "session_meta")?.payload;
+  assert.ok(sessionMeta?.sessionId, "The canonical rollout must identify the session");
+  assert.ok(usage.inputTokens > 0 && usage.outputTokens > 0);
+  const expectedReceipt = {
+    sessionId: sessionMeta.sessionId,
+    cwd: session.cwd,
+    currentDir: session.cwd,
+    projectDir: session.cwd,
+    model: usage.models[0].model,
+    costUsd: usage.costUsd,
+    hasUnknownCost: usage.hasUnknownCost,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+  };
+  await waitForFrameText(
+    session,
+    new RegExp(`STATUS_HOOK_135_OK_${usage.outputTokens}\\b`, "u"),
+    "the custom status-line command with canonical output tokens",
+    15_000,
+  );
+  const receipts = (await readFile(receiptPath, "utf8"))
+    .split("\n").slice(0, -1).filter(Boolean).map((line) => JSON.parse(line));
+  assert.ok(receipts.some((receipt) => {
+    try {
+      assert.deepEqual(receipt, expectedReceipt);
+      return true;
+    } catch {
+      return false;
+    }
+  }), `No custom status-line receipt matches canonical usage: ${JSON.stringify({ expectedReceipt, receipts })}`);
+  const admission = (await session.readRolloutItems())
+    .filter((item) => item.type === "event_msg" && item.payload?.msg?.type === "execution_admission")
+    .map((item) => item.payload.msg.payload)
+    .filter((event) => event.kind === "tool_exec" && event.stepId.startsWith("hook:StatusLine:"));
+  assert.ok(admission.some((event) => event.event === "dispatched" && admission.some((completed) =>
+    completed.stepId === event.stepId && completed.event === "reconciled",
+  )), "The daemon must dispatch and reconcile the status-line hook through execution admission");
+  await session.submitSlashCommand("/cost");
+  await waitForFrameText(session, /BY MODEL/u, "matching model usage in cost dialog", 15_000);
+}

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -128,6 +128,8 @@ import type {
   SessionRewindFilesToMessageResult,
   SessionShellExecuteParams,
   SessionShellExecuteResult,
+  SessionStatusLineExecuteParams,
+  SessionStatusLineExecuteResult,
   SessionSetModelParams,
   SessionSetModelResult,
   SessionSetPermissionModeParams,
@@ -2796,6 +2798,23 @@ export class AgenCDaemonAgentManager {
     return { requestId: params.requestId, decision: "cancelled" };
   }
 
+  async executeSessionStatusLine(
+    params: SessionStatusLineExecuteParams,
+    signal?: AbortSignal,
+  ): Promise<SessionStatusLineExecuteResult> {
+    if (this.#runner?.executeAgentStatusLine === undefined) {
+      throw new AgenCDaemonAgentLifecycleError(
+        "BACKGROUND_RUNNER_UNAVAILABLE",
+        "session.statusLine.execute requires a live daemon runtime",
+      );
+    }
+    const agentId = await this.#resolveActiveAgentIdForSession(
+      params.sessionId,
+      { allowExecuteStatusLine: true },
+    );
+    return this.#runner.executeAgentStatusLine(agentId, params, signal);
+  }
+
   async executeSessionShell(
     params: SessionShellExecuteParams,
     signal?: AbortSignal,
@@ -3836,6 +3855,7 @@ export class AgenCDaemonAgentManager {
       readonly allowApplyConfig?: boolean;
       readonly allowCodePrediction?: boolean;
       readonly allowExecuteShell?: boolean;
+      readonly allowExecuteStatusLine?: boolean;
     } = {},
   ): Promise<string> {
     if (this.#sessionManager === undefined) {
@@ -3910,6 +3930,9 @@ export class AgenCDaemonAgentManager {
     const hasExecuteShellRunner =
       options.allowExecuteShell === true &&
       this.#runner?.executeAgentShell !== undefined;
+    const hasExecuteStatusLineRunner =
+      options.allowExecuteStatusLine === true &&
+      this.#runner?.executeAgentStatusLine !== undefined;
     if (
       !hasToolDecisionRunner &&
       !hasCancelRunner &&
@@ -3932,7 +3955,8 @@ export class AgenCDaemonAgentManager {
       !hasSetHooksDisabledRunner &&
       !hasApplyConfigRunner &&
       !hasCodePredictionRunner &&
-      !hasExecuteShellRunner
+      !hasExecuteShellRunner &&
+      !hasExecuteStatusLineRunner
     ) {
       throw new AgenCDaemonAgentLifecycleError(
         "BACKGROUND_RUNNER_UNAVAILABLE",

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import { readFileSync, readdirSync } from "node:fs";
 import { join as joinPath } from "node:path";
 import { withLocalMcpAccess } from "../mcp-client/local-control.js";
+import { executeSessionStatusLine } from "../hooks/status-line-executor.js";
 import {
   CompletedAgentEventCache,
   completedEventReplayRequired,
@@ -139,6 +140,8 @@ import type {
   SessionPermissionRuleMutationParams,
   SessionShellExecuteParams,
   SessionShellExecuteResult,
+  SessionStatusLineExecuteParams,
+  SessionStatusLineExecuteResult,
 } from "./protocol/index.js";
 import type { AgenCRealtimeThreadBinding } from "./realtime.js";
 import type { AgenCRealtimeCallClient } from "./realtime-transport.js";
@@ -2126,6 +2129,25 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       pruneMessageSubmissionCache(active.messageSubmissionsById);
     });
     return promise;
+  }
+
+  async executeAgentStatusLine(
+    agentId: string,
+    params: SessionStatusLineExecuteParams,
+    signal?: AbortSignal,
+  ): Promise<SessionStatusLineExecuteResult> {
+    const active = this.#active.get(agentId);
+    if (active === undefined || !isRunnableActiveAgent(active)) {
+      throw new Error(`AgenC daemon agent not running: ${agentId}`);
+    }
+    if (active.sessionBinding?.sessionId !== params.sessionId) {
+      throw new Error("Status line request does not own this runtime session");
+    }
+    return executeSessionStatusLine(
+      active.bootstrap.session,
+      params.presentation,
+      signal,
+    );
   }
 
   async executeAgentShell(

--- a/runtime/src/app-server/background-agent-runner/daemon-events.ts
+++ b/runtime/src/app-server/background-agent-runner/daemon-events.ts
@@ -651,6 +651,7 @@ const CANONICAL_CORE_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
   "request_permissions",
   "permission_decision",
   "execution_admission",
+  "session_usage",
   "artifact_intent",
   "artifact_committed",
   "recovery_decision",

--- a/runtime/src/app-server/background-agent-runner/journal-reconstruction.ts
+++ b/runtime/src/app-server/background-agent-runner/journal-reconstruction.ts
@@ -8,6 +8,7 @@ import type { LocalRuntimeBootstrap } from "../../bin/bootstrap.js";
 import type { Event } from "../../session/event-log.js";
 import { classifyTurnTerminal, type TurnTerminal } from "../../contracts/turn-terminal.js";
 import type { RolloutItem } from "../../session/rollout-item.js";
+import { isAdmissionUsageSummary } from "../../session/usage-summary.js";
 import {
   reconstructFromRollout,
 } from "../../session/rollout-reconstruction.js";
@@ -207,8 +208,11 @@ function closedTurnResult(
 function transcriptNoticesFromRollout(
   items: readonly RolloutItem[],
   boundaryIndex: number,
+  runId: string,
 ): readonly SessionTranscriptV2Event[] {
   const notices: SessionTranscriptV2Event[] = [];
+  let usageNotice: SessionTranscriptV2Event | undefined;
+  let usageSequence = -1;
   const seenEventIds = new Set<string>();
   const closedTurnIds = new Set<string>();
   let currentTurnId: string | undefined;
@@ -221,6 +225,24 @@ function transcriptNoticesFromRollout(
       : `legacy-notice:${index}:${event.id}`);
     if (seenEventIds.has(eventId)) continue;
     seenEventIds.add(eventId);
+    if (event.msg.type === "session_usage") {
+      const summary = event.msg.payload;
+      if (!isAdmissionUsageSummary(summary)) {
+        throw new Error("Canonical session usage payload is invalid");
+      }
+      if (summary.runId === runId && summary.sequence > usageSequence) {
+        usageSequence = summary.sequence;
+        usageNotice = {
+          eventId, committedSequence, type: "session_usage",
+          payload: {
+            ...summary,
+            models: summary.models.map((model) => ({ ...model })),
+            agents: summary.agents.map((agent) => ({ ...agent })),
+          },
+        };
+      }
+      continue;
+    }
     if (event.msg.type === "token_count") {
       notices.push({ eventId, committedSequence, type: "token_count", payload: { ...event.msg.payload } });
       continue;
@@ -251,6 +273,7 @@ function transcriptNoticesFromRollout(
       });
     }
   }
+  if (usageNotice !== undefined) notices.push(usageNotice);
   return notices;
 }
 
@@ -467,7 +490,7 @@ export function sessionTranscriptV2FromRollout(
     historyEpoch: historyEpochForBoundary(runId, boundaryId),
     asOfSequence,
     messages,
-    events: transcriptNoticesFromRollout(items, boundaryIndex),
+    events: transcriptNoticesFromRollout(items, boundaryIndex, runId),
     ...(activeTurn !== undefined ? { activeTurn } : {}),
     ...(turnResults.length > 0 ? { turnResults } : {}),
   };

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -60,6 +60,8 @@ import type {
   SessionPermissionRuleMutationResult,
   SessionShellExecuteParams,
   SessionShellExecuteResult,
+  SessionStatusLineExecuteParams,
+  SessionStatusLineExecuteResult,
 } from "../protocol/index.js";
 import type { AgenCRealtimeThreadBinding } from "../realtime.js";
 import type { AgenCRealtimeCallClient } from "../realtime-transport.js";
@@ -510,6 +512,11 @@ export interface AgenCBackgroundAgentRunner {
     params: SessionShellExecuteParams,
     signal?: AbortSignal,
   ): Promise<SessionShellExecuteResult>;
+  executeAgentStatusLine?(
+    agentId: string,
+    params: SessionStatusLineExecuteParams,
+    signal?: AbortSignal,
+  ): Promise<SessionStatusLineExecuteResult>;
   /** Resolve the live route without exposing the primary provider to callers. */
   resolveCodePredictionSource?(
     agentId: string,

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -191,6 +191,8 @@ import {
   type SessionFileRewindParams,
   type SessionShellExecuteParams,
   type SessionShellExecuteResult,
+  type SessionStatusLineExecuteParams,
+  type SessionStatusLineExecuteResult,
   type SessionSetModelParams,
   type SessionSetPermissionModeParams,
   type SessionPermissionRuleMutationParams,
@@ -281,6 +283,7 @@ const MINIMUM_PROTOCOL_MINOR_BY_METHOD: Readonly<
   "session.mcp.status": 3,
   "session.permissions.mutateRule": 7,
   "session.shell.execute": 9,
+  "session.statusLine.execute": 11,
 });
 
 const CSV_JOB_REVIEW_MAX_PAGE_SIZE = 100;
@@ -462,6 +465,10 @@ function buildServerCapabilities(
       "rewindFilesToMessage",
     ),
     "session.shell.execute": hasMethod(agentManager, "executeSessionShell"),
+    "session.statusLine.execute": hasMethod(
+      agentManager,
+      "executeSessionStatusLine",
+    ),
     "session.setModel": hasMethod(agentManager, "setSessionModel"),
     "session.setPermissionMode": hasMethod(
       agentManager,
@@ -563,6 +570,7 @@ export interface AgenCDaemonDispatcherOptions {
   > & {
     readonly listPermissions?: AgenCDaemonAgentManager["listPermissions"];
     readonly getSessionHooksStatus?: AgenCDaemonAgentManager["getSessionHooksStatus"];
+    readonly executeSessionStatusLine?: AgenCDaemonAgentManager["executeSessionStatusLine"];
     readonly setSessionHooksDisabled?: AgenCDaemonAgentManager["setSessionHooksDisabled"];
   };
   readonly initializeAuthenticator?: (
@@ -671,6 +679,7 @@ export class AgenCDaemonJsonRpcDispatcher {
   > & {
     readonly listPermissions?: AgenCDaemonAgentManager["listPermissions"];
     readonly getSessionHooksStatus?: AgenCDaemonAgentManager["getSessionHooksStatus"];
+    readonly executeSessionStatusLine?: AgenCDaemonAgentManager["executeSessionStatusLine"];
     readonly setSessionHooksDisabled?: AgenCDaemonAgentManager["setSessionHooksDisabled"];
   };
   readonly #initializeAuthenticator:
@@ -1471,6 +1480,19 @@ export class AgenCDaemonJsonRpcDispatcher {
             ),
           ),
         );
+      case "session.statusLine.execute": {
+        if (this.#agentManager.executeSessionStatusLine === undefined) {
+          return methodNotImplementedResponse(id, method);
+        }
+        const result = await this.#agentManager.executeSessionStatusLine(
+          validateSessionStatusLineExecuteParams(params),
+          signal,
+        );
+        return internalSuccessResponse(
+          id,
+          validateSessionStatusLineExecuteResult(result),
+        );
+      }
       case "session.shell.execute": {
         const validated = validateSessionShellExecuteParams(params);
         const result = await this.#agentManager.executeSessionShell(
@@ -2376,6 +2398,7 @@ function methodSupportsRequestCancellation(
     method === "session.partialCompactFromMessage" ||
     method === "session.rewindConversationToMessage" ||
     method === "session.shell.execute" ||
+    method === "session.statusLine.execute" ||
     method === "workspace.editor.predict" ||
     method === "message.stream" ||
     method === "message.send"
@@ -3506,6 +3529,69 @@ function validateSessionFileRewindParams(
     );
   }
   return validated as SessionFileRewindParams;
+}
+
+function validateSessionStatusLineExecuteParams(
+  params: JsonObject,
+): SessionStatusLineExecuteParams {
+  const methodName = "session.statusLine.execute";
+  const validated = validateObjectShape(params, {
+    methodName,
+    stringFields: ["sessionId"],
+    objectFields: ["presentation"],
+  });
+  validateRequiredString(validated, methodName, "sessionId");
+  validateMaximumUtf8Bytes(validated.sessionId, methodName, "sessionId", 1_024);
+  if (validated.presentation !== undefined) {
+    const presentation = validateObjectShape(
+      validated.presentation as JsonObject,
+      {
+        methodName: `${methodName}.presentation`,
+        stringFields: ["vimMode"],
+      },
+    );
+    if (
+      presentation.vimMode !== undefined &&
+      presentation.vimMode !== "NORMAL" &&
+      presentation.vimMode !== "INSERT"
+    ) {
+      throw invalidParams(
+        `${methodName}.presentation vimMode must be NORMAL or INSERT`,
+      );
+    }
+  }
+  return validated as SessionStatusLineExecuteParams;
+}
+
+function validateSessionStatusLineExecuteResult(
+  value: unknown,
+): SessionStatusLineExecuteResult {
+  if (!isPlainJsonObject(value)) {
+    throw new Error("session.statusLine.execute returned a non-object result");
+  }
+  const allowedKeys = new Set(["status", "text", "reason"]);
+  if (
+    Object.keys(value).some((key) => !allowedKeys.has(key)) ||
+    !["rendered", "disabled", "blocked", "unavailable", "error"].includes(
+      String(value.status),
+    )
+  ) {
+    throw new Error("session.statusLine.execute returned an invalid result");
+  }
+  for (const field of ["text", "reason"] as const) {
+    if (
+      value[field] !== undefined &&
+      (typeof value[field] !== "string" ||
+        Buffer.byteLength(value[field], "utf8") >
+          (field === "text" ? 16_384 : 256))
+    ) {
+      throw new Error(`session.statusLine.execute returned invalid ${field}`);
+    }
+  }
+  if ((value.status === "rendered") !== (typeof value.text === "string")) {
+    throw new Error("session.statusLine.execute returned inconsistent text");
+  }
+  return value as unknown as SessionStatusLineExecuteResult;
 }
 
 function validateSessionShellExecuteParams(

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -33,7 +33,7 @@ export const JSON_RPC_VERSION = "2.0" as const;
  * Clients that need any of these additive surfaces must not negotiate an older
  * daemon.
  */
-export const AGENC_DAEMON_PROTOCOL_VERSION = "1.10.0" as const;
+export const AGENC_DAEMON_PROTOCOL_VERSION = "1.11.0" as const;
 export const AGENC_DAEMON_PROTOCOL_SCHEMA_ID =
   "urn:agenc:app-server:protocol" as const;
 export const AGENC_DAEMON_PROTOCOL_PACKAGE_NAME =
@@ -192,6 +192,7 @@ export const AGENC_DAEMON_INTERNAL_METHODS = [
   "session.permissions.mutateRule",
   "session.hooks.status",
   "session.hooks.setDisabled",
+  "session.statusLine.execute",
   "session.applyConfig",
   "session.mcp.reconnectServer",
   "session.mcp.enableServer",
@@ -980,6 +981,14 @@ export const AGENC_DAEMON_INTERNAL_METHOD_SPECS = defineInternalMethodSpecs({
     result: "object",
     description:
       "TUI-internal request to enable/disable the daemon-owned session's hooks runtime for the session.",
+  },
+  "session.statusLine.execute": {
+    method: "session.statusLine.execute",
+    direction: "client-to-server",
+    params: "required",
+    result: "object",
+    description:
+      "TUI-internal request to render the configured status command under the daemon-owned session's authority.",
   },
   "session.applyConfig": {
     method: "session.applyConfig",
@@ -1818,6 +1827,21 @@ export interface SessionHooksStatusParams extends JsonObject {
 export interface SessionHooksSetDisabledParams extends JsonObject {
   readonly sessionId: string;
   readonly disabled: boolean;
+}
+
+export interface SessionStatusLinePresentation extends JsonObject {
+  readonly vimMode?: "NORMAL" | "INSERT";
+}
+
+export interface SessionStatusLineExecuteParams extends JsonObject {
+  readonly sessionId: string;
+  readonly presentation?: SessionStatusLinePresentation;
+}
+
+export interface SessionStatusLineExecuteResult extends JsonObject {
+  readonly status: "rendered" | "disabled" | "blocked" | "unavailable" | "error";
+  readonly text?: string;
+  readonly reason?: string;
 }
 
 /**
@@ -3211,8 +3235,37 @@ export interface SessionTranscriptV2TurnResult extends JsonObject {
 export interface SessionTranscriptV2Event extends JsonObject {
   readonly eventId: string;
   readonly committedSequence: number;
-  readonly type: "token_count" | "turn_failed" | "turn_aborted";
+  readonly type: "token_count" | "session_usage" | "turn_failed" | "turn_aborted";
   readonly payload: {
+    readonly runId?: string;
+    readonly sequence?: number;
+    readonly costUsd?: number;
+    readonly heldCostUsd?: number;
+    readonly inputTokens?: number;
+    readonly outputTokens?: number;
+    readonly modelCalls?: number;
+    readonly hasUnknownCost?: boolean;
+    readonly models?: readonly {
+      readonly model: string;
+      readonly provider?: string;
+      readonly costUsd: number;
+      readonly heldCostUsd: number;
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly totalTokens: number;
+      readonly modelCalls: number;
+      readonly hasUnknownCost: boolean;
+    }[];
+    readonly agents?: readonly {
+      readonly runId: string;
+      readonly costUsd: number;
+      readonly heldCostUsd: number;
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly totalTokens: number;
+      readonly modelCalls: number;
+      readonly hasUnknownCost: boolean;
+    }[];
     readonly promptTokens?: number;
     readonly completionTokens?: number;
     readonly totalTokens?: number;
@@ -3958,6 +4011,7 @@ export interface AgenCDaemonInternalResultByMethod {
   readonly "session.permissions.mutateRule": SessionPermissionRuleMutationResult;
   readonly "session.hooks.status": SessionHooksStatusResult;
   readonly "session.hooks.setDisabled": SessionHooksSetDisabledResult;
+  readonly "session.statusLine.execute": SessionStatusLineExecuteResult;
   readonly "session.applyConfig": SessionApplyConfigResult;
   readonly "session.mcp.reconnectServer": SessionMcpServerMutationResult;
   readonly "session.mcp.enableServer": SessionMcpServerMutationResult;

--- a/runtime/src/app-server/run-journal-replay.ts
+++ b/runtime/src/app-server/run-journal-replay.ts
@@ -448,7 +448,7 @@ function legacyAdmissionFields(payload: JsonObject): Partial<RunJournalEvent> {
 
 function categoryFor(type: string): RunJournalCategory {
   if (type === "execution_admission") return "admission";
-  if (type === "token_count") return "budget";
+  if (type === "token_count" || type === "session_usage") return "budget";
   if (type === "request_permissions" || type.startsWith("permission_")) {
     return "permission";
   }

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -2571,6 +2571,7 @@ type DeferredWorkspaceEditorSessionSurface = Pick<
 
 type TuiSessionShape = DeferredWorkspaceEditorSessionSurface & {
   executeShellCommand?: AgenCTuiBridgeSession["executeShellCommand"];
+  executeDaemonStatusLine?: AgenCTuiBridgeSession["executeDaemonStatusLine"];
   readonly services?: {
     readonly mcpManager?: NonNullable<Session["services"]["mcpManager"]>;
     readonly [key: string]: unknown;
@@ -3951,6 +3952,13 @@ async function createDeferredDaemonPromptTuiSession(params: {
     // `/hooks` reads the daemon session's REAL configured-hooks runtime
     // through liveSession.getDaemonHooksStatus. Hooks live on the daemon
     // agent session, so there is nothing to inspect pre-first-turn.
+    executeDaemonStatusLine: async (presentation, signal) => {
+      signal?.throwIfAborted();
+      if (liveSession?.executeDaemonStatusLine === undefined) {
+        return { status: "unavailable", reason: "session_not_ready" };
+      }
+      return liveSession.executeDaemonStatusLine(presentation, signal);
+    },
     getDaemonHooksStatus: async () => {
       if (liveSession === null) {
         throw new Error(

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1569,6 +1569,9 @@ async function bootstrapLocalRuntimeSessionScoped(
       runId: conversationId,
       sessionId: conversationId,
       autonomous: executionAdmissionAutonomous,
+      ...(maxBudgetUsdFromAgenCConfig(startup.config) !== undefined
+        ? { maxCostUsd: maxBudgetUsdFromAgenCConfig(startup.config) }
+        : {}),
     },
     budget: resolveExecutionAdmissionBudgetPolicy({
       budget: startup.config.budget,
@@ -2150,6 +2153,7 @@ async function bootstrapLocalRuntimeSessionScoped(
                   conversationId: s.conversationId,
                   workspaceRoot,
                   signal: startupSignal,
+                  session: s,
                 });
               }
             } catch {

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -4600,6 +4600,7 @@ export async function startCronSchedulerRunner(opts: {
   readonly conversationId: string;
   readonly workspaceRoot: string;
   readonly signal?: AbortSignal;
+  readonly session?: Session;
 }): Promise<void> {
   opts.signal?.throwIfAborted();
   if (opts.conversationId.trim().length === 0) {
@@ -4608,11 +4609,22 @@ export async function startCronSchedulerRunner(opts: {
   if (opts.workspaceRoot.trim().length === 0) {
     throw new Error("Cron scheduler requires an owning workspace root");
   }
+  if (opts.session !== undefined && opts.session.conversationId !== opts.conversationId) {
+    throw new Error("Cron scheduler session does not match the owning conversation");
+  }
   const { setScheduledTasksEnabled } = await import("../bootstrap/state.js");
   opts.signal?.throwIfAborted();
   const { getCronScheduler } = await import("../utils/cronScheduler.js");
   opts.signal?.throwIfAborted();
   setScheduledTasksEnabled(true);
+  if (typeof opts.session?.submit === "function") {
+    const { startSessionCronScheduler } =
+      await import("../session/session-cron-scheduler.js");
+    opts.signal?.throwIfAborted();
+    await startSessionCronScheduler(opts.session, opts.workspaceRoot);
+    opts.signal?.throwIfAborted();
+    return;
+  }
   const scheduler = getCronScheduler();
   scheduler.start({
     queueOwner: {
@@ -4650,7 +4662,11 @@ function createCronAndWorkflowTools(
             description:
               "true (default) reschedules after each fire; false fires once and deletes itself.",
           },
-          durable: { type: "boolean" },
+          durable: {
+            type: "boolean",
+            description:
+              "false (default) keeps the job in this session; true persists it across restarts. Delivery-routed jobs are always durable.",
+          },
           announceChannel: {
             type: "string",
             description:
@@ -4671,7 +4687,8 @@ function createCronAndWorkflowTools(
         additionalProperties: false,
       },
       execute: async (args) => {
-        const conversationId = opts.getSession()?.conversationId;
+        const session = opts.getSession();
+        const conversationId = session?.conversationId;
         if (typeof conversationId !== "string" || conversationId.length === 0) {
           return refusal({ error: "CronCreate requires an active owning conversation" });
         }
@@ -4706,7 +4723,7 @@ function createCronAndWorkflowTools(
         // Delivery-routed jobs are executed by the gateway from the persisted
         // task file — they must be durable or the gateway can never see them.
         const durable =
-          deliver !== undefined ? true : (boolValue(args.durable) ?? true);
+          deliver !== undefined ? true : (boolValue(args.durable) ?? false);
         const id = await addCronTask(
           schedule,
           prompt,
@@ -4723,6 +4740,7 @@ function createCronAndWorkflowTools(
         await startCronSchedulerRunner({
           conversationId,
           workspaceRoot: opts.workspaceRoot,
+          session: session ?? undefined,
         });
         return json({
           cron: {
@@ -4752,7 +4770,8 @@ function createCronAndWorkflowTools(
         additionalProperties: false,
       },
       execute: async (args) => {
-        const conversationId = opts.getSession()?.conversationId;
+        const session = opts.getSession();
+        const conversationId = session?.conversationId;
         if (typeof conversationId !== "string" || conversationId.length === 0) {
           return refusal({ error: "CronDelete requires an active owning conversation" });
         }
@@ -4766,8 +4785,11 @@ function createCronAndWorkflowTools(
         );
         const existed = before.some((task) => task.id === id);
         await removeCronTasks([id], opts.workspaceRoot, conversationId);
-        const { getCronScheduler } = await import("../utils/cronScheduler.js");
-        await getCronScheduler().reschedule();
+        await startCronSchedulerRunner({
+          conversationId,
+          workspaceRoot: opts.workspaceRoot,
+          session: session ?? undefined,
+        });
         return json({ deleted: existed, id });
       },
     },

--- a/runtime/src/bootstrap/state.ts
+++ b/runtime/src/bootstrap/state.ts
@@ -882,6 +882,7 @@ export type SessionCronTask = {
   prompt: string;
   createdAt: number;
   recurring?: boolean;
+  lastFiredAt?: number;
   /**
    * Exact conversation that created this in-memory task. Session cron tasks
    * share process-global bootstrap state, so they must never be runnable,

--- a/runtime/src/budget/admission-client.ts
+++ b/runtime/src/budget/admission-client.ts
@@ -6,6 +6,7 @@ import type {
   AdmissionLease,
   AdmissionReconcileResult,
   AdmissionUsage,
+  AdmissionUsageSummary,
 } from "./admission-types.js";
 
 export interface AdmissionClientScope {
@@ -133,6 +134,8 @@ export interface ExecutionAdmissionClient {
     readonly afterSequence?: number;
     readonly limit?: number;
   }): readonly AdmissionJournalEvent[];
+  getUsageSummary?(): AdmissionUsageSummary;
+  subscribeUsage?(listener: (summary: AdmissionUsageSummary) => void): () => void;
   subscribe(listener: (event: AdmissionJournalEvent) => void): () => void;
 }
 

--- a/runtime/src/budget/admission-types.ts
+++ b/runtime/src/budget/admission-types.ts
@@ -85,6 +85,28 @@ export interface AdmissionJournalEvent {
 
 export type AdmissionEventListener = (event: AdmissionJournalEvent) => void;
 
+export interface AdmissionUsageTotals {
+  readonly costUsd: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly modelCalls: number;
+  readonly hasUnknownCost: boolean;
+  readonly heldCostUsd: number;
+}
+
+export interface AdmissionUsageSummary extends AdmissionUsageTotals {
+  readonly runId: string;
+  readonly sequence: number;
+  readonly models: readonly (AdmissionUsageTotals & {
+    readonly model: string;
+    readonly provider?: string;
+  })[];
+  readonly agents: readonly (AdmissionUsageTotals & {
+    readonly runId: string;
+  })[];
+}
+
 /** Durable allow result produced by the SQLite repository. */
 export interface AdmissionGrant {
   readonly decision: "allow";

--- a/runtime/src/budget/execution-admission-kernel.ts
+++ b/runtime/src/budget/execution-admission-kernel.ts
@@ -8,6 +8,7 @@ import type {
   AdmissionLease,
   AdmissionReconcileResult,
   AdmissionUsage,
+  AdmissionUsageSummary,
   PersistedAdmissionRecord,
   RuntimeAdmissionRequest,
 } from "./admission-types.js";
@@ -60,6 +61,12 @@ interface WorkspaceBinding {
   readonly repository: ExecutionAdmissionRepository;
   readonly aliases: Set<string>;
   lastJournalSequence: number;
+}
+
+interface UsageSubscription {
+  readonly binding: ClientBinding;
+  readonly listener: (summary: AdmissionUsageSummary) => void;
+  signature: string;
 }
 
 interface ActiveCapacity {
@@ -197,6 +204,7 @@ export class ExecutionAdmissionKernel {
     string,
     Set<(event: AdmissionJournalEvent) => void>
   >();
+  readonly #usageListeners = new Map<WorkspaceBinding, Set<UsageSubscription>>();
   #limits: AdmissionConcurrencyLimits;
   #drainScheduled = false;
   #closed = false;
@@ -346,8 +354,21 @@ export class ExecutionAdmissionKernel {
     if (deadlineAt !== undefined && deadlineAt <= this.#timestamp()) {
       this.cancelRun(options.scope.runId, "deadline_expired");
     }
-    const budget = rootBudgetState(scope, options.budget);
-    return new KernelAdmissionClient(this, { workspace, scope, budget });
+    const proposedBudget = rootBudgetState(scope, options.budget);
+    const maxCostUsd = workspace.repository.bindRunCostLimit(
+      scope.runId,
+      proposedBudget.scopes[0]!,
+    );
+    const effectiveScope: AdmissionClientScope = {
+      ...scope,
+      ...(maxCostUsd !== undefined ? { maxCostUsd, hasHardCostCap: true } : {}),
+    };
+    const budget = rootBudgetState(effectiveScope, options.budget);
+    return new KernelAdmissionClient(this, {
+      workspace,
+      scope: effectiveScope,
+      budget,
+    });
   }
 
   updateLimits(limits: AdmissionConcurrencyLimits): void {
@@ -625,6 +646,33 @@ export class ExecutionAdmissionKernel {
     });
   }
 
+  getUsageSummary(binding: ClientBinding): AdmissionUsageSummary {
+    this.#assertOpen();
+    return binding.workspace.repository.getUsageSummary(
+      binding.scope.runId,
+      binding.budget.runAllocationKey,
+    );
+  }
+
+  subscribeUsage(
+    binding: ClientBinding,
+    listener: (summary: AdmissionUsageSummary) => void,
+  ): () => void {
+    const summary = this.getUsageSummary(binding);
+    const subscription: UsageSubscription = {
+      binding,
+      listener,
+      signature: JSON.stringify({ ...summary, sequence: 0 }),
+    };
+    const listeners = this.#usageListeners.get(binding.workspace) ?? new Set();
+    listeners.add(subscription);
+    this.#usageListeners.set(binding.workspace, listeners);
+    return () => {
+      listeners.delete(subscription);
+      if (listeners.size === 0) this.#usageListeners.delete(binding.workspace);
+    };
+  }
+
   subscribe(
     runId: string,
     listener: (event: AdmissionJournalEvent) => void,
@@ -850,6 +898,7 @@ export class ExecutionAdmissionKernel {
     this.#active.clear();
     this.#listeners.clear();
     this.#criticalListeners.clear();
+    this.#usageListeners.clear();
     for (const binding of this.#byStatePath.values()) {
       binding.driver.close();
     }
@@ -1326,6 +1375,18 @@ export class ExecutionAdmissionKernel {
     return found;
   }
 
+  #publishUsage(binding: WorkspaceBinding): void {
+    for (const subscription of this.#usageListeners.get(binding) ?? []) {
+      try {
+        const summary = this.getUsageSummary(subscription.binding);
+        const signature = JSON.stringify({ ...summary, sequence: 0 });
+        if (signature === subscription.signature) continue;
+        subscription.listener(summary);
+        subscription.signature = signature;
+      } catch {}
+    }
+  }
+
   #publishNewJournal(binding: WorkspaceBinding): void {
     while (true) {
       const events = binding.repository.listJournal({
@@ -1356,6 +1417,7 @@ export class ExecutionAdmissionKernel {
             // Observers never get to roll back a committed admission event.
           }
         }
+        this.#publishUsage(binding);
       }
       if (events.length < JOURNAL_PAGE_SIZE) return;
     }
@@ -1437,6 +1499,14 @@ class KernelAdmissionClient implements ExecutionAdmissionClient {
 
   subscribe(listener: (event: AdmissionJournalEvent) => void): () => void {
     return this.kernel.subscribe(this.scope.runId, listener);
+  }
+
+  getUsageSummary(): AdmissionUsageSummary {
+    return this.kernel.getUsageSummary(this.binding);
+  }
+
+  subscribeUsage(listener: (summary: AdmissionUsageSummary) => void): () => void {
+    return this.kernel.subscribeUsage(this.binding, listener);
   }
 
   subscribeCritical(

--- a/runtime/src/commands/cost.ts
+++ b/runtime/src/commands/cost.ts
@@ -28,6 +28,7 @@ import {
   formatUsdCost,
 } from "../session/cost.js";
 import { asRecord } from "../utils/record.js";
+import { isAdmissionUsageSummary } from "../session/usage-summary.js";
 import { openAsyncLocalJsxCommand } from "./local-jsx-command.js";
 import {
   safeExecute,
@@ -46,6 +47,8 @@ export interface CostModelRow {
 
 /** One per-agent row. Tokens are real; cost is an estimate (or unknown). */
 export interface CostAgentRow {
+  readonly runId?: string;
+  readonly costUsd?: number;
   readonly label: string;
   readonly status: string;
   readonly tokenCount?: number;
@@ -96,9 +99,9 @@ function readCostSidecar(session: unknown): CostSidecarLike | null {
   return asRecord(sidecar) as CostSidecarLike | null;
 }
 
-function callNumber(fn: (() => number) | undefined): number | undefined {
+function callNumber(fn: (() => number) | undefined, receiver: CostSidecarLike): number | undefined {
   if (typeof fn !== "function") return undefined;
-  const value = fn();
+  const value = fn.call(receiver);
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
@@ -124,17 +127,17 @@ function readSessionTotals(sidecar: CostSidecarLike | null): {
     }),
   );
   return {
-    ...(callNumber(sidecar.getTotalCostUsd) !== undefined
-      ? { totalCostUsd: callNumber(sidecar.getTotalCostUsd) }
+    ...(callNumber(sidecar.getTotalCostUsd, sidecar) !== undefined
+      ? { totalCostUsd: callNumber(sidecar.getTotalCostUsd, sidecar) }
       : {}),
-    ...(callNumber(sidecar.getTotalInputTokens) !== undefined
-      ? { inputTokens: callNumber(sidecar.getTotalInputTokens) }
+    ...(callNumber(sidecar.getTotalInputTokens, sidecar) !== undefined
+      ? { inputTokens: callNumber(sidecar.getTotalInputTokens, sidecar) }
       : {}),
-    ...(callNumber(sidecar.getTotalOutputTokens) !== undefined
-      ? { outputTokens: callNumber(sidecar.getTotalOutputTokens) }
+    ...(callNumber(sidecar.getTotalOutputTokens, sidecar) !== undefined
+      ? { outputTokens: callNumber(sidecar.getTotalOutputTokens, sidecar) }
       : {}),
-    ...(callNumber(sidecar.getTotalTurns) !== undefined
-      ? { turns: callNumber(sidecar.getTotalTurns) }
+    ...(callNumber(sidecar.getTotalTurns, sidecar) !== undefined
+      ? { turns: callNumber(sidecar.getTotalTurns, sidecar) }
       : {}),
     hasUnknownCost:
       typeof sidecar.hasUnknownModelCost === "function"
@@ -171,6 +174,7 @@ function readAgentRows(appState: unknown): CostAgentRow[] {
           : "agent";
     const role = typeof task.agentType === "string" ? task.agentType : "agent";
     rows.push({
+      ...(typeof task.agentId === "string" ? { runId: task.agentId } : {}),
       label: `${truncate(name, 40)} · ${role}`,
       status: typeof task.status === "string" ? task.status : "unknown",
       ...(tokenCount !== undefined ? { tokenCount } : {}),
@@ -192,48 +196,48 @@ function truncate(value: string, max: number): string {
  * — exported so tests can feed known usage and assert the rendered numbers.
  */
 export function buildCostReport(ctx: SlashCommandContext): CostReport {
-  const sidecar = readCostSidecar(ctx.session);
-  const totals = readSessionTotals(sidecar);
   const getAppState = ctx.appState?.getAppState;
   const agents =
     typeof getAppState === "function" ? readAgentRows(getAppState()) : [];
 
-  // Fallback session total: when the sidecar reports no real session figure
-  // (e.g. a local/self-hosted model with no cost tracking), the bulk of a
-  // fan-out's cost still lives in the per-agent rows we already estimated.
-  // Summing them answers "how much is this costing" with an explicit estimate
-  // rather than a useless "—". The real-sidecar path is left untouched.
-  const agentCostUsd = agents.reduce(
-    (sum, a) => sum + (a.estimatedCostUsd ?? 0),
-    0,
-  );
-  const anyAgentCost = agents.some((a) => a.estimatedCostUsd !== undefined);
-  const agentTokens = agents.reduce((sum, a) => sum + (a.tokenCount ?? 0), 0);
+  const usage = ctx.appState?.getSessionUsage?.() ??
+    ctx.session.services?.executionAdmission?.getUsageSummary?.();
+  if (isAdmissionUsageSummary(usage)) {
+    return {
+      totalCostUsd: usage.costUsd,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens: usage.totalTokens,
+      hasUnknownCost: usage.hasUnknownCost,
+      models: usage.models.map((model) => ({
+        label: model.provider ? `${model.provider}/${model.model}` : model.model,
+        inputTokens: model.inputTokens,
+        outputTokens: model.outputTokens,
+        costUsd: model.costUsd,
+      })),
+      agents: usage.agents.map((agent) => {
+        const metadata = agents.find((row) => row.runId === agent.runId);
+        return {
+          runId: agent.runId,
+          label: metadata?.label ?? agent.runId,
+          status: metadata?.status ?? "recorded",
+          tokenCount: agent.totalTokens,
+          costUsd: agent.costUsd,
+          ...(metadata?.toolUseCount !== undefined ? { toolUseCount: metadata.toolUseCount } : {}),
+        };
+      }),
+    };
+  }
 
-  const realTotalCost = totals.totalCostUsd;
-  const realTotalTokens =
+  const totals = readSessionTotals(readCostSidecar(ctx.session));
+  const totalCostUsd = totals.totalCostUsd;
+  const totalTokens =
     totals.inputTokens !== undefined && totals.outputTokens !== undefined
       ? totals.inputTokens + totals.outputTokens
       : undefined;
 
-  const totalCostUsd =
-    realTotalCost !== undefined
-      ? realTotalCost
-      : anyAgentCost
-        ? agentCostUsd
-        : undefined;
-  const totalTokens =
-    realTotalTokens !== undefined
-      ? realTotalTokens
-      : agentTokens > 0
-        ? agentTokens
-        : undefined;
-  const totalIsEstimated =
-    realTotalCost === undefined && (anyAgentCost || agentTokens > 0);
-
   return {
     ...(totalCostUsd !== undefined ? { totalCostUsd } : {}),
-    ...(totalIsEstimated ? { totalIsEstimated: true } : {}),
     ...(totals.inputTokens !== undefined
       ? { inputTokens: totals.inputTokens }
       : {}),
@@ -242,7 +246,7 @@ export function buildCostReport(ctx: SlashCommandContext): CostReport {
       : {}),
     ...(totalTokens !== undefined ? { totalTokens } : {}),
     ...(totals.turns !== undefined ? { turns: totals.turns } : {}),
-    hasUnknownCost: totals.hasUnknownCost,
+    hasUnknownCost: totals.hasUnknownCost || agents.length > 0,
     models: totals.models,
     agents,
   };
@@ -289,7 +293,9 @@ export function formatCostReport(report: CostReport): string {
       const tokens =
         a.tokenCount !== undefined ? `${formatTokenCount(a.tokenCount)} tokens` : "—";
       const spend =
-        a.estimatedCostUsd !== undefined
+        a.costUsd !== undefined
+          ? formatUsdCost(a.costUsd)
+          : a.estimatedCostUsd !== undefined
           ? `${formatUsdCost(a.estimatedCostUsd)} est.`
           : "—";
       lines.push(`  ${a.status} ${a.label}: ${tokens} · ${spend}`);
@@ -297,7 +303,7 @@ export function formatCostReport(report: CostReport): string {
   } else {
     lines.push("Agents: none active");
   }
-  lines.push("  • per-agent $ is estimated from token totals; — = unknown.");
+  lines.push("Agent costs use recorded usage when available; estimates are marked est.");
   return lines.join("\n");
 }
 

--- a/runtime/src/commands/status.ts
+++ b/runtime/src/commands/status.ts
@@ -83,8 +83,14 @@ export function summarizeGitStatus(params: {
   readonly branch: GitCommandResult;
   readonly porcelain: GitCommandResult;
 }): GitStatusSummary {
-  if (params.insideWorkTree.code !== 0) {
-    return { state: "not-repo", message: "Run /status inside a git work tree for branch state." };
+  if (params.insideWorkTree.code !== 0 || params.insideWorkTree.stdout.trim() !== "true") {
+    if (
+      params.insideWorkTree.code === 0 ||
+      /^fatal: not a git repository \(or any /m.test(params.insideWorkTree.stderr)
+    ) {
+      return { state: "not-repo", message: "Run /status inside a git work tree for branch state." };
+    }
+    return { state: "error", message: params.insideWorkTree.stderr || "git repository discovery failed" };
   }
   if (params.branch.code !== 0 || params.porcelain.code !== 0) {
     return {
@@ -107,17 +113,22 @@ async function collectGitStatus(
   git: GitRunner = runGit,
 ): Promise<GitStatusSummary> {
   const insideWorkTree = await git(["rev-parse", "--is-inside-work-tree"], cwd);
-  if (insideWorkTree.code !== 0) {
+  if (insideWorkTree.code !== 0 || insideWorkTree.stdout.trim() !== "true") {
     return summarizeGitStatus({
       insideWorkTree,
       branch: { stdout: "", stderr: "", code: 0 },
       porcelain: { stdout: "", stderr: "", code: 0 },
     });
   }
-  const [branch, porcelain] = await Promise.all([
-    git(["rev-parse", "--abbrev-ref", "HEAD"], cwd),
+  const [symbolicBranch, porcelain] = await Promise.all([
+    git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd),
     git(["status", "--porcelain"], cwd),
   ]);
+  let branch = symbolicBranch;
+  if (symbolicBranch.code === 1) {
+    const head = await git(["rev-parse", "--verify", "HEAD"], cwd);
+    branch = head.code === 0 ? { ...head, stdout: "" } : head;
+  }
   return summarizeGitStatus({ insideWorkTree, branch, porcelain });
 }
 

--- a/runtime/src/commands/types.ts
+++ b/runtime/src/commands/types.ts
@@ -18,6 +18,7 @@
 
 import type { Session } from "../session/session.js";
 import type { ConfigStore } from "../config/store.js";
+import type { AdmissionUsageSummary } from "../budget/admission-types.js";
 
 export type SlashCommandSurface = "runtime" | "daemon-tui";
 
@@ -27,6 +28,7 @@ export type SlashCommandSurface = "runtime" | "daemon-tui";
  * waiting for a future turn boundary.
  */
 export interface SlashCommandAppStateBridge {
+  readonly getSessionUsage?: () => AdmissionUsageSummary | null;
   /** Read the live TUI app state for commands that report runtime surfaces. */
   readonly getAppState?: () => unknown;
   /** Update the model slug shown in the status bar. */

--- a/runtime/src/hooks/status-line-executor.ts
+++ b/runtime/src/hooks/status-line-executor.ts
@@ -1,0 +1,293 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import type { SessionStatusLineExecuteResult as SessionStatusLineResult, SessionStatusLinePresentation } from "../app-server/protocol/index.js";
+import { AdmissionDeniedError } from "../budget/admission-client.js";
+import { mergeConfigLayerSnapshots } from "../config/repository.js";
+import { validateStatusLineConfig } from "../config/schema.js";
+import type { Session } from "../session/session.js";
+import { isAdmissionUsageSummary } from "../session/usage-summary.js";
+import { VERSION } from "../version.js";
+import { asRecord } from "../utils/record.js";
+import { workspaceMutationCoordinators, WorkspaceMutationCoordinatorError } from "../workspace/mutation-coordinator.js";
+import { createWorkspaceOperationLifetime, runWithWorkspaceOperationLifetime } from "../workspace/tool-operation-lifetime.js";
+import { runHookCommand } from "./engine/command-runner.js";
+
+const activeSessions = new WeakSet<Session>();
+const TIMEOUT_MS = 5_000;
+const MAX_INPUT_BYTES = 65_536;
+const MAX_OUTPUT_BYTES = 16_384;
+const latestUsageBySession = new WeakMap<Session, { value: ReturnType<typeof contextUsage> }>();
+
+function contextUsage(value: unknown) {
+  const payload = asRecord(value);
+  if (payload === null || typeof payload.promptTokens !== "number" || typeof payload.completionTokens !== "number") return null;
+  const counts = [payload.promptTokens, payload.completionTokens, payload.cachedInputTokens ?? 0, payload.cacheCreationInputTokens ?? 0];
+  if (!counts.every((count) => typeof count === "number" && Number.isSafeInteger(count) && count >= 0)) return null;
+  const cached = Number(counts[2]);
+  const created = Number(counts[3]);
+  return {
+    input_tokens: Math.max(0, payload.promptTokens - cached - created),
+    output_tokens: payload.completionTokens,
+    cache_read_input_tokens: cached,
+    cache_creation_input_tokens: created,
+  };
+}
+
+function latestContextUsage(session: Session) {
+  const existing = latestUsageBySession.get(session);
+  if (existing !== undefined) return existing.value;
+  const initial = session.state.unsafePeek().initialTokenUsage;
+  const current = { value: isMainUsage(initial) ? contextUsage(initial) : null };
+  const path = session.rolloutStore?.rolloutPath;
+  if (path !== undefined) {
+    let descriptor: number | undefined;
+    try {
+      descriptor = openSync(path, "r");
+      const size = fstatSync(descriptor).size;
+      const offset = Math.max(0, size - MAX_INPUT_BYTES);
+      const buffer = Buffer.alloc(Math.min(size, MAX_INPUT_BYTES));
+      const count = readSync(descriptor, buffer, 0, buffer.length, offset);
+      const lines = buffer.toString("utf8", 0, count).split("\n");
+      if (offset > 0) lines.shift();
+      for (const line of lines.reverse()) {
+        try {
+          const item = asRecord(JSON.parse(line));
+          const event = asRecord(item?.payload);
+          const message = asRecord(event?.msg);
+          if (item?.type === "compaction_committed" || item?.type === "compacted" ||
+              (item?.type === "event_msg" && contextWasReplaced(message?.type))) {
+            current.value = null;
+            break;
+          }
+          if (item?.type === "event_msg" && message?.type === "token_count" && isMainUsage(message.payload)) {
+            current.value = contextUsage(message.payload);
+            break;
+          }
+        } catch {}
+      }
+    } catch {
+      current.value = null;
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+    }
+  }
+  session.eventLog.subscribe((event) => {
+    if (event.msg.type === "token_count" && isMainUsage(event.msg.payload)) current.value = contextUsage(event.msg.payload);
+    else if (contextWasReplaced(event.msg.type)) current.value = null;
+  });
+  latestUsageBySession.set(session, current);
+  return current.value;
+}
+
+function isMainUsage(value: unknown): boolean {
+  const payload = asRecord(value);
+  return typeof payload?.provider === "string" && payload.provider.length > 0 &&
+    typeof payload.model === "string" && payload.model.length > 0;
+}
+
+function contextWasReplaced(type: unknown): boolean {
+  return type === "history_cleared" || type === "transcript_epoch" || type === "context_compacted";
+}
+
+function executionBlock(session: Session): SessionStatusLineResult | undefined {
+  if (session.eventLog.isClosed || session.abortController.signal.aborted ||
+      session.services.mcpStartupCancellationToken.isCancelled()) {
+    return { status: "unavailable", reason: "session_closed" };
+  }
+  if (session.services.runtimeOptions.simpleMode || session.services.hooksRuntime?.isDisabled()) {
+    return { status: "disabled", reason: "hooks_disabled" };
+  }
+  const authority = session.services.hookExecutionAuthority;
+  if (authority === undefined) return { status: "blocked", reason: "missing_session_authority" };
+  const decision = authority.decision("command");
+  if (!decision.allowed) return { status: "blocked", reason: decision.reason };
+  return undefined;
+}
+
+function statusLineInput(session: Session, presentation: SessionStatusLinePresentation): string | undefined {
+  const configStore = session.services.configStore;
+  const usage = session.services.executionAdmission?.getUsageSummary?.();
+  const admission = session.services.executionAdmission;
+  if (configStore === undefined || !isAdmissionUsageSummary(usage) ||
+      usage.runId !== admission?.scope.runId || admission.scope.sessionId !== session.conversationId) return undefined;
+  const config = configStore.current();
+  const sidecar = session.services.costSidecar;
+  const cwd = session.sessionConfiguration.cwd;
+  const projectRoot = configStore.projectRoot;
+  if (!isAbsolute(cwd) || !isAbsolute(projectRoot)) return undefined;
+  const model = session.sessionConfiguration.collaborationMode.model;
+  const currentUsage = latestContextUsage(session);
+  const currentInput = currentUsage === null ? null : currentUsage.input_tokens + currentUsage.cache_read_input_tokens + currentUsage.cache_creation_input_tokens;
+  const contextWindow = session.modelInfo.contextWindow;
+  const usedPercentage = currentInput === null || contextWindow === undefined || contextWindow <= 0
+    ? null : Math.max(0, Math.min(100, Math.round(currentInput / contextWindow * 100)));
+  const worktree = session.pendingWorktreeState;
+  const source = session.sessionConfiguration.sessionSource;
+  const agentRole = typeof source === "object" && source.kind === "subagent" && source.source.kind === "thread_spawn"
+    ? source.source.agentRole : undefined;
+  return JSON.stringify({
+    session_id: session.conversationId,
+    transcript_path: session.rolloutStore?.rolloutPath ?? "",
+    cwd,
+    permission_mode: session.services.permissionModeRegistry.current().mode,
+    model: { id: model, display_name: model },
+    workspace: { current_dir: cwd, project_dir: projectRoot, added_dirs: [...session.services.permissionModeRegistry.current().additionalWorkingDirectories.keys()] },
+    version: VERSION,
+    output_style: { name: config.outputStyle ?? "default" },
+    cost: {
+      total_cost_usd: usage.costUsd,
+      has_unknown_cost: usage.hasUnknownCost,
+      total_duration_ms: sidecar?.getTotalDurationMs() ?? 0,
+      total_api_duration_ms: sidecar?.getTotalApiDurationMs() ?? 0,
+      total_lines_added: sidecar?.getTotalLinesAdded() ?? 0,
+      total_lines_removed: sidecar?.getTotalLinesRemoved() ?? 0,
+    },
+    context_window: {
+      total_input_tokens: usage.inputTokens,
+      total_output_tokens: usage.outputTokens,
+      context_window_size: session.modelInfo.contextWindow ?? null,
+      current_usage: currentUsage,
+      used_percentage: usedPercentage,
+      remaining_percentage: usedPercentage === null ? null : 100 - usedPercentage,
+    },
+    exceeds_200k_tokens: currentInput === null ? null : currentInput + currentUsage!.output_tokens > 200_000,
+    ...(agentRole !== undefined ? { agent: { name: agentRole } } : {}),
+    ...(worktree === null ? {} : { worktree: {
+      path: worktree.handle.path,
+      branch: worktree.handle.branch,
+      original_cwd: worktree.originalCwd,
+    } }),
+    ...(presentation.vimMode !== undefined ? { vim: { mode: presentation.vimMode } } : {}),
+  });
+}
+
+async function runSessionStatusLine(
+  session: Session,
+  presentation: SessionStatusLinePresentation,
+  signal: AbortSignal,
+): Promise<SessionStatusLineResult> {
+  const blocked = executionBlock(session);
+  if (blocked !== undefined) return blocked;
+  signal.throwIfAborted();
+  const configStore = session.services.configStore;
+  if (configStore === undefined) return { status: "unavailable", reason: "configuration_unavailable" };
+  const config = configStore.current();
+  const sessionConfig = session.sessionConfiguration;
+  const managed = mergeConfigLayerSnapshots(configStore.sources("managed"));
+  if (managed?.disableAllHooks === true) return { status: "disabled", reason: "managed_hooks_disabled" };
+  const command = validateStatusLineConfig(
+    managed?.allowManagedHooksOnly === true || config.disableAllHooks === true
+      ? managed?.statusLine
+      : config.statusLine,
+  );
+  if (command === undefined) return { status: "disabled", reason: "not_configured" };
+  const admission = session.services.executionAdmission;
+  const broker = session.services.sandboxExecutionBroker;
+  const shell = session.services.userShell;
+  if (admission === undefined || broker === undefined || shell === undefined) {
+    return { status: "blocked", reason: "execution_boundary_unavailable" };
+  }
+  const input = statusLineInput(session, presentation);
+  if (input === undefined) return { status: "unavailable", reason: "session_input_unavailable" };
+  if (Buffer.byteLength(input, "utf8") > MAX_INPUT_BYTES) return { status: "error", reason: "input_too_large" };
+  const workspaceRegistry = workspaceMutationCoordinators.forHome(configStore.homeContext.path);
+  const workspaceToken = workspaceRegistry.beginToolOperation(sessionConfig.cwd, "StatusLine");
+  const lifetime = createWorkspaceOperationLifetime(() => workspaceRegistry.endToolOperation(workspaceToken));
+  let completedReservationId: string | undefined;
+  try {
+    return await runWithWorkspaceOperationLifetime(lifetime, async () => {
+      const lease = await admission.acquire({
+        stepId: `hook:StatusLine:${randomUUID()}`,
+        kind: "tool_exec",
+        sessionId: session.conversationId,
+        parentScopeId: "hook:StatusLine",
+        maxInputTokens: 0,
+        maxOutputTokens: 0,
+        maxCostUsd: 0,
+      }, signal);
+      const reservationId = lease.reservation.reservationId;
+      completedReservationId = reservationId;
+      let dispatched = false;
+      let settled = false;
+      try {
+        const effectSignal = AbortSignal.any([signal, lease.signal]);
+        effectSignal.throwIfAborted();
+        const blockedAfterAdmission = executionBlock(session);
+        if (blockedAfterAdmission !== undefined) return blockedAfterAdmission;
+        if (configStore.current() !== config || session.sessionConfiguration !== sessionConfig) return { status: "unavailable", reason: "configuration_changed" };
+        const freshInput = statusLineInput(session, presentation);
+        if (freshInput === undefined) return { status: "unavailable", reason: "session_input_unavailable" };
+        if (Buffer.byteLength(freshInput, "utf8") > MAX_INPUT_BYTES) return { status: "error", reason: "input_too_large" };
+        admission.markDispatched(reservationId, {
+          boundary: "tool_effect",
+          details: { hookEvent: "StatusLine" },
+        });
+        dispatched = true;
+        const result = await runHookCommand({
+          command: command.command,
+          cwd: sessionConfig.cwd,
+          env: { ...shell.childEnvironment, AGENC_PROJECT_DIR: configStore.projectRoot },
+          shellPath: shell.path,
+          commandWrapperArgv: shell.commandWrapperArgv,
+          stdin: freshInput,
+          timeoutMs: TIMEOUT_MS,
+          signal: effectSignal,
+          sandboxExecutionBroker: broker,
+        });
+        if (effectSignal.aborted || result.status === "timeout" || result.status === "skipped") {
+          admission.holdUnknown(reservationId, "status_line_cancelled_after_dispatch");
+        } else {
+          admission.reconcile(reservationId, { inputTokens: 0, outputTokens: 0, costUsd: 0 });
+        }
+        settled = true;
+        if (effectSignal.aborted) return { status: "unavailable", reason: "cancelled" };
+        if (result.status !== "success") return { status: "error", reason: "command_failed" };
+        if (result.error !== undefined || Buffer.byteLength(result.stdout, "utf8") > MAX_OUTPUT_BYTES) {
+          return { status: "error", reason: "output_too_large" };
+        }
+        const text = result.stdout.trim().split("\n").flatMap((line) => line.trim() || []).join("\n");
+        return { status: "rendered", text };
+      } finally {
+        if (!settled) {
+          if (dispatched) admission.holdUnknown(reservationId, "status_line_failed_after_dispatch");
+          else admission.void(reservationId, "status_line_stopped_before_dispatch");
+        }
+      }
+    });
+  } finally {
+    await lifetime.release();
+    await lifetime.settled();
+    if (completedReservationId !== undefined) admission.acknowledgeCompletion(completedReservationId);
+  }
+}
+
+export function executeSessionStatusLine(
+  session: Session,
+  presentation: SessionStatusLinePresentation = {},
+  signal?: AbortSignal,
+): Promise<SessionStatusLineResult> {
+  if (activeSessions.has(session)) return Promise.resolve({ status: "unavailable", reason: "busy" });
+  activeSessions.add(session);
+  const timeout = new AbortController();
+  const timer = setTimeout(() => timeout.abort(), TIMEOUT_MS);
+  timer.unref?.();
+  const signals = [timeout.signal, session.abortController.signal];
+  const shutdownSignal = session.services.mcpStartupCancellationToken.signal;
+  if (shutdownSignal !== undefined) signals.push(shutdownSignal);
+  if (signal !== undefined) signals.push(signal);
+  const combined = AbortSignal.any(signals);
+  const operation = Promise.resolve().then(() => runSessionStatusLine(session, presentation, combined))
+    .then((result): SessionStatusLineResult => timeout.signal.aborted ? { status: "error", reason: "timeout" } : result)
+    .catch((error: unknown): SessionStatusLineResult => {
+      if (timeout.signal.aborted) return { status: "error", reason: "timeout" };
+      if (combined.aborted) return { status: "unavailable", reason: "cancelled" };
+      if (error instanceof AdmissionDeniedError) return { status: "blocked", reason: "admission_denied" };
+      if (error instanceof WorkspaceMutationCoordinatorError) return { status: "blocked", reason: "editor_workspace_owned" };
+      return { status: "error", reason: "execution_failed" };
+    }).finally(() => {
+      clearTimeout(timer);
+      activeSessions.delete(session);
+    });
+  return session.trackDurableOperation(operation);
+}

--- a/runtime/src/permissions/risk.ts
+++ b/runtime/src/permissions/risk.ts
@@ -11,6 +11,7 @@ const DATA_BEARING_BUILTIN_TOOL_NAMES = new Set([
   "Write",
   "Edit",
   "NotebookEdit",
+  "CronCreate",
 ]);
 
 const SHELL_COMMAND_FRAGMENT = String.raw`[^;&|\n]*`;
@@ -37,6 +38,9 @@ export function classifyApprovalRisk(input: {
     typeof input.request?.ctx?.toolName === "string"
       ? input.request.ctx.toolName
       : undefined;
+  if (requestToolName === "CronDelete" || input.toolName === "CronDelete") {
+    return "destructive";
+  }
   const command = input.toolInput === undefined
     ? input.command
     : approvalActionText(input.toolInput, input.toolName ?? requestToolName);
@@ -75,6 +79,7 @@ export function typedConfirmationWordForRisk(input: {
   readonly toolInput?: unknown;
 }): string {
   if (input.risk !== "destructive") return "yes";
+  if (input.toolName === "CronDelete") return "delete";
   const command = input.toolInput === undefined
     ? input.command
     : approvalActionText(input.toolInput, input.toolName);

--- a/runtime/src/session/autonomous-mode.ts
+++ b/runtime/src/session/autonomous-mode.ts
@@ -46,6 +46,7 @@ export interface SessionEditorInteraction {
 export interface SessionSubmitOptions {
   readonly clientMessageId?: string;
   readonly source?: SessionSubmitSource;
+  readonly onAccepted?: () => void | Promise<void>;
   /**
    * Transcript-facing input for this submission. `undefined` means render the
    * caller's submitted text, while `null` suppresses the user-message row for

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -46,6 +46,7 @@ import {
 } from "../state/recovery-contract.js";
 import type { RolloutItem } from "./rollout-item.js";
 import type { ResponseItem } from "./rollout-item.js";
+import { isAdmissionUsageSummary } from "./usage-summary.js";
 import {
   emptyReducedState,
   reduce,
@@ -1401,6 +1402,7 @@ function nextPostCommitBookkeeping(
   current: PostCommitBookkeeping,
   expectedRunId: string | undefined,
 ): PostCommitBookkeeping | "later_work" {
+  if (isUsageObservation(item)) return current;
   if (
     item.type === "compaction_cleanup_pending" &&
     item.payload.attempt_id === committed.intent?.attempt_id
@@ -1433,6 +1435,11 @@ function isCausalAutoCompactionBoundary(item: RolloutItem): boolean {
       item.payload.msg.payload.summary,
     )
   );
+}
+
+function isUsageObservation(item: RolloutItem): boolean {
+  return item.type === "event_msg" && item.payload.msg.type === "session_usage" &&
+    isAdmissionUsageSummary(item.payload.msg.payload);
 }
 
 function strictOptions(
@@ -1488,6 +1495,7 @@ function observeAdmission(
 ): void {
   if (attempt.terminal) return;
   const item = record.item;
+  if (isUsageObservation(item)) return;
   if (
     (item.type === "compaction_committed" ||
       item.type === "compaction_failed") &&

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -21,7 +21,7 @@
 
 import type { LLMContentPart, LLMMessage, LLMUsage } from "../llm/types.js";
 import type { AgentStatus } from "../agents/status.js";
-import type { AdmissionJournalEvent } from "../budget/admission-types.js";
+import type { AdmissionJournalEvent, AdmissionUsageSummary } from "../budget/admission-types.js";
 import type {
   EffectBoundary,
   EffectNoEffectProof,
@@ -1225,6 +1225,10 @@ export type EventMsg =
       readonly payload: AdmissionJournalEvent;
     }
   | {
+      readonly type: "session_usage";
+      readonly payload: AdmissionUsageSummary;
+    }
+  | {
       readonly type: "guardian_assessment";
       readonly payload: GuardianAssessmentEvent;
     }
@@ -1453,6 +1457,7 @@ export const KNOWN_EVENT_TYPES = Object.freeze(
     "run_cancel_requested",
     "recovery_decision",
     "execution_admission",
+    "session_usage",
     "guardian_assessment",
     "review_delegate_started",
     "review_delegate_completed",

--- a/runtime/src/session/execution-admission-journal.ts
+++ b/runtime/src/session/execution-admission-journal.ts
@@ -1,7 +1,8 @@
 /** Canonical rollout projection for execution-admission transitions. */
 
+import { randomUUID } from "node:crypto";
 import type { ExecutionAdmissionClient } from "../budget/admission-client.js";
-import type { AdmissionJournalEvent } from "../budget/admission-types.js";
+import type { AdmissionJournalEvent, AdmissionUsageSummary } from "../budget/admission-types.js";
 import type { Event } from "./event-log.js";
 import type { RolloutStore } from "./rollout-store.js";
 import type { Session } from "./session.js";
@@ -24,6 +25,7 @@ export function bindExecutionAdmissionJournal(
   };
   const unsubscribe =
     admission.subscribeCritical?.(append) ?? admission.subscribe(append);
+  let unsubscribeUsage: (() => void) | undefined;
   try {
     // Subscribe first, then converge the durable pre-bind history. JavaScript
     // cannot interleave another admission mutation during this synchronous
@@ -63,11 +65,25 @@ export function bindExecutionAdmissionJournal(
       }
       if (page.length < EXECUTION_ADMISSION_CATCHUP_PAGE_SIZE) break;
     }
+    let lastUsageSequence = -1;
+    const appendUsage = (summary: AdmissionUsageSummary): void => {
+      if (summary.sequence <= lastUsageSequence) return;
+      if (typeof session.conversationId === "string" && summary.runId !== session.conversationId) return;
+      session.emit({ id: `usage:${summary.runId}:${summary.sequence}`, eventId: randomUUID(), msg: { type: "session_usage", payload: summary } }, { durable: true });
+      lastUsageSequence = summary.sequence;
+    };
+    unsubscribeUsage = admission.subscribeUsage?.(appendUsage);
+    const usage = admission.getUsageSummary?.();
+    if (usage !== undefined) appendUsage(usage);
   } catch (error) {
+    unsubscribeUsage?.();
     unsubscribe();
     throw error;
   }
-  return unsubscribe;
+  return () => {
+    unsubscribeUsage?.();
+    unsubscribe();
+  };
 }
 
 /**

--- a/runtime/src/session/session-cron-scheduler.ts
+++ b/runtime/src/session/session-cron-scheduler.ts
@@ -1,0 +1,167 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  getSessionCronTasks,
+  removeSessionCronTasks,
+  removeSessionCronTasksForConversation,
+} from "../bootstrap/state.js";
+import { CronScheduler } from "../utils/cronScheduler.js";
+import { listAllCronTasks, mutateCronFile, type CronTask } from "../utils/cronTasks.js";
+import { emitWarning } from "./event-log.js";
+import type { Session } from "./session.js";
+
+type SessionCronOwner = {
+  readonly scheduler: CronScheduler;
+  readonly workspaceRoot: string;
+  closed: boolean;
+  ready: boolean;
+};
+
+const sessionOwners = new WeakMap<Session, SessionCronOwner>();
+const workspaceOwners = new Map<string, Set<SessionCronOwner>>();
+
+class ScheduledTaskCancelled extends Error {}
+
+function matchesScheduledOccurrence(current: CronTask, expected: Readonly<CronTask>): boolean {
+  return current.id === expected.id && current.cron === expected.cron &&
+    current.prompt === expected.prompt && current.createdAt === expected.createdAt &&
+    current.recurring === expected.recurring && current.lastFiredAt === expected.lastFiredAt &&
+    current.deliver === undefined;
+}
+
+async function claimScheduledOccurrence(
+  task: Readonly<CronTask>,
+  firedAt: number,
+  conversationId: string,
+  workspaceRoot: string,
+  assertActive: () => void,
+): Promise<boolean> {
+  if (task.durable === false) {
+    assertActive();
+    const current = getSessionCronTasks().find((candidate) =>
+      candidate.queueOwner.conversationId === conversationId &&
+      matchesScheduledOccurrence(candidate, task),
+    );
+    if (current === undefined) return false;
+    if (task.recurring) current.lastFiredAt = firedAt;
+    else removeSessionCronTasks([task.id], conversationId);
+    return true;
+  }
+  return mutateCronFile(workspaceRoot, (state) => {
+    assertActive();
+    const current = state.tasks.find((candidate) => matchesScheduledOccurrence(candidate, task));
+    if (current === undefined) return false;
+    if (task.recurring) current.lastFiredAt = firedAt;
+    else state.tasks = state.tasks.filter((candidate) => candidate.id !== task.id);
+    return true;
+  });
+}
+
+export async function startSessionCronScheduler(
+  session: Session,
+  workspaceRoot: string,
+): Promise<CronScheduler> {
+  session.abortController.signal.throwIfAborted();
+  const startupSignal = session.services.mcpStartupCancellationToken.signal;
+  startupSignal?.throwIfAborted();
+  const canonicalRoot = realpathSync(resolve(workspaceRoot));
+  let owner = sessionOwners.get(session);
+  if (owner !== undefined && (owner.closed || owner.workspaceRoot !== canonicalRoot)) {
+    throw new Error("Cron scheduler session ownership is no longer valid");
+  }
+  if (owner === undefined) {
+    const owners = workspaceOwners.get(canonicalRoot) ?? new Set<SessionCronOwner>();
+    workspaceOwners.set(canonicalRoot, owners);
+    let currentOwner: SessionCronOwner;
+    const scheduler = new CronScheduler({
+      loadTasks: async (directory, conversationId) => {
+        const tasks = await listAllCronTasks(directory, conversationId);
+        if (currentOwner.closed) return [];
+        const ownsDurableTasks = [...owners].find((candidate) => candidate.ready) === currentOwner;
+        return tasks.filter((task) => task.durable === false || ownsDurableTasks);
+      },
+      enqueue: async (command, task, firedAt) => {
+        let accepted = false;
+        const assertActive = (): void => {
+          if (currentOwner.closed) throw new Error("Cron scheduler session is closed");
+          session.abortController.signal.throwIfAborted();
+          startupSignal?.throwIfAborted();
+        };
+        try {
+          assertActive();
+          await session.submit(command.value, {
+            displayUserMessage: null,
+            onAccepted: async () => {
+              if (!await claimScheduledOccurrence(
+                task, firedAt, session.conversationId, canonicalRoot, assertActive,
+              )) throw new ScheduledTaskCancelled();
+              accepted = true;
+              assertActive();
+            },
+          });
+        } catch (error) {
+          if (error instanceof ScheduledTaskCancelled) return "cancelled" as const;
+          scheduler.stop();
+          if (accepted || !currentOwner.closed) {
+            emitWarning(
+              session.eventLog,
+              session.nextInternalSubId(),
+              "scheduled_turn_failed",
+              `Scheduled turn failed ${accepted ? "after acceptance; the attempt will not be replayed" : "before acceptance; the job is retained"}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+          if (!accepted) throw error;
+        }
+        return "accepted" as const;
+      },
+    });
+    currentOwner = { scheduler, workspaceRoot: canonicalRoot, closed: false, ready: false };
+    owner = currentOwner;
+    owners.add(owner);
+    sessionOwners.set(session, owner);
+    let closePromise: Promise<void> | undefined;
+    let unsubscribeReady = (): void => {};
+    const close = (): Promise<void> => {
+      if (closePromise !== undefined) return closePromise;
+      currentOwner.closed = true;
+      scheduler.stop();
+      unsubscribeReady();
+      removeSessionCronTasksForConversation(session.conversationId);
+      session.abortController.signal.removeEventListener("abort", onAbort);
+      startupSignal?.removeEventListener("abort", onAbort);
+      closePromise = scheduler.drain().then(async () => {
+        owners.delete(currentOwner);
+        sessionOwners.delete(session);
+        if (owners.size === 0) workspaceOwners.delete(canonicalRoot);
+        await Promise.all([...owners].map((remaining) => remaining.scheduler.reschedule()));
+      });
+      return closePromise;
+    };
+    const onAbort = (): void => {
+      void close().catch(() => undefined);
+    };
+    session.abortController.signal.addEventListener("abort", onAbort, { once: true });
+    startupSignal?.addEventListener("abort", onAbort, { once: true });
+    session.onBeforeDurableClose(close);
+    unsubscribeReady = session.onTurnDriverReady(() => {
+      if (currentOwner.closed) return;
+      owners.delete(currentOwner);
+      owners.add(currentOwner);
+      currentOwner.ready = true;
+      scheduler.start({
+        queueOwner: { kind: "session", conversationId: session.conversationId },
+        workspaceRoot: canonicalRoot,
+      });
+    });
+  }
+  if (owner.ready) {
+    owner.scheduler.start({
+      queueOwner: { kind: "session", conversationId: session.conversationId },
+      workspaceRoot: canonicalRoot,
+    });
+  }
+  await Promise.all(
+    [...(workspaceOwners.get(canonicalRoot) ?? [])].map((current) => current.scheduler.reschedule()),
+  );
+  return owner.scheduler;
+}

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -2590,6 +2590,7 @@ export class Session {
 
   /** Bootstrap-owned submit hook used by the TUI contract. */
   private turnDriverHooks: SessionTurnDriverHooks | null = null;
+  private readonly turnDriverReadyListeners = new Set<() => void>();
   /**
    * SessionStart hooks may be deferred when the atomic first turn is an
    * Editor read-only/proposal-only interaction. This prevents arbitrary
@@ -3492,6 +3493,23 @@ export class Session {
 
   installTurnDriverHooks(hooks: SessionTurnDriverHooks | null): void {
     this.turnDriverHooks = hooks;
+    if (hooks !== null && this.lifecycleState === "open") {
+      const listeners = [...this.turnDriverReadyListeners];
+      this.turnDriverReadyListeners.clear();
+      for (const listener of listeners) listener();
+    }
+  }
+
+  onTurnDriverReady(listener: () => void): () => void {
+    if (this.lifecycleState !== "open") {
+      throw new Error("cannot schedule a turn after shutdown");
+    }
+    if (this.turnDriverHooks !== null) {
+      listener();
+      return () => {};
+    }
+    this.turnDriverReadyListeners.add(listener);
+    return () => { this.turnDriverReadyListeners.delete(listener); };
   }
 
   installDeferredSessionStartHook(hook: (() => Promise<void>) | null): void {
@@ -3763,6 +3781,12 @@ export class Session {
       }
       if (this.lifecycleState !== "open") {
         throw new Error("session is shutting down");
+      }
+      if (opts.onAccepted !== undefined) {
+        await opts.onAccepted();
+        if (this.lifecycleState !== "open") {
+          throw new Error("session is shutting down");
+        }
       }
       await hooks.submit(message, opts);
     });

--- a/runtime/src/session/usage-summary.ts
+++ b/runtime/src/session/usage-summary.ts
@@ -1,0 +1,46 @@
+import type { AdmissionUsageSummary, AdmissionUsageTotals } from "../budget/admission-types.js";
+import { asRecord } from "../utils/record.js";
+
+function isUsageTotals(value: unknown): value is AdmissionUsageTotals {
+  const record = asRecord(value);
+  if (record === null || typeof record.hasUnknownCost !== "boolean") return false;
+  for (const key of ["costUsd", "heldCostUsd"]) {
+    const amount = record[key];
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) return false;
+  }
+  for (const key of ["inputTokens", "outputTokens", "totalTokens", "modelCalls"]) {
+    const count = record[key];
+    if (typeof count !== "number" || !Number.isSafeInteger(count) || count < 0) return false;
+  }
+  return true;
+}
+
+export function isAdmissionUsageSummary(value: unknown): value is AdmissionUsageSummary {
+  const record = asRecord(value);
+  return record !== null && isUsageTotals(record) &&
+    typeof record.runId === "string" && record.runId.length > 0 &&
+    typeof record.sequence === "number" && Number.isSafeInteger(record.sequence) && record.sequence >= 0 &&
+    Array.isArray(record.models) && record.models.every((entry: unknown) => {
+      const model = asRecord(entry);
+      return model !== null && isUsageTotals(model) &&
+        typeof model.model === "string" &&
+        (model.provider === undefined || typeof model.provider === "string");
+    }) &&
+    Array.isArray(record.agents) && record.agents.every((entry: unknown) => {
+      const agent = asRecord(entry);
+      return agent !== null && isUsageTotals(agent) &&
+        typeof agent.runId === "string" && agent.runId.length > 0;
+    });
+}
+
+export function latestSessionUsage(
+  current: AdmissionUsageSummary | null,
+  event: unknown,
+): AdmissionUsageSummary | null {
+  const record = asRecord(event);
+  const message = asRecord(record?.msg) ?? record;
+  if (message?.type !== "session_usage" || !isAdmissionUsageSummary(message.payload)) return current;
+  const summary = message.payload;
+  if (current !== null && (summary.runId !== current.runId || summary.sequence <= current.sequence)) return current;
+  return summary;
+}

--- a/runtime/src/state/execution-admission.ts
+++ b/runtime/src/state/execution-admission.ts
@@ -10,6 +10,8 @@ import type {
   AdmissionReconcileResult,
   AdmissionRecoveryReport,
   AdmissionUsage,
+  AdmissionUsageSummary,
+  AdmissionUsageTotals,
   PersistedAdmissionRecord,
   PersistedAdmissionStatus,
   RuntimeAdmissionRequest,
@@ -270,6 +272,48 @@ interface ReservationRow {
   readonly updated_at: string;
 }
 
+interface UsageAggregateRow {
+  readonly run_id: string;
+  readonly kind: string;
+  readonly model: string | null;
+  readonly provider: string | null;
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly total_tokens: number;
+  readonly cost_nanos: number;
+  readonly held_cost_nanos: number;
+  readonly model_calls: number;
+  readonly unknown_count: number;
+}
+
+function sumUsageRows(rows: readonly UsageAggregateRow[]): AdmissionUsageTotals {
+  let costNanos = 0;
+  let heldCostNanos = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let modelCalls = 0;
+  let hasUnknownCost = false;
+  for (const row of rows) {
+    costNanos += row.cost_nanos;
+    heldCostNanos += row.held_cost_nanos;
+    inputTokens += row.input_tokens;
+    outputTokens += row.output_tokens;
+    totalTokens += row.total_tokens;
+    modelCalls += row.model_calls;
+    hasUnknownCost ||= row.unknown_count > 0;
+  }
+  return {
+    costUsd: nanosToUsd(costNanos),
+    heldCostUsd: nanosToUsd(heldCostNanos),
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    modelCalls,
+    hasUnknownCost,
+  };
+}
+
 interface CancellationJobPreStateRow {
   readonly id: string;
   readonly admission_queue_sequence: number;
@@ -466,6 +510,47 @@ export class ExecutionAdmissionRepository {
           .run(effective ?? null, at, normalizedRunId);
       }
       return effective;
+    });
+  }
+
+  bindRunCostLimit(
+    ownerRunId: string,
+    scope: AdmissionBudgetScope,
+  ): number | undefined {
+    requireNonEmpty(ownerRunId, "bindRunCostLimit.ownerRunId");
+    const key = requireNonEmpty(scope.key, "bindRunCostLimit.scope.key");
+    const proposed =
+      scope.maxCostUsd === undefined ? undefined : usdToNanos(scope.maxCostUsd);
+    const now = this.#timestamp();
+    return this.#driver.transactionImmediate(() => {
+      const existing = this.#allocationLocked(key);
+      if (existing === undefined && proposed === undefined) return undefined;
+      if (
+        existing !== undefined &&
+        proposed !== undefined &&
+        (existing.max_cost_nanos === null || proposed < existing.max_cost_nanos)
+      ) {
+        this.#driver
+          .prepareState(
+            `UPDATE execution_admission_allocations
+             SET max_cost_nanos = ?, updated_at = ? WHERE scope_key = ?`,
+          )
+          .run(proposed, now, key);
+      }
+      const persisted = this.#allocationLocked(key)?.max_cost_nanos ?? proposed;
+      const allocation = this.#ensureAllocationLocked(
+        ownerRunId,
+        {
+          ...scope,
+          ...(persisted !== undefined
+            ? { maxCostUsd: nanosToUsd(persisted) }
+            : {}),
+        },
+        now,
+      );
+      return allocation.max_cost_nanos === null
+        ? undefined
+        : nanosToUsd(allocation.max_cost_nanos);
     });
   }
 
@@ -1473,6 +1558,75 @@ export class ExecutionAdmissionRepository {
     };
   }
 
+  getUsageSummary(runId: string, allocationKey: string): AdmissionUsageSummary {
+    requireNonEmpty(runId, "runId");
+    requireNonEmpty(allocationKey, "allocationKey");
+    return this.#driver.transaction(() => {
+      const sequence = this.#driver
+        .prepareState<[], { readonly sequence: number }>(
+          "SELECT COALESCE(MAX(sequence), 0) AS sequence FROM execution_admission_journal",
+        )
+        .get()?.sequence ?? 0;
+      const rows = this.#driver
+        .prepareState<[string], UsageAggregateRow>(
+          `SELECT reservation.run_id, reservation.kind, reservation.model, reservation.provider,
+             COALESCE(SUM(CASE WHEN reservation.status IN ('reconciled', 'provider_overrun', 'held_unknown')
+               THEN COALESCE(reservation.actual_input_tokens, 0) ELSE 0 END), 0) AS input_tokens,
+             COALESCE(SUM(CASE WHEN reservation.status IN ('reconciled', 'provider_overrun', 'held_unknown')
+               THEN COALESCE(reservation.actual_output_tokens, 0) ELSE 0 END), 0) AS output_tokens,
+             COALESCE(SUM(CASE WHEN reservation.status IN ('reconciled', 'provider_overrun', 'held_unknown')
+               THEN COALESCE(reservation.actual_tokens, 0) ELSE 0 END), 0) AS total_tokens,
+             COALESCE(SUM(CASE WHEN reservation.status IN ('reconciled', 'provider_overrun')
+               THEN COALESCE(reservation.actual_cost_nanos, 0) ELSE 0 END), 0) AS cost_nanos,
+             COALESCE(SUM(CASE WHEN reservation.status IN ('reserved', 'dispatched', 'held_unknown') OR
+               (reservation.status = 'provider_overrun' AND reservation.actual_cost_nanos IS NULL)
+               THEN reservation.reserved_cost_nanos ELSE 0 END), 0) AS held_cost_nanos,
+             SUM(CASE WHEN reservation.kind = 'model_turn'
+               AND reservation.status IN ('reconciled', 'provider_overrun', 'held_unknown')
+               AND reservation.actual_tokens IS NOT NULL THEN 1 ELSE 0 END) AS model_calls,
+             SUM(CASE WHEN reservation.status = 'held_unknown' OR
+               (reservation.status IN ('reconciled', 'provider_overrun') AND reservation.actual_cost_nanos IS NULL)
+               THEN 1 ELSE 0 END) AS unknown_count
+           FROM execution_admission_reservations AS reservation
+           JOIN execution_admission_reservation_allocations AS allocation
+             ON allocation.reservation_id = reservation.reservation_id AND allocation.scope_key = ?
+           WHERE reservation.status != 'voided'
+           GROUP BY reservation.run_id, reservation.kind, reservation.model, reservation.provider
+           ORDER BY reservation.run_id, reservation.kind, reservation.model, reservation.provider`,
+        )
+        .all(allocationKey);
+      const modelRows = new Map<string, UsageAggregateRow[]>();
+      const agentRows = new Map<string, UsageAggregateRow[]>();
+      for (const row of rows) {
+        if (row.kind === "model_turn") {
+          const key = JSON.stringify([row.provider, row.model]);
+          const group = modelRows.get(key) ?? [];
+          group.push(row);
+          modelRows.set(key, group);
+        }
+        if (row.run_id !== runId) {
+          const group = agentRows.get(row.run_id) ?? [];
+          group.push(row);
+          agentRows.set(row.run_id, group);
+        }
+      }
+      return {
+        runId,
+        sequence,
+        ...sumUsageRows(rows),
+        models: [...modelRows.values()].map((group) => ({
+          model: group[0]!.model ?? "unknown",
+          ...(group[0]!.provider !== null ? { provider: group[0]!.provider! } : {}),
+          ...sumUsageRows(group),
+        })),
+        agents: [...agentRows].map(([agentRunId, group]) => ({
+          runId: agentRunId,
+          ...sumUsageRows(group),
+        })),
+      };
+    });
+  }
+
   listAllocations(
     options: {
       readonly ownerRunId?: string;
@@ -1801,7 +1955,8 @@ export class ExecutionAdmissionRepository {
     }
     if (
       maxCostNanos !== undefined &&
-      existing.max_cost_nanos !== maxCostNanos
+      (existing.max_cost_nanos === null ||
+        maxCostNanos < existing.max_cost_nanos)
     ) {
       throw new AdmissionAllocationConflictError(key, "maxCostUsd");
     }

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -18,6 +18,7 @@ import {
   type CompactionRolloutType,
 } from "../session/compaction-event-reader.js";
 import { validatePendingAdmissionFallbackSlice } from "../session/turn-checkpoint-slice.js";
+import { isAdmissionUsageSummary } from "../session/usage-summary.js";
 
 type KnownRolloutItem = Exclude<RolloutItem, { readonly type: "unknown" }>;
 type KnownRolloutType = KnownRolloutItem["type"];
@@ -681,6 +682,11 @@ const isTurnCheckpoint: Validator<
   AllKeys<TurnCheckpointPayload>
 > = (value): value is TurnCheckpointPayload => isTurnCheckpointShape(value);
 
+const isSessionUsage: Validator<
+  EventPayload<"session_usage">,
+  AllKeys<EventPayload<"session_usage">>
+> = isAdmissionUsageSummary;
+
 const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
   session_meta: objectShape(
     {
@@ -1183,6 +1189,7 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
       details: isRecord,
     },
   ),
+  session_usage: isSessionUsage,
   guardian_assessment: objectShape(
     {
       id: isString,

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -33,6 +33,8 @@ import PromptInput from "./PromptInput/PromptInput.js";
 import { CostThresholdDialog } from "./dialogs/CostThresholdDialog.js";
 import { LedgerVerificationOverlay } from "./LedgerVerificationOverlay.js";
 import { FullscreenLayout } from "./FullscreenLayout.js";
+import { SessionUsageContext } from "../context/sessionUsageContext.js";
+import { StatusLineExecutionContext } from "../context/statusLineExecutionContext.js";
 import { WorkbenchLayout } from "../workbench/WorkbenchLayout.js";
 import { PredictionConsentOverlay } from "../workbench/PredictionConsentOverlay.js";
 import { ApprovalSurfaceBridge } from "../workbench/approvals/ApprovalSurfaceBridge.js";
@@ -5083,6 +5085,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         ? { configStore: props.session.services.configStore }
         : {}),
       appState: {
+        getSessionUsage: () => transcript.sessionUsage ?? null,
         getAppState: () => appStateStore.getState(),
         setModel,
         setAppState,
@@ -5104,6 +5107,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       availableTools,
       commandRegistry,
       props.session,
+      transcript.sessionUsage,
       setAppState,
       setModel,
       setToolJSX,
@@ -7366,7 +7370,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
   // size and the bottom slot has 0 height. KeybindingSetup must remain a
   // context provider, not a Box.
   const body = (
-    <>
+    <StatusLineExecutionContext value={props.session.executeDaemonStatusLine}>
+    <SessionUsageContext value={transcript.sessionUsage ?? null}>
       <AnimatedTerminalTitle isAnimating={titleIsAnimating} title={title} />
       <GlobalKeybindingHandlers
         screen={screen as any}
@@ -7443,6 +7448,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           contextPctLabel={contextPctLabel}
           modelDisplayContext={remoteAuthSessionContext}
           sessionCostUsd={transcript.sessionCostUsd}
+          sessionCostUnknown={transcript.sessionUsage?.hasUnknownCost}
           onEditorInteraction={handleEditorInteraction}
           codePrediction={codePrediction}
           editorMutationBlockedReason={workspaceEditorBlockers.editor}
@@ -7481,7 +7487,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           onClose={handleCloseMessageSelector}
         />
       ) : null}
-    </>
+    </SessionUsageContext>
+    </StatusLineExecutionContext>
   );
   if (fullscreen) {
     return (

--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 import React, { createContext, type ReactNode, type RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { fileURLToPath } from 'url';
 import { useFullscreenMode } from '../context/fullscreenModeContext.js';
+import { useSessionUsage } from '../context/sessionUsageContext.js';
 import { ModalContext } from '../context/modalContext';
 import { PromptOverlayProvider } from '../context/promptOverlayContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize';
@@ -588,15 +589,22 @@ function useGitChromeLabel(): string | null {
 const SPEND_REFRESH_MS = 5_000;
 
 function useSessionSpendLabel(): string {
-  const [spend, setSpend] = useState(() => formatUsdCost(getTotalCost()));
+  const usage = useSessionUsage();
+  const hasUsageContext = usage !== undefined;
+  const [spend, setSpend] = useState(() => hasUsageContext ? '' : formatUsdCost(getTotalCost()));
   useEffect(() => {
-    const interval = setInterval(() => {
+    if (hasUsageContext) return;
+    const refresh = (): void => {
       const next = formatUsdCost(getTotalCost());
       setSpend(prev => (prev === next ? prev : next));
-    }, SPEND_REFRESH_MS);
+    };
+    refresh();
+    const interval = setInterval(refresh, SPEND_REFRESH_MS);
     interval.unref?.();
     return () => clearInterval(interval);
-  }, []);
+  }, [hasUsageContext]);
+  if (usage === null) return '—';
+  if (usage !== undefined) return `${formatUsdCost(usage.costUsd)}${usage.hasUnknownCost ? ' +?' : ''}`;
   return spend;
 }
 

--- a/runtime/src/tui/components/v2/CostUsageModal.tsx
+++ b/runtime/src/tui/components/v2/CostUsageModal.tsx
@@ -112,7 +112,9 @@ export function CostUsageModal({
               key={`agent-${i}`}
               label={a.label}
               value={
-                a.estimatedCostUsd !== undefined
+                a.costUsd !== undefined
+                  ? formatUsdCost(a.costUsd)
+                  : a.estimatedCostUsd !== undefined
                   ? `${formatUsdCost(a.estimatedCostUsd)} est.`
                   : '—'
               }
@@ -122,7 +124,7 @@ export function CostUsageModal({
         )}
       </Box>
       <ThemedText color="muted3">
-        per-agent $ estimated from token totals; — = unknown
+        Recorded usage when available; estimates are marked est.
       </ThemedText>
     </Popup>
   )

--- a/runtime/src/tui/context/sessionUsageContext.tsx
+++ b/runtime/src/tui/context/sessionUsageContext.tsx
@@ -1,0 +1,10 @@
+import { createContext, useContext } from "react";
+import type { AdmissionUsageTotals } from "../../budget/admission-types.js";
+
+export type SessionUsageSnapshot = Pick<AdmissionUsageTotals, "costUsd" | "hasUnknownCost">;
+
+export const SessionUsageContext = createContext<SessionUsageSnapshot | null | undefined>(undefined);
+
+export function useSessionUsage(): SessionUsageSnapshot | null | undefined {
+  return useContext(SessionUsageContext);
+}

--- a/runtime/src/tui/context/statusLineExecutionContext.tsx
+++ b/runtime/src/tui/context/statusLineExecutionContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+import type {
+  SessionStatusLineExecuteResult,
+  SessionStatusLinePresentation,
+} from "../../app-server/protocol/index.js";
+
+export type DaemonStatusLineExecutor = (
+  presentation: SessionStatusLinePresentation,
+  signal?: AbortSignal,
+) => Promise<SessionStatusLineExecuteResult>;
+
+export const StatusLineExecutionContext = createContext<
+  DaemonStatusLineExecutor | undefined
+>(undefined);
+
+export function useDaemonStatusLineExecutor(): DaemonStatusLineExecutor | undefined {
+  return useContext(StatusLineExecutionContext);
+}

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -51,6 +51,9 @@ import type {
   SessionHooksStatusResult,
   SessionHooksSetDisabledParams,
   SessionHooksSetDisabledResult,
+  SessionStatusLinePresentation,
+  SessionStatusLineExecuteParams,
+  SessionStatusLineExecuteResult,
   SessionApplyConfigParams,
   SessionApplyConfigResult,
   SessionSnapshotResult,
@@ -320,6 +323,10 @@ export interface AgenCTuiBridgeSession extends AgenCCompactProgressControls {
     readonly rule: string;
   }): Promise<SessionPermissionRuleMutationResult>;
   getDaemonHooksStatus?(): Promise<SessionHooksStatusResult>;
+  executeDaemonStatusLine?(
+    presentation: SessionStatusLinePresentation,
+    signal?: AbortSignal,
+  ): Promise<SessionStatusLineExecuteResult>;
   setDaemonHooksDisabled?(
     disabled: boolean,
   ): Promise<SessionHooksSetDisabledResult>;
@@ -537,6 +544,11 @@ export interface AgenCDaemonTuiClient {
     params?: JsonObject,
     options?: { readonly signal?: AbortSignal },
   ): Promise<SessionHooksStatusResult>;
+  request(
+    method: "session.statusLine.execute",
+    params?: JsonObject,
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<SessionStatusLineExecuteResult>;
   request(
     method: "session.hooks.setDisabled",
     params?: JsonObject,
@@ -1628,6 +1640,24 @@ export function createDaemonTuiSession<
           );
         }
       }),
+    executeDaemonStatusLine: async (presentation, signal) => {
+      signal?.throwIfAborted();
+      try {
+        return await client.request("session.statusLine.execute", {
+          sessionId,
+          presentation: {
+            ...(presentation.vimMode !== undefined
+              ? { vimMode: presentation.vimMode }
+              : {}),
+          },
+        } satisfies SessionStatusLineExecuteParams, { signal });
+      } catch (error) {
+        signal?.throwIfAborted();
+        return error instanceof AgenCDaemonResponseError && error.code === -32601
+          ? { status: "unavailable", reason: "unsupported_method" }
+          : { status: "error", reason: "request_failed" };
+      }
+    },
     getDaemonHooksStatus: async () =>
       client.request("session.hooks.status", {
         sessionId,

--- a/runtime/src/tui/daemon-transcript-snapshot.ts
+++ b/runtime/src/tui/daemon-transcript-snapshot.ts
@@ -4,6 +4,7 @@ import type {
 } from "../app-server/protocol/index.js";
 import { isRecord } from "../utils/record.js";
 import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
+import { isAdmissionUsageSummary } from "../session/usage-summary.js";
 
 export function daemonTranscriptSnapshotEvents(
   snapshot: SessionTranscriptV2Result,
@@ -51,8 +52,11 @@ export function daemonTranscriptSnapshotEvents(
       !Number.isSafeInteger(notice.committedSequence) ||
       notice.committedSequence < 0 || notice.committedSequence > snapshot.asOfSequence ||
       !isRecord(notice.payload) ||
-      (notice.type !== "token_count" && notice.type !== "turn_failed" && notice.type !== "turn_aborted") ||
-      (notice.type !== "token_count" && classifyTurnTerminal(notice) === undefined)
+      (notice.type !== "token_count" && notice.type !== "session_usage" && notice.type !== "turn_failed" && notice.type !== "turn_aborted") ||
+      (notice.type === "session_usage" && (
+        !isAdmissionUsageSummary(notice.payload) || notice.payload.runId !== snapshot.runId
+      )) ||
+      (notice.type !== "token_count" && notice.type !== "session_usage" && classifyTurnTerminal(notice) === undefined)
     ) {
       throw new Error("Daemon returned an invalid transcript notice");
     }
@@ -100,13 +104,21 @@ export function daemonTranscriptSnapshotCoversEvent(
   if (params.runId !== undefined && params.runId !== snapshot.runId) return false;
   const sequence = params.sequence;
   if (
-    transcriptEvent.type === "token_count" || transcriptEvent.type === "turn_failed" ||
+    transcriptEvent.type === "token_count" || transcriptEvent.type === "session_usage" || transcriptEvent.type === "turn_failed" ||
     transcriptEvent.type === "turn_aborted" || transcriptEvent.type === "error"
   ) {
     if (sequence !== undefined && (
       typeof sequence !== "number" || !Number.isSafeInteger(sequence) || sequence < 0 ||
       sequence > snapshot.asOfSequence
     )) return false;
+    if (transcriptEvent.type === "session_usage") {
+      const summary = transcriptEvent.payload;
+      if (!isAdmissionUsageSummary(summary) || summary.runId !== snapshot.runId) return false;
+      return snapshot.events?.some((notice) =>
+        notice.type === "session_usage" && isAdmissionUsageSummary(notice.payload) &&
+        notice.payload.runId === summary.runId && notice.payload.sequence >= summary.sequence,
+      ) ?? false;
+    }
     const eventId = params.eventId ?? transcriptEvent.eventId;
     if (snapshot.events?.some((notice) =>
       (typeof eventId === "string" && notice.eventId === eventId) ||

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -10,6 +10,8 @@ import {
   type ModelUsage,
 } from "../session/cost.js";
 import type { Event } from "../session/event-log.js";
+import type { AdmissionUsageSummary } from "../budget/admission-types.js";
+import { latestSessionUsage } from "../session/usage-summary.js";
 import type {
   HistoryReplacedEvent,
   RuntimeTranscriptMessage,
@@ -106,6 +108,7 @@ export interface AdaptedTranscript {
    * makes workbench chrome update on the same render as the completed turn.
    */
   readonly sessionCostUsd: number;
+  readonly sessionUsage?: AdmissionUsageSummary | null;
 }
 
 const SYNTHETIC_MODEL = "agenc";
@@ -1854,6 +1857,7 @@ export function adaptTranscriptEvents(
   let turnStreamedChars = 0;
   let latestUsage: AdaptedTranscript["latestUsage"] = null;
   let sessionCostUsd = 0;
+  let sessionUsage: AdmissionUsageSummary | null = null;
   let streamingThinking:
     | {
         thinking: string;
@@ -1925,6 +1929,9 @@ export function adaptTranscriptEvents(
     const nextUuid = (): string => `${event.key}:${blockIndex++}`;
 
     switch (event.type) {
+      case "session_usage":
+        sessionUsage = latestSessionUsage(sessionUsage, event);
+        break;
       case "history_cleared":
         out.length = 0;
         seen.clear();
@@ -2996,7 +3003,8 @@ export function adaptTranscriptEvents(
     streamingThinking,
     turnStreamedChars,
     latestUsage,
-    sessionCostUsd,
+    sessionCostUsd: sessionUsage?.costUsd ?? sessionCostUsd,
+    sessionUsage,
   };
 }
 
@@ -3005,6 +3013,7 @@ interface TranscriptState {
   readonly keys: ReadonlySet<string>;
   readonly maxSeq: number | null;
   readonly sessionCostUsd: number;
+  readonly sessionUsage: AdmissionUsageSummary | null;
 }
 
 type TranscriptAction =
@@ -3118,6 +3127,7 @@ function buildTranscriptState(
   const events: SessionTranscriptEvent[] = [];
   let maxSeq: number | null = null;
   let sessionCostUsd = 0;
+  let sessionUsage: AdmissionUsageSummary | null = null;
 
   for (const event of orderSequencedEvents(unorderedEvents)) {
     const key = eventKey(event);
@@ -3133,13 +3143,14 @@ function buildTranscriptState(
     if (keys.has(key)) continue;
     keys.add(key);
     sessionCostUsd += tokenCountCostUsd(event);
+    sessionUsage = latestSessionUsage(sessionUsage, event);
     events.push(clampEventForStorage(event));
     maxSeq = maxEventSeq(maxSeq, event);
   }
 
   evictOldestEvents(events, keys);
 
-  return { events, keys, maxSeq, sessionCostUsd };
+  return { events, keys, maxSeq, sessionCostUsd, sessionUsage };
 }
 
 function reducer(state: TranscriptState, action: TranscriptAction): TranscriptState {
@@ -3160,6 +3171,7 @@ function reducer(state: TranscriptState, action: TranscriptAction): TranscriptSt
           ...rebuilt,
           sessionCostUsd:
             state.sessionCostUsd + tokenCountCostUsd(action.event),
+          sessionUsage: latestSessionUsage(state.sessionUsage, action.event),
         };
       }
 
@@ -3179,6 +3191,7 @@ function reducer(state: TranscriptState, action: TranscriptAction): TranscriptSt
         keys,
         maxSeq: seq === null ? state.maxSeq : maxEventSeq(state.maxSeq, action.event),
         sessionCostUsd: state.sessionCostUsd + tokenCountCostUsd(action.event),
+        sessionUsage: latestSessionUsage(state.sessionUsage, action.event),
       };
     }
     case "appendBatch": {
@@ -3201,35 +3214,40 @@ function reducer(state: TranscriptState, action: TranscriptAction): TranscriptSt
       ) {
         const knownKeys = new Set(state.keys);
         let addedCostUsd = 0;
+        let sessionUsage = state.sessionUsage;
         for (const event of action.events) {
           const key = eventKey(event);
           if (knownKeys.has(key)) continue;
           knownKeys.add(key);
           addedCostUsd += tokenCountCostUsd(event);
+          sessionUsage = latestSessionUsage(sessionUsage, event);
         }
         const rebuilt = buildTranscriptState([...state.events, ...action.events]);
         return {
           ...rebuilt,
           sessionCostUsd: state.sessionCostUsd + addedCostUsd,
+          sessionUsage,
         };
       }
       const keys = state.keys as Set<string>;
       const pending: SessionTranscriptEvent[] = [];
       let maxSeq = state.maxSeq;
       let sessionCostUsd = state.sessionCostUsd;
+      let sessionUsage = state.sessionUsage;
       for (const event of action.events) {
         const key = eventKey(event);
         if (keys.has(key)) continue;
         pending.push(clampEventForStorage(event));
         keys.add(key);
         sessionCostUsd += tokenCountCostUsd(event);
+        sessionUsage = latestSessionUsage(sessionUsage, event);
         const seq = eventSeq(event);
         maxSeq = seq === null ? maxSeq : maxEventSeq(maxSeq, event);
       }
       if (pending.length === 0) return state;
       const events = [...state.events, ...pending];
       evictOldestEvents(events, keys);
-      return { events, keys, maxSeq, sessionCostUsd };
+      return { events, keys, maxSeq, sessionCostUsd, sessionUsage };
     }
   }
 }
@@ -3238,7 +3256,7 @@ export function createSessionTranscriptStateForTesting(
   events: readonly SessionTranscriptEvent[],
 ): TranscriptState {
   return reducer(
-    { events: [], keys: new Set(), maxSeq: null, sessionCostUsd: 0 },
+    { events: [], keys: new Set(), maxSeq: null, sessionCostUsd: 0, sessionUsage: null },
     { kind: "reset", events },
   );
 }
@@ -3304,6 +3322,7 @@ export function useSessionTranscript(
     keys: new Set(),
     maxSeq: null,
     sessionCostUsd: 0,
+    sessionUsage: null,
   });
 
   useEffect(() => {
@@ -3385,8 +3404,10 @@ export function useSessionTranscript(
     // `state.sessionCostUsd` survives the event ring buffer and transcript
     // clear/replacement events; the adapter's local total covers standalone
     // callers and matches this value until old events are evicted.
-    return adapted.sessionCostUsd === state.sessionCostUsd
-      ? adapted
-      : { ...adapted, sessionCostUsd: state.sessionCostUsd };
-  }, [state.events, state.sessionCostUsd, startupMessages]);
+    return {
+      ...adapted,
+      sessionCostUsd: state.sessionUsage?.costUsd ?? state.sessionCostUsd,
+      sessionUsage: state.sessionUsage,
+    };
+  }, [state.events, state.sessionCostUsd, state.sessionUsage, startupMessages]);
 }

--- a/runtime/src/tui/session-types.ts
+++ b/runtime/src/tui/session-types.ts
@@ -63,6 +63,8 @@ import type {
   SessionRollbackCompactionResult,
   SessionExtendCompactionRollbackRetentionResult,
   SessionShellExecuteResult,
+  SessionStatusLinePresentation,
+  SessionStatusLineExecuteResult,
 } from "../app-server/protocol/index.js";
 
 export interface AgenCCompactProgressControls {
@@ -89,6 +91,10 @@ export interface AgenCShellExecuteParams {
 }
 
 export interface AgenCBridgeSession extends AgenCCompactProgressControls {
+  executeDaemonStatusLine?(
+    presentation: SessionStatusLinePresentation,
+    signal?: AbortSignal,
+  ): Promise<SessionStatusLineExecuteResult>;
   readonly conversationId: string;
   /** Immutable role-discovery identity; execution cwd may move independently. */
   readonly roleWorkspace?: Pick<AgentRoleWorkspace, "id" | "cwd">;

--- a/runtime/src/tui/startup/StatusLine.tsx
+++ b/runtime/src/tui/startup/StatusLine.tsx
@@ -2,10 +2,13 @@
 import { feature } from 'bun:bundle';
 import * as React from 'react';
 import { memo, useCallback, useEffect, useRef } from 'react';
+import type { SessionStatusLineExecuteResult, SessionStatusLinePresentation } from '../../app-server/protocol/index.js';
 import type { ProviderAuthReadContext } from '../../utils/auth.js';
 import { getIsRemoteMode, getKairosActive, getMainThreadAgentType, getOriginalCwd, getSessionId } from '../../bootstrap/state.js';
 import { DEFAULT_OUTPUT_STYLE_NAME } from '../../constants/outputStyles.js';
 import { useFullscreenMode } from '../context/fullscreenModeContext.js';
+import { useSessionUsage, type SessionUsageSnapshot } from '../context/sessionUsageContext.js';
+import { useDaemonStatusLineExecutor, type DaemonStatusLineExecutor } from '../context/statusLineExecutionContext.js';
 import { useNotifications } from '../context/notifications.js';
 import { getTotalAPIDuration, getTotalCost, getTotalDuration, getTotalInputTokens, getTotalLinesAdded, getTotalLinesRemoved, getTotalOutputTokens } from '../../cost/tracker.js';
 import { useMainLoopModel } from '../hooks/useMainLoopModel.js';
@@ -33,7 +36,7 @@ export function statusLineShouldDisplay(settings: ReadonlySettings): boolean {
   if (feature('KAIROS') && getKairosActive()) return false;
   return settings?.statusLine !== undefined;
 }
-function buildStatusLineCommandInput(exceeds200kTokens: boolean, settings: ReadonlySettings, messages: Message[], addedDirs: string[], mainLoopModel: ModelName, providerContext: ProviderAuthReadContext, vimMode?: VimMode): StatusLineCommandInput {
+function buildStatusLineCommandInput(exceeds200kTokens: boolean, settings: ReadonlySettings, messages: Message[], addedDirs: string[], mainLoopModel: ModelName, providerContext: ProviderAuthReadContext, vimMode?: VimMode, sessionUsage?: SessionUsageSnapshot | null): StatusLineCommandInput {
   const agentType = getMainThreadAgentType();
   const worktreeSession = getCurrentWorktreeSession();
   const outputStyleName = settings?.outputStyle || DEFAULT_OUTPUT_STYLE_NAME;
@@ -61,7 +64,8 @@ function buildStatusLineCommandInput(exceeds200kTokens: boolean, settings: Reado
       name: outputStyleName
     },
     cost: {
-      total_cost_usd: getTotalCost(),
+      total_cost_usd: sessionUsage === undefined ? getTotalCost() : sessionUsage?.costUsd ?? 0,
+      ...(sessionUsage !== undefined ? { has_unknown_cost: sessionUsage?.hasUnknownCost ?? true } : {}),
       total_duration_ms: getTotalDuration(),
       total_api_duration_ms: getTotalAPIDuration(),
       total_lines_added: getTotalLinesAdded(),
@@ -113,6 +117,41 @@ type Props = {
 export function getLastAssistantMessageId(messages: Message[]): string | null {
   return getLastAssistantMessage(messages)?.uuid ?? null;
 }
+
+async function executeDaemonStatusLineWhenReady(
+  execute: DaemonStatusLineExecutor,
+  presentation: SessionStatusLinePresentation,
+  signal: AbortSignal,
+): Promise<SessionStatusLineExecuteResult> {
+  for (let attempt = 0; ; attempt += 1) {
+    signal.throwIfAborted();
+    const result = await execute(presentation, signal);
+    signal.throwIfAborted();
+    if (result.status !== 'unavailable' || result.reason !== 'busy' || attempt === 9) return result;
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', abort);
+        reject(signal.reason);
+      };
+      const timer = setTimeout(() => {
+        signal.removeEventListener('abort', abort);
+        resolve();
+      }, 500);
+      signal.addEventListener('abort', abort, { once: true });
+      if (signal.aborted) abort();
+    });
+  }
+}
+
+function daemonStatusLineNotice(result: SessionStatusLineExecuteResult): string | undefined {
+  if (result.status === 'blocked') return 'status line command blocked by session hook policy';
+  if (result.reason === 'unsupported_method') return 'status line command is not supported by this daemon';
+  if (result.reason === 'timeout') return 'status line command timed out';
+  if (result.status === 'error') return 'status line command failed';
+  return undefined;
+}
+
 function StatusLineInner({
   messagesRef,
   lastAssistantMessageId,
@@ -124,11 +163,19 @@ function StatusLineInner({
   const additionalWorkingDirectories = useAppState(s => s.toolPermissionContext.additionalWorkingDirectories);
   const statusLineText = useAppState(s => s.statusLineText);
   const setAppState = useSetAppState();
+  const setAppStateRef = useRef(setAppState);
+  setAppStateRef.current = setAppState;
   const settings = useSettings();
   const isFullscreen = useFullscreenMode();
+  const sessionUsage = useSessionUsage();
+  const daemonExecutor = useDaemonStatusLineExecutor();
+  const usageCost = sessionUsage?.costUsd;
+  const usageUnknown = sessionUsage === undefined ? undefined : sessionUsage?.hasUnknownCost ?? true;
   const {
     addNotification
   } = useNotifications();
+  const addNotificationRef = useRef(addNotification);
+  addNotificationRef.current = addNotification;
   // AppState-sourced model — same source as API requests. getMainLoopModel()
   // reads the session ConfigStore snapshot, so another session's /model write
   // would leak into this session's statusline (tracked in upstream issue #37596).
@@ -143,6 +190,10 @@ function StatusLineInner({
   addedDirsRef.current = additionalWorkingDirectories;
   const mainLoopModelRef = useRef(mainLoopModel);
   mainLoopModelRef.current = mainLoopModel;
+  const sessionUsageRef = useRef(sessionUsage);
+  sessionUsageRef.current = sessionUsage;
+  const daemonExecutorRef = useRef(daemonExecutor);
+  daemonExecutorRef.current = daemonExecutor;
 
   // Track previous state to detect changes and cache expensive calculations
   const previousStateRef = useRef<{
@@ -151,12 +202,16 @@ function StatusLineInner({
     permissionMode: PermissionMode;
     vimMode: VimMode | undefined;
     mainLoopModel: ModelName;
+    usageCost: number | undefined;
+    usageUnknown: boolean | undefined;
   }>({
     messageId: null,
     exceeds200kTokens: false,
     permissionMode,
     vimMode,
-    mainLoopModel
+    mainLoopModel,
+    usageCost,
+    usageUnknown,
   });
 
   // Debounce timer ref
@@ -179,19 +234,36 @@ function StatusLineInner({
     const logResult = logNextResultRef.current;
     logNextResultRef.current = false;
     try {
-      let exceeds200kTokens = previousStateRef.current.exceeds200kTokens;
+      let text: string;
+      const executeDaemonStatusLine = daemonExecutorRef.current;
+      if (executeDaemonStatusLine !== undefined) {
+        const result = await executeDaemonStatusLineWhenReady(
+          executeDaemonStatusLine,
+          isVimModeEnabled() ? { vimMode: vimModeRef.current ?? 'INSERT' } : {},
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+        const notice = daemonStatusLineNotice(result);
+        if (notice !== undefined) {
+          addNotificationRef.current({ key: 'statusline-command-unavailable', text: notice, color: 'warning', priority: 'low' });
+        }
+        if (result.status === 'unavailable' && result.reason === 'busy') return;
+        text = result.status === 'rendered' ? result.text ?? '' : '';
+      } else {
+        let exceeds200kTokens = previousStateRef.current.exceeds200kTokens;
 
-      // Only recalculate 200k check if messages changed
-      const currentMessageId = getLastAssistantMessageId(msgs);
-      if (currentMessageId !== previousStateRef.current.messageId) {
-        exceeds200kTokens = doesMostRecentAssistantMessageExceed200k(msgs);
-        previousStateRef.current.messageId = currentMessageId;
-        previousStateRef.current.exceeds200kTokens = exceeds200kTokens;
+        // Only recalculate 200k check if messages changed
+        const currentMessageId = getLastAssistantMessageId(msgs);
+        if (currentMessageId !== previousStateRef.current.messageId) {
+          exceeds200kTokens = doesMostRecentAssistantMessageExceed200k(msgs);
+          previousStateRef.current.messageId = currentMessageId;
+          previousStateRef.current.exceeds200kTokens = exceeds200kTokens;
+        }
+        const statusInput = buildStatusLineCommandInput(exceeds200kTokens, settingsRef.current, msgs, Array.from(addedDirsRef.current.keys()), mainLoopModelRef.current, providerContext, vimModeRef.current, sessionUsageRef.current);
+        text = await executeStatusLineCommand(statusInput, controller.signal, undefined, logResult);
       }
-      const statusInput = buildStatusLineCommandInput(exceeds200kTokens, settingsRef.current, msgs, Array.from(addedDirsRef.current.keys()), mainLoopModelRef.current, providerContext, vimModeRef.current);
-      const text = await executeStatusLineCommand(statusInput, controller.signal, undefined, logResult);
       if (!controller.signal.aborted) {
-        setAppState(prev => {
+        setAppStateRef.current(prev => {
           if (prev.statusLineText === text) return prev;
           return {
             ...prev,
@@ -200,9 +272,14 @@ function StatusLineInner({
         });
       }
     } catch {
-      // Silently ignore errors in status line updates
+      if (daemonExecutorRef.current !== undefined && !controller.signal.aborted) {
+        addNotificationRef.current({ key: 'statusline-command-unavailable', text: 'status line command failed', color: 'warning', priority: 'low' });
+        setAppStateRef.current(prev => prev.statusLineText === '' ? prev : { ...prev, statusLineText: '' });
+      }
     }
-  }, [messagesRef, providerContext, setAppState]);
+  }, [messagesRef, providerContext]);
+  const doUpdateRef = useRef(doUpdate);
+  doUpdateRef.current = doUpdate;
 
   // Stable debounced schedule function — no deps, uses refs
   const scheduleUpdate = useCallback(() => {
@@ -217,15 +294,17 @@ function StatusLineInner({
 
   // Only trigger update when assistant message, permission mode, vim mode, or model actually changes
   useEffect(() => {
-    if (lastAssistantMessageId !== previousStateRef.current.messageId || permissionMode !== previousStateRef.current.permissionMode || vimMode !== previousStateRef.current.vimMode || mainLoopModel !== previousStateRef.current.mainLoopModel) {
+    if (lastAssistantMessageId !== previousStateRef.current.messageId || permissionMode !== previousStateRef.current.permissionMode || vimMode !== previousStateRef.current.vimMode || mainLoopModel !== previousStateRef.current.mainLoopModel || usageCost !== previousStateRef.current.usageCost || usageUnknown !== previousStateRef.current.usageUnknown) {
       // Don't update messageId here — let doUpdate handle it so
       // exceeds200kTokens is recalculated with the latest messages
       previousStateRef.current.permissionMode = permissionMode;
       previousStateRef.current.vimMode = vimMode;
       previousStateRef.current.mainLoopModel = mainLoopModel;
+      previousStateRef.current.usageCost = usageCost;
+      previousStateRef.current.usageUnknown = usageUnknown;
       scheduleUpdate();
     }
-  }, [lastAssistantMessageId, permissionMode, vimMode, mainLoopModel, scheduleUpdate]);
+  }, [lastAssistantMessageId, permissionMode, vimMode, mainLoopModel, usageCost, usageUnknown, scheduleUpdate]);
 
   // When the statusLine command changes (hot reload), log the next result
   const statusLineCommand = settings?.statusLine?.command;
@@ -241,6 +320,7 @@ function StatusLineInner({
 
   // Separate effect for logging on mount
   useEffect(() => {
+    if (daemonExecutorRef.current !== undefined) return;
     const statusLine = settings?.statusLine;
     if (statusLine) {
       // Log if status line is configured but disabled by disableAllHooks
@@ -268,16 +348,14 @@ function StatusLineInner({
 
   // Initial update on mount + cleanup on unmount
   useEffect(() => {
-    void doUpdate();
+    void doUpdateRef.current();
     return () => {
       abortControllerRef.current?.abort();
       if (debounceTimerRef.current !== undefined) {
         clearTimeout(debounceTimerRef.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
-  }, []); // Only run once on mount, not when doUpdate changes
+  }, [daemonExecutor]);
 
   // Get padding from settings or default to 0
   const paddingX = settings?.statusLine?.padding ?? 0;

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -74,6 +74,7 @@ type Props = {
   readonly modelDisplayContext?: ModelDisplayReadContext;
   /** Live cumulative spend projected from bridge `token_count` events. */
   readonly sessionCostUsd?: number;
+  readonly sessionCostUnknown?: boolean;
   readonly onEditorInteraction?: (intent: BufferIntegrationIntent) => void;
   readonly codePrediction?: BufferCodePredictionUi;
   readonly editorMutationBlockedReason?: string | null;
@@ -95,6 +96,7 @@ export function WorkbenchLayout({
   contextPctLabel = null,
   modelDisplayContext,
   sessionCostUsd = 0,
+  sessionCostUnknown = false,
   onEditorInteraction,
   codePrediction,
   editorMutationBlockedReason = null,
@@ -329,6 +331,7 @@ export function WorkbenchLayout({
                 focused={focusedPane === "agents"}
                 width={agentsWidth}
                 sessionCostUsd={sessionCostUsd}
+                sessionCostUnknown={sessionCostUnknown}
               />
             </NoSelect>
           ) : null}
@@ -386,6 +389,7 @@ export function WorkbenchLayout({
                 focused={true}
                 width={Math.min(34, frameColumns)}
                 sessionCostUsd={sessionCostUsd}
+                sessionCostUnknown={sessionCostUnknown}
               />
             </NoSelect>
           </Box>

--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -17,10 +17,12 @@ export function AgentsRail({
   focused,
   width,
   sessionCostUsd = 0,
+  sessionCostUnknown = false,
 }: {
   readonly focused: boolean;
   readonly width: number;
   readonly sessionCostUsd?: number;
+  readonly sessionCostUnknown?: boolean;
 }): React.ReactElement {
   const tasks = useAppState((state) => state.tasks);
   const remoteCount = useAppState((state) => state.remoteBackgroundTaskCount);
@@ -99,17 +101,19 @@ export function AgentsRail({
           />
         ))}
       </Box>
-      <AgentRailSpend sessionCostUsd={sessionCostUsd} />
+      <AgentRailSpend sessionCostUsd={sessionCostUsd} sessionCostUnknown={sessionCostUnknown} />
     </Box>
   );
 }
 
 function AgentRailSpend({
   sessionCostUsd,
+  sessionCostUnknown = false,
 }: {
   readonly sessionCostUsd: number;
+  readonly sessionCostUnknown?: boolean;
 }): React.ReactElement {
-  const spend = formatUsdCost(sessionCostUsd);
+  const spend = `${formatUsdCost(sessionCostUsd)}${sessionCostUnknown ? "+?" : ""}`;
   return (
     <Box
       height={2}

--- a/runtime/src/utils/cronScheduler.ts
+++ b/runtime/src/utils/cronScheduler.ts
@@ -64,7 +64,8 @@ export type CronEnqueue = (command: {
   isMeta: true;
   queueOwner: CronSessionQueueOwner;
   agentId?: string;
-}) => void;
+}, task: Readonly<CronTask>, firedAt: number) =>
+  void | Promise<void | "accepted" | "cancelled">;
 
 /**
  * Frozen authority for one scheduler lifetime. The process-wide scheduler is
@@ -491,13 +492,39 @@ export class CronScheduler {
         this.firedThrough.delete(task.id);
         continue;
       }
-      this.deps.enqueue({
+      const completion = this.deps.enqueue({
         value: task.prompt,
         mode: "task-notification",
         isMeta: true,
         queueOwner: { ...queueOwner },
         ...(task.agentId ? { agentId: task.agentId } : {}),
-      });
+      }, task, now);
+      if (completion !== undefined) {
+        let result: void | "accepted" | "cancelled";
+        try {
+          result = await completion;
+        } catch (error) {
+          this.stop(activation);
+          throw error;
+        } finally {
+          this.inFlightUntil.delete(task.id);
+        }
+        if (result === "cancelled") continue;
+        dispatched += 1;
+        if (result === "accepted") continue;
+        if (task.recurring) {
+          if (task.durable !== false) {
+            await markCronTasksFired([task.id], now, activation.workspaceRoot);
+          }
+        } else {
+          await removeCronTasks(
+            [task.id],
+            activation.workspaceRoot,
+            activation.queueOwner.conversationId,
+          );
+        }
+        continue;
+      }
       dispatched += 1;
 
       if (task.recurring) {

--- a/runtime/tests/app-server-protocol/portal.contract.test.ts
+++ b/runtime/tests/app-server-protocol/portal.contract.test.ts
@@ -129,8 +129,8 @@ describe("AgenC portal protocol contract", () => {
       id: "initialize",
       method: "initialize",
       params: {
-        protocolVersion: "1.10.0",
-        protocol: { version: "1.10.0" },
+        protocolVersion: "1.11.0",
+        protocol: { version: "1.11.0" },
         clientName: "agenc-portal",
         capabilities: AGENC_PORTAL_CLIENT_CAPABILITY_FLAGS,
       },

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -6145,7 +6145,7 @@ describe("AgenC background agent lifecycle", () => {
         id: "future-protocol",
         method: "initialize",
         params: {
-          protocol: { version: "1.11.0" },
+          protocol: { version: "1.12.0" },
           clientName: "contract-test",
         },
       }),
@@ -6157,8 +6157,8 @@ describe("AgenC background agent lifecycle", () => {
         message: "Unsupported protocol version",
         data: {
           code: "PROTOCOL_VERSION_UNSUPPORTED",
-          clientVersion: "1.11.0",
-          serverVersion: "1.10.0",
+          clientVersion: "1.12.0",
+          serverVersion: "1.11.0",
         },
       },
     });
@@ -6223,16 +6223,16 @@ describe("AgenC background agent lifecycle", () => {
       id: 1,
       result: {
         type: "initialized",
-        protocolVersion: "1.10.0",
-        protocol: { version: "1.10.0" },
+        protocolVersion: "1.11.0",
+        protocol: { version: "1.11.0" },
         capabilities: {},
       },
     });
-    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.10.0");
+    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.11.0");
     expect(connection.initializeState).toMatchObject({
-      protocol: { version: "1.10.0" },
+      protocol: { version: "1.11.0" },
       clientProtocol: { version: "1.0.0" },
-      serverProtocol: { version: "1.10.0" },
+      serverProtocol: { version: "1.11.0" },
       clientCapabilities: { experimentalApi: true },
     });
     expect(

--- a/runtime/tests/app-server/agent-lifecycle.status-line.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.status-line.contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
+
+async function createOwner(runtimeAvailable = true, closed = false) {
+  const sessions = new AgenCDaemonSessionManager();
+  const timestamp = "2026-09-10T12:00:00.000Z";
+  await sessions.restoreSession({
+    sessionId: "owner-session", agentId: "owner-agent", status: "waiting",
+    createdAt: timestamp, initialPrompt: "deferred status line",
+  });
+  const executeAgentStatusLine = vi.fn(async () => ({ status: "rendered" as const, text: "owner" }));
+  const startAgent = vi.fn(async () => ({
+    agentId: "unused", startedAt: timestamp, status: "running" as const,
+  }));
+  const agents = new AgenCDaemonAgentManager({
+    sessionManager: sessions,
+    runner: { startAgent, executeAgentStatusLine },
+  });
+  await agents.restoreAgent({
+    agentId: "owner-agent", objective: "deferred status line",
+    startedAt: timestamp, lastActiveAt: timestamp,
+    sessionIds: ["owner-session"], runtimeAvailable,
+  });
+  if (closed) await sessions.terminateSession({ sessionId: "owner-session" });
+  return { agents, executeAgentStatusLine, startAgent };
+}
+
+describe("status line daemon session ownership", () => {
+  it("routes to the exact owner without starting a turn", async () => {
+    const { agents, executeAgentStatusLine, startAgent } = await createOwner();
+    const params = { sessionId: "owner-session", presentation: { vimMode: "INSERT" as const } };
+    const controller = new AbortController();
+    await expect(agents.executeSessionStatusLine(params, controller.signal)).resolves.toEqual({
+      status: "rendered", text: "owner",
+    });
+    expect(executeAgentStatusLine).toHaveBeenCalledWith("owner-agent", params, controller.signal);
+    expect(startAgent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { runtimeAvailable: false, closed: false, sessionId: "owner-session" },
+    { runtimeAvailable: true, closed: true, sessionId: "owner-session" },
+    { runtimeAvailable: true, closed: false, sessionId: "different-session" },
+  ])("rejects absent, closed and recovered-only owners: %j", async (state) => {
+    const { agents, executeAgentStatusLine, startAgent } = await createOwner(state.runtimeAvailable, state.closed);
+    await expect(agents.executeSessionStatusLine({ sessionId: state.sessionId })).rejects.toThrow();
+    expect(executeAgentStatusLine).not.toHaveBeenCalled();
+    expect(startAgent).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -1260,6 +1260,110 @@ function configureSessionShellHarness(
 }
 
 describe("AgenC delegate background-agent runner", () => {
+  it("[status-line] reaches the bound deferred owner's executor without a model turn", async () => {
+    const agentId = "status-line-deferred-agent";
+    const sessionId = "status-line-bound-session";
+    const harness = makeTopLevelRunner({
+      conversationId: agentId,
+      threadInitialStatus: { status: "pending_init" } as AgentStatus,
+      runtimeSimpleMode: true,
+    });
+    Object.assign(harness.session.services, {
+      mcpStartupCancellationToken: {
+        isCancelled: () => false,
+        signal: new AbortController().signal,
+      },
+    });
+    await harness.runner.startAgent({
+      objective: "defer status-line work",
+      deferInitialTurn: true,
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await harness.runner.attachAgentSessionEvents(agentId, { sessionId, emit: async () => {} });
+    const trackOperation = vi.spyOn(harness.session, "trackDurableOperation");
+    try {
+      await expect(harness.runner.executeAgentStatusLine(agentId, { sessionId })).resolves.toEqual({
+        status: "disabled",
+        reason: "hooks_disabled",
+      });
+      expect(trackOperation).toHaveBeenCalledOnce();
+      expect(harness.control.sendInput).not.toHaveBeenCalled();
+      expect(harness.stub.thread.submit).not.toHaveBeenCalled();
+    } finally {
+      trackOperation.mockRestore();
+      await harness.runner.stopAgent(agentId);
+    }
+  });
+
+  it.each(["absent", "unbound", "mismatched"])("[status-line] rejects %s ownership before entering the executor", async (state) => {
+    const agentId = `status-line-${state}-agent`;
+    const harness = makeTopLevelRunner({
+      conversationId: agentId,
+      threadInitialStatus: { status: "pending_init" } as AgentStatus,
+    });
+    if (state !== "absent") {
+      await harness.runner.startAgent({
+        objective: "defer status-line work",
+        deferInitialTurn: true,
+        unattendedAllow: [],
+        unattendedDeny: [],
+      });
+    }
+    if (state === "mismatched") {
+      await harness.runner.attachAgentSessionEvents(agentId, {
+        sessionId: "different-owner",
+        emit: async () => {},
+      });
+    }
+    const trackOperation = vi.spyOn(harness.session, "trackDurableOperation");
+    try {
+      await expect(harness.runner.executeAgentStatusLine(agentId, { sessionId: agentId })).rejects.toThrow(
+        state === "absent" ? "not running" : "does not own this runtime session",
+      );
+      expect(trackOperation).not.toHaveBeenCalled();
+      expect(harness.control.sendInput).not.toHaveBeenCalled();
+      expect(harness.stub.thread.submit).not.toHaveBeenCalled();
+    } finally {
+      trackOperation.mockRestore();
+      await harness.runner.stopAgent(agentId);
+    }
+  });
+
+  it("[status-line] rejects closed ingress while the bound runtime is still draining", async () => {
+    const agentId = "status-line-draining-agent";
+    const shutdownEntered = Promise.withResolvers<void>();
+    const releaseShutdown = Promise.withResolvers<void>();
+    const harness = makeTopLevelRunner({
+      conversationId: agentId,
+      threadInitialStatus: { status: "pending_init" } as AgentStatus,
+      bootstrapShutdown: vi.fn(async () => {
+        shutdownEntered.resolve();
+        await releaseShutdown.promise;
+      }),
+    });
+    await harness.runner.startAgent({
+      objective: "defer status-line work",
+      deferInitialTurn: true,
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await harness.runner.attachAgentSessionEvents(agentId, { sessionId: agentId, emit: async () => {} });
+    const stopping = harness.runner.stopAgent(agentId);
+    const trackOperation = vi.spyOn(harness.session, "trackDurableOperation");
+    try {
+      await shutdownEntered.promise;
+      await expect(harness.runner.executeAgentStatusLine(agentId, { sessionId: agentId })).rejects.toThrow("not running");
+      expect(trackOperation).not.toHaveBeenCalled();
+      expect(harness.control.sendInput).not.toHaveBeenCalled();
+      expect(harness.stub.thread.submit).not.toHaveBeenCalled();
+    } finally {
+      releaseShutdown.resolve();
+      await stopping;
+      trackOperation.mockRestore();
+    }
+  });
+
   it("[managed-thread] runs a deferred session shell through the canonical live router authorities", async () => {
     const harness = makeTopLevelRunner({
       conversationId: "session-direct-shell-authorities",

--- a/runtime/tests/app-server/daemon-dispatcher.status-line.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.status-line.contract.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
+import { isDaemonControlMessage, isDaemonPriorityMessage } from "./overload.js";
+import {
+  AGENC_DAEMON_PROTOCOL_VERSION,
+  AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
+  type SessionStatusLineExecuteParams,
+} from "./protocol/index.js";
+
+const method = "session.statusLine.execute";
+const request = { jsonrpc: "2.0", id: "status-line", method, params: { sessionId: "owner" } };
+
+async function connect(
+  executeSessionStatusLine?: (
+    params: SessionStatusLineExecuteParams,
+    signal: AbortSignal,
+  ) => Promise<unknown>,
+  version = AGENC_DAEMON_PROTOCOL_VERSION,
+) {
+  const connection = new AgenCDaemonJsonRpcDispatcher({
+    agentManager: { executeSessionStatusLine } as never,
+  }).createConnection();
+  const initialized = await connection.dispatch({
+    jsonrpc: "2.0", id: "init", method: "initialize",
+    params: { protocol: { version } },
+  });
+  return { connection, initialized };
+}
+
+describe("daemon-owned status line execution", () => {
+  it("advertises the capability and forwards only presentation plus cancellation", async () => {
+    const execute = vi.fn(async () => ({ status: "rendered", text: "ready" }));
+    const { connection, initialized } = await connect(execute);
+    expect(initialized).toMatchObject({ result: { capabilities: {
+      [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: { [method]: true },
+    } } });
+    const params = { sessionId: "owner", presentation: { vimMode: "NORMAL" } };
+    await expect(connection.dispatch({ ...request, params })).resolves.toMatchObject({
+      result: { status: "rendered", text: "ready" },
+    });
+    expect(execute).toHaveBeenCalledWith(params, expect.any(AbortSignal));
+    expect(isDaemonControlMessage(request)).toBe(false);
+    expect(isDaemonPriorityMessage(request)).toBe(false);
+  });
+
+  it("does not advertise execution without a live implementation", async () => {
+    const { connection, initialized } = await connect();
+    expect(initialized).toMatchObject({ result: { capabilities: {
+      [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: { [method]: false },
+    } } });
+    await expect(connection.dispatch(request)).resolves.toMatchObject({ error: { code: -32601 } });
+  });
+
+  it("rejects old protocol clients", async () => {
+    const execute = vi.fn(async () => ({ status: "disabled" }));
+    const { connection } = await connect(execute, "1.10.0");
+    await expect(connection.dispatch(request)).resolves.toMatchObject({ error: { code: -32601 } });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects forged authority and malformed or unbounded presentation", async () => {
+    const execute = vi.fn(async () => ({ status: "disabled" }));
+    const { connection } = await connect(execute);
+    const malformed = [
+      {}, { sessionId: " " }, { sessionId: "😀".repeat(257) },
+      ...["command", "cwd", "env", "shell", "cost", "session_id", "timeoutMs", "bypass"].map(
+        (field) => ({ ...request.params, [field]: "forged" }),
+      ),
+      { ...request.params, presentation: { vimMode: "REPLACE" } },
+      { ...request.params, presentation: { command: "forged" } },
+      { ...request.params, presentation: [] },
+      { ...request.params, presentation: null },
+    ];
+    for (const params of malformed) {
+      await expect(connection.dispatch({ ...request, params })).resolves.toMatchObject({
+        error: { code: -32602 },
+      });
+    }
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("bounds daemon output and rejects inconsistent results", async () => {
+    for (const result of [
+      null, { status: "ready" }, { status: "rendered" },
+      { status: "blocked", text: "leaked" },
+      { status: "rendered", text: 12 },
+      { status: "rendered", text: "😀".repeat(16_385) },
+      { status: "error", reason: "x".repeat(257) },
+      { status: "disabled", command: "leaked" },
+    ]) {
+      const { connection } = await connect(async () => result);
+      await expect(connection.dispatch(request)).resolves.toMatchObject({ error: { code: -32603 } });
+    }
+  });
+
+  it.each(["request", "disconnect"])("propagates %s cancellation", async (cause) => {
+    let observedSignal: AbortSignal | undefined;
+    const { connection } = await connect(async (_params, signal) => {
+      observedSignal = signal;
+      await new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return { status: "unavailable", reason: "cancelled" };
+    });
+    const pending = connection.dispatch(request);
+    await vi.waitFor(() => expect(observedSignal).toBeDefined());
+    if (cause === "disconnect") {
+      await connection.close();
+    } else {
+      await expect(connection.dispatch({
+        jsonrpc: "2.0", id: "cancel", method: "request.cancel",
+        params: { requestId: request.id, reason: "refresh" },
+      })).resolves.toMatchObject({ result: { cancelled: true } });
+    }
+    expect(observedSignal?.aborted).toBe(true);
+    await expect(pending).resolves.toMatchObject({ error: { data: { code: "REQUEST_CANCELLED" } } });
+  });
+});

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -195,6 +195,7 @@ const expectedInternalMethods = [
   "session.permissions.mutateRule",
   "session.hooks.status",
   "session.hooks.setDisabled",
+  "session.statusLine.execute",
   "session.applyConfig",
   "session.mcp.reconnectServer",
   "session.mcp.enableServer",
@@ -239,7 +240,7 @@ function compileDefinitionValidator(
 
 describe("AgenC daemon protocol surface", () => {
   it("defines the current live attach-settings contract", () => {
-    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.10.0");
+    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.11.0");
 
     const status: AgenCDaemonInternalResultByMethod["session.hooks.status"] = {
       sessionId: "session-bare",

--- a/runtime/tests/bin/agenc.deferred-input.test.ts
+++ b/runtime/tests/bin/agenc.deferred-input.test.ts
@@ -477,6 +477,37 @@ function daemonHarness(
 }
 
 describe("deferred daemon input ownership", () => {
+  it("keeps cold status-line rendering unavailable without creating an agent or control client", async () => {
+    const harness = daemonHarness();
+    const session = await createDeferredInputSession({ baseSession: harness.baseSession, deps: harness.deps });
+    const statusSession = session as typeof session & Pick<
+      import("../../src/tui/daemon-session.js").AgenCTuiBridgeSession, "executeDaemonStatusLine"
+    >;
+    await expect(statusSession.executeDaemonStatusLine?.({ vimMode: "NORMAL" })).resolves.toEqual({
+      status: "unavailable", reason: "session_not_ready",
+    });
+    expect(harness.startPromptAgent).not.toHaveBeenCalled();
+    expect(harness.deps.createConnectedTuiClient).not.toHaveBeenCalled();
+    expect(harness.requests).toHaveLength(0);
+  });
+
+  it("forwards status-line requests after live activation without another model turn", async () => {
+    const harness = daemonHarness();
+    const session = await createDeferredInputSession({ baseSession: harness.baseSession, deps: harness.deps });
+    await session.submit("first turn");
+    const messageRequestsBefore = harness.requests.filter(request => request.method === "message.send" || request.method === "message.stream").length;
+    const statusSession = session as typeof session & Pick<
+      import("../../src/tui/daemon-session.js").AgenCTuiBridgeSession, "executeDaemonStatusLine"
+    >;
+    const controller = new AbortController();
+    await statusSession.executeDaemonStatusLine?.({ vimMode: "INSERT" }, controller.signal);
+    expect(harness.client.request).toHaveBeenLastCalledWith("session.statusLine.execute", {
+      sessionId: "session-1", presentation: { vimMode: "INSERT" },
+    }, { signal: controller.signal });
+    expect(harness.startPromptAgent).toHaveBeenCalledOnce();
+    expect(harness.requests.filter(request => request.method === "message.send" || request.method === "message.stream")).toHaveLength(messageRequestsBefore);
+  });
+
   it.each(["emit", "slash"] as const)("rolls back failed subscriptions before local %s delivery", async delivery => {
     const harness = daemonHarness();
     const session = await createDeferredInputSession({

--- a/runtime/tests/bin/bootstrap.aggregate-budget.test.ts
+++ b/runtime/tests/bin/bootstrap.aggregate-budget.test.ts
@@ -1,0 +1,244 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bootstrapLocalRuntimeSession } from "../../src/bin/bootstrap.js";
+import type { ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { Session } from "../../src/session/session.js";
+import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
+import { openStateDatabases } from "../../src/state/sqlite-driver.js";
+
+let home: string;
+let workspace: string;
+let configPath: string;
+const shutdowns = new Set<() => Promise<void>>();
+const kernels = new Set<ExecutionAdmissionKernel>();
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "agenc-aggregate-budget-home-"));
+  workspace = await mkdtemp(join(tmpdir(), "agenc-aggregate-budget-project-"));
+  configPath = join(home, "audit.toml");
+  await mkdir(join(workspace, ".git"));
+  const provider = await import("../../src/llm/provider.js");
+  vi.spyOn(provider, "createProvider").mockReturnValue({
+    name: "budget-fixture",
+    chat: vi.fn().mockRejectedValue(new Error("No model dispatch expected")),
+  } as never);
+  vi.spyOn(Session.prototype, "startMcpManager").mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  for (const shutdown of shutdowns) await shutdown();
+  shutdowns.clear();
+  for (const kernel of kernels) kernel.close();
+  kernels.clear();
+  vi.restoreAllMocks();
+  await Promise.all([
+    rm(home, { recursive: true, force: true }),
+    rm(workspace, { recursive: true, force: true }),
+  ]);
+});
+
+async function bootstrap(config: string, resume = false) {
+  await writeFile(configPath, `config_version = 2\n${config}\n`, "utf8");
+  const boot = await bootstrapLocalRuntimeSession({
+    apiKey: "budget-fixture-only",
+    conversationId: "aggregate-budget-parent",
+    resumeConversation: resume,
+    cwd: workspace,
+    argv: ["node", "agenc", "--config", configPath],
+    env: {
+      PATH: process.env.PATH,
+      HOME: home,
+      AGENC_HOME: home,
+      AGENC_WORKSPACE: workspace,
+    },
+    fetchImpl: vi.fn<typeof fetch>().mockRejectedValue(new Error("Offline fixture")),
+  });
+  shutdowns.add(boot.shutdown);
+  const client = boot.session.services.executionAdmission;
+  if (client === undefined) throw new Error("Missing canonical admission client");
+  return { ...boot, client };
+}
+
+function acquire(client: ExecutionAdmissionClient, stepId: string, cost: number | null) {
+  return client.acquire({
+    stepId,
+    kind: "model_turn",
+    model: "budget-fixture",
+    provider: "budget-fixture",
+    maxInputTokens: 1,
+    maxOutputTokens: 1,
+    maxCostUsd: cost,
+  });
+}
+
+function allocations() {
+  const driver = openStateDatabases({ cwd: workspace, agencHome: home });
+  try {
+    return new ExecutionAdmissionRepository(driver).listAllocations();
+  } finally {
+    driver.close();
+  }
+}
+
+describe("canonical aggregate bootstrap dollar cap", () => {
+  it("shares a flat $3 cap across the parent and concurrent workers", async () => {
+    const boot = await bootstrap("max_budget_usd = 3");
+    const first = boot.client.forSession({ runId: "worker-first", sessionId: "worker-first" });
+    const second = boot.client.forSession({ runId: "worker-second", sessionId: "worker-second" });
+    const clients = [boot.client, first, second];
+    const leases = await Promise.all(clients.map((client) => acquire(client, "parallel", 1)));
+
+    await expect(acquire(first, "one-nano-over", 0.000000001)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    expect(clients.every((client) => client.scope.hasHardCostCap === true)).toBe(true);
+    expect(allocations().find((row) => row.key === "run:aggregate-budget-parent"))
+      .toMatchObject({ maxCostUsd: 3, usedCostUsd: 0, heldCostUsd: 3 });
+
+    first.reconcile(leases[1]!.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.25,
+    });
+    const replacement = await acquire(second, "freed-reservation", 0.75);
+    await expect(acquire(boot.client, "still-over", 0.000000001)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    boot.client.reconcile(leases[0]!.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.5,
+    });
+    second.reconcile(leases[2]!.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.5,
+    });
+    second.reconcile(replacement.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.25,
+    });
+    expect(allocations().find((row) => row.key === "run:aggregate-budget-parent"))
+      .toMatchObject({ maxCostUsd: 3, usedCostUsd: 1.5, heldCostUsd: 0 });
+    await expect(acquire(first, "unknown-price", null)).rejects.toMatchObject({
+      reason: "unpriced_under_hard_cap",
+    });
+  });
+
+  it.each([
+    { flat: 3, nested: 2, expected: 2 },
+    { flat: 3, nested: 5, expected: 3 },
+    { flat: 3, nested: 0, expected: 0 },
+  ])("combines flat $flat and nested $nested caps at $expected", async ({ flat, nested, expected }) => {
+    const boot = await bootstrap(`max_budget_usd = ${flat}\n[agent.budget]\ndollar_cap = ${nested}`);
+    expect(boot.client.scope.maxCostUsd).toBe(expected);
+    await expect(acquire(boot.client, "over-minimum", expected + 0.000000001))
+      .rejects.toMatchObject({ reason: "budget_exceeded" });
+  });
+
+  it("retains a stricter enabled calendar budget alongside the flat cap", async () => {
+    const boot = await bootstrap("max_budget_usd = 3\n[budget]\nenabled = true\nenforce_interactive = true\ndaily_usd = 1");
+    expect(boot.client.scope.maxCostUsd).toBe(3);
+    const lease = await acquire(boot.client, "daily-exact-fit", 1);
+    const child = boot.client.forSession({ runId: "daily-child", sessionId: "daily-child" });
+    await expect(acquire(child, "daily-over", 0.000000001)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    boot.client.void(lease.reservation.reservationId, "fixture complete");
+  });
+
+  it("adds a flat cap on legacy resume without resetting parent or child spend", async () => {
+    const first = await bootstrap("");
+    const child = first.client.forSession({ runId: "legacy-child", sessionId: "legacy-child" });
+    for (const client of [first.client, child]) {
+      const lease = await acquire(client, "legacy-spend", 1);
+      client.reconcile(lease.reservation.reservationId, {
+        inputTokens: 1, outputTokens: 1, costUsd: 1,
+      });
+    }
+    await first.shutdown();
+    shutdowns.delete(first.shutdown);
+
+    const resumed = await bootstrap("max_budget_usd = 3", true);
+    const worker = resumed.client.forSession({ runId: "resumed-child", sessionId: "resumed-child" });
+    await expect(acquire(worker, "legacy-over", 1.000000001)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    const lease = await acquire(worker, "legacy-exact-fit", 1);
+    expect(allocations().find((row) => row.key === "run:aggregate-budget-parent"))
+      .toMatchObject({ maxCostUsd: 3, usedCostUsd: 2, heldCostUsd: 1 });
+    worker.void(lease.reservation.reservationId, "fixture complete");
+  });
+
+  it("preserves a cap when resumed config raises or omits it, and allows tightening", async () => {
+    let boot = await bootstrap("max_budget_usd = 3");
+    const lease = await acquire(boot.client, "spent-before-restart", 1);
+    boot.client.reconcile(lease.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.5,
+    });
+    for (const config of ["max_budget_usd = 8", "", "max_budget_usd = 2"]) {
+      await boot.shutdown();
+      shutdowns.delete(boot.shutdown);
+      boot = await bootstrap(config, true);
+      const cap = config.endsWith("2") ? 2 : 3;
+      expect(boot.client.scope).toMatchObject({ maxCostUsd: cap, hasHardCostCap: true });
+      await expect(acquire(boot.client, `resume-${config}`, cap - 0.5 + 0.000000001))
+        .rejects.toMatchObject({ reason: "budget_exceeded" });
+      expect(allocations().find((row) => row.key === "run:aggregate-budget-parent"))
+        .toMatchObject({ maxCostUsd: cap, usedCostUsd: 0.5, heldCostUsd: 0 });
+    }
+  });
+
+  it("honors nano-USD boundaries without rounding a shared hold down", async () => {
+    const boot = await bootstrap("max_budget_usd = 0.000000003");
+    const child = boot.client.forSession({ runId: "nano-child", sessionId: "nano-child" });
+    const lease = await acquire(boot.client, "two-nanos", 0.000000002);
+    await expect(acquire(child, "two-more-nanos", 0.000000002)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    boot.client.reconcile(lease.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.000000001,
+    });
+    const exact = await acquire(child, "remaining-nanos", 0.000000002);
+    child.void(exact.reservation.reservationId, "fixture complete");
+  });
+
+  it("tightens against active reservations and rejects stale bindings without resetting holds", async () => {
+    const kernel = new ExecutionAdmissionKernel({ agencHome: home });
+    kernels.add(kernel);
+    const bind = (maxCostUsd: number) => kernel.bindClient({
+      cwd: workspace,
+      scope: { runId: "tightening-parent", sessionId: "tightening-parent", autonomous: false, maxCostUsd },
+    });
+    const original = bind(3);
+    const active = await acquire(original, "active-before-tightening", 0.75);
+    const tighter = bind(0.5);
+    await expect(acquire(original, "stale-binding", 0.01)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    await expect(acquire(tighter, "tight-binding", 0)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    original.reconcile(active.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 0.25,
+    });
+    const final = await acquire(tighter, "after-settlement", 0.25);
+    expect(allocations().find((row) => row.key === "run:tightening-parent"))
+      .toMatchObject({ maxCostUsd: 0.5, usedCostUsd: 0.25, heldCostUsd: 0.25 });
+    tighter.void(final.reservation.reservationId, "fixture complete");
+  });
+
+  it("retains legacy spend above a newly bound cap and denies further work", async () => {
+    const kernel = new ExecutionAdmissionKernel({ agencHome: home });
+    kernels.add(kernel);
+    const scope = { runId: "legacy-over-cap", sessionId: "legacy-over-cap", autonomous: false };
+    const legacy = kernel.bindClient({ cwd: workspace, scope });
+    const lease = await acquire(legacy, "legacy-expense", 4);
+    legacy.reconcile(lease.reservation.reservationId, {
+      inputTokens: 1, outputTokens: 1, costUsd: 4,
+    });
+    const capped = kernel.bindClient({ cwd: workspace, scope: { ...scope, maxCostUsd: 3 } });
+    await expect(acquire(capped, "zero-cost-after-cap", 0)).rejects.toMatchObject({
+      reason: "budget_exceeded",
+    });
+    expect(allocations().find((row) => row.key === "run:legacy-over-cap"))
+      .toMatchObject({ maxCostUsd: 3, usedCostUsd: 4, heldCostUsd: 0 });
+  });
+});

--- a/runtime/tests/bin/cron-live-tools.test.ts
+++ b/runtime/tests/bin/cron-live-tools.test.ts
@@ -90,6 +90,28 @@ afterEach(async () => {
 });
 
 describe("live Cron tools drive the real scheduler", () => {
+  it("defaults to session-only storage and preserves delivery durability", async () => {
+    const tools = cronTools();
+    const localResult = await tools.get("CronCreate")!.execute({
+      cron: "*/5 * * * *", prompt: "session check",
+    });
+    const local = JSON.parse(String(localResult.content)).cron;
+    expect(local.durable).toBe(false);
+    expect(await listAllCronTasks(tempRoot)).toEqual([]);
+    expect(await listAllCronTasks(tempRoot, conversationId)).toContainEqual(
+      expect.objectContaining({ id: local.id, durable: false }),
+    );
+    const deliveryResult = await tools.get("CronCreate")!.execute({
+      cron: "*/5 * * * *", prompt: "delivery check", durable: false,
+      announceChannel: "stdio", announceTo: "test-recipient",
+    });
+    const delivery = JSON.parse(String(deliveryResult.content)).cron;
+    expect(delivery.durable).toBe(true);
+    expect(await listAllCronTasks(tempRoot)).toContainEqual(
+      expect.objectContaining({ id: delivery.id, deliver: { channel: "stdio", to: "test-recipient" } }),
+    );
+  });
+
   it("CronCreate persists into the scheduler's store; CronList/CronDelete round-trip", async () => {
     const tools = cronTools();
     const created = await tools.get("CronCreate")!.execute({

--- a/runtime/tests/budget/execution-admission-usage.test.ts
+++ b/runtime/tests/budget/execution-admission-usage.test.ts
@@ -1,0 +1,172 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
+import type { AdmissionUsageSummary } from "../../src/budget/admission-types.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+
+let home: string;
+let workspace: string;
+let kernel: ExecutionAdmissionKernel;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-usage-home-"));
+  workspace = mkdtempSync(join(tmpdir(), "agenc-usage-project-"));
+  mkdirSync(join(workspace, ".git"));
+  kernel = new ExecutionAdmissionKernel({ agencHome: home });
+});
+
+afterEach(() => {
+  kernel.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function bind(runId: string, cwd = workspace) {
+  return kernel.bindClient({
+    cwd,
+    scope: { runId, sessionId: runId, autonomous: false, maxCostUsd: 3 },
+  });
+}
+
+function acquire(client: ExecutionAdmissionClient, stepId: string, cost = 1) {
+  return client.acquire({
+    stepId,
+    kind: "model_turn",
+    model: "usage-fixture",
+    provider: "usage-fixture",
+    maxInputTokens: 4,
+    maxOutputTokens: 2,
+    maxCostUsd: cost,
+  });
+}
+
+function observe(client: ExecutionAdmissionClient) {
+  const snapshots: AdmissionUsageSummary[] = [];
+  if (client.subscribeUsage === undefined) throw new Error("Missing usage subscription");
+  const unsubscribe = client.subscribeUsage((summary) => snapshots.push(summary));
+  return { snapshots, unsubscribe };
+}
+
+describe("canonical allocation usage observers", () => {
+  it("reports descendants once without rewriting their journal identity", async () => {
+    const parent = bind("parent");
+    const child = parent.forSession({ runId: "child", sessionId: "child" });
+    const grandchild = child.forSession({ runId: "grandchild", sessionId: "grandchild" });
+    const parentJournal: string[] = [];
+    parent.subscribe((event) => parentJournal.push(event.runId));
+    const observed = observe(parent);
+    for (const [index, client] of [parent, child, grandchild].entries()) {
+      const lease = await acquire(client, "sample");
+      client.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+      client.reconcile(lease.reservation.reservationId, {
+        inputTokens: 4, outputTokens: 2, costUsd: (index + 1) / 10,
+      });
+    }
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      runId: "parent", costUsd: 0.6, inputTokens: 12, outputTokens: 6,
+      totalTokens: 18, modelCalls: 3, heldCostUsd: 0, hasUnknownCost: false,
+    });
+    expect(child.getUsageSummary?.()).toMatchObject({
+      runId: "child", costUsd: 0.5, modelCalls: 2,
+    });
+    expect(observed.snapshots.at(-1)?.costUsd).toBe(0.6);
+    expect(new Set(parentJournal)).toEqual(new Set(["parent"]));
+    expect(observed.snapshots.map((snapshot) => snapshot.sequence))
+      .toEqual([...observed.snapshots.map((snapshot) => snapshot.sequence)].sort((left, right) => left - right));
+    observed.unsubscribe();
+  });
+
+  it("does not notify unrelated run scopes in the same or another workspace", async () => {
+    const parent = bind("parent");
+    const sibling = bind("unrelated");
+    const otherWorkspace = join(home, "other-project");
+    mkdirSync(join(otherWorkspace, ".git"), { recursive: true });
+    const outside = bind("outside", otherWorkspace);
+    const observed = observe(parent);
+    for (const client of [sibling, outside]) {
+      const lease = await acquire(client, "unrelated-spend");
+      client.reconcile(lease.reservation.reservationId, {
+        inputTokens: 4, outputTokens: 2, costUsd: 0.5,
+      });
+    }
+    expect(observed.snapshots).toEqual([]);
+    expect(parent.getUsageSummary?.()).toMatchObject({ costUsd: 0, modelCalls: 0 });
+    observed.unsubscribe();
+  });
+
+  it("keeps unknown holds separate from actual usage and refreshes after late reconciliation", async () => {
+    const parent = bind("parent");
+    const child = parent.forSession({ runId: "child", sessionId: "child" });
+    const observed = observe(parent);
+    const lease = await acquire(child, "unknown-response");
+    child.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    child.holdUnknown(lease.reservation.reservationId, "fixture missing usage");
+    expect(observed.snapshots.at(-1)).toMatchObject({
+      costUsd: 0, modelCalls: 0, hasUnknownCost: true, heldCostUsd: 1,
+    });
+    child.reconcile(lease.reservation.reservationId, {
+      inputTokens: 4, outputTokens: 2, costUsd: 0.25,
+    });
+    expect(observed.snapshots.at(-1)).toMatchObject({
+      costUsd: 0.25, modelCalls: 1, hasUnknownCost: false, heldCostUsd: 0,
+    });
+    const count = observed.snapshots.length;
+    child.reconcile(lease.reservation.reservationId, {
+      inputTokens: 4, outputTokens: 2, costUsd: 0.25,
+    });
+    expect(observed.snapshots).toHaveLength(count);
+    observed.unsubscribe();
+  });
+
+  it("drops observers on unsubscribe and restores authoritative totals after restart", async () => {
+    const parent = bind("parent");
+    const observed = observe(parent);
+    const lease = await acquire(parent, "sample");
+    observed.unsubscribe();
+    const count = observed.snapshots.length;
+    parent.reconcile(lease.reservation.reservationId, {
+      inputTokens: 4, outputTokens: 2, costUsd: 0.25,
+    });
+    expect(observed.snapshots).toHaveLength(count);
+    kernel.close();
+    kernel = new ExecutionAdmissionKernel({ agencHome: home });
+    kernel.initializeExistingState();
+    const restored = bind("parent");
+    expect(restored.getUsageSummary?.()).toMatchObject({ costUsd: 0.25, modelCalls: 1 });
+    const renewed = observe(restored);
+    const next = await acquire(restored, "next");
+    restored.void(next.reservation.reservationId, "fixture complete");
+    expect(renewed.snapshots.at(-1)).toMatchObject({ costUsd: 0.25, heldCostUsd: 0 });
+    expect(observed.snapshots).toHaveLength(count);
+    renewed.unsubscribe();
+  });
+
+  it("retries a failed observer on the next journal boundary without charging usage twice", async () => {
+    const parent = bind("parent");
+    const unrelated = bind("unrelated");
+    const lease = await acquire(parent, "sample");
+    const snapshots: AdmissionUsageSummary[] = [];
+    let attempts = 0;
+    const unsubscribe = parent.subscribeUsage?.((summary) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("fixture observer unavailable");
+      snapshots.push(summary);
+    });
+    parent.reconcile(lease.reservation.reservationId, {
+      inputTokens: 4, outputTokens: 2, costUsd: 0.25,
+    });
+    expect(attempts).toBe(1);
+    expect(snapshots).toEqual([]);
+    const other = await acquire(unrelated, "next-boundary");
+    expect(attempts).toBe(2);
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({ costUsd: 0.25, modelCalls: 1, heldCostUsd: 0 });
+    unrelated.void(other.reservation.reservationId, "fixture complete");
+    expect(attempts).toBe(2);
+    expect(parent.getUsageSummary?.()).toMatchObject({ costUsd: 0.25, modelCalls: 1 });
+    unsubscribe?.();
+  });
+});

--- a/runtime/tests/commands/cost.test.ts
+++ b/runtime/tests/commands/cost.test.ts
@@ -179,23 +179,18 @@ describe("/cost", () => {
     );
   });
 
-  it("falls back to an ESTIMATED session total from agents when the sidecar reports none", () => {
-    // The local-model case: no cost sidecar, but spawned agents carry real
-    // token counts. The session line must answer "how much is this costing"
-    // with an explicit estimate, not a useless "—".
+  it("does not label a partial agent estimate as the session total", () => {
     const report = buildCostReport(contextWith({ appState: AGENT_APP_STATE }));
-    // Runner agent has 40K tokens (opus) -> a positive estimate; main-session skipped.
     expect(report.agents).toHaveLength(1);
     const agentEstimate = report.agents[0]!.estimatedCostUsd;
     expect(agentEstimate).toBeGreaterThan(0);
-    expect(report.totalCostUsd).toBeCloseTo(agentEstimate!, 6);
-    expect(report.totalIsEstimated).toBe(true);
-    expect(report.totalTokens).toBe(40_000);
+    expect(report.totalCostUsd).toBeUndefined();
+    expect(report.totalIsEstimated).toBeUndefined();
+    expect(report.totalTokens).toBeUndefined();
 
     const out = formatCostReport(report);
-    expect(out).toContain("est. (from agent tokens)");
-    expect(out).not.toContain("cost tracking unavailable");
-    expect(out).toContain("40.0K total est.");
+    expect(out).toContain("cost tracking unavailable");
+    expect(out).not.toContain("40.0K total est.");
   });
 
   it("opens the cost modal when the interactive TUI surface is available", async () => {

--- a/runtime/tests/commands/status-git.test.ts
+++ b/runtime/tests/commands/status-git.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { statusCommand } from "../../src/commands/status.js";
+import { openStatusDashboard } from "../../src/commands/status-menu.js";
+import type { Session } from "../../src/session/session.js";
+
+vi.mock("../../src/commands/status-menu.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/commands/status-menu.js")>(),
+  openStatusDashboard: vi.fn(() => true),
+}));
+
+let workspace: string;
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: workspace, encoding: "utf8" });
+}
+
+async function statusRow() {
+  const result = await statusCommand.execute({
+    session: { conversationId: "status-git-fixture", services: {}, createdAtMs: 0 } as Session,
+    cwd: workspace,
+    home: workspace,
+    argsRaw: "",
+  });
+  expect(result.kind).toBe("skip");
+  const snapshot = vi.mocked(openStatusDashboard).mock.lastCall?.[1];
+  expect(snapshot).toBeDefined();
+  const row = snapshot!.rows.find((entry) => entry.section === "git");
+  expect(row).toBeDefined();
+  return row!;
+}
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "agenc-status-git-"));
+  vi.mocked(openStatusDashboard).mockClear();
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+describe("status on real git worktrees", () => {
+  it("reports an unborn empty branch as clean", async () => {
+    git("init", "--quiet", "--initial-branch=main");
+    expect(await statusRow()).toMatchObject({ value: "clean", state: "ok", detail: "branch main" });
+  });
+
+  it("reports staged and untracked files on an unborn branch", async () => {
+    git("init", "--quiet", "--initial-branch=main");
+    await writeFile(join(workspace, "staged.txt"), "staged\n");
+    await writeFile(join(workspace, "untracked.txt"), "untracked\n");
+    git("add", "staged.txt");
+    expect(await statusRow()).toMatchObject({ value: "dirty", state: "warn", detail: "branch main; 2 changed files" });
+  });
+
+  it("keeps committed clean and dirty branches accurate", async () => {
+    git("init", "--quiet", "--initial-branch=main");
+    await writeFile(join(workspace, "tracked.txt"), "initial\n");
+    git("add", "tracked.txt");
+    git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture");
+    expect(await statusRow()).toMatchObject({ value: "clean", state: "ok", detail: "branch main" });
+    await writeFile(join(workspace, "tracked.txt"), "modified\n");
+    expect(await statusRow()).toMatchObject({ value: "dirty", state: "warn", detail: "branch main; 1 changed files" });
+  });
+
+  it("reports detached HEAD without a branch error", async () => {
+    git("init", "--quiet", "--initial-branch=main");
+    git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgsign=false", "commit", "--quiet", "--allow-empty", "-m", "fixture");
+    git("checkout", "--quiet", "--detach", "HEAD");
+    expect(await statusRow()).toMatchObject({ value: "clean", state: "ok", detail: "branch detached" });
+  });
+
+  it("reports a directory outside git as informational", async () => {
+    expect(await statusRow()).toMatchObject({ value: "not a git repository", state: "info" });
+  });
+
+  it("does not present a bare repository as a worktree", async () => {
+    git("init", "--quiet", "--bare");
+    expect(await statusRow()).toMatchObject({ value: "not a git repository", state: "info" });
+  });
+
+  it("preserves a real git status failure", async () => {
+    git("init", "--quiet", "--initial-branch=main");
+    await writeFile(join(workspace, ".git", "index"), "invalid index\n");
+    const row = await statusRow();
+    expect(row).toMatchObject({ value: "error", state: "error" });
+    expect(row.detail).toMatch(/index/i);
+    expect(row.detail).not.toMatch(/ambiguous argument.*HEAD/i);
+  });
+
+  it("preserves git configuration failures during repository discovery", async () => {
+    git("init", "--quiet", "--initial-branch=main");
+    await writeFile(join(workspace, ".git", "config"), "[invalid\n");
+    const row = await statusRow();
+    expect(row).toMatchObject({ value: "error", state: "error" });
+    expect(row.detail).toMatch(/config/i);
+  });
+});

--- a/runtime/tests/commands/status.test.ts
+++ b/runtime/tests/commands/status.test.ts
@@ -227,7 +227,7 @@ describe("status git summary", () => {
   it("detects non-git directories", () => {
     expect(
       summarizeGitStatus({
-        insideWorkTree: { stdout: "", stderr: "fatal", code: 128 },
+        insideWorkTree: { stdout: "", stderr: "fatal: not a git repository (or any of the parent directories): .git", code: 128 },
         branch: { stdout: "", stderr: "", code: 0 },
         porcelain: { stdout: "", stderr: "", code: 0 },
       }).state,

--- a/runtime/tests/cronScheduler.test.ts
+++ b/runtime/tests/cronScheduler.test.ts
@@ -207,6 +207,8 @@ describe("CronScheduler", () => {
         isMeta: true,
         queueOwner: TEST_ACTIVATION.queueOwner,
       }),
+      expect.objectContaining({ id: "bbbb0002" }),
+      expect.any(Number),
     );
     // After firing, the next wake is rescheduled (driver re-armed), not dead.
     const tel = sched.getLastTelemetry();

--- a/runtime/tests/helpers/compaction-transaction-harness.ts
+++ b/runtime/tests/helpers/compaction-transaction-harness.ts
@@ -20,6 +20,14 @@ export interface CompactionTransactionHarness {
   close(): void;
 }
 
+export function attachCompactionSession(session: Session, harness: CompactionTransactionHarness): void {
+  session.mountRolloutStore(harness.store);
+  session.eventLog.seedCanonicalHistory(harness.store.readAll().flatMap((item) =>
+    item.type === "event_msg" ? [item.payload] : [],
+  ));
+  harness.session.emit = session.emit.bind(session);
+}
+
 export function bindCompactionTransactionHarness(
   store: RolloutStore,
   options: {

--- a/runtime/tests/hooks/status-line-executor.test.ts
+++ b/runtime/tests/hooks/status-line-executor.test.ts
@@ -1,0 +1,327 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AdmissionDeniedError } from "../../src/budget/admission-client.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import type { AgenCConfig } from "../../src/config/schema.js";
+import { createHookExecutionAuthority } from "../../src/hooks/execution-authority.js";
+import { executeSessionStatusLine } from "../../src/hooks/status-line-executor.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { workspaceMutationCoordinators } from "../../src/workspace/mutation-coordinator.js";
+import { createTestConfigStore, mkSession } from "../fixtures.js";
+
+const cleanups: (() => void)[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  workspaceMutationCoordinators.clearForTests();
+  for (const cleanup of cleanups.splice(0).reverse()) cleanup();
+});
+
+function nodeCommand(script: string): string {
+  return `${JSON.stringify(process.execPath)} -e '${script.replaceAll("'", "'\\''")}'`;
+}
+
+async function fixture(options: {
+  command?: string;
+  trusted?: boolean;
+  allowUntrustedHooks?: boolean;
+  simpleMode?: boolean;
+  config?: AgenCConfig;
+} = {}) {
+  const home = mkdtempSync(join(tmpdir(), "agenc-status-line-"));
+  cleanups.push(() => rmSync(home, { recursive: true, force: true }));
+  const cwd = join(home, "project");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  const kernel = new ExecutionAdmissionKernel({ agencHome: home });
+  cleanups.push(() => kernel.close());
+  const admission = kernel.bindClient({ cwd, scope: { runId: "conv-test", sessionId: "conv-test", autonomous: false } });
+  const configStore = createTestConfigStore({ cwd, base: {
+    statusLine: { type: "command", command: options.command ?? "printf owner-status" },
+    ...options.config,
+  } });
+  await configStore.reload();
+  const shutdown = new AbortController();
+  const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd });
+  const runtimeOptions = { simpleMode: options.simpleMode ?? false, allowUntrustedHooks: options.allowUntrustedHooks ?? false };
+  const { session, events } = mkSession({
+    cwd,
+    modelInfo: { contextWindow: 400_000 },
+    services: {
+      configStore,
+      executionAdmission: admission,
+      sandboxExecutionBroker: broker,
+      hookExecutionAuthority: createHookExecutionAuthority({ runtimeOptions, isWorkspaceTrusted: () => options.trusted ?? true }),
+      mcpStartupCancellationToken: { signal: shutdown.signal, cancel: () => shutdown.abort(), isCancelled: () => shutdown.signal.aborted },
+      userShell: {
+        path: "/bin/sh", commandWrapperArgv: [],
+        childEnvironment: { PATH: "/usr/bin:/bin", HOME: home, AGENC_HOME: home },
+        deriveExecArgs: (command) => ["-c", command],
+      },
+    },
+  });
+  return { session, events, home, cwd, admission, broker, configStore, shutdown };
+}
+
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("status-line process did not start");
+}
+
+describe.skipIf(process.platform === "win32")("daemon-owned status-line executor", () => {
+  test("uses owner command, workspace, environment, model, and aggregate ledger without model turns", async () => {
+    const owner = await fixture({ command: nodeCommand('let input="";process.stdin.on("data",chunk=>input+=chunk);process.stdin.on("end",()=>process.stdout.write(JSON.stringify({input:JSON.parse(input),cwd:process.cwd(),home:process.env.HOME,project:process.env.AGENC_PROJECT_DIR,path:process.env.PATH})))') });
+    const lease = await owner.admission.acquire({ stepId: "prior-model", kind: "model_turn", maxInputTokens: 40, maxOutputTokens: 10, maxCostUsd: 0.5 });
+    owner.admission.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    owner.admission.reconcile(lease.reservation.reservationId, { inputTokens: 23, outputTokens: 7, costUsd: 0.25 });
+    owner.admission.acknowledgeCompletion(lease.reservation.reservationId);
+    const result = await executeSessionStatusLine(owner.session, { vimMode: "NORMAL" });
+    expect(result.status).toBe("rendered");
+    expect(JSON.parse(result.text!)).toMatchObject({
+      cwd: owner.cwd, home: owner.home, project: owner.configStore.projectRoot, path: "/usr/bin:/bin",
+      input: {
+        session_id: owner.session.conversationId, cwd: owner.cwd,
+        workspace: { current_dir: owner.cwd, project_dir: owner.configStore.projectRoot },
+        model: { id: "test-model" }, vim: { mode: "NORMAL" },
+        cost: { total_cost_usd: 0.25, has_unknown_cost: false },
+        context_window: { total_input_tokens: 23, total_output_tokens: 7 },
+      },
+    });
+    expect(owner.admission.getUsageSummary?.()).toMatchObject({ costUsd: 0.25, modelCalls: 1 });
+    expect(owner.events).toEqual([]);
+    expect(owner.admission.replayJournal?.().some((event) => event.kind === "tool_exec")).toBe(true);
+  });
+
+  test.each([
+    [{ trusted: false }, "blocked"],
+    [{ trusted: false, allowUntrustedHooks: true }, "rendered"],
+    [{ trusted: false, allowUntrustedHooks: true, simpleMode: true }, "blocked"],
+  ] as const)("preserves hook authority for %j", async (options, status) => {
+    const owner = await fixture(options);
+    const spawn = vi.spyOn(owner.broker, "prepareSpawn");
+    const result = await executeSessionStatusLine(owner.session);
+    expect(result.status).toBe(status);
+    expect(spawn).toHaveBeenCalledTimes(status === "rendered" ? 1 : 0);
+  });
+
+  test("managed-only selection ignores the effective user command", async () => {
+    const owner = await fixture({ config: { disableAllHooks: true } });
+    vi.spyOn(owner.configStore, "sources").mockImplementation((scope) => scope === "managed" ? [{ scope: "managed", label: "managed", config: { statusLine: { type: "command", command: "printf managed-status" } } }] : []);
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "rendered", text: "managed-status" });
+    vi.spyOn(owner.configStore, "sources").mockReturnValue([{ scope: "managed", label: "managed", config: { disableAllHooks: true } }]);
+    const spawn = vi.spyOn(owner.broker, "prepareSpawn");
+    expect(await executeSessionStatusLine(owner.session)).toMatchObject({ status: "disabled" });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test("mutable hook suppression and missing command perform no admission", async () => {
+    const owner = await fixture();
+    const acquire = vi.spyOn(owner.admission, "acquire");
+    Object.assign(owner.session.services, { hooksRuntime: { isDisabled: () => true } });
+    expect(await executeSessionStatusLine(owner.session)).toMatchObject({ status: "disabled" });
+    Object.assign(owner.session.services, { hooksRuntime: undefined });
+    vi.spyOn(owner.configStore, "current").mockReturnValue({});
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "disabled", reason: "not_configured" });
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
+  test.each(["executionAdmission", "sandboxExecutionBroker", "hookExecutionAuthority"])("fails closed without %s", async (service) => {
+    const owner = await fixture();
+    const spawn = vi.spyOn(owner.broker, "prepareSpawn");
+    Object.assign(owner.session.services, { [service]: undefined });
+    expect(await executeSessionStatusLine(owner.session)).toMatchObject({ status: "blocked" });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test("admission denial and sandbox failure do not run a command", async () => {
+    const owner = await fixture();
+    const acquire = vi.spyOn(owner.admission, "acquire").mockRejectedValueOnce(new AdmissionDeniedError("test_denied"));
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "blocked", reason: "admission_denied" });
+    acquire.mockRestore();
+    vi.spyOn(owner.broker, "prepareSpawn").mockImplementation(() => { throw new Error("boundary unavailable"); });
+    const acknowledge = vi.spyOn(owner.admission, "acknowledgeCompletion");
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "error", reason: "execution_failed" });
+    expect(acknowledge).toHaveBeenCalledOnce();
+  });
+
+  test("keeps concurrent sessions isolated and applies captured wrappers", async () => {
+    const first = await fixture({ command: 'printf "%s" "$AGENC_PROJECT_DIR:$AGENC_STATUS_WRAPPER"' });
+    const second = await fixture({ command: 'printf "%s" "$AGENC_PROJECT_DIR:$AGENC_STATUS_WRAPPER"' });
+    Object.assign(first.session.services.userShell, { commandWrapperArgv: ["env", "AGENC_STATUS_WRAPPER=first", "/bin/sh", "-c"] });
+    Object.assign(second.session.services.userShell, { commandWrapperArgv: ["env", "AGENC_STATUS_WRAPPER=second", "/bin/sh", "-c"] });
+    expect(await Promise.all([executeSessionStatusLine(first.session), executeSessionStatusLine(second.session)]))
+      .toEqual([{ status: "rendered", text: `${first.configStore.projectRoot}:first` }, { status: "rendered", text: `${second.configStore.projectRoot}:second` }]);
+  });
+
+  test("returns busy without cancelling another request and tracks physical work", async () => {
+    const owner = await fixture({ command: "sleep 0.1; printf complete" });
+    const tracked = vi.spyOn(owner.session, "trackDurableOperation");
+    const first = executeSessionStatusLine(owner.session);
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "unavailable", reason: "busy" });
+    expect(await first).toEqual({ status: "rendered", text: "complete" });
+    expect(tracked).toHaveBeenCalledOnce();
+    expect(await executeSessionStatusLine(owner.session)).toMatchObject({ status: "rendered" });
+  });
+
+  test.each(["caller", "shutdown"])("drains a subprocess on %s cancellation before acknowledging completion", async (source) => {
+    const owner = await fixture();
+    const marker = join(owner.home, "child.pid");
+    vi.spyOn(owner.configStore, "current").mockReturnValue({ statusLine: { type: "command", command: nodeCommand(`require("node:fs").writeFileSync(${JSON.stringify(marker)},String(process.pid));setInterval(()=>{},1000)`) } });
+    const controller = new AbortController();
+    const acknowledge = vi.spyOn(owner.admission, "acknowledgeCompletion");
+    const pending = executeSessionStatusLine(owner.session, {}, controller.signal);
+    await waitForFile(marker);
+    const pid = Number(readFileSync(marker, "utf8"));
+    expect(acknowledge).not.toHaveBeenCalled();
+    if (source === "caller") controller.abort();
+    else owner.shutdown.abort();
+    expect(await pending).toMatchObject({ status: "unavailable", reason: "cancelled" });
+    expect(() => process.kill(pid, 0)).toThrow();
+    expect(acknowledge).toHaveBeenCalledOnce();
+  });
+
+  test("hard timeout applies even with a caller signal and includes admission waiting", async () => {
+    const owner = await fixture();
+    vi.spyOn(owner.admission, "acquire").mockImplementation((_input, signal) => new Promise((_resolve, reject) => {
+      signal!.addEventListener("abort", () => reject(signal!.reason), { once: true });
+    }));
+    const spawn = vi.spyOn(owner.broker, "prepareSpawn");
+    expect(await executeSessionStatusLine(owner.session, {}, new AbortController().signal))
+      .toEqual({ status: "error", reason: "timeout" });
+    expect(spawn).not.toHaveBeenCalled();
+  }, 8_000);
+
+  test("rejects oversized output without exposing a partial status", async () => {
+    const owner = await fixture({ command: nodeCommand('process.stdout.write("x".repeat(17000))') });
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "error", reason: "output_too_large" });
+  });
+
+  test("restores available context, follows live usage, and preserves approved additional directories", async () => {
+    const owner = await fixture({ command: "cat" });
+    owner.session.state.unsafePeek().initialTokenUsage = Object.assign({ promptTokens: 200_001, completionTokens: 10, cachedInputTokens: 1_000 }, { model: "test-model", provider: "grok" });
+    const permissions = owner.session.services.permissionModeRegistry.current();
+    vi.spyOn(owner.session.services.permissionModeRegistry, "current").mockReturnValue({
+      ...permissions,
+      additionalWorkingDirectories: new Map([[owner.home, { path: owner.home, source: "session" }]]) as typeof permissions.additionalWorkingDirectories,
+    });
+    const restored = await executeSessionStatusLine(owner.session);
+    expect(JSON.parse(restored.text!)).toMatchObject({
+      exceeds_200k_tokens: true,
+      workspace: { added_dirs: [owner.home] },
+      context_window: { used_percentage: 50, remaining_percentage: 50,
+        current_usage: { input_tokens: 199_001, output_tokens: 10, cache_read_input_tokens: 1_000 } },
+    });
+    owner.session.emit({ id: "new-usage", msg: { type: "token_count", payload: { promptTokens: 40_000, completionTokens: 100, model: "test-model", provider: "grok" } } });
+    const updated = await executeSessionStatusLine(owner.session);
+    expect(JSON.parse(updated.text!)).toMatchObject({ exceeds_200k_tokens: false, context_window: { used_percentage: 10, current_usage: { input_tokens: 40_000 } } });
+  });
+
+  test("reads only the bounded canonical tail and reports unknown context when absent", async () => {
+    const owner = await fixture({ command: "cat" });
+    const missing = await executeSessionStatusLine(owner.session);
+    expect(JSON.parse(missing.text!)).toMatchObject({ exceeds_200k_tokens: null, context_window: { current_usage: null, used_percentage: null } });
+    const resumed = await fixture({ command: "cat" });
+    const path = join(resumed.home, "rollout.jsonl");
+    writeFileSync(path, `${"x".repeat(100_000)}\n${JSON.stringify({ type: "event_msg", payload: { msg: { type: "token_count", payload: { promptTokens: 80_000, completionTokens: 10, model: "test-model", provider: "grok" } } } })}\n`);
+    Object.defineProperty(resumed.session, "rolloutStore", { get: () => ({ rolloutPath: path }) });
+    expect(JSON.parse((await executeSessionStatusLine(resumed.session)).text!)).toMatchObject({ context_window: { used_percentage: 20, current_usage: { input_tokens: 80_000 } } });
+  });
+
+  test("revokes a queued command when its owner configuration changes", async () => {
+    const owner = await fixture();
+    let release!: () => void;
+    let admitted!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const acquired = new Promise<void>((resolve) => { admitted = resolve; });
+    const original = owner.admission.acquire.bind(owner.admission);
+    vi.spyOn(owner.admission, "acquire").mockImplementationOnce(async (input, signal) => {
+      const lease = await original(input, signal);
+      admitted();
+      await gate;
+      return lease;
+    });
+    const spawn = vi.spyOn(owner.broker, "prepareSpawn");
+    const voidReservation = vi.spyOn(owner.admission, "void");
+    const pending = executeSessionStatusLine(owner.session);
+    await acquired;
+    vi.spyOn(owner.configStore, "current").mockReturnValue({ statusLine: { type: "command", command: "printf new-command" } });
+    release();
+    expect(await pending).toEqual({ status: "unavailable", reason: "configuration_changed" });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(voidReservation).toHaveBeenCalledOnce();
+  });
+
+  test("hard deadline physically stops a live child even with a caller signal", async () => {
+    const owner = await fixture();
+    const marker = join(owner.home, "timeout.pid");
+    vi.spyOn(owner.configStore, "current").mockReturnValue({ statusLine: { type: "command", command: nodeCommand(`require("node:fs").writeFileSync(${JSON.stringify(marker)},String(process.pid));setInterval(()=>{},1000)`) } });
+    const pending = executeSessionStatusLine(owner.session, {}, new AbortController().signal);
+    await waitForFile(marker);
+    const pid = Number(readFileSync(marker, "utf8"));
+    expect(await pending).toEqual({ status: "error", reason: "timeout" });
+    expect(() => process.kill(pid, 0)).toThrow();
+  }, 8_000);
+
+  test.each(["history_cleared", "transcript_epoch", "context_compacted"] as const)("invalidates live context at %s without losing cumulative usage", async (type) => {
+    const owner = await fixture({ command: "cat" });
+    owner.session.state.unsafePeek().initialTokenUsage = Object.assign({ promptTokens: 200_000, completionTokens: 10 }, { model: "test-model", provider: "grok" });
+    expect(JSON.parse((await executeSessionStatusLine(owner.session)).text!).context_window.used_percentage).toBe(50);
+    owner.session.eventLog.emit({ id: "reset", msg: { type, payload: {} } } as never);
+    const result = JSON.parse((await executeSessionStatusLine(owner.session)).text!);
+    expect(result.context_window.current_usage).toBeNull();
+    expect(result.context_window.used_percentage).toBeNull();
+    expect(result.exceeds_200k_tokens).toBeNull();
+    expect(result.cost.total_cost_usd).toBe(0);
+  });
+
+  test.each(["compaction_committed", "history_cleared"])("does not restore old context before a canonical %s tail", async (type) => {
+    const owner = await fixture({ command: "cat" });
+    const path = join(owner.home, "replaced-rollout.jsonl");
+    const reset = type === "history_cleared" ? { type: "event_msg", payload: { msg: { type, payload: { timestamp: 1 } } } } : { type };
+    writeFileSync(path, [
+      { type: "event_msg", payload: { msg: { type: "token_count", payload: { promptTokens: 200_000, completionTokens: 10, model: "test-model", provider: "grok" } } } },
+      reset,
+    ].map((item) => JSON.stringify(item)).join("\n"));
+    Object.defineProperty(owner.session, "rolloutStore", { get: () => ({ rolloutPath: path }) });
+    expect(JSON.parse((await executeSessionStatusLine(owner.session)).text!).context_window.current_usage).toBeNull();
+  });
+
+  test("blocks configured commands while Editor owns the workspace", async () => {
+    const owner = await fixture();
+    const registry = workspaceMutationCoordinators.forHome(owner.configStore.homeContext.path);
+    registry.acquireEditor(owner.cwd, { workspaceRoot: owner.cwd, editorInstanceId: "status-line-editor" });
+    const spawn = vi.spyOn(owner.broker, "prepareSpawn");
+    const acquire = vi.spyOn(owner.admission, "acquire");
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "blocked", reason: "editor_workspace_owned" });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
+  test("holds the Editor fence until a cancelled process physically settles", async () => {
+    const owner = await fixture();
+    const marker = join(owner.home, "editor-fence.pid");
+    vi.spyOn(owner.configStore, "current").mockReturnValue({ statusLine: { type: "command", command: nodeCommand(`require("node:fs").writeFileSync(${JSON.stringify(marker)},String(process.pid));setInterval(()=>{},1000)`) } });
+    const registry = workspaceMutationCoordinators.forHome(owner.configStore.homeContext.path);
+    const controller = new AbortController();
+    const pending = executeSessionStatusLine(owner.session, {}, controller.signal);
+    await waitForFile(marker);
+    expect(() => registry.acquireEditor(owner.cwd, { workspaceRoot: owner.cwd, editorInstanceId: "during-status-line" })).toThrow(/active tool/u);
+    controller.abort();
+    expect(() => registry.acquireEditor(owner.cwd, { workspaceRoot: owner.cwd, editorInstanceId: "before-drain" })).toThrow(/active tool/u);
+    expect(await pending).toMatchObject({ status: "unavailable" });
+    expect(() => process.kill(Number(readFileSync(marker, "utf8")), 0)).toThrow();
+    expect(() => registry.acquireEditor(owner.cwd, { workspaceRoot: owner.cwd, editorInstanceId: "after-drain" })).not.toThrow();
+  });
+
+  test("auxiliary MCP sampling does not replace main conversation context", async () => {
+    const owner = await fixture({ command: "cat" });
+    await executeSessionStatusLine(owner.session);
+    owner.session.emit({ id: "main", msg: { type: "token_count", payload: { promptTokens: 200_000, completionTokens: 10, model: "test-model", provider: "grok" } } });
+    owner.session.emit({ id: "auxiliary", msg: { type: "token_count", payload: { promptTokens: 100, completionTokens: 5, model: "test-model" } } });
+    expect(JSON.parse((await executeSessionStatusLine(owner.session)).text!)).toMatchObject({ context_window: { used_percentage: 50, current_usage: { input_tokens: 200_000 } } });
+  });
+});

--- a/runtime/tests/permissions/cron-approval-risk.test.tsx
+++ b/runtime/tests/permissions/cron-approval-risk.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { classifyApprovalRisk, typedConfirmationWordForRisk } from "../../src/permissions/risk.js";
+import type { ApprovalCtx } from "../../src/tools/orchestrator.js";
+import { AgenCPermissionOverlay, type PendingRequest } from "../../src/tui/permission-requests.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+const bindings = vi.hoisted(() => ({ handlers: {} as Record<string, () => unknown> }));
+
+vi.mock("../../src/tui/ink.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/tui/ink.js")>(),
+  useInput: () => {},
+}));
+vi.mock("../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybindings: (handlers: Record<string, () => unknown>) => { bindings.handlers = handlers; },
+}));
+
+describe("cron approval operation classification", () => {
+  it.each([
+    "Run the tests. Do not create, list, or delete cron jobs.",
+    "Review documentation containing rm -rf without executing it.",
+    "Report whether the transfer and stake examples are documented.",
+  ])("treats the CronCreate prompt as scheduled data: %s", (prompt) => {
+    const toolInput = { cron: "* * * * *", prompt, recurring: false, durable: false };
+    const risk = classifyApprovalRisk({
+      request: { ctx: { toolName: "CronCreate" } },
+      description: "Permission required to use CronCreate",
+      command: JSON.stringify(toolInput),
+      toolInput,
+    });
+    expect(risk).toBe("low");
+    expect(typedConfirmationWordForRisk({ risk, toolName: "CronCreate", toolInput })).toBe("yes");
+  });
+
+  it("requires deletion confirmation for the actual CronDelete operation", () => {
+    const toolInput = { id: "scheduled-job" };
+    const risk = classifyApprovalRisk({ request: { ctx: { toolName: "CronDelete" } }, toolInput });
+    expect(risk).toBe("destructive");
+    expect(classifyApprovalRisk({ toolName: "CronDelete" })).toBe("destructive");
+    expect(typedConfirmationWordForRisk({ risk, toolName: "CronDelete", toolInput })).toBe("delete");
+  });
+
+  it.each([
+    ["CronCreate", { prompt: "Report only", action: "delete" }],
+    ["CronCreate", { prompt: "Report only", command: "rm -rf /tmp/fixture" }],
+    ["mcp.scheduler.CronCreate", { prompt: "delete records" }],
+    ["unknown_scheduler", { query: "DELETE FROM jobs" }],
+    ["exec_command", { cmd: "rm -rf /tmp/fixture" }],
+    ["write_stdin", { session_id: 1, chars: "rm -rf /tmp/fixture\n" }],
+  ])("preserves destructive action checks for %s", (toolName, toolInput) => {
+    expect(classifyApprovalRisk({ toolName, toolInput })).toBe("destructive");
+  });
+
+  it.each(["CronCreate", "CronDelete"])("renders operation-appropriate confirmation for %s", async (toolName) => {
+    const resolve = vi.fn();
+    const input = toolName === "CronCreate"
+      ? { cron: "* * * * *", prompt: "Run tests. Do not delete cron jobs.", recurring: false }
+      : { id: "scheduled-job" };
+    const request: PendingRequest = {
+      id: "cron-approval",
+      ctx: { callId: "cron-approval", toolName, turnId: "turn-1" } as ApprovalCtx,
+      input,
+      description: `Permission required to use ${toolName}`,
+      resolve,
+    };
+    const rendered = await renderToString(
+      <AgenCPermissionOverlay request={request} tools={[{ name: toolName }]} />,
+      { columns: 120, rows: 40 },
+    );
+    if (toolName === "CronCreate") {
+      expect(rendered).not.toContain("DESTRUCTIVE");
+      bindings.handlers["confirm:yes"]?.();
+      expect(resolve).toHaveBeenCalledWith({ kind: "approved" });
+    } else {
+      expect(rendered).toContain("DESTRUCTIVE");
+      expect(bindings.handlers["confirm:yes"]?.()).toBe(false);
+      expect(resolve).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -347,7 +347,7 @@ describe("agenc-sdk client over the in-process transport", () => {
     const initialized = await daemon.client.initialize();
     expect(initialized).toMatchObject({
       type: "initialized",
-      protocol: { version: "1.10.0" },
+      protocol: { version: "1.11.0" },
     });
 
     const session = await daemon.client.createSession({

--- a/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
+++ b/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
@@ -75,7 +75,7 @@ class PromptTransport implements AgencTransport {
     readonly response: Deferred<AgencDaemonResponse<"message.send">>;
   }> = [];
   client?: AgencClient;
-  initializeVersion = "1.10.0";
+  initializeVersion = "1.11.0";
   initializeFailures = 0;
   attachRuntimeOptions: unknown;
   attachRuntimeSettings: unknown = VALID_ATTACH_RUNTIME_SETTINGS;
@@ -119,7 +119,8 @@ class PromptTransport implements AgencTransport {
               this.initializeVersion === "1.7.0" ||
               this.initializeVersion === "1.8.0" ||
               this.initializeVersion === "1.9.0" ||
-              this.initializeVersion === "1.10.0",
+              this.initializeVersion === "1.10.0" ||
+              this.initializeVersion === "1.11.0",
           },
         },
       });
@@ -361,7 +362,7 @@ describe("agenc-sdk prompt race safety", () => {
       );
       expect(initializes).toHaveLength(2);
       expect(initializes.map((request) => request.params)).toEqual([
-        expect.objectContaining({ protocol: { version: "1.10.0" } }),
+        expect.objectContaining({ protocol: { version: "1.11.0" } }),
         expect.objectContaining({ protocol: { version } }),
       ]);
       expect(client.negotiatedProtocolVersion).toBe(version);

--- a/runtime/tests/services/compact/usage-observer-boundary.contract.test.ts
+++ b/runtime/tests/services/compact/usage-observer-boundary.contract.test.ts
@@ -1,0 +1,104 @@
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+import type { AdmissionUsageSummary } from "../../../src/budget/admission-types.js";
+import { compactConversation } from "../../../src/services/compact/compact.js";
+import { COMPACTION_SOURCE_DIGEST_DOMAIN } from "../../../src/services/compact/transaction-types.js";
+import type { RuntimeMessage } from "../../../src/services/compact/types.js";
+import { scanCanonicalRollout } from "../../../src/session/canonical-rollout-scanner.js";
+import type { EventMsg } from "../../../src/session/event-log.js";
+import { createCompactionTransactionHarness, createProvider, type CompactionTransactionHarness } from "../../helpers/compaction-transaction-harness.js";
+
+function sourceMessages(): readonly RuntimeMessage[] {
+  return Array.from({ length: 8 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" as const : "assistant" as const,
+    content: `source-${index}:${"x".repeat(4_000)}`,
+  }));
+}
+
+function usage(runId: string): AdmissionUsageSummary {
+  return {
+    runId, sequence: 10, costUsd: 0.1, heldCostUsd: 0,
+    inputTokens: 10, outputTokens: 2, totalTokens: 12,
+    modelCalls: 1, hasUnknownCost: false, models: [], agents: [],
+  };
+}
+
+function emit(fixture: CompactionTransactionHarness, identity: string, msg: EventMsg): void {
+  fixture.session.emit({ id: identity, eventId: identity, msg }, { durable: true });
+}
+
+describe("observational usage inside compaction bookkeeping", () => {
+  it("keeps admission valid when usage is emitted during a real provider transaction", async () => {
+    const source = sourceMessages();
+    const provider = createProvider();
+    let fixture: CompactionTransactionHarness;
+    fixture = createCompactionTransactionHarness(source, {
+      chat: async (messages) => {
+        emit(fixture, "provider-usage", { type: "session_usage", payload: usage(fixture.store.sessionId) });
+        return provider.chat(messages);
+      },
+    });
+    try {
+      const result = await compactConversation(source, fixture.context);
+      expect(result.transaction).toBeDefined();
+      const scan = scanCanonicalRollout(fixture.store.rolloutPath, {
+        sessionTempRoot: tmpdir(), expectedRunId: fixture.store.sessionId, expectedEpoch: 1,
+        compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+      });
+      expect(scan.attempts.get(result.transaction!.attempt_id)?.admissionValid).toBe(true);
+    } finally {
+      fixture.close();
+    }
+  });
+
+  it("preserves same-session rollback across snapshots around all automatic bookkeeping boundaries", async () => {
+    const source = sourceMessages();
+    const fixture = createCompactionTransactionHarness(source, { compactionMode: "automatic" });
+    try {
+      const result = await compactConversation(source, fixture.context);
+      const attemptId = result.transaction!.attempt_id;
+      emit(fixture, "usage-before-context", { type: "session_usage", payload: usage(fixture.store.sessionId) });
+      emit(fixture, "context-boundary", { type: "context_compacted", payload: { summary: "auto-compact boundary (turnId=usage-test)" } });
+      emit(fixture, "usage-before-meta", { type: "session_usage", payload: usage(fixture.store.sessionId) });
+      const meta = fixture.store.readAll().find((item) => item.type === "session_meta");
+      if (meta === undefined) throw new Error("Missing session metadata");
+      fixture.store.appendRollout(meta, { durable: true });
+      emit(fixture, "usage-after-meta", { type: "session_usage", payload: usage(fixture.store.sessionId) });
+      const rollback = fixture.store.rollbackCompaction({ attemptId, nowMs: Date.now() });
+      expect(rollback.rollback_mode).toBe("same_session");
+      expect(rollback.source_history).toEqual(source);
+    } finally {
+      fixture.close();
+    }
+  });
+
+  it("still treats real conversation work after a snapshot as a rollback boundary", async () => {
+    const source = sourceMessages();
+    const fixture = createCompactionTransactionHarness(source);
+    try {
+      const result = await compactConversation(source, fixture.context);
+      emit(fixture, "usage-only", { type: "session_usage", payload: usage(fixture.store.sessionId) });
+      fixture.store.appendRollout({ type: "response_item", payload: { role: "user", content: "New work" } }, { durable: true });
+      expect(() => fixture.store.rollbackCompaction({ attemptId: result.transaction!.attempt_id, nowMs: Date.now() }))
+        .toThrow(/reviewed branch target/);
+    } finally {
+      fixture.close();
+    }
+  });
+
+  it("rejects malformed usage rather than treating it as harmless bookkeeping", () => {
+    const fixture = createCompactionTransactionHarness(sourceMessages());
+    try {
+      emit(fixture, "invalid-usage", {
+        type: "session_usage", payload: { ...usage(fixture.store.sessionId), heldCostUsd: -1 },
+      });
+      expect(() => scanCanonicalRollout(fixture.store.rolloutPath, {
+        sessionTempRoot: tmpdir(), expectedRunId: fixture.store.sessionId, expectedEpoch: 1,
+        compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+      })).toThrow(/payload does not match the runtime schema/);
+    } finally {
+      fixture.close();
+    }
+  });
+});

--- a/runtime/tests/session/event-log.test.ts
+++ b/runtime/tests/session/event-log.test.ts
@@ -372,10 +372,11 @@ describe("I-8 emitError helper", () => {
 
 describe("I-26 forward-compat + schema version", () => {
   test("KNOWN_EVENT_TYPES contains all known variants", () => {
-    expect(KNOWN_EVENT_TYPES.size).toBe(83);
+    expect(KNOWN_EVENT_TYPES.size).toBe(84);
     expect(isKnownEventType("entered_review_mode")).toBe(true);
     expect(isKnownEventType("run_suspended")).toBe(true);
     expect(isKnownEventType("run_resumed")).toBe(true);
+    expect(isKnownEventType("session_usage")).toBe(true);
   });
 
   test("isKnownEventType detects known + unknown", () => {

--- a/runtime/tests/session/run-turn.compaction-request.test.ts
+++ b/runtime/tests/session/run-turn.compaction-request.test.ts
@@ -7,7 +7,10 @@ import { buildSamplingRequestContract } from "../../src/session/run-turn-samplin
 import { buildInitialTurnState } from "../../src/session/turn-state.js";
 import { toAgenCRuntimeMessages } from "../../src/session/runtime-message-conversion.js";
 import { mkCtx, mkSession } from "../fixtures.js";
-import { createCompactionTransactionHarness } from "../helpers/compaction-transaction-harness.js";
+import {
+  attachCompactionSession,
+  createCompactionTransactionHarness,
+} from "../helpers/compaction-transaction-harness.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -31,7 +34,7 @@ describe("automatic compaction sampling request accounting", () => {
         executionAdmission: harness.session.services.executionAdmission,
       },
     });
-    session.mountRolloutStore(harness.store);
+    attachCompactionSession(session, harness);
     Object.assign(harness.provider, { tokenCountCapability: undefined });
     vi.spyOn(session.services.registry, "toLLMTools").mockReturnValue([
       {

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -122,6 +122,12 @@ import type { AgentId } from "../types/ids.js";
 import { StreamingToolExecutor as LiveStreamingToolExecutor } from "../phases/_deps/tool-runtime.js";
 import type { PhaseEvent } from "../phases/events.js";
 import { SHARED_READ } from "../tools/concurrency.js";
+import { createModelFacingTools } from "../bin/model-facing-tools.js";
+import { __installDaemonTurnDriverHooksForTest } from "../app-server/background-agent-runner.js";
+import { startSessionCronScheduler } from "./session-cron-scheduler.js";
+import { resetCronSchedulerForTests } from "../utils/cronScheduler.js";
+import { addCronTask, listAllCronTasks, readCronTasks } from "../utils/cronTasks.js";
+import { resetStateForTests, setScheduledTasksEnabled } from "../bootstrap/state.js";
 import { StreamModelError } from "../phases/stream-model.js";
 import type { ToolRegistry } from "../tool-registry.js";
 import type { PostToolUseHook } from "../tools/hooks.js";
@@ -463,6 +469,7 @@ function mkPersonalityModelMessages(): ModelMessages {
 }
 
 function mkSession(opts: {
+  readonly conversationId?: string;
   readonly provider: LLMProvider;
   readonly registry: ToolRegistry;
   readonly codeModeService?: SessionServices["codeModeService"];
@@ -597,7 +604,7 @@ function mkSession(opts: {
       ? { initialModel: state.sessionConfiguration.collaborationMode.model }
       : {}),
     environment: providerEnvironment,
-    sessionId: "conv-test",
+    sessionId: opts.conversationId ?? "conv-test",
     resolvePreparationRequest: (selection) => ({
       requested: resolveProviderRuntimeRequest({
         provider: selection.provider,
@@ -610,7 +617,7 @@ function mkSession(opts: {
     }),
   });
   const session = new Session({
-    conversationId: "conv-test",
+    conversationId: opts.conversationId ?? "conv-test",
     services: { ...services, providerService },
     initialState: state as unknown as SessionOpts["initialState"],
     features: mkFeatures(),
@@ -761,6 +768,430 @@ function mkStaticToolRegistry(
     dispatch: async () => ({ content, isError: false }),
   } as unknown as ToolRegistry;
 }
+
+describe("daemon-owned scheduled turns", () => {
+  async function withCronSessions(
+    work: (fixture: {
+      readonly workspaceRoot: string;
+      readonly create: (conversationId?: string, provider?: LLMProvider, registry?: ToolRegistry) => ReturnType<typeof mkSession>;
+      readonly start: (session: Session) => Promise<Awaited<ReturnType<typeof startSessionCronScheduler>>>;
+      readonly add: (session: Session, options?: { recurring?: boolean; durable?: boolean }) => Promise<string>;
+      readonly advance: () => Promise<void>;
+    }) => Promise<void>,
+  ): Promise<void> {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-daemon-cron-turn-"));
+    const sessions: Session[] = [];
+    const schedulers = new Set<Awaited<ReturnType<typeof startSessionCronScheduler>>>();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
+    vi.setSystemTime(new Date("2026-09-09T12:00:30Z"));
+    setScheduledTasksEnabled(true);
+    try {
+      await work({
+        workspaceRoot,
+        create: (conversationId = "cron-owner", provider = mkProvider({ content: "scheduled result" }), registry = mkRegistry()) => {
+          const fixture = mkSession({
+            conversationId,
+            provider,
+            registry,
+            sessionConfiguration: { cwd: workspaceRoot },
+          });
+          sessions.push(fixture.session);
+          return fixture;
+        },
+        start: async (session) => {
+          const scheduler = await startSessionCronScheduler(session, workspaceRoot);
+          schedulers.add(scheduler);
+          return scheduler;
+        },
+        add: (session, options = {}) => addCronTask(
+          "* * * * *", "run the scheduled check", options.recurring ?? false,
+          options.durable ?? false, undefined, undefined,
+          { kind: "session", conversationId: session.conversationId }, workspaceRoot,
+        ),
+        advance: async () => {
+          await vi.advanceTimersByTimeAsync(60_000);
+          for (let round = 0; round < 25; round += 1) {
+            await new Promise<void>((resolveRound) => setImmediate(resolveRound));
+          }
+          await vi.advanceTimersByTimeAsync(0);
+        },
+      });
+    } finally {
+      for (const session of sessions) session.abortController.abort();
+      await Promise.all([...schedulers].map((scheduler) => scheduler.drain()));
+      await resetCronSchedulerForTests();
+      vi.useRealTimers();
+      resetStateForTests();
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  }
+
+  test("live CronCreate wakes an idle daemon driver and executes exactly one tool turn", async () => {
+    await withCronSessions(async ({ create, start, workspaceRoot, advance }) => {
+      const seenMessages: LLMMessage[][] = [];
+      const { provider, calls } = mkSingleToolFollowUpProvider({ seenMessages });
+      const tool = vi.fn(async () => ({ content: "CHECK_DONE", isError: false }));
+      const registry = mkStaticToolRegistry();
+      registry.tools[0]!.execute = tool;
+      const { session, events } = create("cron-owner", provider, registry);
+      __installDaemonTurnDriverHooksForTest(session, session.services.configStore!);
+      const submit = vi.spyOn(session, "submit");
+      const cronCreate = createModelFacingTools({ workspaceRoot, getSession: () => session })
+        .find((candidate) => candidate.name === "CronCreate")!;
+      const created = await cronCreate.execute({
+        cron: "* * * * *", prompt: "run the scheduled check", recurring: false, durable: false,
+      });
+      expect(created.isError).toBeUndefined();
+      expect(JSON.parse(String(created.content)).cron.durable).toBe(false);
+      expect(await readCronTasks(workspaceRoot)).toEqual([]);
+      expect(calls()).toBe(0);
+      await advance();
+      expect(submit).toHaveBeenCalledTimes(1);
+      await submit.mock.results[0]!.value;
+      const scheduler = await start(session);
+      await scheduler.drain();
+      expect(calls()).toBe(2);
+      expect(tool).toHaveBeenCalledTimes(1);
+      expect(events.filter((event) => event.msg.type === "turn_started")).toHaveLength(1);
+      expect(events.filter((event) => event.msg.type === "turn_complete")).toHaveLength(1);
+      expect(events.filter((event) => event.msg.type === "tool_call_started")).toHaveLength(1);
+      expect(getCommandQueueSnapshot()).toEqual([]);
+      expect(await listAllCronTasks(workspaceRoot, session.conversationId)).toEqual([]);
+      await advance();
+      await scheduler.drain();
+      expect(calls()).toBe(2);
+    });
+  });
+
+  test("busy turns retain one-shots until acceptance and serialize the attempt", async () => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const { session } = create();
+      const busy = Promise.withResolvers<void>();
+      const scheduled = Promise.withResolvers<void>();
+      const calls: string[] = [];
+      session.installTurnDriverHooks({ submit: async (message) => {
+        calls.push(String(message));
+        await (message === "busy" ? busy.promise : scheduled.promise);
+      } });
+      const active = session.submit("busy");
+      try {
+        await add(session);
+        const scheduler = await start(session);
+        await advance();
+        expect(calls).toEqual(["busy"]);
+        expect(await listAllCronTasks(workspaceRoot, session.conversationId)).toHaveLength(1);
+        busy.resolve();
+        await active;
+        await advance();
+        expect(calls).toEqual(["busy", "run the scheduled check"]);
+        expect(await listAllCronTasks(workspaceRoot, session.conversationId)).toEqual([]);
+        scheduled.resolve();
+        await scheduler.drain();
+        expect(await listAllCronTasks(workspaceRoot, session.conversationId)).toEqual([]);
+      } finally {
+        busy.resolve();
+        scheduled.resolve();
+      }
+    });
+  });
+
+  test("CronDelete cancels a queued turn without suppressing another scheduled tool turn", async () => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const busy = Promise.withResolvers<void>();
+      const started = Promise.withResolvers<void>();
+      const seenMessages: LLMMessage[][] = [];
+      const scheduled = mkSingleToolFollowUpProvider({ seenMessages });
+      let samples = 0;
+      const provider: LLMProvider = {
+        ...mkProvider({}),
+        chatStream: async (messages, onChunk, options) => {
+          samples += 1;
+          if (samples === 1) {
+            started.resolve();
+            await busy.promise;
+            return mkProvider({ content: "busy turn finished" }).chatStream(messages, onChunk, options);
+          }
+          return scheduled.provider.chatStream(messages, onChunk, options);
+        },
+      };
+      const tool = vi.fn(async () => ({ content: "SURVIVOR_DONE", isError: false }));
+      const registry = mkStaticToolRegistry();
+      registry.tools[0]!.execute = tool;
+      const { session } = create("cron-delete", provider, registry);
+      __installDaemonTurnDriverHooksForTest(session, session.services.configStore!);
+      const active = session.submit("busy");
+      try {
+        await started.promise;
+        const cancelledId = await add(session, { durable: true });
+        await addCronTask("* * * * *", "survivor check", false, true, undefined, undefined,
+          { kind: "session", conversationId: session.conversationId }, workspaceRoot);
+        const scheduler = await start(session);
+        await advance();
+        expect(samples).toBe(1);
+        const cronDelete = createModelFacingTools({ workspaceRoot, getSession: () => session })
+          .find((candidate) => candidate.name === "CronDelete")!;
+        const result = await cronDelete.execute({ id: cancelledId });
+        expect(JSON.parse(String(result.content)).deleted).toBe(true);
+        busy.resolve();
+        await active;
+        await advance();
+        await scheduler.drain();
+        expect(tool).toHaveBeenCalledTimes(1);
+        expect(samples).toBe(3);
+        expect(seenMessages.flat().some((message) => testMessageText(message).includes("run the scheduled check"))).toBe(false);
+        expect(seenMessages.flat().some((message) => testMessageText(message).includes("survivor check"))).toBe(true);
+      } finally {
+        busy.resolve();
+        await active;
+      }
+    });
+  });
+
+  test("a durable claim is absent from a restarted reader before the first tool finishes", async () => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const pending = Promise.withResolvers<void>();
+      const started = Promise.withResolvers<void>();
+      const provider = mkSingleToolFollowUpProvider({ seenMessages: [] }).provider;
+      const tool = vi.fn(async () => {
+        started.resolve();
+        await pending.promise;
+        return { content: "committed side effect", isError: false };
+      });
+      const registry = mkStaticToolRegistry();
+      registry.tools[0]!.execute = tool;
+      const { session } = create("cron-durable-claim", provider, registry);
+      __installDaemonTurnDriverHooksForTest(session, session.services.configStore!);
+      try {
+        await add(session, { durable: true });
+        const scheduler = await start(session);
+        await advance();
+        await started.promise;
+        expect(await readCronTasks(workspaceRoot)).toEqual([]);
+        const replacement = create("cron-restarted-reader").session;
+        const replacementAttempt = vi.fn(async () => {});
+        replacement.installTurnDriverHooks({ submit: replacementAttempt });
+        const replacementScheduler = await start(replacement);
+        await advance();
+        await replacementScheduler.drain();
+        expect(replacementAttempt).not.toHaveBeenCalled();
+        expect(tool).toHaveBeenCalledTimes(1);
+        pending.resolve();
+        await scheduler.drain();
+      } finally {
+        pending.resolve();
+      }
+    });
+  });
+
+  test.each([false, true])("persisted rearm waits for a submit driver and respects closed=%s", async (closed) => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const { session } = create();
+      await add(session, { durable: true });
+      const scheduler = await start(session);
+      await advance();
+      await scheduler.drain();
+      expect(await readCronTasks(workspaceRoot)).toHaveLength(1);
+      const attempt = vi.fn(async () => {});
+      if (closed) {
+        session.beginShutdown();
+        session.abortController.abort();
+      }
+      session.installTurnDriverHooks({ submit: attempt });
+      await advance();
+      await scheduler.drain();
+      expect(attempt).toHaveBeenCalledTimes(closed ? 0 : 1);
+      expect(await readCronTasks(workspaceRoot)).toHaveLength(closed ? 1 : 0);
+    });
+  });
+
+  test.each(["failed", "aborted"] as const)("an actual tool turn that ends %s consumes its one-shot without replay", async (outcome) => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      let session: Session;
+      let samples = 0;
+      const provider: LLMProvider = {
+        ...mkProvider({}),
+        chatStream: async () => {
+          samples += 1;
+          if (samples > 1) throw new LLMAuthenticationError("scheduled provider failure");
+          return {
+            content: "", toolCalls: [{ id: "scheduled_tool", name: "queue_tool", arguments: "{}" }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "test-model", finishReason: "tool_calls",
+          };
+        },
+      };
+      const registry = mkStaticToolRegistry();
+      const tool = vi.fn(async () => {
+        if (outcome === "aborted") await session.abortAllTasks("interrupted");
+        return { content: "side effect committed", isError: false };
+      });
+      registry.tools[0]!.execute = tool;
+      const fixture = create("cron-failure", provider, registry);
+      session = fixture.session;
+      __installDaemonTurnDriverHooksForTest(session, session.services.configStore!);
+      await add(session, { durable: true });
+      const scheduler = await start(session);
+      await advance();
+      await scheduler.drain();
+      expect(tool).toHaveBeenCalledTimes(1);
+      expect(fixture.events.filter((event) => event.msg.type === `turn_${outcome}`)).toHaveLength(1);
+      expect(await readCronTasks(workspaceRoot)).toEqual([]);
+      await advance();
+      await scheduler.drain();
+      expect(tool).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("queued shutdown preserves durable jobs that never crossed acceptance", async () => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const { session } = create();
+      const busy = Promise.withResolvers<void>();
+      const calls: string[] = [];
+      session.installTurnDriverHooks({ submit: async (message) => {
+        calls.push(String(message));
+        await busy.promise;
+      } });
+      const active = session.submit("busy");
+      try {
+        await add(session, { durable: true });
+        const scheduler = await start(session);
+        await advance();
+        session.beginShutdown();
+        session.abortController.abort();
+        busy.resolve();
+        await active;
+        await scheduler.drain();
+        expect(calls).toEqual(["busy"]);
+        expect(await readCronTasks(workspaceRoot)).toHaveLength(1);
+      } finally {
+        busy.resolve();
+      }
+    });
+  });
+
+  test.each(["preparation failed", "unexpected driver failure"])(
+    "consumes an accepted failed one-shot without replay when %s",
+    async (message) => {
+      await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+        const { session, events } = create();
+        const attempt = vi.fn(async () => { throw new Error(message); });
+        session.installTurnDriverHooks({ submit: attempt });
+        await add(session, { durable: true });
+        const scheduler = await start(session);
+        await advance();
+        await scheduler.drain();
+        expect(attempt).toHaveBeenCalledTimes(1);
+        expect(await readCronTasks(workspaceRoot)).toEqual([]);
+        expect(events).toContainEqual(expect.objectContaining({ msg: {
+          type: "warning",
+          payload: expect.objectContaining({ cause: "scheduled_turn_failed", message: expect.stringContaining(message) }),
+        } }));
+        await advance();
+        expect(attempt).toHaveBeenCalledTimes(1);
+      });
+    },
+  );
+
+  test("recurring work does not overlap while an earlier attempt is still active", async () => {
+    await withCronSessions(async ({ create, add, start, advance }) => {
+      const { session } = create();
+      const pending = Promise.withResolvers<void>();
+      const attempt = vi.fn(async () => pending.promise);
+      session.installTurnDriverHooks({ submit: attempt });
+      try {
+        await add(session, { recurring: true });
+        const scheduler = await start(session);
+        await advance();
+        await advance();
+        await advance();
+        expect(attempt).toHaveBeenCalledTimes(1);
+        session.abortController.abort();
+        pending.resolve();
+        await scheduler.drain();
+      } finally {
+        pending.resolve();
+      }
+    });
+  });
+
+  test("a failed session-only recurring attempt does not replay its slot when rearmed", async () => {
+    await withCronSessions(async ({ create, add, start, advance }) => {
+      const { session } = create();
+      const attempt = vi.fn(async () => { throw new Error("scheduled attempt failed"); });
+      session.installTurnDriverHooks({ submit: attempt });
+      await add(session, { recurring: true });
+      const scheduler = await start(session);
+      await advance();
+      await scheduler.drain();
+      expect(attempt).toHaveBeenCalledTimes(1);
+      await start(session);
+      await vi.advanceTimersByTimeAsync(0);
+      await scheduler.drain();
+      expect(attempt).toHaveBeenCalledTimes(1);
+      await advance();
+      await scheduler.drain();
+      expect(attempt).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("abort during durable claim commit prevents dispatch after the claim", async () => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const { session, events } = create();
+      const attempt = vi.fn(async () => {});
+      session.installTurnDriverHooks({ submit: attempt });
+      await add(session, { durable: true });
+      const cronTasks = await import("../utils/cronTasks.js");
+      const mutate = cronTasks.mutateCronFile;
+      const claim = vi.spyOn(cronTasks, "mutateCronFile").mockImplementation(async (directory, update) => {
+        const result = await mutate(directory, update);
+        session.abortController.abort(new Error("cancelled during durable claim"));
+        return result;
+      });
+      try {
+        const scheduler = await start(session);
+        await advance();
+        await scheduler.drain();
+        expect(attempt).not.toHaveBeenCalled();
+        expect(await readCronTasks(workspaceRoot)).toEqual([]);
+        expect(events).toContainEqual(expect.objectContaining({ msg: {
+          type: "warning",
+          payload: expect.objectContaining({ cause: "scheduled_turn_failed", message: expect.stringContaining("after acceptance") }),
+        } }));
+      } finally {
+        claim.mockRestore();
+      }
+    });
+  });
+
+  test("sibling sessions run their own jobs and share one durable owner with close-time handoff", async () => {
+    await withCronSessions(async ({ create, add, start, workspaceRoot, advance }) => {
+      const first = create("cron-first").session;
+      const second = create("cron-second").session;
+      const firstAttempt = vi.fn(async () => {});
+      const secondAttempt = vi.fn(async () => {});
+      first.installTurnDriverHooks({ submit: firstAttempt });
+      second.installTurnDriverHooks({ submit: secondAttempt });
+      await add(first, { durable: true });
+      await add(second);
+      const firstScheduler = await start(first);
+      const secondScheduler = await start(second);
+      await advance();
+      await Promise.all([firstScheduler.drain(), secondScheduler.drain()]);
+      expect(firstAttempt).toHaveBeenCalledTimes(1);
+      expect(secondAttempt).toHaveBeenCalledTimes(1);
+      expect(await readCronTasks(workspaceRoot)).toEqual([]);
+      await add(second, { durable: true });
+      await start(second);
+      first.abortController.abort();
+      await firstScheduler.drain();
+      await advance();
+      await secondScheduler.drain();
+      expect(firstAttempt).toHaveBeenCalledTimes(1);
+      expect(secondAttempt).toHaveBeenCalledTimes(2);
+      expect(await readCronTasks(workspaceRoot)).toEqual([]);
+    });
+  });
+});
 
 describe("runTurn — T6 gap #119 lifecycle emits", () => {
   test("stops before sampling when the canonical session cost cap is exhausted", async () => {

--- a/runtime/tests/session/session.test.ts
+++ b/runtime/tests/session/session.test.ts
@@ -80,9 +80,13 @@ import {
   materializeAgentInvocationMessages,
 } from "../contracts/agent-invocation-envelope.js";
 import {
+  attachCompactionSession,
   createCompactionTransactionHarness,
   createProvider as createCompactionProvider,
 } from "../helpers/compaction-transaction-harness.js";
+import { sessionTranscriptV2FromRollout } from "../app-server/background-agent-runner/journal-reconstruction.js";
+import { daemonTranscriptSnapshotEvents } from "../tui/daemon-transcript-snapshot.js";
+import { adaptTranscriptEvents } from "../tui/session-transcript.js";
 import { CompactionReconstructionRequiredError } from "../services/compact/transaction-types.js";
 import {
   getSessionTempNamespaceName,
@@ -2381,8 +2385,9 @@ describe("Session.partialCompactFromMessage", () => {
         admissionRequired: true,
       },
     });
-    session.rolloutStore = harness.store;
+    attachCompactionSession(session, harness);
     try {
+      expect(session.eventLog.lastSeq).toBe(1);
       await session.state.with((state) => {
         state.history = sourceHistory;
       });
@@ -2420,6 +2425,18 @@ describe("Session.partialCompactFromMessage", () => {
           (message) => message.content === sourceHistory[2]?.content,
         ),
       ).toBe(false);
+      const items = harness.store.readAll();
+      const events = items.flatMap((item) => item.type === "event_msg" ? [item.payload] : []);
+      expect(events.map((event) => event.seq)).toEqual(events.map((_, index) => index + 1));
+      const usage = events.filter((event) => event.msg.type === "session_usage").at(-1)?.msg;
+      expect(usage).toMatchObject({ type: "session_usage", payload: {
+        runId: session.conversationId, modelCalls: 1, hasUnknownCost: false,
+      } });
+      if (usage?.type !== "session_usage") throw new Error("Missing compaction usage");
+      expect(usage.payload.costUsd).toBeGreaterThan(0);
+      const snapshot = sessionTranscriptV2FromRollout(items, session.conversationId, session.conversationId);
+      const restored = adaptTranscriptEvents(daemonTranscriptSnapshotEvents(snapshot, session.conversationId));
+      expect(restored.sessionCostUsd).toBe(usage.payload.costUsd);
     } finally {
       harness.close();
     }
@@ -2468,7 +2485,7 @@ describe("Session.partialCompactFromMessage", () => {
         admissionRequired: true,
       },
     });
-    session.rolloutStore = harness.store;
+    attachCompactionSession(session, harness);
     try {
       await session.state.with((state) => {
         state.history = sourceHistory;
@@ -2530,7 +2547,7 @@ describe("Session.partialCompactFromMessage", () => {
         admissionRequired: true,
       },
     });
-    session.rolloutStore = harness.store;
+    attachCompactionSession(session, harness);
     try {
       await session.state.with((state) => {
         state.history = sourceHistory;

--- a/runtime/tests/state/execution-admission-usage.test.ts
+++ b/runtime/tests/state/execution-admission-usage.test.ts
@@ -1,0 +1,195 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { bindExecutionAdmissionJournal } from "../../src/session/execution-admission-journal.js";
+import type { Session } from "../../src/session/session.js";
+import type { Event, EventMsg } from "../../src/session/event-log.js";
+
+let home: string;
+let cwd: string;
+const kernels: ExecutionAdmissionKernel[] = [];
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-usage-state-"));
+  cwd = join(home, "project");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+});
+
+afterEach(() => {
+  for (const kernel of kernels.splice(0)) kernel.close();
+  rmSync(home, { recursive: true, force: true });
+});
+
+function createKernel(): ExecutionAdmissionKernel {
+  const kernel = new ExecutionAdmissionKernel({ agencHome: home });
+  kernels.push(kernel);
+  return kernel;
+}
+
+function bind(kernel: ExecutionAdmissionKernel, runId: string): ExecutionAdmissionClient {
+  return kernel.bindClient({ cwd, scope: { runId, sessionId: runId, autonomous: false } });
+}
+
+async function reserve(client: ExecutionAdmissionClient, stepId: string, costUsd = 0.5) {
+  return client.acquire({
+    stepId,
+    kind: "model_turn",
+    model: "grok-test",
+    provider: "grok",
+    maxInputTokens: 20,
+    maxOutputTokens: 20,
+    maxCostUsd: costUsd,
+  });
+}
+
+async function spend(client: ExecutionAdmissionClient, stepId: string, costUsd: number) {
+  const lease = await reserve(client, stepId, costUsd);
+  const reservationId = lease.reservation.reservationId;
+  client.markDispatched(reservationId, { boundary: "provider_wire" });
+  client.reconcile(reservationId, { inputTokens: 10, outputTokens: 5, costUsd });
+  client.acknowledgeCompletion(reservationId);
+}
+
+describe("canonical session usage", () => {
+  it("counts descendants once, excludes unrelated runs, and scopes child totals", async () => {
+    const kernel = createKernel();
+    const parent = bind(kernel, "parent");
+    const core = parent.forSession({ runId: "core", sessionId: "core" });
+    const tests = parent.forSession({ runId: "tests", sessionId: "tests" });
+    const grandchild = core.forSession({ runId: "grandchild", sessionId: "grandchild" });
+    await spend(parent, "parent-work", 0.11);
+    await spend(core, "core-work", 0.22);
+    await spend(tests, "tests-work", 0.33);
+    await spend(grandchild, "grandchild-work", 0.44);
+    await spend(bind(kernel, "unrelated"), "other-work", 0.5);
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      runId: "parent", costUsd: 1.1, inputTokens: 40, outputTokens: 20,
+      totalTokens: 60, modelCalls: 4, hasUnknownCost: false, heldCostUsd: 0,
+      models: [{ model: "grok-test", provider: "grok", costUsd: 1.1, modelCalls: 4 }],
+      agents: [
+        { runId: "core", costUsd: 0.22 },
+        { runId: "grandchild", costUsd: 0.44 },
+        { runId: "tests", costUsd: 0.33 },
+      ],
+    });
+    expect(core.getUsageSummary?.()).toMatchObject({
+      costUsd: 0.66, modelCalls: 2, agents: [{ runId: "grandchild", costUsd: 0.44 }],
+    });
+    expect(tests.getUsageSummary?.()).toMatchObject({ costUsd: 0.33, agents: [] });
+  });
+
+  it("never presents open or unknown reservations as recorded spend", async () => {
+    const parent = bind(createKernel(), "parent");
+    const lease = await reserve(parent, "unknown");
+    expect(parent.getUsageSummary?.()).toMatchObject({ costUsd: 0, heldCostUsd: 0.5, modelCalls: 0 });
+    parent.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    parent.holdUnknown(lease.reservation.reservationId, "provider disconnected");
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      costUsd: 0, heldCostUsd: 0.5, hasUnknownCost: true, totalTokens: 0, modelCalls: 0,
+    });
+    parent.acknowledgeCompletion(lease.reservation.reservationId);
+  });
+
+  it("includes priced tool work in actual totals without adding model calls", async () => {
+    const parent = bind(createKernel(), "parent");
+    const child = parent.forSession({ runId: "worker", sessionId: "worker" });
+    await spend(parent, "model-work", 0.2);
+    const lease = await child.acquire({
+      stepId: "priced-tool",
+      kind: "tool_exec",
+      maxInputTokens: 0,
+      maxOutputTokens: 0,
+      maxCostUsd: 0.5,
+    });
+    const reservationId = lease.reservation.reservationId;
+    child.markDispatched(reservationId, { boundary: "tool_exec" });
+    child.reconcile(reservationId, { inputTokens: 0, outputTokens: 0, costUsd: 0.3 });
+    child.acknowledgeCompletion(reservationId);
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      costUsd: 0.5, modelCalls: 1, inputTokens: 10, outputTokens: 5,
+      totalTokens: 15, heldCostUsd: 0, hasUnknownCost: false,
+      models: [{ model: "grok-test", provider: "grok", costUsd: 0.2, modelCalls: 1 }],
+      agents: [{ runId: "worker", costUsd: 0.3, modelCalls: 0, totalTokens: 0 }],
+    });
+    expect(child.getUsageSummary?.()).toMatchObject({
+      costUsd: 0.3, modelCalls: 0, models: [], agents: [],
+    });
+  });
+
+  it("retains reported tokens when only the price is unknown", async () => {
+    const parent = bind(createKernel(), "parent");
+    const child = parent.forSession({ runId: "worker", sessionId: "worker" });
+    const lease = await reserve(child, "unpriced-response");
+    child.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    child.reconcile(lease.reservation.reservationId, { inputTokens: 10, outputTokens: 5, costUsd: null });
+    child.acknowledgeCompletion(lease.reservation.reservationId);
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      costUsd: 0, heldCostUsd: 0.5, hasUnknownCost: true,
+      inputTokens: 10, outputTokens: 5, totalTokens: 15, modelCalls: 1,
+      models: [{ model: "grok-test", totalTokens: 15, modelCalls: 1, hasUnknownCost: true }],
+      agents: [{ runId: "worker", totalTokens: 15, modelCalls: 1, hasUnknownCost: true }],
+    });
+    child.reconcile(lease.reservation.reservationId, { inputTokens: 10, outputTokens: 5, costUsd: 0.2 });
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      costUsd: 0.2, heldCostUsd: 0, hasUnknownCost: false, totalTokens: 15, modelCalls: 1,
+    });
+  });
+
+  it("preserves a retained unknown-cost hold on token-only provider overrun", async () => {
+    const parent = bind(createKernel(), "parent");
+    const lease = await reserve(parent, "overrun");
+    parent.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    parent.reconcile(lease.reservation.reservationId, { inputTokens: 50, outputTokens: 1, costUsd: null });
+    parent.acknowledgeCompletion(lease.reservation.reservationId);
+    expect(parent.getUsageSummary?.()).toMatchObject({
+      costUsd: 0, heldCostUsd: 0.5, hasUnknownCost: true, totalTokens: 51, modelCalls: 1,
+    });
+  });
+
+  it("reports provider-reported overrun cost rather than its reservation", async () => {
+    const parent = bind(createKernel(), "parent");
+    const lease = await reserve(parent, "overrun");
+    parent.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    parent.reconcile(lease.reservation.reservationId, { inputTokens: 10, outputTokens: 5, costUsd: 0.75 });
+    parent.acknowledgeCompletion(lease.reservation.reservationId);
+    expect(parent.getUsageSummary?.()).toMatchObject({ costUsd: 0.75, heldCostUsd: 0, hasUnknownCost: false });
+  });
+
+  it("restores aggregate usage from SQLite after restart without counting it again", async () => {
+    const first = createKernel();
+    const parent = bind(first, "parent");
+    await spend(parent.forSession({ runId: "worker", sessionId: "worker" }), "work", 0.2);
+    const before = parent.getUsageSummary?.();
+    first.close();
+    const restored = bind(createKernel(), "parent");
+    expect(restored.getUsageSummary?.()).toMatchObject({ costUsd: 0.2, modelCalls: 1 });
+    expect(restored.getUsageSummary?.().sequence).toBeGreaterThanOrEqual(before!.sequence);
+    await spend(restored, "follow-up", 0.1);
+    expect(restored.getUsageSummary?.()).toMatchObject({ costUsd: 0.3, modelCalls: 2 });
+  });
+
+  it("projects initial and child usage into the parent stream and unsubscribes cleanly", async () => {
+    const parent = bind(createKernel(), "parent");
+    const child = parent.forSession({ runId: "worker", sessionId: "worker" });
+    const events: EventMsg[] = [];
+    const session = {
+      emit(event: Event): Event {
+        events.push(event.msg);
+        return event;
+      },
+    } as unknown as Session;
+    const unbind = bindExecutionAdmissionJournal(session, parent);
+    expect(events.some((event) => event.type === "session_usage" && event.payload.costUsd === 0)).toBe(true);
+    await spend(child, "work", 0.25);
+    const snapshots = events.filter((event) => event.type === "session_usage");
+    expect(snapshots.at(-1)?.payload).toMatchObject({ costUsd: 0.25, agents: [{ runId: "worker", costUsd: 0.25 }] });
+    expect(events.some((event) => event.type === "execution_admission" && event.payload.runId === "worker")).toBe(false);
+    unbind();
+    const count = events.length;
+    await spend(child, "after-unbind", 0.1);
+    expect(events).toHaveLength(count);
+  });
+});

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -884,10 +884,10 @@ describe("strict canonical journal contract", () => {
   });
 
   it("keeps an exhaustive fail-closed schema for every known event discriminant", () => {
-    expect(KNOWN_EVENT_TYPES.size).toBe(83);
+    expect(KNOWN_EVENT_TYPES.size).toBe(84);
     expect(CANONICAL_EVENT_SCHEMA_TYPES).toEqual([...KNOWN_EVENT_TYPES].sort());
     expect(CANONICAL_EVENT_SCHEMA_TYPES).toEqual(
-      expect.arrayContaining(["run_suspended", "run_resumed"]),
+      expect.arrayContaining(["run_suspended", "run_resumed", "session_usage"]),
     );
     const eventsWithoutRequiredFields = new Set([
       "context_compacted",

--- a/runtime/tests/tools/AgentTool/inProcessRunner.compaction.test.ts
+++ b/runtime/tests/tools/AgentTool/inProcessRunner.compaction.test.ts
@@ -325,7 +325,24 @@ describe('in-process teammate canonical rollout ownership', () => {
       ).toHaveLength(1)
 
       const parentJournalAfter = harness.store.readAll()
-      expect(parentJournalAfter).toEqual(parentJournalBefore)
+      expect(parentJournalAfter.slice(0, parentJournalBefore.length)).toEqual(parentJournalBefore)
+      const addedUsage = parentJournalAfter.slice(parentJournalBefore.length)
+      expect(addedUsage.length).toBeGreaterThan(0)
+      for (const item of addedUsage) {
+        expect(item).toMatchObject({
+          type: 'event_msg',
+          payload: { msg: { type: 'session_usage', payload: { runId: parent.conversationId } } },
+        })
+      }
+      const lastUsage = addedUsage.at(-1)
+      if (lastUsage?.type !== 'event_msg' || lastUsage.payload.msg.type !== 'session_usage') {
+        throw new Error('missing parent usage snapshot')
+      }
+      expect(lastUsage.payload.msg.payload).toEqual(rootAdmission.getUsageSummary?.())
+      expect(lastUsage.payload.msg.payload).toMatchObject({
+        inputTokens: 128, outputTokens: 128, modelCalls: 1, heldCostUsd: 0, hasUnknownCost: false,
+      })
+      expect(lastUsage.payload.msg.payload.costUsd).toBeGreaterThan(0)
       expect(JSON.stringify(parentJournalAfter)).not.toContain(
         'teammate-tool-1',
       )

--- a/runtime/tests/tools/ScheduleCronTool.execution.test.ts
+++ b/runtime/tests/tools/ScheduleCronTool.execution.test.ts
@@ -77,3 +77,16 @@ test("ScheduleCron tools create, list, and delete a session cron job", async () 
   const afterDelete = await CronListTool.call({}, toolContext);
   expect(afterDelete.data.jobs).toEqual([]);
 });
+
+test("ScheduleCron defaults to session-only jobs while delivery forces durability", async () => {
+  await setTempProjectRoot();
+  const local = await CronCreateTool.call({
+    cron: "*/5 * * * *", prompt: "local default",
+  }, toolContext);
+  expect(local.data.durable).toBe(false);
+  const delivery = await CronCreateTool.call({
+    cron: "*/5 * * * *", prompt: "delivery default", durable: false,
+    announceChannel: "stdio", announceTo: "test-recipient",
+  }, toolContext);
+  expect(delivery.data.durable).toBe(true);
+});

--- a/runtime/tests/tui/components/FullscreenLayout.session-usage.test.tsx
+++ b/runtime/tests/tui/components/FullscreenLayout.session-usage.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { FullscreenLayout } from "./FullscreenLayout.js";
+import { FullscreenModeProvider } from "../context/fullscreenModeContext.js";
+import { SessionUsageContext } from "../context/sessionUsageContext.js";
+import { AppStateProvider, getDefaultAppState } from "../state/AppState.js";
+import { Text } from "../ink.js";
+import { renderToString } from "../../utils/staticRender.js";
+
+const mocks = vi.hoisted(() => ({ getTotalCost: vi.fn(() => 9) }));
+
+vi.mock("../../cost/tracker.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../cost/tracker.js")>(),
+  getTotalCost: mocks.getTotalCost,
+}));
+
+beforeEach(() => mocks.getTotalCost.mockClear());
+afterEach(() => vi.restoreAllMocks());
+
+describe("alternate fullscreen canonical spend", () => {
+  test.each([
+    [{ costUsd: 1.25, hasUnknownCost: false }, "$1.25"],
+    [{ costUsd: 0, hasUnknownCost: false }, "$0.00"],
+    [{ costUsd: 0.5, hasUnknownCost: true }, "$0.500 +?"],
+    [null, "—"],
+  ] as const)("renders the scoped snapshot %j without sidecar polling", async (usage, label) => {
+    const timer = vi.spyOn(globalThis, "setInterval");
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <SessionUsageContext value={usage}>
+          <FullscreenModeProvider enabled>
+            <FullscreenLayout scrollable={<Text>ready</Text>} bottom={<Text>prompt</Text>} />
+          </FullscreenModeProvider>
+        </SessionUsageContext>
+      </AppStateProvider>,
+      { columns: 100, rows: 24 },
+    );
+    expect(output).toContain(`spend ${label}`);
+    expect(mocks.getTotalCost).not.toHaveBeenCalled();
+    expect(timer.mock.calls.some((call) => call[1] === 5_000)).toBe(false);
+  });
+
+  test("retains the sidecar fallback outside a daemon usage provider", async () => {
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <FullscreenModeProvider enabled>
+          <FullscreenLayout scrollable={<Text>ready</Text>} bottom={<Text>prompt</Text>} />
+        </FullscreenModeProvider>
+      </AppStateProvider>,
+      { columns: 100, rows: 24 },
+    );
+    expect(output).toContain("spend $9.00");
+    expect(mocks.getTotalCost).toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -3054,6 +3054,47 @@ describe("AgenC TUI daemon session adapter", () => {
     ]);
   });
 
+  it("sends only owned status-line identity and presentation with transport cancellation", async () => {
+    const client = createClient();
+    const request = vi.spyOn(client, "request").mockResolvedValue({ status: "rendered", text: "daemon-cost" });
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1",
+    });
+    const controller = new AbortController();
+    await expect(session.executeDaemonStatusLine?.({
+      vimMode: "NORMAL", sessionId: "foreign-session", command: "never-send", cost: 100,
+    }, controller.signal)).resolves.toEqual({ status: "rendered", text: "daemon-cost" });
+    expect(request).toHaveBeenCalledWith("session.statusLine.execute", {
+      sessionId: "session_1", presentation: { vimMode: "NORMAL" },
+    }, { signal: controller.signal });
+    request.mockRestore();
+  });
+
+  it.each([
+    [new AgenCDaemonResponseError({ code: -32601, message: "unsupported" }), "unavailable", "unsupported_method"],
+    [new Error("private transport detail"), "error", "request_failed"],
+  ] as const)("does not retry status-line transport failure %s", async (error, status, reason) => {
+    const client = createClient();
+    const request = vi.spyOn(client, "request").mockRejectedValue(error);
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1",
+    });
+    await expect(session.executeDaemonStatusLine?.({})).resolves.toEqual({ status, reason });
+    expect(request).toHaveBeenCalledOnce();
+    request.mockRestore();
+  });
+
+  it("does not dispatch a status-line request with an already cancelled signal", async () => {
+    const client = createClient();
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1",
+    });
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled status"));
+    await expect(session.executeDaemonStatusLine?.({}, controller.signal)).rejects.toThrow("cancelled status");
+    expect(client.requests).toHaveLength(0);
+  });
+
   it("forwards setDaemonHooksDisabled to the daemon session.hooks.setDisabled RPC", async () => {
     const client = createClient();
     const session = createDaemonTuiSession({

--- a/runtime/tests/tui/parity/session-transcript-hook.streaming-tool-use.parity.test.ts
+++ b/runtime/tests/tui/parity/session-transcript-hook.streaming-tool-use.parity.test.ts
@@ -17,8 +17,9 @@ describe("R5 useSessionTranscript exposes streamingToolUses on transcript snapsh
       /const\s+adapted\s*=\s*adaptTranscriptEvents\s*\(\s*state\.events\s*,\s*startupMessages\s*\)/,
     );
     expect(source).toMatch(
-      /return\s+adapted\.sessionCostUsd\s*===\s*state\.sessionCostUsd\s*\?\s*adapted\s*:\s*\{\s*\.\.\.adapted\s*,\s*sessionCostUsd:\s*state\.sessionCostUsd\s*\}/s,
+      /return\s+\{\s*\.\.\.adapted\s*,\s*sessionCostUsd:\s*state\.sessionUsage\?\.costUsd\s*\?\?\s*state\.sessionCostUsd\s*,\s*sessionUsage:\s*state\.sessionUsage\s*,?\s*\}/s,
     );
+    expect(source).toMatch(/\[state\.events,\s*state\.sessionCostUsd,\s*state\.sessionUsage,\s*startupMessages\]/);
   });
 
   test("B5.6 the snapshot returned by adaptTranscriptEvents always has streamingToolUses, including in the no-events case the hook produces on first mount", () => {

--- a/runtime/tests/tui/session-usage-display.test.tsx
+++ b/runtime/tests/tui/session-usage-display.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { CostReport } from "../../src/commands/cost.js";
+import { CostUsageModal } from "../../src/tui/components/v2/CostUsageModal.js";
+import { AppStateProvider, getDefaultAppState } from "../../src/tui/state/AppState.js";
+import { AgentsRail } from "../../src/tui/workbench/agents/AgentsRail.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+vi.mock("../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybindings: () => {},
+}));
+
+describe("canonical session usage display", () => {
+  it("renders recorded worker cost instead of its competing token estimate", async () => {
+    const report: CostReport = {
+      totalCostUsd: 1.071394005, hasUnknownCost: false, models: [],
+      agents: [{ label: "test worker", status: "completed", costUsd: 0.230392001, estimatedCostUsd: 9 }],
+    };
+    const output = await renderToString(<CostUsageModal report={report} onDone={() => {}} active={false} />, 120);
+    expect(output).toContain("$1.07");
+    expect(output).toContain("$0.23");
+    expect(output).not.toContain("$9.00");
+  });
+
+  it.each([false, true])("renders aggregate rail spending with unknown=%s", async (unknown) => {
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <AgentsRail width={45} focused={false} sessionCostUsd={1.071394005} sessionCostUnknown={unknown} />
+      </AppStateProvider>,
+      100,
+    );
+    expect(output).toContain("$1.07");
+    expect(output.includes("$1.07+?")).toBe(unknown);
+  });
+});

--- a/runtime/tests/tui/session-usage-observer.integration.test.ts
+++ b/runtime/tests/tui/session-usage-observer.integration.test.ts
@@ -1,0 +1,118 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { daemonEventFromUnboundSessionEvent } from "../../src/app-server/background-agent-runner/daemon-events.js";
+import { sessionTranscriptV2FromRollout } from "../../src/app-server/background-agent-runner/journal-reconstruction.js";
+import { buildCanonicalRunReplay } from "../../src/app-server/run-journal-replay.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+import type { AdmissionUsageSummary } from "../../src/budget/admission-types.js";
+import type { EventMsg } from "../../src/session/event-log.js";
+import type { RolloutItem } from "../../src/session/rollout-item.js";
+import { isCanonicalEventPayload } from "../../src/state/recovery-journal-schema.js";
+import { daemonTranscriptSnapshotCoversEvent, daemonTranscriptSnapshotEvents } from "../../src/tui/daemon-transcript-snapshot.js";
+
+function usage(sequence = 10, runId = "parent"): AdmissionUsageSummary {
+  return {
+    runId, sequence, costUsd: 1.25, heldCostUsd: 0.5,
+    inputTokens: 100, outputTokens: 20, totalTokens: 120,
+    modelCalls: 2, hasUnknownCost: true, models: [], agents: [],
+  };
+}
+
+function event(sequence: number, msg: EventMsg): Extract<RolloutItem, { type: "event_msg" }> {
+  return {
+    type: "event_msg",
+    payload: { id: `event:${sequence}`, eventId: `event:${sequence}`, seq: sequence, msg },
+  };
+}
+
+function notification(item: Extract<RolloutItem, { type: "event_msg" }>): JsonObject {
+  return { params: { runId: "parent", sequence: item.payload.seq, eventId: item.payload.eventId } };
+}
+
+function transcript(item: Extract<RolloutItem, { type: "event_msg" }>): JsonObject {
+  return { ...item.payload.msg, eventId: item.payload.eventId } as JsonObject;
+}
+
+describe("canonical session usage observer integration", () => {
+  it("accepts zero-sequence initial snapshots and finite cumulative totals", () => {
+    expect(isCanonicalEventPayload("session_usage", usage(0))).toBe(true);
+    expect(isCanonicalEventPayload("session_usage", usage())).toBe(true);
+  });
+
+  it.each([
+    { sequence: -1 }, { sequence: 1.5 }, { costUsd: -1 }, { heldCostUsd: Infinity },
+    { totalTokens: 1.5 }, { inputTokens: -1 }, { hasUnknownCost: "false" },
+    { models: [{ model: "invalid" }] }, { agents: [{ runId: "invalid" }] }, { runId: "" },
+  ])("rejects malformed usage payloads %j", (invalid) => {
+    expect(isCanonicalEventPayload("session_usage", { ...usage(), ...invalid })).toBe(false);
+  });
+
+  it("forwards the original live canonical event identity", () => {
+    const item = event(1, { type: "session_usage", payload: usage() });
+    expect(daemonEventFromUnboundSessionEvent(item.payload)).toMatchObject({
+      id: "event:1", eventId: "event:1", sequence: 1,
+      type: "session_usage", payload: usage(),
+    });
+    expect(daemonEventFromUnboundSessionEvent({ msg: item.payload.msg })).toBeNull();
+  });
+
+  it("restores only the newest matching run snapshot across history resets", () => {
+    const old = event(1, { type: "session_usage", payload: usage(10) });
+    const current = event(2, { type: "session_usage", payload: usage(20) });
+    const items: RolloutItem[] = [
+      old, current,
+      event(3, { type: "session_usage", payload: usage(30, "compact-child") }),
+      event(4, { type: "session_usage", payload: usage(15) }),
+      event(5, { type: "history_cleared", payload: {} }),
+    ];
+    const snapshot = sessionTranscriptV2FromRollout(items, "session", "parent");
+    expect(snapshot.events?.filter((entry) => entry.type === "session_usage")).toEqual([
+      { eventId: "event:2", committedSequence: 2, type: "session_usage", payload: usage(20) },
+    ]);
+    const restored = daemonTranscriptSnapshotEvents(snapshot, "session");
+    expect(restored.filter((entry) => entry.type === "session_usage")).toHaveLength(1);
+    expect(restored[0]?.payload).toEqual(usage(20));
+    for (const item of [old, current]) {
+      expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(item), transcript(item))).toBe(true);
+    }
+    const later = event(6, { type: "session_usage", payload: usage(21) });
+    expect(daemonTranscriptSnapshotCoversEvent(snapshot, notification(later), transcript(later))).toBe(false);
+    expect(daemonTranscriptSnapshotCoversEvent({ ...snapshot, events: undefined }, notification(old), transcript(old))).toBe(false);
+  });
+
+  it.each([usage(3, "another-run"), { ...usage(), heldCostUsd: -1 }])(
+    "rejects mismatched or malformed usage in daemon snapshots",
+    (payload) => {
+      const snapshot = sessionTranscriptV2FromRollout([], "session", "parent");
+      expect(() => daemonTranscriptSnapshotEvents({
+        ...snapshot,
+        asOfSequence: 1,
+        events: [{ eventId: "usage", committedSequence: 1, type: "session_usage", payload }],
+      }, "session")).toThrow(/invalid transcript notice/);
+    },
+  );
+
+  it("classifies canonical usage replay as budget evidence", () => {
+    const database = new Database(":memory:");
+    try {
+      database.exec(`
+        CREATE TABLE threads (thread_id TEXT PRIMARY KEY, rollout_path TEXT, archived_rollout_path TEXT);
+        CREATE TABLE thread_rollout_items (
+          id INTEGER PRIMARY KEY, thread_id TEXT, source_path TEXT, item_index INTEGER,
+          item_type TEXT, event_id TEXT, event_seq INTEGER, payload_json TEXT
+        );
+        INSERT INTO threads VALUES ('parent', '/rollout/parent.jsonl', NULL);
+      `);
+      const item = event(1, { type: "session_usage", payload: usage() });
+      database.prepare("INSERT INTO thread_rollout_items VALUES (1, 'parent', '/rollout/parent.jsonl', 1, 'event_msg', 'event:1', 1, ?)")
+        .run(JSON.stringify(item.payload));
+      const replay = buildCanonicalRunReplay(database, {
+        projectDir: "/project", stateDbPath: "/project/state.sqlite", logsDbPath: "/project/logs.sqlite",
+      }, "parent", 0, 10);
+      expect(replay.events).toMatchObject([{ category: "budget", kind: "session_usage", payload: usage() }]);
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/runtime/tests/tui/session-usage-summary.test.ts
+++ b/runtime/tests/tui/session-usage-summary.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import type { AdmissionUsageSummary, AdmissionUsageTotals } from "../../src/budget/admission-types.js";
+import { buildCostReport, formatCostReport } from "../../src/commands/cost.js";
+import type { SlashCommandContext } from "../../src/commands/types.js";
+import { CostSidecar } from "../../src/session/cost.js";
+import { isAdmissionUsageSummary, latestSessionUsage } from "../../src/session/usage-summary.js";
+import {
+  adaptTranscriptEvents,
+  appendSessionTranscriptBatchForTesting,
+  appendSessionTranscriptEventForTesting,
+  createSessionTranscriptStateForTesting,
+  type SessionTranscriptEvent,
+} from "../../src/tui/session-transcript.js";
+
+function totals(costUsd: number): AdmissionUsageTotals {
+  return { costUsd, inputTokens: 20, outputTokens: 10, totalTokens: 30, modelCalls: 1, hasUnknownCost: false, heldCostUsd: 0 };
+}
+
+function summary(sequence = 10, costUsd = 1.071394005): AdmissionUsageSummary {
+  return {
+    ...totals(costUsd), runId: "parent", sequence,
+    models: [{ ...totals(costUsd), model: "grok-4.6", provider: "grok" }],
+    agents: [{ ...totals(0.230392001), runId: "worker" }],
+  };
+}
+
+function usageEvent(value: unknown, seq = 1): SessionTranscriptEvent {
+  return { id: `event-${seq}`, seq, type: "session_usage", payload: value };
+}
+
+function commandContext(usage?: AdmissionUsageSummary): SlashCommandContext {
+  return {
+    session: { services: { costSidecar: new CostSidecar() } } as SlashCommandContext["session"],
+    argsRaw: "", cwd: "/tmp/project", home: "/tmp",
+    appState: {
+      ...(usage !== undefined ? { getSessionUsage: () => usage } : {}),
+      getAppState: () => ({ tasks: {
+        worker: { agentId: "worker", type: "local_agent", agentType: "runner", description: "Worker", status: "completed", model: "grok-4.6", progress: { tokenCount: 80000 } },
+      } }),
+    },
+  };
+}
+
+describe("session usage projection", () => {
+  it("uses the same exact aggregate for transcript and cost report without adding worker rows again", () => {
+    const usage = summary();
+    const transcript = adaptTranscriptEvents([
+      { type: "token_count", payload: { promptTokens: 1000, completionTokens: 200, model: "grok-4.6", provider: "grok" } },
+      usageEvent(usage),
+      { type: "token_count", payload: { promptTokens: 1000, completionTokens: 200, model: "grok-4.6", provider: "grok" } },
+    ]);
+    const report = buildCostReport(commandContext(usage));
+    expect(transcript.sessionCostUsd).toBe(usage.costUsd);
+    expect(report.totalCostUsd).toBe(transcript.sessionCostUsd);
+    expect(report.totalIsEstimated).toBeUndefined();
+    expect(report.agents[0]).toMatchObject({ costUsd: 0.230392001, tokenCount: 30, status: "completed" });
+    expect(report.agents[0]!.estimatedCostUsd).toBeUndefined();
+    expect(formatCostReport(report)).toContain("Session cost: $1.07");
+    expect(transcript.latestUsage?.input_tokens).toBe(1000);
+  });
+
+  it("restores a snapshot even when no parent token_count events remain", () => {
+    const usage = summary();
+    const transcript = adaptTranscriptEvents([usageEvent(usage)]);
+    expect(transcript.sessionCostUsd).toBe(usage.costUsd);
+    expect(transcript.sessionUsage).toEqual(usage);
+    expect(transcript.latestUsage).toBeNull();
+  });
+
+  it("preserves cumulative usage over history resets, event eviction and out-of-order batches", () => {
+    let state = createSessionTranscriptStateForTesting([usageEvent(summary(), 1)]);
+    state = appendSessionTranscriptBatchForTesting(state, Array.from({ length: 4100 }, (_, index) => ({
+      type: "warning", id: `padding-${index}`, seq: index + 2, payload: { message: "padding" },
+    })));
+    expect(state.events.some((event) => "type" in event && event.type === "session_usage")).toBe(false);
+    expect(state.sessionUsage?.costUsd).toBe(1.071394005);
+    state = appendSessionTranscriptBatchForTesting(state, [
+      { type: "history_cleared", id: "clear", seq: 4102, payload: {} },
+      usageEvent(summary(11, 1.2), 4103),
+      usageEvent(summary(9, 0.9), 2),
+    ]);
+    expect(state.sessionUsage).toEqual(summary(11, 1.2));
+    state = appendSessionTranscriptEventForTesting(state, usageEvent(summary(8, 0.8), 1));
+    expect(state.sessionUsage).toEqual(summary(11, 1.2));
+    const restored = createSessionTranscriptStateForTesting([usageEvent(summary(11, 1.2))]);
+    expect(restored.sessionUsage).toEqual(state.sessionUsage);
+  });
+
+  it("ignores replay duplicates and foreign compact-child snapshots", () => {
+    const usage = summary();
+    expect(latestSessionUsage(usage, usageEvent(summary()))).toBe(usage);
+    expect(latestSessionUsage(usage, usageEvent({ ...summary(12), runId: "compact-child" }))).toBe(usage);
+    expect(latestSessionUsage(usage, { msg: { type: "session_usage", payload: summary(11, 1.2) } })).toEqual(summary(11, 1.2));
+  });
+
+  it.each([
+    { costUsd: Number.NaN }, { costUsd: -1 }, { heldCostUsd: Number.POSITIVE_INFINITY },
+    { sequence: -1 }, { totalTokens: 1.5 }, { hasUnknownCost: "false" },
+    { models: [{}] }, { agents: [{ ...totals(1), runId: "" }] },
+  ])("ignores malformed usage fields %j", (invalid) => {
+    const usage = summary();
+    const malformed = { ...summary(11), ...invalid };
+    expect(isAdmissionUsageSummary(malformed)).toBe(false);
+    expect(latestSessionUsage(usage, usageEvent(malformed))).toBe(usage);
+  });
+
+  it("marks unknown cost and never substitutes the reserved amount for actual spend", () => {
+    const usage = { ...summary(), costUsd: 0.4, heldCostUsd: 2, hasUnknownCost: true };
+    const report = buildCostReport(commandContext(usage));
+    expect(report.totalCostUsd).toBe(0.4);
+    expect(report.hasUnknownCost).toBe(true);
+    expect(formatCostReport(report)).toContain("some pricing unknown");
+  });
+
+  it("preserves actual ledger rows after the worker disappears from the UI task list", () => {
+    const context = commandContext(summary());
+    const report = buildCostReport({ ...context, appState: { getSessionUsage: () => summary() } });
+    expect(report.agents[0]).toMatchObject({ label: "worker", status: "recorded", costUsd: 0.230392001 });
+    expect(report.totalCostUsd).toBe(1.071394005);
+  });
+
+  it("reads the live admission summary in an in-process command context", () => {
+    const usage = summary();
+    const context = commandContext();
+    const report = buildCostReport({
+      ...context,
+      session: { services: { executionAdmission: { getUsageSummary: () => usage } } } as SlashCommandContext["session"],
+    });
+    expect(report.totalCostUsd).toBe(usage.costUsd);
+  });
+
+  it("binds real CostSidecar accessors when canonical usage is unavailable", () => {
+    expect(() => buildCostReport(commandContext())).not.toThrow();
+    expect(buildCostReport(commandContext()).totalCostUsd).toBe(0);
+    expect(buildCostReport(commandContext()).hasUnknownCost).toBe(true);
+  });
+});

--- a/runtime/tests/tui/startup/StatusLine.test.tsx
+++ b/runtime/tests/tui/startup/StatusLine.test.tsx
@@ -1,11 +1,13 @@
 import { PassThrough } from 'node:stream'
 
 import React from 'react'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { createRoot } from '../ink/root.js'
 import { TEST_REMOTE_AUTH_SESSION_CONTEXT } from '../remoteAuthSessionContext.fixture.js'
 import { StatusLine } from './StatusLine.js'
+import { SessionUsageContext } from '../context/sessionUsageContext.js'
+import { StatusLineExecutionContext, type DaemonStatusLineExecutor } from '../context/statusLineExecutionContext.js'
 
 const mocks = vi.hoisted(() => ({
   appState: {
@@ -16,6 +18,8 @@ const mocks = vi.hoisted(() => ({
     statusLineText: '',
   } as Record<string, unknown>,
   executeStatusLineCommand: vi.fn(async () => 'custom-status'),
+  getTotalCost: vi.fn(() => 9),
+  addNotification: vi.fn(),
 }))
 
 vi.mock('bun:bundle', () => ({
@@ -42,7 +46,7 @@ vi.mock('../../bootstrap/state.js', () => ({
 
 vi.mock('../../cost/tracker.js', () => ({
   getTotalAPIDuration: () => 0,
-  getTotalCost: () => 0,
+  getTotalCost: mocks.getTotalCost,
   getTotalDuration: () => 0,
   getTotalInputTokens: () => 0,
   getTotalLinesAdded: () => 0,
@@ -62,7 +66,7 @@ vi.mock('../hooks/useSettings.js', () => ({
 
 vi.mock('../context/notifications.js', () => ({
   useNotifications: () => ({
-    addNotification: vi.fn(),
+    addNotification: mocks.addNotification,
   }),
 }))
 
@@ -177,7 +181,9 @@ function createTestStreams(): {
 }
 
 describe('StatusLine vim mode display', () => {
+  afterEach(() => vi.unstubAllGlobals())
   beforeEach(() => {
+    vi.stubGlobal('MACRO', { VERSION: '99.0.0-test' })
     mocks.appState = {
       toolPermissionContext: {
         mode: 'default',
@@ -186,6 +192,8 @@ describe('StatusLine vim mode display', () => {
       statusLineText: '',
     }
     mocks.executeStatusLineCommand.mockClear()
+    mocks.getTotalCost.mockClear()
+    mocks.addNotification.mockClear()
   })
 
   test.each(['NORMAL', 'INSERT'] as const)(
@@ -217,4 +225,316 @@ describe('StatusLine vim mode display', () => {
       expect(output()).toContain(`-- ${vimMode} --`)
     },
   )
+
+  test.each([
+    [{ costUsd: 0, hasUnknownCost: false }, 0, false],
+    [{ costUsd: 1.25, hasUnknownCost: true }, 1.25, true],
+    [null, 0, true],
+  ] as const)('passes scoped cost and unknown pricing for %j', async (usage, costUsd, unknown) => {
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+    try {
+      root.render(
+        <SessionUsageContext value={usage}>
+          <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+            providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+        </SessionUsageContext>,
+      )
+      await sleep(25)
+      expect(mocks.executeStatusLineCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ cost: expect.objectContaining({ total_cost_usd: costUsd, has_unknown_cost: unknown }) }),
+        expect.any(AbortSignal), undefined, true,
+      )
+      expect(mocks.getTotalCost).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('refreshes child-only usage changes without a new assistant message', async () => {
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+    const statusLine = <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+      providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+    try {
+      root.render(<SessionUsageContext value={{ costUsd: 0.25, hasUnknownCost: false }}>{statusLine}</SessionUsageContext>)
+      await sleep(25)
+      mocks.executeStatusLineCommand.mockClear()
+      root.render(<SessionUsageContext value={{ costUsd: 0.75, hasUnknownCost: true }}>{statusLine}</SessionUsageContext>)
+      await sleep(350)
+      expect(mocks.executeStatusLineCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ cost: expect.objectContaining({ total_cost_usd: 0.75, has_unknown_cost: true }) }),
+        expect.any(AbortSignal), undefined, expect.any(Boolean),
+      )
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('executes only the daemon command with presentation, never local identity or cost', async () => {
+    const execute = vi.fn<DaemonStatusLineExecutor>(async () => ({ status: 'rendered', text: 'daemon-status' }))
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+          providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} vimMode="NORMAL" />
+      </StatusLineExecutionContext>)
+      await sleep(25)
+      expect(execute).toHaveBeenCalledWith({ vimMode: 'NORMAL' }, expect.any(AbortSignal))
+      expect(mocks.appState.statusLineText).toBe('daemon-status')
+      expect(mocks.executeStatusLineCommand).not.toHaveBeenCalled()
+      expect(mocks.getTotalCost).not.toHaveBeenCalled()
+      expect(mocks.addNotification).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test.each(['disabled', 'blocked', 'unavailable', 'error', 'rejected'] as const)(
+    'clears stale text without local fallback when daemon status is %s', async status => {
+      mocks.appState.statusLineText = 'stale-status'
+      const execute = vi.fn<DaemonStatusLineExecutor>(async () => {
+        if (status === 'rejected') throw new Error('transport failed')
+        return { status, reason: 'not_available', text: 'must-not-render' }
+      })
+      const { stdout, stdin } = createTestStreams()
+      const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+      try {
+        root.render(<StatusLineExecutionContext value={execute}>
+          <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+            providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+        </StatusLineExecutionContext>)
+        await sleep(25)
+        expect(execute).toHaveBeenCalledOnce()
+        expect(mocks.appState.statusLineText).toBe('')
+        expect(mocks.executeStatusLineCommand).not.toHaveBeenCalled()
+      } finally {
+        root.unmount()
+        stdin.end()
+        stdout.end()
+      }
+    },
+  )
+
+  test('cancels superseded daemon renders and ignores late settlement after unmount', async () => {
+    let resolvePrevious: ((value: { status: 'rendered'; text: string }) => void) | undefined
+    const previous = vi.fn<DaemonStatusLineExecutor>(() => new Promise(resolve => { resolvePrevious = resolve }))
+    let currentSignal: AbortSignal | undefined
+    const current = vi.fn<DaemonStatusLineExecutor>(async (_presentation, signal) => {
+      currentSignal = signal
+      return { status: 'rendered', text: 'current-session' }
+    })
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    const child = <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+      providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+    try {
+      root.render(<StatusLineExecutionContext value={previous}>{child}</StatusLineExecutionContext>)
+      await sleep(25)
+      const previousSignal = previous.mock.calls[0]?.[1]
+      expect(previousSignal?.aborted).toBe(false)
+      root.render(<StatusLineExecutionContext value={current}>{child}</StatusLineExecutionContext>)
+      await sleep(25)
+      expect(previousSignal?.aborted).toBe(true)
+      expect(mocks.appState.statusLineText).toBe('current-session')
+      root.unmount()
+      expect(currentSignal?.aborted).toBe(true)
+      resolvePrevious?.({ status: 'rendered', text: 'stale-session' })
+      await sleep(10)
+      expect(mocks.appState.statusLineText).toBe('current-session')
+      expect(mocks.executeStatusLineCommand).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('refreshes the daemon on child cost settlement with no assistant-message change', async () => {
+    const execute = vi.fn<DaemonStatusLineExecutor>(async () => ({ status: 'rendered', text: 'aggregate' }))
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    const child = <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+      providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <SessionUsageContext value={{ costUsd: 0, hasUnknownCost: false }}>{child}</SessionUsageContext>
+      </StatusLineExecutionContext>)
+      await sleep(25)
+      expect(execute).toHaveBeenCalledOnce()
+      root.render(<StatusLineExecutionContext value={execute}>
+        <SessionUsageContext value={{ costUsd: 1.25, hasUnknownCost: true }}>{child}</SessionUsageContext>
+      </StatusLineExecutionContext>)
+      await sleep(350)
+      expect(execute).toHaveBeenCalledTimes(2)
+      expect(mocks.executeStatusLineCommand).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('never reports a stale daemon policy decision after the renderer unmounts', async () => {
+    let resolve: ((value: { status: 'blocked'; reason: string }) => void) | undefined
+    const execute = vi.fn<DaemonStatusLineExecutor>(() => new Promise(settle => { resolve = settle }))
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+          providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+      </StatusLineExecutionContext>)
+      await sleep(25)
+      root.unmount()
+      resolve?.({ status: 'blocked', reason: 'untrusted_workspace' })
+      await sleep(10)
+      expect(execute.mock.calls[0]?.[1]?.aborted).toBe(true)
+      expect(mocks.addNotification).not.toHaveBeenCalled()
+      expect(mocks.executeStatusLineCommand).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('waits for the previous daemon process to drain without blanking the current status', async () => {
+    mocks.appState.statusLineText = 'last-valid-status'
+    const execute = vi.fn<DaemonStatusLineExecutor>()
+      .mockResolvedValueOnce({ status: 'unavailable', reason: 'busy' })
+      .mockResolvedValue({ status: 'rendered', text: 'drained-status' })
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+          providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+      </StatusLineExecutionContext>)
+      await sleep(25)
+      expect(execute).toHaveBeenCalledOnce()
+      expect(mocks.appState.statusLineText).toBe('last-valid-status')
+      await sleep(550)
+      expect(execute).toHaveBeenCalledTimes(2)
+      expect(mocks.appState.statusLineText).toBe('drained-status')
+      expect(mocks.executeStatusLineCommand).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('stops the bounded busy retry when the status line unmounts', async () => {
+    const execute = vi.fn<DaemonStatusLineExecutor>(async () => ({ status: 'unavailable', reason: 'busy' }))
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+          providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+      </StatusLineExecutionContext>)
+      await sleep(25)
+      root.unmount()
+      await sleep(550)
+      expect(execute).toHaveBeenCalledOnce()
+      expect(execute.mock.calls[0]?.[1]?.aborted).toBe(true)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('caps busy retries and keeps the last valid output', async () => {
+    mocks.appState.statusLineText = 'last-valid-status'
+    const execute = vi.fn<DaemonStatusLineExecutor>(async () => ({ status: 'unavailable', reason: 'busy' }))
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+          providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+      </StatusLineExecutionContext>)
+      await vi.advanceTimersByTimeAsync(5150)
+      expect(execute).toHaveBeenCalledTimes(10)
+      expect(mocks.appState.statusLineText).toBe('last-valid-status')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      vi.useRealTimers()
+    }
+  })
+
+  test.each([
+    [{ status: 'blocked', reason: 'untrusted_workspace' }, 'status line command blocked by session hook policy'],
+    [{ status: 'error', reason: 'timeout' }, 'status line command timed out'],
+    [{ status: 'unavailable', reason: 'unsupported_method' }, 'status line command is not supported by this daemon'],
+  ] as const)('shows a static notice for daemon result %j', async (result, text) => {
+    const execute = vi.fn<DaemonStatusLineExecutor>(async () => result)
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({ stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream, patchConsole: false })
+    try {
+      root.render(<StatusLineExecutionContext value={execute}>
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+          providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />
+      </StatusLineExecutionContext>)
+      await sleep(25)
+      expect(mocks.addNotification).toHaveBeenCalledOnce()
+      expect(mocks.addNotification).toHaveBeenCalledWith(expect.objectContaining({ text }))
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('retains legacy sidecar cost when no usage context exists', async () => {
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+    try {
+      root.render(<StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null}
+        providerContext={TEST_REMOTE_AUTH_SESSION_CONTEXT} />)
+      await sleep(25)
+      expect(mocks.executeStatusLineCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ cost: expect.objectContaining({ total_cost_usd: 9 }) }),
+        expect.any(AbortSignal), undefined, true,
+      )
+      expect(mocks.getTotalCost).toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- Execute custom status-line commands in the owning daemon session. The client sends presentation state only. Preserve workspace trust, managed policy, bare mode, sandboxing, admission, cancellation, and process cleanup.
- Run idle `/loop` jobs through the daemon session queue with atomic occurrence claims and cancellation. Make new CronCreate jobs session-only unless durability is requested.
- Include child-agent spending in canonical usage displays and the shared budget cap. Preserve unknown costs and usage observations across replay and compaction.
- Stop treating CronCreate prompt text as a destructive command. Report unborn Git branches correctly in `/status`.
- Add protocol 1.11 capability negotiation and keep the generated SDK declarations aligned.

## Verification

The custom-command PTY regression fails on the previous build because the command never executes. The updated check requires rendered custom output, a subprocess receipt matching canonical session usage, and dispatched/reconciled execution admission.

- Runtime and SDK builds, runtime/test-support/SDK typechecks, generated SDK parity, and real-PTY startup checks pass.
- Targeted checks pass: 142 client/UI tests, 53 hook/authority/process tests, 217 daemon ownership/lifecycle tests, 225 SDK tests, 16 protocol-contract tests, and 92 Linux/portable process tests. These groups overlap and are not a combined test count.
- PTY scenarios 135, 03, 69, and 132 pass against production commit `5c84624f8dc0`, including command execution, model completion, cost display, and the shared agent/editor workflow.
- The OS-isolated full suite reports 24,882 passing tests and seven failures. One failure was an outdated future-protocol fixture; the test-only follow-up `7e523718e32b` corrects it, and all 141 tests in that file pass. The other six failures reproduce on unchanged main and are listed below.
- Independent code and regression-test reviews approve both commits. The follow-up changes only eight version literals, leaving production code and build/PTY inputs unchanged.

Tests use temporary state and scripted providers, without paid model calls. The agent-surface check reaches the same pre-existing agent CLI contract failure; no contract is relaxed to pass it.

## Existing failures

Six failures were reproduced on unchanged main at `3326f14f08372ae22aaa4b98f3006655b3a98b81`: hermetic live-test discovery, the agent CLI local-MCP request contract, daemon crash-restart recovery, home-state authority inventory, FND source-bound benchmark metadata, and the legacy permission-import inventory. These checks remain unchanged.

Scheduler occurrence claims provide at-most-once acceptance, not lossless recovery from a crash after a claim. Scheduler tests cover real session queues and filesystem persistence; they do not simulate competing daemon processes or an OS kill after a tool effect.

Hosted test CI remains disabled. This PR does not publish a release or enable auto-merge.
