### PR TITLE
fix(permissions): recognize signed session plan files in checkPermissions

### DIFF
--- a/runtime/src/permissions/path-validation.ts
+++ b/runtime/src/permissions/path-validation.ts
@@ -33,6 +33,7 @@ import {
 import {
   withSignedAllowedRoots,
 } from "../agents/_deps/filesystem-args.js";
+import { matchesVerifiedSessionPlanFile } from "../tools/system/filesystem.js";
 import type {
   PermissionDecisionReason,
   PermissionResult,
@@ -666,6 +667,17 @@ export function checkToolPathPermission(
       behavior: "deny",
       message: `Permission to ${verb} ${opts.path} has been denied.`,
       decisionReason,
+    };
+  }
+
+  if (matchesVerifiedSessionPlanFile(opts.path, opts.cwd, opts.input)) {
+    return {
+      behavior: "allow",
+      updatedInput: opts.input,
+      decisionReason: {
+        type: "other",
+        reason: "Signed active-session plan file",
+      },
     };
   }
 

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -43,7 +43,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { resolve, dirname, basename, join } from "node:path";
+import { resolve, dirname, basename, join, isAbsolute, normalize } from "node:path";
 import { resolveHomeContext } from "../../config/home.js";
 // Imported from the defining module rather than the `memory/index.js` barrel.
 // The barrel re-exports the recall pipeline, which reaches `utils/ide.ts` and
@@ -1204,6 +1204,23 @@ export function verifiedPlanFileContextFromArgs(
     ...ctx,
     agencHome: resolveHomeContext({ AGENC_HOME: injectedAgencHome }).path,
   };
+}
+
+/**
+ * True when `targetPath` is the signed active-session plan-file family.
+ * Same authority as {@link safePathAllowingSessionPlanFile}: verified
+ * session id + injected home, exact plan prefix, no AGENC_HOME widening.
+ */
+export function matchesVerifiedSessionPlanFile(
+  targetPath: string,
+  cwd: string,
+  args: Record<string, unknown> | undefined,
+): boolean {
+  const planCtx = verifiedPlanFileContextFromArgs(args);
+  if (planCtx === null || hasUnsafeShape(targetPath)) return false;
+  const absolute = isAbsolute(targetPath) ? targetPath : resolve(cwd, targetPath);
+  const identity = normalizeFilesystemUnicodeIdentity(normalize(absolute));
+  return isSessionPlanFile(identity, planCtx);
 }
 
 export async function safePathAllowingSessionPlanFile(

--- a/runtime/tests/permissions/signed-session-plan-file.test.ts
+++ b/runtime/tests/permissions/signed-session-plan-file.test.ts
@@ -1,0 +1,260 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import type { ToolEvaluatorContext } from "../../src/permissions/evaluator.js";
+import { applyPermissionUpdate } from "../../src/permissions/permission-updates.js";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { createApplyPatchTool } from "../../src/tools/apply-patch/tool.js";
+import {
+  createFileEditTool,
+  createFileMultiEditTool,
+} from "../../src/tools/system/file-edit.js";
+import { createFileReadTool } from "../../src/tools/system/file-read.js";
+import { createFileWriteTool } from "../../src/tools/system/file-write.js";
+import {
+  SESSION_AGENC_HOME_ARG,
+  SESSION_ID_ARG,
+  SESSION_ID_SIG_ARG,
+  matchesVerifiedSessionPlanFile,
+  recordSessionRead,
+  signSessionId,
+} from "../../src/tools/system/filesystem.js";
+import {
+  clearAllPlanSlugs,
+  getPlanFilePath,
+  setPlanSlug,
+} from "../../src/planning/plan-files.js";
+
+describe("signed active-session plan file permissions", () => {
+  const sessionId = "test-session-plan-perm";
+  let workspace = "";
+  let agencHome = "";
+  let planPath = "";
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), "agenc-plan-perm-ws-"));
+    agencHome = await mkdtemp(join(tmpdir(), "agenc-plan-perm-home-"));
+    setPlanSlug({ agencHome, sessionId }, "ivory-bridge-aaed0227");
+    planPath = getPlanFilePath({ agencHome, sessionId });
+    await writeFile(planPath, "# Plan\n\n- [ ] Ship signed path\n", "utf8");
+  });
+
+  afterEach(async () => {
+    clearAllPlanSlugs();
+    if (workspace) await rm(workspace, { recursive: true, force: true });
+    if (agencHome) await rm(agencHome, { recursive: true, force: true });
+    workspace = "";
+    agencHome = "";
+    planPath = "";
+  });
+
+  function signedArgs(
+    extra: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      file_path: planPath,
+      cwd: workspace,
+      [SESSION_ID_ARG]: sessionId,
+      [SESSION_ID_SIG_ARG]: signSessionId(sessionId),
+      [SESSION_AGENC_HOME_ARG]: agencHome,
+      ...extra,
+    };
+  }
+
+  function evaluator(
+    mode: "acceptEdits" | "default" = "acceptEdits",
+    context = createEmptyToolPermissionContext({ mode }),
+  ): ToolEvaluatorContext {
+    return {
+      getAppState() {
+        return {
+          toolPermissionContext: context,
+          denialTracking: { consecutiveDenials: 0, totalDenials: 0 },
+          autoModeActive: false,
+        };
+      },
+      session: {},
+    } as ToolEvaluatorContext;
+  }
+
+  test("matchesVerifiedSessionPlanFile uses the same signed context as execute", () => {
+    expect(
+      matchesVerifiedSessionPlanFile(planPath, workspace, signedArgs()),
+    ).toBe(true);
+    expect(
+      matchesVerifiedSessionPlanFile(planPath, workspace, {
+        ...signedArgs(),
+        [SESSION_ID_SIG_ARG]: "deadbeef",
+      }),
+    ).toBe(false);
+    expect(
+      matchesVerifiedSessionPlanFile(
+        join(agencHome, "plans", "not-active.md"),
+        workspace,
+        signedArgs({ file_path: join(agencHome, "plans", "not-active.md") }),
+      ),
+    ).toBe(false);
+  });
+
+  test("FileRead checkPermissions allows the signed plan then execute succeeds", async () => {
+    const tool = createFileReadTool({ allowedPaths: [workspace] });
+    const permission = tool.checkPermissions?.(signedArgs(), evaluator());
+    expect(permission?.behavior).toBe("allow");
+    if (!permission || permission.behavior !== "allow") {
+      throw new Error("expected FileRead allow");
+    }
+    const result = await tool.execute(permission.updatedInput ?? signedArgs());
+    expect(result.isError).toBeUndefined();
+    expect(String(result.content)).toContain("Ship signed path");
+  });
+
+  test("Write checkPermissions allows the signed plan then execute succeeds", async () => {
+    const original = await readFile(planPath, "utf8");
+    const fileStats = await stat(planPath);
+    recordSessionRead(sessionId, planPath, {
+      content: original,
+      timestamp: fileStats.mtimeMs,
+      viewKind: "full",
+    });
+    const tool = createFileWriteTool({ allowedPaths: [workspace] });
+    const args = signedArgs({ content: "# Plan\n\n- [x] Wrote\n" });
+    const permission = tool.checkPermissions?.(args, evaluator());
+    expect(permission?.behavior).toBe("allow");
+    if (!permission || permission.behavior !== "allow") {
+      throw new Error("expected Write allow");
+    }
+    const result = await tool.execute(permission.updatedInput ?? args);
+    expect(result.isError).toBeUndefined();
+    await expect(readFile(planPath, "utf8")).resolves.toContain("Wrote");
+  });
+
+  test("Edit checkPermissions allows the signed plan then execute succeeds", async () => {
+    const original = await readFile(planPath, "utf8");
+    const fileStats = await stat(planPath);
+    recordSessionRead(sessionId, planPath, {
+      content: original,
+      timestamp: fileStats.mtimeMs,
+      viewKind: "full",
+    });
+    const tool = createFileEditTool({ allowedPaths: [workspace] });
+    const args = signedArgs({
+      old_string: "Ship signed path",
+      new_string: "Ship edit",
+    });
+    const permission = tool.checkPermissions?.(args, evaluator());
+    expect(permission?.behavior).toBe("allow");
+    if (!permission || permission.behavior !== "allow") {
+      throw new Error("expected Edit allow");
+    }
+    const result = await tool.execute(permission.updatedInput ?? args);
+    expect(result.isError).toBeUndefined();
+    await expect(readFile(planPath, "utf8")).resolves.toContain("Ship edit");
+  });
+
+  test("MultiEdit checkPermissions allows the signed plan then execute succeeds", async () => {
+    const original = await readFile(planPath, "utf8");
+    const fileStats = await stat(planPath);
+    recordSessionRead(sessionId, planPath, {
+      content: original,
+      timestamp: fileStats.mtimeMs,
+      viewKind: "full",
+    });
+    const tool = createFileMultiEditTool({ allowedPaths: [workspace] });
+    const args = signedArgs({
+      edits: [
+        { old_string: "Ship signed path", new_string: "Ship multi-edit" },
+      ],
+    });
+    const permission = tool.checkPermissions?.(args, evaluator());
+    expect(permission?.behavior).toBe("allow");
+    if (!permission || permission.behavior !== "allow") {
+      throw new Error("expected MultiEdit allow");
+    }
+    const result = await tool.execute(permission.updatedInput ?? args);
+    expect(result.isError).toBeUndefined();
+    await expect(readFile(planPath, "utf8")).resolves.toContain(
+      "Ship multi-edit",
+    );
+  });
+
+  test("apply_patch checkPermissions allows the signed plan then execute succeeds", async () => {
+    const original = await readFile(planPath, "utf8");
+    const fileStats = await stat(planPath);
+    recordSessionRead(sessionId, planPath, {
+      content: original,
+      timestamp: fileStats.mtimeMs,
+      viewKind: "full",
+    });
+    const tool = createApplyPatchTool({
+      cwd: workspace,
+      allowedPaths: [workspace],
+    });
+    const args = {
+      input: `*** Begin Patch
+*** Update File: ${planPath}
+@@
+-# Plan
++# Patched plan
+*** End Patch`,
+      cwd: workspace,
+      [SESSION_ID_ARG]: sessionId,
+      [SESSION_ID_SIG_ARG]: signSessionId(sessionId),
+      [SESSION_AGENC_HOME_ARG]: agencHome,
+    };
+    const permission = tool.checkPermissions?.(args, evaluator());
+    expect(permission?.behavior).toBe("allow");
+    if (!permission || permission.behavior !== "allow") {
+      throw new Error("expected apply_patch allow");
+    }
+    const result = await tool.execute(permission.updatedInput ?? args);
+    expect(result.isError, String(result.content)).toBeUndefined();
+    await expect(readFile(planPath, "utf8")).resolves.toContain("Patched plan");
+  });
+
+  test("explicit deny still wins over the signed plan exception", () => {
+    const tool = createFileWriteTool({ allowedPaths: [workspace] });
+    const denied = applyPermissionUpdate(
+      createEmptyToolPermissionContext({ mode: "acceptEdits" }),
+      {
+        type: "addRules",
+        destination: "userSettings",
+        behavior: "deny",
+        rules: [{ toolName: "Write", ruleContent: planPath }],
+      },
+    );
+    const permission = tool.checkPermissions?.(
+      signedArgs({ content: "nope" }),
+      evaluator("acceptEdits", denied),
+    );
+    expect(permission?.behavior).toBe("deny");
+  });
+
+  test("invalid signatures, other sessions, and sibling AGENC_HOME files still ask", () => {
+    const tool = createFileReadTool({ allowedPaths: [workspace] });
+    const ctx = evaluator();
+    expect(
+      tool.checkPermissions?.(
+        { ...signedArgs(), [SESSION_ID_SIG_ARG]: "not-a-signature" },
+        ctx,
+      )?.behavior,
+    ).toBe("ask");
+    expect(
+      tool.checkPermissions?.(
+        {
+          ...signedArgs(),
+          [SESSION_ID_ARG]: "other-session",
+          [SESSION_ID_SIG_ARG]: signSessionId("other-session"),
+        },
+        ctx,
+      )?.behavior,
+    ).toBe("ask");
+    const sibling = join(agencHome, "config.json");
+    expect(
+      tool.checkPermissions?.(signedArgs({ file_path: sibling }), ctx)
+        ?.behavior,
+    ).toBe("ask");
+  });
+});

--- a/runtime/tests/permissions/signed-session-plan-file.test.ts
+++ b/runtime/tests/permissions/signed-session-plan-file.test.ts
@@ -27,6 +27,7 @@ import {
   getPlanFilePath,
   setPlanSlug,
 } from "../../src/planning/plan-files.js";
+import type { Tool } from "../../src/tools/Tool.js";
 
 describe("signed active-session plan file permissions", () => {
   const sessionId = "test-session-plan-perm";
@@ -80,6 +81,32 @@ describe("signed active-session plan file permissions", () => {
     } as ToolEvaluatorContext;
   }
 
+  async function markPlanRead(): Promise<void> {
+    const original = await readFile(planPath, "utf8");
+    const fileStats = await stat(planPath);
+    recordSessionRead(sessionId, planPath, {
+      content: original,
+      timestamp: fileStats.mtimeMs,
+      viewKind: "full",
+    });
+  }
+
+  async function expectAllowThenExecute(
+    label: string,
+    tool: Tool,
+    args: Record<string, unknown>,
+    snippet: string,
+  ): Promise<void> {
+    const permission = tool.checkPermissions?.(args, evaluator());
+    expect(permission?.behavior, label).toBe("allow");
+    if (!permission || permission.behavior !== "allow") {
+      throw new Error(`expected ${label} allow`);
+    }
+    const result = await tool.execute(permission.updatedInput ?? args);
+    expect(result.isError, String(result.content)).toBeUndefined();
+    await expect(readFile(planPath, "utf8")).resolves.toContain(snippet);
+  }
+
   test("matchesVerifiedSessionPlanFile uses the same signed context as execute", () => {
     expect(
       matchesVerifiedSessionPlanFile(planPath, workspace, signedArgs()),
@@ -99,123 +126,64 @@ describe("signed active-session plan file permissions", () => {
     ).toBe(false);
   });
 
-  test("FileRead checkPermissions allows the signed plan then execute succeeds", async () => {
-    const tool = createFileReadTool({ allowedPaths: [workspace] });
-    const permission = tool.checkPermissions?.(signedArgs(), evaluator());
-    expect(permission?.behavior).toBe("allow");
-    if (!permission || permission.behavior !== "allow") {
-      throw new Error("expected FileRead allow");
-    }
-    const result = await tool.execute(permission.updatedInput ?? signedArgs());
-    expect(result.isError).toBeUndefined();
-    expect(String(result.content)).toContain("Ship signed path");
-  });
-
-  test("Write checkPermissions allows the signed plan then execute succeeds", async () => {
-    const original = await readFile(planPath, "utf8");
-    const fileStats = await stat(planPath);
-    recordSessionRead(sessionId, planPath, {
-      content: original,
-      timestamp: fileStats.mtimeMs,
-      viewKind: "full",
-    });
-    const tool = createFileWriteTool({ allowedPaths: [workspace] });
-    const args = signedArgs({ content: "# Plan\n\n- [x] Wrote\n" });
-    const permission = tool.checkPermissions?.(args, evaluator());
-    expect(permission?.behavior).toBe("allow");
-    if (!permission || permission.behavior !== "allow") {
-      throw new Error("expected Write allow");
-    }
-    const result = await tool.execute(permission.updatedInput ?? args);
-    expect(result.isError).toBeUndefined();
-    await expect(readFile(planPath, "utf8")).resolves.toContain("Wrote");
-  });
-
-  test("Edit checkPermissions allows the signed plan then execute succeeds", async () => {
-    const original = await readFile(planPath, "utf8");
-    const fileStats = await stat(planPath);
-    recordSessionRead(sessionId, planPath, {
-      content: original,
-      timestamp: fileStats.mtimeMs,
-      viewKind: "full",
-    });
-    const tool = createFileEditTool({ allowedPaths: [workspace] });
-    const args = signedArgs({
-      old_string: "Ship signed path",
-      new_string: "Ship edit",
-    });
-    const permission = tool.checkPermissions?.(args, evaluator());
-    expect(permission?.behavior).toBe("allow");
-    if (!permission || permission.behavior !== "allow") {
-      throw new Error("expected Edit allow");
-    }
-    const result = await tool.execute(permission.updatedInput ?? args);
-    expect(result.isError).toBeUndefined();
-    await expect(readFile(planPath, "utf8")).resolves.toContain("Ship edit");
-  });
-
-  test("MultiEdit checkPermissions allows the signed plan then execute succeeds", async () => {
-    const original = await readFile(planPath, "utf8");
-    const fileStats = await stat(planPath);
-    recordSessionRead(sessionId, planPath, {
-      content: original,
-      timestamp: fileStats.mtimeMs,
-      viewKind: "full",
-    });
-    const tool = createFileMultiEditTool({ allowedPaths: [workspace] });
-    const args = signedArgs({
-      edits: [
-        { old_string: "Ship signed path", new_string: "Ship multi-edit" },
-      ],
-    });
-    const permission = tool.checkPermissions?.(args, evaluator());
-    expect(permission?.behavior).toBe("allow");
-    if (!permission || permission.behavior !== "allow") {
-      throw new Error("expected MultiEdit allow");
-    }
-    const result = await tool.execute(permission.updatedInput ?? args);
-    expect(result.isError).toBeUndefined();
-    await expect(readFile(planPath, "utf8")).resolves.toContain(
+  test("FileRead/Write/Edit/MultiEdit allow the signed plan then execute", async () => {
+    await markPlanRead();
+    const allowed = [workspace];
+    await expectAllowThenExecute(
+      "FileRead",
+      createFileReadTool({ allowedPaths: allowed }),
+      signedArgs(),
+      "Ship signed path",
+    );
+    await expectAllowThenExecute(
+      "Write",
+      createFileWriteTool({ allowedPaths: allowed }),
+      signedArgs({ content: "# Plan\n\n- [x] Wrote\n" }),
+      "Wrote",
+    );
+    await markPlanRead();
+    await expectAllowThenExecute(
+      "Edit",
+      createFileEditTool({ allowedPaths: allowed }),
+      signedArgs({
+        old_string: "Wrote",
+        new_string: "Ship edit",
+      }),
+      "Ship edit",
+    );
+    await markPlanRead();
+    await expectAllowThenExecute(
+      "MultiEdit",
+      createFileMultiEditTool({ allowedPaths: allowed }),
+      signedArgs({
+        edits: [{ old_string: "Ship edit", new_string: "Ship multi-edit" }],
+      }),
       "Ship multi-edit",
     );
   });
 
-  test("apply_patch checkPermissions allows the signed plan then execute succeeds", async () => {
-    const original = await readFile(planPath, "utf8");
-    const fileStats = await stat(planPath);
-    recordSessionRead(sessionId, planPath, {
-      content: original,
-      timestamp: fileStats.mtimeMs,
-      viewKind: "full",
-    });
-    const tool = createApplyPatchTool({
-      cwd: workspace,
-      allowedPaths: [workspace],
-    });
-    const args = {
-      input: `*** Begin Patch
+  test("apply_patch allows the signed plan then execute succeeds", async () => {
+    await markPlanRead();
+    await expectAllowThenExecute(
+      "apply_patch",
+      createApplyPatchTool({ cwd: workspace, allowedPaths: [workspace] }),
+      {
+        input: `*** Begin Patch
 *** Update File: ${planPath}
 @@
 -# Plan
 +# Patched plan
 *** End Patch`,
-      cwd: workspace,
-      [SESSION_ID_ARG]: sessionId,
-      [SESSION_ID_SIG_ARG]: signSessionId(sessionId),
-      [SESSION_AGENC_HOME_ARG]: agencHome,
-    };
-    const permission = tool.checkPermissions?.(args, evaluator());
-    expect(permission?.behavior).toBe("allow");
-    if (!permission || permission.behavior !== "allow") {
-      throw new Error("expected apply_patch allow");
-    }
-    const result = await tool.execute(permission.updatedInput ?? args);
-    expect(result.isError, String(result.content)).toBeUndefined();
-    await expect(readFile(planPath, "utf8")).resolves.toContain("Patched plan");
+        cwd: workspace,
+        [SESSION_ID_ARG]: sessionId,
+        [SESSION_ID_SIG_ARG]: signSessionId(sessionId),
+        [SESSION_AGENC_HOME_ARG]: agencHome,
+      },
+      "Patched plan",
+    );
   });
 
   test("explicit deny still wins over the signed plan exception", () => {
-    const tool = createFileWriteTool({ allowedPaths: [workspace] });
     const denied = applyPermissionUpdate(
       createEmptyToolPermissionContext({ mode: "acceptEdits" }),
       {
@@ -225,7 +193,9 @@ describe("signed active-session plan file permissions", () => {
         rules: [{ toolName: "Write", ruleContent: planPath }],
       },
     );
-    const permission = tool.checkPermissions?.(
+    const permission = createFileWriteTool({
+      allowedPaths: [workspace],
+    }).checkPermissions?.(
       signedArgs({ content: "nope" }),
       evaluator("acceptEdits", denied),
     );
@@ -251,10 +221,11 @@ describe("signed active-session plan file permissions", () => {
         ctx,
       )?.behavior,
     ).toBe("ask");
-    const sibling = join(agencHome, "config.json");
     expect(
-      tool.checkPermissions?.(signedArgs({ file_path: sibling }), ctx)
-        ?.behavior,
+      tool.checkPermissions?.(
+        signedArgs({ file_path: join(agencHome, "config.json") }),
+        ctx,
+      )?.behavior,
     ).toBe("ask");
   });
 });


### PR DESCRIPTION
## Changes

Closes #2131.

`FileRead` / `Write` / `Edit` / `MultiEdit` / `apply_patch` `checkPermissions` asked for approval when the target was the signed active-session plan file outside the workspace. Execute already allowed that path via `safePathAllowingSessionPlanFile`.

- After explicit deny rules, `checkToolPathPermission` calls `matchesVerifiedSessionPlanFile`, which reuses the execution-boundary verifier (session HMAC + injected `AGENC_HOME`).
- Invalid signatures, another session's plan, and sibling files under `AGENC_HOME` still ask. Deny rules still win. `AGENC_HOME` is not a general allowed root.

Does not change the plan-mode mutating-tool gate (open Cursor PR #2254). That is a different layer.

## Verification

- `runtime/tests/permissions/signed-session-plan-file.test.ts` plus `path-validation.test.ts` 28/28 (hermetic vitest, Node 26.7.0).
- `npm run typecheck` on the runtime workspace.