### PR TITLE
fix(runtime): repair 13 live workflow audit failures

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -476,8 +476,8 @@ jobs:
             numPassedTestSuites: 3,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 15,
-            numPassedTests: 15,
+            numTotalTests: 17,
+            numPassedTests: 17,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -511,7 +511,7 @@ jobs:
             );
           }
           console.log(
-            "real-kernel sandbox lane passed 15 tests in 2 files with zero skipped",
+            "real-kernel sandbox lane passed 17 tests in 2 files with zero skipped",
           );
           NODE
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,6 +26,16 @@ With no subcommand, AgenC starts the interactive TUI (or continues/resumes a
 session when those flags are set). A positional prompt without `--print` /
 `--no-tui` still goes through the normal startup path.
 
+Unknown options before the positional prompt exit with code 2 without starting
+a model call. Use `--` when literal prompt text starts with a dash:
+
+```bash
+agenc --print -- "--max-budget-usd is not a supported option; explain this error"
+```
+
+Options after the first positional prompt token are prompt text. Set a session
+spending cap with `AGENC_MAX_BUDGET_USD`, not `--max-budget-usd`.
+
 ### Global / session options
 
 From `formatCliHelpText()`:
@@ -391,6 +401,14 @@ do not advance the returned cursor past a missing range. Pre-M4 runs can fall
 back to the project-database-scoped execution-admission journal, which is
 labeled as a compatibility source. An admission-only record is not presented
 as a fabricated terminal result.
+
+Worktree children can store their canonical journal separately from their
+admission accounting. In that case, `source.projectDir` identifies the journal,
+while `source.admissionProjectDir` and `source.admissionLastSequence` identify
+the accounting database and the latest admission event for the run subtree.
+The admission sequence is not a replay cursor. Evidence from separate databases
+is marked partial rather than claiming a single atomic snapshot. Conflicting
+owners still fail with `RUN_ID_AMBIGUOUS`; changing cwd does not select an owner.
 
 ---
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -114,6 +114,22 @@ accept `agentId`; use `attachAgent()` for an existing agent. The lower-level
 workspace and intends to permit command hook effects there. The field never
 permits HTTP, prompt, or agent hook effects.
 
+SDK sessions capture command environment values from `envOverrides`. An omitted
+`PATH` means an empty command search path, including after cold resume; it does
+not inherit the daemon's `PATH`. For a command-capable local session, pass the
+embedding application's intended path explicitly, for example
+`envOverrides: { PATH: process.env.PATH ?? "" }`. Do not forward the entire
+environment just to populate `PATH`.
+
+The public CLI supplies its captured command environment automatically. On
+Linux, a restrictive sandbox may need a trusted system directory containing
+`bubblewrap` in the session's `PATH`. If that environment cannot enforce the
+configured filesystem policy, a custom status command returns `blocked` with
+reason `sandbox_policy_unexpressible`; no process starts and its admission
+reservation is voided. Check the session environment and run `agenc doctor`
+rather than weakening the sandbox. Commands interrupted after they start still
+retain unknown-effect accounting until their outcome is established.
+
 `dangerouslyBypassApprovalsAndSandbox` defaults to `false`. Set it to `true`
 only when the embedding application deliberately grants both approval bypass
 and unrestricted OS execution to the new session. The daemon retains that

--- a/packages/agenc-sdk/src/protocol-wire.generated.ts
+++ b/packages/agenc-sdk/src/protocol-wire.generated.ts
@@ -1068,6 +1068,8 @@ export interface RunAdmissionSummary extends JsonObject {
 export interface RunStateSource extends JsonObject {
     readonly kind: "existing_state_database";
     readonly projectDir: string;
+    readonly admissionProjectDir?: string;
+    readonly admissionLastSequence?: number;
     readonly readonly: true;
 }
 
@@ -1246,6 +1248,8 @@ export type RunEvidenceCompleteness = "complete" | "partial" | "admission_source
 export interface RunEvidenceSource extends JsonObject {
     readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
     readonly projectDir: string;
+    readonly admissionProjectDir?: string;
+    readonly admissionLastSequence?: number;
     readonly admissionJournal: boolean;
     readonly workflowEvidenceIncluded: boolean;
     readonly completeness: RunEvidenceCompleteness;

--- a/runtime/scripts/check-tui-e2e/scenarios/135-session-usage-legacy-footer.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/135-session-usage-legacy-footer.mjs
@@ -6,7 +6,7 @@ import { waitForFrameText } from "../helpers/workbench-buffer-neovim.mjs";
 
 export const meta = {
   description: "The alternate footer, custom status-line command, and cost dialog receive canonical daemon usage.",
-  args: ["--dangerously-bypass-approvals-and-sandbox"],
+  args: [],
   env: { AGENC_TUI_WORKBENCH: "0" },
   slimCwd: true,
   timeoutMs: 90_000,
@@ -15,7 +15,7 @@ export const meta = {
 export default async function (session) {
   const configPath = join(session.gateState.agencHome, "config.toml");
   const scriptPath = join(session.gateState.agencHome, "status-line-135.mjs");
-  const receiptPath = join(session.gateState.agencHome, "status-line-135.jsonl");
+  const receiptPath = join(session.cwd, "status-line-135.jsonl");
   const existingConfig = await readFile(configPath, "utf8");
   assert.doesNotMatch(existingConfig, /^\[statusLine\]/mu);
   await writeFile(scriptPath, [

--- a/runtime/scripts/check-tui-e2e/scenarios/136-workbench-cell-resize.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/136-workbench-cell-resize.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { renderPtyRows } from "../harness.mjs";
+import { waitForFrameText } from "../helpers/workbench-buffer-neovim.mjs";
+
+export const meta = {
+  description: "Workbench prompt and agents cells survive repeated live terminal resizing.",
+  env: { AGENC_TUI_WORKBENCH: "1" },
+  slimCwd: true,
+  timeoutMs: 60_000,
+};
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+const prompt = "START " + Array.from({ length: 32 }, (_, index) => `word${index.toString().padStart(2, "0")}`).join(" ") + " END";
+
+async function resize(session, columns) {
+  session.cols = columns;
+  session.term.resize(columns, session.rows);
+  await sleep(400);
+}
+
+function cells(session) {
+  return renderPtyRows(session.raw, { cols: session.cols, rows: session.rows });
+}
+
+export default async function (session) {
+  session.cols = 160;
+  session.rows = 48;
+  await session.start();
+  await session.waitForPrompt({ timeout: 20_000 });
+  await session.type(prompt);
+  await session.submit();
+  await session.waitForAssistantReply({ timeout: 20_000 });
+  await session.waitForPrompt({ timeout: 10_000 });
+
+  for (const columns of [160, 200, 160]) {
+    await resize(session, columns);
+    await waitForFrameText(session, /START[\s\S]*END/u, "complete submitted prompt");
+    const rows = cells(session);
+    assert.ok(rows.some((row) => row.includes("WORKSPACE")));
+    assert.ok(rows.some((row) => row.includes("AGENTS")));
+    const startRow = rows.findIndex((row) => row.includes("START"));
+    const endRow = rows.findIndex((row, index) => index >= startRow && row.includes("END"));
+    const contentColumn = rows[startRow].indexOf("START");
+    const frameColumns = columns - 4;
+    const rightEdge = 2 + frameColumns - Math.max(24, Math.floor(frameColumns * 0.19)) - 3;
+    assert.equal(rows.slice(startRow, endRow + 1).map((row) => row.slice(contentColumn, rightEdge).trim()).join(" "), prompt);
+  }
+
+  await session.submitSlashCommand("/agents");
+  await waitForFrameText(session, /delegate-capable[\s\S]*name · Role/u, "agents table");
+  for (const columns of [160, 200, 160]) {
+    await resize(session, columns);
+    const rows = cells(session);
+    const header = rows.findIndex((row) => row.includes("name · Role"));
+    const markers = ["default", "runner", "verification", "Plan", "scanner", "when-to-use", "tools", "model", "budget"];
+    const positions = markers.map((marker) => rows.findIndex((row, index) => index > header && new RegExp(`\\b${marker}\\b`, "u").test(row)));
+    assert.ok(header >= 0 && positions.every((position) => position >= 0), `Missing agents table cells at ${columns} columns: ${markers.filter((_, index) => positions[index] < 0).join(", ")}\n${rows.join("\n")}`);
+    assert.equal(new Set(positions).size, markers.length, rows.join("\n"));
+  }
+  session.send("q");
+  await session.waitForPrompt({ timeout: 10_000 });
+}

--- a/runtime/src/agents/_deps/filesystem-args.ts
+++ b/runtime/src/agents/_deps/filesystem-args.ts
@@ -27,11 +27,14 @@
  */
 
 import { randomBytes, createHmac, timingSafeEqual } from "node:crypto";
+import type { SessionPlanFileAuthority } from "../../planning/session-plan-authority.js";
 
 export const SESSION_ID_ARG = "__agencSessionId";
 export const SESSION_ID_SIG_ARG = "__agencSessionIdSig";
 export const SESSION_ALLOWED_ROOTS_ARG = "__agencSessionAllowedRoots";
 export const SESSION_ALLOWED_ROOTS_SIG_ARG = "__agencSessionAllowedRootsSig";
+export const SESSION_PLAN_FILE_ARG = "__agencSessionPlanFile";
+export const SESSION_PLAN_FILE_SIG_ARG = "__agencSessionPlanFileSig";
 
 /**
  * Per-process secret keying the trusted-roots HMAC. Generated once at
@@ -40,6 +43,56 @@ export const SESSION_ALLOWED_ROOTS_SIG_ARG = "__agencSessionAllowedRootsSig";
  * same Node runtime, they share this secret and signatures verify.
  */
 const PROCESS_SECRET = randomBytes(32);
+
+function planFileSignature(authority: SessionPlanFileAuthority): string {
+  return createHmac("sha256", PROCESS_SECRET)
+    .update(JSON.stringify([
+      "session-plan-file-v1",
+      authority.sessionId,
+      authority.agencHome,
+      authority.planFilePath,
+      authority.agentId ?? null,
+    ]))
+    .digest("hex");
+}
+
+export function signedSessionPlanFileArgs(
+  authority: SessionPlanFileAuthority | null,
+): Record<string, unknown> {
+  return {
+    [SESSION_PLAN_FILE_ARG]: authority,
+    [SESSION_PLAN_FILE_SIG_ARG]: authority === null ? null : planFileSignature(authority),
+  };
+}
+
+export function verifySessionPlanFileArgs(
+  args: Record<string, unknown>,
+): SessionPlanFileAuthority | null {
+  const value = args[SESSION_PLAN_FILE_ARG];
+  const signature = args[SESSION_PLAN_FILE_SIG_ARG];
+  if (
+    value === null || typeof value !== "object" || Array.isArray(value) ||
+    typeof signature !== "string"
+  ) return null;
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.sessionId !== "string" ||
+    typeof candidate.agencHome !== "string" ||
+    typeof candidate.planFilePath !== "string"
+  ) return null;
+  if (candidate.agentId !== undefined && typeof candidate.agentId !== "string") return null;
+  const authority = {
+    sessionId: candidate.sessionId,
+    agencHome: candidate.agencHome,
+    planFilePath: candidate.planFilePath,
+    ...(typeof candidate.agentId === "string" ? { agentId: candidate.agentId } : {}),
+  };
+  const expected = Buffer.from(planFileSignature(authority), "hex");
+  const supplied = Buffer.from(signature, "hex");
+  return supplied.length === expected.length && timingSafeEqual(supplied, expected)
+    ? Object.freeze(authority)
+    : null;
+}
 
 /**
  * Deterministic canonical serialization of a roots array: dedupe, sort,

--- a/runtime/src/agents/delegate.ts
+++ b/runtime/src/agents/delegate.ts
@@ -17,6 +17,7 @@
  */
 
 import type { Session } from "../session/session.js";
+import type { ToolEffectDispositionEvidence } from "../contracts/run-contracts.js";
 import type { LLMMessage } from "../llm/types.js";
 import type { LLMContentPart } from "../llm/types.js";
 import {
@@ -50,6 +51,7 @@ import {
   hasWorktreeChanges,
   captureBaseCommit,
   removeAgentWorktree,
+  WorktreePreconditionError,
 } from "./worktree.js";
 import { runAgent } from "./run-agent.js";
 import { ResumeManager } from "./resume.js";
@@ -134,6 +136,7 @@ export type DelegateOutcome =
         | "retryable_capacity"
         | "spawn_failed";
       readonly reason: string;
+      readonly effectDisposition?: ToolEffectDispositionEvidence;
     };
 
 // ─────────────────────────────────────────────────────────────────────
@@ -148,9 +151,13 @@ export async function delegate(opts: DelegateOpts): Promise<DelegateOutcome> {
     code: Extract<DelegateOutcome, { kind: "rejected" }>["code"],
     category: Extract<DelegateOutcome, { kind: "rejected" }>["category"],
     reason: string,
+    effectDisposition?: ToolEffectDispositionEvidence,
   ): Extract<DelegateOutcome, { kind: "rejected" }> => {
     opts.capacityPermit?.cancel();
-    return { kind: "rejected", code, category, reason };
+    return {
+      kind: "rejected", code, category, reason,
+      ...(effectDisposition !== undefined ? { effectDisposition } : {}),
+    };
   };
 
   if (opts.invocationEnvelope !== undefined) {
@@ -194,10 +201,14 @@ export async function delegate(opts: DelegateOpts): Promise<DelegateOutcome> {
       process.cwd();
     const canonicalGitRoot = findGitRoot(workspaceRoot);
     if (!canonicalGitRoot) {
+      const refusal = new WorktreePreconditionError(
+        "worktree isolation requested but cwd is not inside a git repository",
+      );
       return reject(
         "WORKTREE_UNAVAILABLE",
         "environment",
-        "worktree isolation requested but cwd is not inside a git repository",
+        refusal.message,
+        refusal.effectDisposition,
       );
     }
     try {
@@ -218,10 +229,30 @@ export async function delegate(opts: DelegateOpts): Promise<DelegateOutcome> {
         worktreeSandboxExecutionBroker,
       );
     } catch (err) {
+      if (worktree?.created) {
+        try {
+          await removeAgentWorktree({
+            path: worktree.path,
+            branch: worktree.branch,
+            gitRoot: worktree.gitRoot,
+            sandboxExecutionBroker: worktreeSandboxExecutionBroker!,
+          });
+        } catch (cleanupError) {
+          emitWarning(
+            opts.parent.eventLog,
+            opts.parent.nextInternalSubId(),
+            "delegate_worktree_cleanup_failed",
+            cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          );
+        }
+      }
       return reject(
         "WORKTREE_UNAVAILABLE",
         "environment",
         `worktree setup failed: ${err instanceof Error ? err.message : String(err)}`,
+        worktree === undefined && err instanceof WorktreePreconditionError
+          ? err.effectDisposition
+          : undefined,
       );
     }
   }
@@ -254,7 +285,14 @@ export async function delegate(opts: DelegateOpts): Promise<DelegateOutcome> {
             opts.parent,
             worktree.gitRoot,
           ),
-      }).catch(() => {});
+      }).catch((cleanupError) => {
+        emitWarning(
+          opts.parent.eventLog,
+          opts.parent.nextInternalSubId(),
+          "delegate_worktree_cleanup_failed",
+          cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        );
+      });
     }
     const reason = err instanceof Error ? err.message : String(err);
     if (err instanceof AgentConcurrencyLimitError) {

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -60,7 +60,11 @@ import {
 import {
   withSignedAllowedRoots,
   withSignedSessionId,
+  signedSessionPlanFileArgs,
+  SESSION_PLAN_FILE_ARG,
+  SESSION_PLAN_FILE_SIG_ARG,
 } from "./_deps/filesystem-args.js";
+import { sessionFilesystemContext, sessionPlanFileAuthority } from "../planning/session-plan-authority.js";
 import {
   Session as ChildSession,
   type InterAgentCommunication as SessionInterAgentCommunication,
@@ -2546,6 +2550,7 @@ export function injectChildToolArgs(
   opts: {
     readonly childConversationId: string;
     readonly worktree?: WorktreeHandle;
+    readonly getSession?: () => Session | null | undefined;
   },
 ): Record<string, unknown> {
   // NOTE: model-supplied `__agenc*` keys are stripped UPSTREAM
@@ -2564,6 +2569,20 @@ export function injectChildToolArgs(
     parsedArgs,
     opts.childConversationId,
   );
+  const childSession = opts.getSession?.();
+  const filesystemContext = sessionFilesystemContext(childSession);
+  const owner = sessionPlanFileAuthority(childSession);
+  const planAuthority = owner?.sessionId === opts.childConversationId ? owner : null;
+  if (filesystemContext?.sessionId === opts.childConversationId) {
+    injectedArgs.__agencHome = filesystemContext.agencHome;
+  }
+  if (planAuthority !== null) {
+    Object.assign(injectedArgs, signedSessionPlanFileArgs(planAuthority));
+    injectedArgs.__agencHome = planAuthority.agencHome;
+  } else {
+    delete injectedArgs[SESSION_PLAN_FILE_ARG];
+    delete injectedArgs[SESSION_PLAN_FILE_SIG_ARG];
+  }
   if (opts.worktree?.path) {
     injectedArgs = withSignedAllowedRoots(injectedArgs, [opts.worktree.path]);
   }
@@ -2627,6 +2646,7 @@ function wrapToolForChild(
     readonly worktree?: WorktreeHandle;
     readonly childToolPolicy?: ChildToolPolicy;
     readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
+    readonly getSession?: () => Session | null | undefined;
   },
 ): Tool {
   return {
@@ -2648,6 +2668,7 @@ async function prepareChildToolCall(
     readonly worktree?: WorktreeHandle;
     readonly childToolPolicy?: ChildToolPolicy;
     readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
+    readonly getSession?: () => Session | null | undefined;
   },
 ): Promise<
   | { readonly args: Record<string, unknown> }

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -682,6 +682,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
       return failSpawn(error instanceof Error ? error.message : String(error));
     }
     let thread: AgentThread | undefined;
+    let rejectedEffectDisposition: ToolResult["effectDisposition"];
     try {
       const childAgentPath = joinAgentPath(current.agentPath, taskName);
       const worktreeSlug =
@@ -719,6 +720,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
           : {}),
       });
       if (outcome.kind === "rejected") {
+        rejectedEffectDisposition = outcome.effectDisposition;
         throw new Error(outcome.reason);
       }
       thread = outcome.thread;
@@ -744,7 +746,12 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
           },
         },
       });
-      return json({ error: reason }, true);
+      return {
+        ...json({ error: reason }, true),
+        ...(rejectedEffectDisposition !== undefined
+          ? { effectDisposition: rejectedEffectDisposition }
+          : {}),
+      };
     }
     if (thread === undefined) {
       return json({ error: "spawn_agent did not return an agent thread" }, true);

--- a/runtime/src/agents/worktree.ts
+++ b/runtime/src/agents/worktree.ts
@@ -39,6 +39,7 @@ import {
   utimesSync,
 } from "node:fs";
 import { createHash } from "node:crypto";
+import { createToolEffectDispositionEvidence } from "../tools/effect-boundary.js";
 import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import { AsyncLock } from "./_deps/async-lock.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
@@ -74,6 +75,21 @@ export interface GitResult {
   readonly code: number;
   readonly stdout: string;
   readonly stderr: string;
+}
+
+export class WorktreePreconditionError extends Error {
+  readonly effectDisposition;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "WorktreePreconditionError";
+    this.effectDisposition = createToolEffectDispositionEvidence({
+      disposition: "confirmed_no_effect",
+      evidenceKind: "boundary_not_crossed",
+      evidenceRef: "worktree:precondition",
+      evidenceMaterial: message,
+    });
+  }
 }
 
 /**
@@ -329,7 +345,11 @@ export interface GetOrCreateOpts {
 export async function getOrCreateWorktree(
   opts: GetOrCreateOpts,
 ): Promise<WorktreeHandle> {
-  validateWorktreeSlug(opts.slug);
+  try {
+    validateWorktreeSlug(opts.slug);
+  } catch (error) {
+    throw new WorktreePreconditionError(error instanceof Error ? error.message : String(error));
+  }
   const branch = worktreeBranchName(opts.slug);
   const workspaceRoot =
     opts.workspaceRoot ?? join(opts.gitRoot, ".agenc-worktrees");
@@ -344,14 +364,14 @@ export async function getOrCreateWorktree(
         return { path, branch, gitRoot: opts.gitRoot, created: false };
       }
       if (existingGitRoot !== null) {
-        throw new Error(
+        throw new WorktreePreconditionError(
           `worktree path ${path} already belongs to ${existingGitRoot}, expected ${opts.gitRoot}`,
         );
       }
     }
 
     if (existsSync(path)) {
-      throw new Error(
+      throw new WorktreePreconditionError(
         `worktree path ${path} already exists but is not a worktree for ${opts.gitRoot}`,
       );
     }
@@ -359,12 +379,23 @@ export async function getOrCreateWorktree(
     // Worktree setup is deliberately local-only. Repository-controlled remotes,
     // credential helpers, and transport helpers are not an implicit capability.
     const base = opts.base ?? "HEAD";
+    const baseResult = await runGit(
+      ["rev-parse", "--verify", "--end-of-options", `${base}^{commit}`],
+      opts.gitRoot,
+      opts.sandboxExecutionBroker,
+    );
+    const baseCommit = baseResult.stdout.trim();
+    if (baseResult.code !== 0 || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(baseCommit)) {
+      throw new WorktreePreconditionError(
+        `worktree base ${base} does not resolve to a commit; create a commit before requesting worktree isolation`,
+      );
+    }
 
     // Register metadata without materializing repository content. Checkout is
     // a second, narrowly granted phase so a configured filter cannot write the
     // common .git directory with Git's inherited authority.
     const addResult = await runGitMutation(
-      ["worktree", "add", "--no-checkout", "-B", branch, path, base],
+      ["worktree", "add", "--no-checkout", "-B", branch, path, baseCommit],
       opts.gitRoot,
       opts.sandboxExecutionBroker,
       opts.gitRoot,

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -2617,7 +2617,7 @@ export class AgenCDaemonAgentManager {
         `AgenC daemon session has no working directory: ${params.sessionId}`,
       );
     }
-    const driver = openStateDatabases({ cwd: session.cwd });
+    const driver = openStateDatabases({ cwd: session.cwd, agencHome: this.#agencHome });
     try {
       const candidates =
         params.toolCallId !== undefined

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -2987,37 +2987,44 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         `AgenC daemon agent ${agentId} does not own session ${params.sessionId}`,
       );
     }
-    const driver = openStateDatabases({ cwd: active.bootstrap.workspaceRoot });
-    try {
-      const outcome = resolveLiveDurableEffectReview(driver, params, {
-        readAll: () => active.bootstrap.rolloutStore.readAll(),
-        append: (eventId, payload) =>
-          active.bootstrap.session.emit(
-            {
-              eventId,
-              id: eventId,
-              msg: { type: "effect_review_resolved", payload },
-            },
-            { durable: true },
-          ),
-        project: (event) =>
-          active.bootstrap.rolloutStore.recordEffectEvent(event),
-      });
-      if (
-        outcome.kind !== "not_found" &&
-        outcome.durable &&
-        params.resolution.workflowStatus !== "pending"
-      ) {
-        resolveLiveEffectPoison(active.bootstrap.session, {
-          callId: params.toolCallId,
-          ...(outcome.runId !== undefined ? { runId: outcome.runId } : {}),
-          ...(outcome.stepId !== undefined ? { stepId: outcome.stepId } : {}),
-        });
-      }
-      return outcome;
-    } finally {
-      driver.close();
+    const session = active.bootstrap.session;
+    const agencHome = session.services.configStore?.homeContext.path;
+    if (agencHome === undefined) {
+      throw new Error("Live effect review requires the owning session's configuration home");
     }
+    return runWithCurrentRuntimeSession(session, () => {
+      const driver = openStateDatabases({ cwd: active.bootstrap.workspaceRoot, agencHome });
+      try {
+        const outcome = resolveLiveDurableEffectReview(driver, params, {
+          readAll: () => active.bootstrap.rolloutStore.readAll(),
+          append: (eventId, payload) =>
+            session.emit(
+              {
+                eventId,
+                id: eventId,
+                msg: { type: "effect_review_resolved", payload },
+              },
+              { durable: true },
+            ),
+          project: (event) =>
+            active.bootstrap.rolloutStore.recordEffectEvent(event),
+        });
+        if (
+          outcome.kind !== "not_found" &&
+          outcome.durable &&
+          params.resolution.workflowStatus !== "pending"
+        ) {
+          resolveLiveEffectPoison(session, {
+            callId: params.toolCallId,
+            ...(outcome.runId !== undefined ? { runId: outcome.runId } : {}),
+            ...(outcome.stepId !== undefined ? { stepId: outcome.stepId } : {}),
+          });
+        }
+        return outcome;
+      } finally {
+        driver.close();
+      }
+    });
   }
 
   // Read the global session-level cache stats tracker (lives in the

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -2767,6 +2767,8 @@ export interface RunDurableRecord extends JsonObject {
 export interface RunStateSource extends JsonObject {
   readonly kind: "existing_state_database";
   readonly projectDir: string;
+  readonly admissionProjectDir?: string;
+  readonly admissionLastSequence?: number;
   readonly readonly: true;
 }
 
@@ -2997,6 +2999,8 @@ export type RunEvidenceCompleteness =
 export interface RunEvidenceSource extends JsonObject {
   readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
   readonly projectDir: string;
+  readonly admissionProjectDir?: string;
+  readonly admissionLastSequence?: number;
   readonly admissionJournal: boolean;
   readonly workflowEvidenceIncluded: boolean;
   readonly completeness: RunEvidenceCompleteness;

--- a/runtime/src/app-server/run-inspection.ts
+++ b/runtime/src/app-server/run-inspection.ts
@@ -89,6 +89,11 @@ interface AgentRunRow {
 interface LocatedRun {
   readonly paths: StateDatabasePaths;
   readonly run?: AgentRunRow;
+  readonly admission?: {
+    readonly paths: StateDatabasePaths;
+    readonly summary: RunStatusResult["admission"];
+    readonly lastSequence: number;
+  };
 }
 
 interface RunTerminalRow {
@@ -231,7 +236,7 @@ export class AgenCDaemonRunInspectionService {
             usage: parseRunUsage(durableTerminal.usage_json),
             lastSequence: durableTerminal.last_sequence,
           },
-          source: runStateSource(located.paths),
+          source: runStateSource(located.paths, located.admission),
         };
       }
       if (run === undefined) {
@@ -254,7 +259,7 @@ export class AgenCDaemonRunInspectionService {
           available: false,
           reason: "terminal_output_not_persisted_in_existing_state",
         },
-        source: runStateSource(located.paths),
+        source: runStateSource(located.paths, located.admission),
       };
     });
   }
@@ -290,7 +295,7 @@ export class AgenCDaemonRunInspectionService {
             ? "admission_source_unavailable"
             : replay.gap !== null
               ? "journal_gap"
-            : afterSequence > 0 || replay.hasMore
+            : afterSequence > 0 || replay.hasMore || located.admission !== undefined
               ? "partial"
               : "complete";
         const bundleDocument = {
@@ -306,6 +311,9 @@ export class AgenCDaemonRunInspectionService {
           gap: replay.gap,
           gapSha256,
           eventHashes,
+          ...(located.admission !== undefined
+            ? { admissionSource: runStateSource(located.paths, located.admission) }
+            : {}),
         } as const;
         const bundle = workflowEvidenceBundle(this.#agencHome, db, runId);
         const result: RunEvidenceResult = {
@@ -315,6 +323,12 @@ export class AgenCDaemonRunInspectionService {
               ? "canonical_run_journal"
               : "existing_m3_admission_state",
             projectDir: located.paths.projectDir,
+            ...(located.admission !== undefined
+              ? {
+                  admissionProjectDir: located.admission.paths.projectDir,
+                  admissionLastSequence: located.admission.lastSequence,
+                }
+              : {}),
             admissionJournal: status.admission.sources.journal,
             workflowEvidenceIncluded: canonicalJournal,
             completeness,
@@ -343,18 +357,20 @@ export class AgenCDaemonRunInspectionService {
   }
 
   #locate(runId: string): LocatedRun {
-    const matches: LocatedRun[] = [];
+    const matches: (LocatedRun & { readonly canonical: boolean; readonly hasAdmission: boolean })[] = [];
+    const discovered: StateDatabasePaths[] = [];
     const seen = new Set<string>();
     for (const paths of this.#stateDatabasePaths()) {
       if (seen.has(paths.stateDbPath)) continue;
       seen.add(paths.stateDbPath);
       if (!existsSync(paths.stateDbPath)) continue;
+      discovered.push(paths);
       const match = withReadonlyStateDatabase(paths, (db) => {
         const run = readAgentRun(db, runId);
-        return run !== undefined ||
-          hasAdmissionState(db, runId) ||
-          hasCanonicalRunState(db, runId)
-          ? { paths, ...(run !== undefined ? { run } : {}) }
+        const canonical = hasCanonicalRunState(db, runId);
+        const hasAdmission = hasAdmissionState(db, runId);
+        return run !== undefined || hasAdmission || canonical
+          ? { paths, canonical, hasAdmission, ...(run !== undefined ? { run } : {}) }
           : undefined;
       });
       if (match !== undefined) matches.push(match);
@@ -365,14 +381,130 @@ export class AgenCDaemonRunInspectionService {
         `no durable run or admission state found for id: ${runId}`,
       );
     }
-    if (matches.length > 1) {
-      throw new AgenCDaemonRunInspectionError(
-        "RUN_ID_AMBIGUOUS",
-        `run id ${runId} exists in multiple project state databases`,
-      );
-    }
-    return matches[0]!;
+    const canonicalMatches = matches.filter((match) => match.canonical);
+    if (canonicalMatches.length === 0 && matches.length === 1) return matches[0]!;
+    if (canonicalMatches.length !== 1) throw ambiguousRunOwner(runId);
+    const canonical = canonicalMatches[0]!;
+    refreshRunJournalProjection(canonical.paths, runId);
+    const authority = withReadonlyStateDatabase(canonical.paths, (db) => readRunAdmissionAuthority(db, runId));
+    if (matches.length === 1 && authority.owner === undefined) return canonical;
+    const admissionMatches = matches.filter((match) => match.hasAdmission);
+    const declaredOwners = authority.owner === undefined ? [] : discovered.filter((paths) =>
+      paths.projectDir === authority.owner?.workspaceId || withReadonlyStateDatabase(paths, (db) =>
+        hasDeclaredAdmissionWorkspace(db, authority.owner!, runId),
+      ),
+    );
+    if (declaredOwners.length > 1) throw ambiguousRunOwner(runId);
+    const declaredOwnerPaths = declaredOwners[0];
+    const owner: LocatedRun | undefined = authority.owner === undefined
+      ? admissionMatches.length === 1 ? admissionMatches[0] : undefined
+      : declaredOwnerPaths === undefined ? undefined : { paths: declaredOwnerPaths };
+    if (owner === undefined || !authority.identitiesValid) throw ambiguousRunOwner(runId);
+    if (matches.some((match) => match.paths.stateDbPath !== canonical.paths.stateDbPath && match.paths.stateDbPath !== owner.paths.stateDbPath)) throw ambiguousRunOwner(runId);
+    const admission = withReadonlyStateDatabase(owner.paths, (db) => db.transaction(() => {
+      verifyRunAdmissionAuthority(db, authority, runId);
+      const runIds = collectRunTreeIds(db, runId);
+      const lastSequence = tableExists(db, "execution_admission_journal")
+        ? db.prepare<unknown[], { last_sequence: number | null }>(
+            `SELECT MAX(sequence) AS last_sequence FROM execution_admission_journal WHERE run_id IN (${placeholders(runIds.length)})`,
+          ).get(...runIds)?.last_sequence ?? 0
+        : 0;
+      return { paths: owner.paths, summary: admissionSummary(db, runId), lastSequence };
+    })());
+    return owner.paths.stateDbPath === canonical.paths.stateDbPath ? canonical : { ...canonical, admission };
   }
+}
+
+interface RunAdmissionAuthority {
+  readonly identitiesValid: boolean;
+  readonly owner?: { readonly workspaceId: string; readonly runId: string; readonly parentRunId?: string };
+  readonly events: readonly JsonObject[];
+}
+
+function ambiguousRunOwner(runId: string): AgenCDaemonRunInspectionError {
+  return new AgenCDaemonRunInspectionError(
+    "RUN_ID_AMBIGUOUS",
+    `run id ${runId} has conflicting or unproved journal/admission owners`,
+  );
+}
+
+function isRunAuthorityObject(value: JsonValue | undefined): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRunAdmissionAuthority(db: BetterSqlite3.Database, runId: string): RunAdmissionAuthority {
+  if (!tableExists(db, "run_journal_bindings") || !tableExists(db, "thread_rollout_items")) {
+    return { identitiesValid: false, events: [] };
+  }
+  const bindings = db.prepare<[string], { child_run_id: string; session_id: string }>(
+    "SELECT child_run_id, session_id FROM run_journal_bindings WHERE run_id = ? LIMIT 33",
+  ).all(runId);
+  const identitiesValid = bindings.length > 0 && bindings.length <= 32 &&
+    bindings.every((binding) => binding.child_run_id === runId && binding.session_id === runId);
+  let owner: RunAdmissionAuthority["owner"];
+  const rows = db.prepare<[string], { item_type: string; payload_json: string }>(
+    `SELECT item_type, payload_json FROM thread_rollout_items
+     WHERE source_path IN (SELECT source_path FROM run_journal_bindings WHERE run_id = ?)
+       AND (item_type = 'session_meta' OR
+         (item_type = 'event_msg' AND json_extract(payload_json, '$.msg.type') = 'execution_admission'))
+     ORDER BY source_path, line_number LIMIT 100001`,
+  ).all(runId);
+  if (rows.length > 100000) throw ambiguousRunOwner(runId);
+  const events: JsonObject[] = [];
+  for (const row of rows) {
+    const payload = parseJsonObject(row.payload_json);
+    if (row.item_type === "session_meta") {
+      if (payload.sessionId !== runId) throw ambiguousRunOwner(runId);
+      if (payload.admissionOwner === undefined) continue;
+      const candidate = payload.admissionOwner;
+      if (!isRunAuthorityObject(candidate) ||
+          candidate.runId !== runId || typeof candidate.workspaceId !== "string" || candidate.workspaceId.length === 0 ||
+          (candidate.parentRunId !== undefined && (typeof candidate.parentRunId !== "string" || candidate.parentRunId.length === 0 || candidate.parentRunId === runId))) {
+        throw ambiguousRunOwner(runId);
+      }
+      const current = { workspaceId: candidate.workspaceId, runId, ...(typeof candidate.parentRunId === "string" ? { parentRunId: candidate.parentRunId } : {}) };
+      if (owner !== undefined && canonicalJson(owner) !== canonicalJson(current)) throw ambiguousRunOwner(runId);
+      owner = current;
+    } else {
+      const message = payload.msg;
+      const event = isRunAuthorityObject(message) ? message.payload : undefined;
+      if (!isRunAuthorityObject(event) || event.runId !== runId ||
+          typeof event.eventId !== "string" || event.eventId !== payload.eventId) throw ambiguousRunOwner(runId);
+      events.push(event);
+    }
+  }
+  return { identitiesValid, ...(owner !== undefined ? { owner } : {}), events };
+}
+
+function verifyRunAdmissionAuthority(db: BetterSqlite3.Database, authority: RunAdmissionAuthority, runId: string): void {
+  if (authority.owner === undefined && authority.events.length === 0) throw ambiguousRunOwner(runId);
+  if (authority.events.length > 0 && !tableExists(db, "execution_admission_journal")) throw ambiguousRunOwner(runId);
+  for (const event of authority.events) {
+    const row = db.prepare<[string], AdmissionJournalRow>(
+      "SELECT * FROM execution_admission_journal WHERE event_id = ?",
+    ).get(String(event.eventId));
+    if (row === undefined || row.run_id !== runId) throw ambiguousRunOwner(runId);
+    const { category: ignoredCategory, ...admissionEvent } = legacyJournalEventFromRow(row);
+    if (canonicalJson(admissionEvent) !== canonicalJson(event)) throw ambiguousRunOwner(runId);
+  }
+  if (authority.owner?.parentRunId !== undefined && tableExists(db, "agent_jobs") && columnExists(db, "agent_jobs", "admission_parent_run_id")) {
+    const parents = db.prepare<[string], { parent_run_id: string | null }>(
+      "SELECT DISTINCT admission_parent_run_id AS parent_run_id FROM agent_jobs WHERE admission_run_id = ?",
+    ).all(runId);
+    if (parents.some((parent) => parent.parent_run_id !== authority.owner?.parentRunId)) throw ambiguousRunOwner(runId);
+  }
+}
+
+function hasDeclaredAdmissionWorkspace(
+  db: BetterSqlite3.Database,
+  owner: NonNullable<RunAdmissionAuthority["owner"]>,
+  runId: string,
+): boolean {
+  if (!tableExists(db, "agent_jobs") || !columnExists(db, "agent_jobs", "admission_workspace_id")) return false;
+  return db.prepare<[string, string, string], { present: number }>(
+    `SELECT 1 AS present FROM agent_jobs
+     WHERE admission_workspace_id = ? AND admission_run_id IN (?, ?) LIMIT 1`,
+  ).get(owner.workspaceId, runId, owner.parentRunId ?? runId) !== undefined;
 }
 
 function hasCanonicalRunState(
@@ -401,7 +533,7 @@ function buildRunStatus(
   located: LocatedRun,
   runId: string,
 ): RunStatusResult {
-  const admission = admissionSummary(db, runId);
+  const admission = located.admission?.summary ?? admissionSummary(db, runId);
   const run = readAgentRun(db, runId) ?? located.run;
   const currentLifecycleEpoch = readCurrentLifecycleEpoch(db, runId);
   const durableTerminal = readCurrentTerminalResult(db, runId);
@@ -431,7 +563,7 @@ function buildRunStatus(
           : "agent_run",
     ...(run !== undefined ? { durableRun: durableRunFromRow(run) } : {}),
     admission,
-    source: runStateSource(located.paths),
+    source: runStateSource(located.paths, located.admission),
     ...(workflow !== undefined ? { workflow } : {}),
   };
 }
@@ -1232,10 +1364,13 @@ function terminalOutcome(status: string): RunResultResult["outcome"] {
   return "failed";
 }
 
-function runStateSource(paths: StateDatabasePaths): RunStatusResult["source"] {
+function runStateSource(paths: StateDatabasePaths, admission?: LocatedRun["admission"]): RunStatusResult["source"] {
   return {
     kind: "existing_state_database",
     projectDir: paths.projectDir,
+    ...(admission !== undefined
+      ? { admissionProjectDir: admission.paths.projectDir, admissionLastSequence: admission.lastSequence }
+      : {}),
     readonly: true,
   };
 }

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -420,8 +420,6 @@ const ZERO_ESTIMATE = {
   maxOutputTokens: 0,
   maxCostUsd: 0,
 } as const;
-const SPAWN_ESTIMATE_INPUT_TOKENS = 1_000_000;
-const SPAWN_ESTIMATE_OUTPUT_TOKENS = 200_000;
 const EVIDENCE_MESSAGE_LIMIT = 20_000;
 
 // ---------------------------------------------------------------------------
@@ -1319,11 +1317,7 @@ export class VerifiedChangeWorkflowController {
             canonicalizeJson({ stepId, childRunId, reviewer: ctx.spec.reviewerModel }),
           ),
           childRunId,
-          estimate: {
-            maxInputTokens: SPAWN_ESTIMATE_INPUT_TOKENS,
-            maxOutputTokens: SPAWN_ESTIMATE_OUTPUT_TOKENS,
-            maxCostUsd: ctx.spec.budget.maxCostUsd ?? null,
-          },
+          estimate: ZERO_ESTIMATE,
           ...(ctx.spec.reviewerModel !== undefined
             ? { model: ctx.spec.reviewerModel }
             : {}),
@@ -1683,14 +1677,7 @@ export class VerifiedChangeWorkflowController {
     if (verification === undefined || review === undefined) {
       throw new Error("record assembly requires verification and review context");
     }
-    const usage = ctx.usage.any
-      ? {
-          inputTokens: ctx.usage.input,
-          outputTokens: ctx.usage.output,
-          totalTokens: ctx.usage.input + ctx.usage.output,
-          costUsd: ctx.usage.cost,
-        }
-      : null;
+    const usage = this.#canonicalUsage(ctx);
     return assembleVerifiedChangeRecord({
       runId: ctx.runId,
       specDigest: ctx.specDigest,
@@ -1758,11 +1745,6 @@ export class VerifiedChangeWorkflowController {
           : outcome.status === "cancelled"
             ? "cancelled"
             : "failed";
-      // The child's usage is already reconciled at its durable source (the
-      // child run's own admission reservations charge the shared allocation
-      // scopes), so it rides `rollupUsage` — accumulated into the run's
-      // terminal usage rollup, never re-reconciled against the parent spawn
-      // reservation (that would double-charge the budget).
       const rollupUsage =
         outcome.usage === null
           ? undefined
@@ -1792,11 +1774,7 @@ export class VerifiedChangeWorkflowController {
         }),
       ),
       childRunId: input.childRunId,
-      estimate: {
-        maxInputTokens: SPAWN_ESTIMATE_INPUT_TOKENS,
-        maxOutputTokens: SPAWN_ESTIMATE_OUTPUT_TOKENS,
-        maxCostUsd: spec.budget.maxCostUsd ?? null,
-      },
+      estimate: ZERO_ESTIMATE,
       ...(spec.model !== undefined ? { model: spec.model } : {}),
       ...(spec.provider !== undefined ? { provider: spec.provider } : {}),
       beforeCommitFailpoints: input.beforeCommitFailpoints ?? [
@@ -2428,14 +2406,14 @@ export class VerifiedChangeWorkflowController {
       }
     }
     try {
-      const usage = ctx.usage.any
-        ? {
-            inputTokens: ctx.usage.input,
-            outputTokens: ctx.usage.output,
-            totalTokens: ctx.usage.input + ctx.usage.output,
-            costUsd: ctx.usage.cost,
-          }
-        : null;
+      let usage: RunUsageTotals | null = null;
+      try {
+        usage = this.#canonicalUsage(ctx);
+      } catch (error) {
+        this.#deps.warn(
+          `workflow ${ctx.runId} canonical usage is unavailable: ${errorMessage(error)}`,
+        );
+      }
       const terminalEvent = ctx.journal.appendTerminal({
         status: terminal.status,
         stopReason: terminal.stopReason,
@@ -2466,6 +2444,20 @@ export class VerifiedChangeWorkflowController {
         `workflow ${ctx.runId} failed to record its terminal result: ${errorMessage(error)}`,
       );
     }
+  }
+
+  #canonicalUsage(ctx: RunContext): RunUsageTotals | null {
+    const summary = ctx.admission.getUsageSummary?.();
+    if (summary !== undefined && summary.runId !== ctx.runId) {
+      throw new Error(`canonical usage belongs to ${summary.runId}, not workflow ${ctx.runId}`);
+    }
+    if (summary === undefined || summary.hasUnknownCost) return null;
+    return {
+      inputTokens: summary.inputTokens,
+      outputTokens: summary.outputTokens,
+      totalTokens: summary.totalTokens,
+      costUsd: summary.costUsd,
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -1124,7 +1124,7 @@ export async function prepareTurnRuntimeInputs(params: {
   readonly registry: { readonly tools: readonly { readonly name: string }[] };
 }): Promise<PreparedTurnRuntimeInputs> {
   const currentConfig = params.configStore.current();
-  const memory = await resolveMemoryPromptInputs();
+  const memory = await resolveMemoryPromptInputs(params.session, params.workspaceRoot);
 
   return {
     memoryPromptText: memory.memoryPrompt,

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1514,6 +1514,8 @@ async function bootstrapLocalRuntimeSessionScoped(
   const baseInstructions = await assembleBaseInstructionsForModel({
     session: {
       services: {
+        configStore,
+        userShell: commandExecutionAuthority,
         runtimeOptions,
         sandboxExecutionBroker,
         providerEnvironment,

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2758,6 +2758,7 @@ function createMcpResourceTools(opts: ModelFacingToolOptions): readonly Tool[] {
 function createSkillInvocationRuntimeTool(opts: ModelFacingToolOptions): Tool {
   return {
     name: "Skill",
+    admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
     description:
       "Execute a skill within the main conversation. When a skill matches the user's request, call this tool before responding. Pass the skill name and optional arguments; available skills are listed in system reminders. Do not use this for MCP tools or names like mcp.server.tool; call MCP tools through their own tool function after system.searchTools discovery.",
     metadata: toolMetadata("skill", {
@@ -4643,6 +4644,7 @@ function createCronAndWorkflowTools(
   return [
     {
       name: "CronCreate",
+      admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
       description:
         "Schedule a recurring (or one-shot) prompt on a five-field cron expression. Jobs are executed by the runtime's own scheduler: when a job comes due its prompt is enqueued as a new turn in this session. Durable jobs persist in .agenc/scheduled_tasks.json and re-arm on restart; non-durable jobs die with the session. Delivery-routed jobs (announceChannel/webhook) instead run in an isolated gateway session and post their result to that channel/webhook — they require durable and a running `agenc gateway run`.",
       metadata: toolMetadata("workflow", {
@@ -4756,6 +4758,7 @@ function createCronAndWorkflowTools(
     },
     {
       name: "CronDelete",
+      admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
       description: "Delete a scheduled prompt job by id.",
       metadata: toolMetadata("workflow", {
         mutating: true,
@@ -4795,6 +4798,7 @@ function createCronAndWorkflowTools(
     },
     {
       name: "CronList",
+      admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
       description:
         "List scheduled prompt jobs (id, cron expression, prompt, recurring).",
       metadata: toolMetadata("workflow", {

--- a/runtime/src/bin/route.ts
+++ b/runtime/src/bin/route.ts
@@ -19,6 +19,7 @@
  */
 
 import {
+  CLI_VALUE_OPTIONS,
   STARTUP_VALUE_OPTIONS,
   tokenizeCliOptionRegion,
 } from "./cli-option-region.js";
@@ -96,17 +97,15 @@ const STARTUP_BOOLEAN_FLAGS = Object.freeze([
   "-c",
   "-p",
   "--print",
+  "--debug",
+  "-d",
+  "--debug-to-stderr",
+  "-d2e",
   AUTONOMOUS_FLAG,
   DANGEROUS_BYPASS_FLAG,
 ] as const);
 
-// gaphunt3 #37: only list value flags that a downstream consumer actually
-// honors. --fork/--sandbox/--approval-policy had no consumer
-// anywhere (classifyCLI/readStartupCliFlags/bootstrap), so stripping them
-// here silently swallowed the flag AND its value, dropping the user's
-// intent with no behavior and no feedback. Removing them lets the flag
-// text fall through as visible prompt content instead of vanishing.
-const STARTUP_VALUE_FLAGS = STARTUP_VALUE_OPTIONS;
+const STARTUP_VALUE_FLAGS = CLI_VALUE_OPTIONS;
 
 function shouldStripValueFlag(arg: string): boolean {
   return STARTUP_VALUE_FLAGS.some(
@@ -239,7 +238,7 @@ function findMissingHeadlessFormatValueFlag(
 }
 
 function shouldStripBooleanFlag(arg: string): boolean {
-  return ROUTING_BOOLEAN_FLAGS.includes(
+  return arg.startsWith("--debug=") || ROUTING_BOOLEAN_FLAGS.includes(
     arg as (typeof ROUTING_BOOLEAN_FLAGS)[number],
   ) ||
     STARTUP_BOOLEAN_FLAGS.includes(
@@ -347,6 +346,23 @@ export function classifyCLI(opts: ClassifyCLIOptions): RouteCLIPlan {
     return {
       kind: "errorAndExit",
       message: `agenc: ${retiredStartupFlagError(retiredStartupFlag)}`,
+      exitCode: 2,
+    };
+  }
+
+  for (let optionIndex = 0; optionIndex < optionArgs.length; optionIndex += 1) {
+    const option = optionArgs[optionIndex]!;
+    if (shouldStripBooleanFlag(option)) continue;
+    if (shouldStripValueFlag(option)) {
+      if (!option.includes("=")) {
+        const value = optionArgs[optionIndex + 1];
+        if (value !== undefined && !value.startsWith("-")) optionIndex += 1;
+      }
+      continue;
+    }
+    return {
+      kind: "errorAndExit",
+      message: `agenc: unknown option '${option}'. Use '--' before literal prompt text that starts with '-'.`,
       exitCode: 2,
     };
   }

--- a/runtime/src/commands/session-compact.ts
+++ b/runtime/src/commands/session-compact.ts
@@ -980,7 +980,7 @@ async function buildSyntheticSystemMessage(opts: {
     // Mirror `prepareTurnRuntimeInputs`: the memory instructions and the
     // directory block are part of every turn's prompt when auto memory is
     // enabled, so /context must count them too.
-    const memory = await resolveMemoryPromptInputs();
+    const memory = await resolveMemoryPromptInputs(opts.session, opts.ctx.cwd);
     const assembled = await assembleSystemPrompt(
       buildAssembleSystemPromptOpts({
         session: opts.session,

--- a/runtime/src/hooks/engine/command-runner.ts
+++ b/runtime/src/hooks/engine/command-runner.ts
@@ -8,7 +8,7 @@ import {
   missingSandboxExecutionBoundary,
   type SandboxExecutionBrokerLike,
 } from "../../sandbox/execution-broker.js";
-import { runSupervisedProcess } from "../../utils/supervisedProcess.js";
+import { runSupervisedProcess, throwIfPreparedSpawnCleanupUnproven } from "../../utils/supervisedProcess.js";
 import {
   commandShellArgs,
   wrapCommandForShell,
@@ -28,6 +28,7 @@ export interface RunHookCommandOptions {
   readonly timeoutMs: number;
   readonly signal?: AbortSignal;
   readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
+  readonly beforeSpawn?: () => void;
 }
 
 export async function runHookCommand(
@@ -41,6 +42,7 @@ export async function runHookCommand(
       stderr: "",
       durationMs: Date.now() - started,
       error: "hook aborted",
+      processStarted: false,
     };
   }
   const env = stringOnlyEnv(opts.env);
@@ -58,11 +60,19 @@ export async function runHookCommand(
     cwd: opts.cwd,
     env,
   });
-  const result = await runSupervisedProcess(preparedSpawn, {
-    timeoutMs: opts.timeoutMs,
-    maxOutputBytes: MAX_HOOK_OUTPUT_CHARS * 2,
-    stdin: opts.stdin,
-    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+  const result = await preparedSpawn.run(async (preparedCommand, lifecycleSignal) => {
+    const signal = opts.signal === undefined
+      ? lifecycleSignal
+      : AbortSignal.any([opts.signal, lifecycleSignal]);
+    if (!signal.aborted) opts.beforeSpawn?.();
+    const completed = await runSupervisedProcess(preparedCommand, {
+      timeoutMs: opts.timeoutMs,
+      maxOutputBytes: MAX_HOOK_OUTPUT_CHARS * 2,
+      stdin: opts.stdin,
+      signal,
+    });
+    throwIfPreparedSpawnCleanupUnproven(completed);
+    return completed;
   });
   const boundedStdout = appendBoundedOutput("", result.stdout.toString("utf8"));
   const boundedStderr = appendBoundedOutput("", result.stderr.toString("utf8"));
@@ -71,6 +81,7 @@ export async function runHookCommand(
     stdout: boundedStdout.value,
     stderr: boundedStderr.value,
     durationMs: Date.now() - started,
+    processStarted: result.processStarted,
   };
   if (result.stopReason === "timeout") {
     return {

--- a/runtime/src/hooks/engine/types.ts
+++ b/runtime/src/hooks/engine/types.ts
@@ -37,6 +37,7 @@ export interface IndividualHookConfig {
 }
 
 export interface CommandRunResult {
+  readonly processStarted?: boolean;
   readonly status: HookRunStatus;
   readonly exitCode?: number;
   readonly stdout: string;

--- a/runtime/src/hooks/status-line-executor.ts
+++ b/runtime/src/hooks/status-line-executor.ts
@@ -5,6 +5,7 @@ import type { SessionStatusLineExecuteResult as SessionStatusLineResult, Session
 import { AdmissionDeniedError } from "../budget/admission-client.js";
 import { mergeConfigLayerSnapshots } from "../config/repository.js";
 import { validateStatusLineConfig } from "../config/schema.js";
+import { SandboxExecutionError } from "../sandbox/execution-broker.js";
 import type { Session } from "../session/session.js";
 import { isAdmissionUsageSummary } from "../session/usage-summary.js";
 import { VERSION } from "../version.js";
@@ -219,11 +220,6 @@ async function runSessionStatusLine(
         const freshInput = statusLineInput(session, presentation);
         if (freshInput === undefined) return { status: "unavailable", reason: "session_input_unavailable" };
         if (Buffer.byteLength(freshInput, "utf8") > MAX_INPUT_BYTES) return { status: "error", reason: "input_too_large" };
-        admission.markDispatched(reservationId, {
-          boundary: "tool_effect",
-          details: { hookEvent: "StatusLine" },
-        });
-        dispatched = true;
         const result = await runHookCommand({
           command: command.command,
           cwd: sessionConfig.cwd,
@@ -234,8 +230,17 @@ async function runSessionStatusLine(
           timeoutMs: TIMEOUT_MS,
           signal: effectSignal,
           sandboxExecutionBroker: broker,
+          beforeSpawn: () => {
+            admission.markDispatched(reservationId, {
+              boundary: "tool_effect",
+              details: { hookEvent: "StatusLine" },
+            });
+            dispatched = true;
+          },
         });
-        if (effectSignal.aborted || result.status === "timeout" || result.status === "skipped") {
+        if (!dispatched) {
+          admission.void(reservationId, "status_line_stopped_before_dispatch");
+        } else if (result.processStarted !== false && (effectSignal.aborted || result.status === "timeout" || result.status === "skipped")) {
           admission.holdUnknown(reservationId, "status_line_cancelled_after_dispatch");
         } else {
           admission.reconcile(reservationId, { inputTokens: 0, outputTokens: 0, costUsd: 0 });
@@ -284,6 +289,7 @@ export function executeSessionStatusLine(
       if (combined.aborted) return { status: "unavailable", reason: "cancelled" };
       if (error instanceof AdmissionDeniedError) return { status: "blocked", reason: "admission_denied" };
       if (error instanceof WorkspaceMutationCoordinatorError) return { status: "blocked", reason: "editor_workspace_owned" };
+      if (error instanceof SandboxExecutionError) return { status: "blocked", reason: error.code };
       return { status: "error", reason: "execution_failed" };
     }).finally(() => {
       clearTimeout(timer);

--- a/runtime/src/memory/memdir.ts
+++ b/runtime/src/memory/memdir.ts
@@ -12,6 +12,8 @@
 import { feature } from 'bun:bundle'
 import { join } from 'path'
 import { getFsImplementation } from '../utils/fsOperations.js'
+import { resolveAutoMemoryDirectory, resolveGlobalMemoryDirectory, type ResolveAutoMemoryDirectoryOptions } from '../services/extractMemories/memory-paths.js'
+import { getProjectDir as getCanonicalProjectDir } from '../session/session-store.js'
 import {
   getAutoMemPath,
   getGlobalMemoryPath,
@@ -157,12 +159,12 @@ export function buildSessionMemoryLayerLines(): string[] {
   ]
 }
 
-export function buildMemoryLayerLines(projectMemoryDir = getProjectMemoryPath()): string[] {
+export function buildMemoryLayerLines(projectMemoryDir = getProjectMemoryPath(), globalMemoryDir = getGlobalMemoryPath(), projectInstructionPath = getProjectInstructionPath()): string[] {
   return [
     '## Memory layers',
     '',
-    `- Global memory: durable user-level memory shared across projects at \`${getGlobalMemoryPath()}\`.`,
-    `- Project memory: durable project-level memory at \`${projectMemoryDir}\` plus project instructions from \`${getProjectInstructionPath()}\`.`,
+    `- Global memory: durable user-level memory shared across projects at \`${globalMemoryDir}\`.`,
+    `- Project memory: durable project-level memory at \`${projectMemoryDir}\` plus project instructions from \`${projectInstructionPath}\`.`,
     '- Session memory: in-conversation state for this current thread. Use plans, tasks, and normal conversation context for information that only matters during this session.',
     '',
   ]
@@ -223,11 +225,12 @@ export function buildMemoryInstructionLines(): string[] {
 export function buildMemoryDirectoryLines(
   projectMemoryDir = getProjectMemoryPath(),
   extraGuidelines?: readonly string[],
+  globalMemoryDir = getGlobalMemoryPath(),
 ): string[] {
   return [
     '# Memory directories',
     '',
-    `- Global memory (user-level, shared across projects): \`${getGlobalMemoryPath()}\``,
+    `- Global memory (user-level, shared across projects): \`${globalMemoryDir}\``,
     `- Project memory (this repository, shared by its git worktrees): \`${projectMemoryDir}\``,
     '- Session memory is the current conversation: use plans and tasks for state that only matters in this session.',
     '',
@@ -247,9 +250,7 @@ export function buildMemoryDirectoryLines(
  * files + MEMORY.md. MEMORY.md is still loaded into context (via agencmd.ts)
  * as the distilled index — this prompt only changes where NEW memories go.
  */
-function buildAssistantDailyLogPrompt(skipIndex = false): string {
-  const projectMemoryDir = getAutoMemPath()
-  const globalMemoryDir = getGlobalMemoryPath()
+function buildAssistantDailyLogPrompt(skipIndex = false, projectMemoryDir = getAutoMemPath(), globalMemoryDir = getGlobalMemoryPath(), owner?: { projectInstructionPath: string; transcriptDir: string }): string {
   // Describe the path as a pattern rather than inlining today's literal path:
   // this prompt is cached by systemPromptSection('memory', ...) and NOT
   // invalidated on date change. The model derives the current date from the
@@ -269,7 +270,7 @@ function buildAssistantDailyLogPrompt(skipIndex = false): string {
     '',
     `You have persistent, file-based memory directories: global memory at \`${globalMemoryDir}\` and project memory at \`${projectMemoryDir}\`. ${DIRS_EXIST_GUIDANCE}`,
     '',
-    ...buildMemoryLayerLines(projectMemoryDir),
+    ...buildMemoryLayerLines(projectMemoryDir, globalMemoryDir, owner?.projectInstructionPath),
     '## Where to save memories',
     '',
     `- Save user-level memories (preferences, corrections, cross-project facts) in global memory at \`${globalMemoryDir}\`. Update that directory's \`${ENTRYPOINT_NAME}\` index when you add, rename, or remove a global memory topic file.`,
@@ -300,7 +301,7 @@ function buildAssistantDailyLogPrompt(skipIndex = false): string {
           `The project \`${ENTRYPOINT_NAME}\` is the distilled index maintained nightly from project logs and is loaded into your context automatically. Read it for orientation, but do not edit the project index directly — record new project information in today's log instead. Global memory has its own \`${ENTRYPOINT_NAME}\`; update the global index when you save global user-level topic files.`,
           '',
         ]),
-    ...buildSearchingPastContextSection([globalMemoryDir, projectMemoryDir]),
+    ...buildSearchingPastContextSection([globalMemoryDir, projectMemoryDir], owner?.transcriptDir),
   ]
 
   return lines.join('\n')
@@ -311,8 +312,8 @@ function buildAssistantDailyLogPrompt(skipIndex = false): string {
  */
 export function buildSearchingPastContextSection(
   durableMemoryDirs: string | readonly string[],
+  projectDir = getProjectDir(getOriginalCwd()),
 ): string[] {
-  const projectDir = getProjectDir(getOriginalCwd())
   const memoryDirs = Array.from(
     new Set(
       (Array.isArray(durableMemoryDirs)
@@ -371,9 +372,14 @@ function quoteShellPath(path: string): string {
  * stays readable and writable as ordinary project memory. Returns null when
  * auto memory is disabled.
  */
-export async function loadMemoryPrompt(): Promise<MemoryPromptSections | null> {
-  const autoEnabled = isAutoMemoryEnabled()
-  if (!autoEnabled) return null
+export async function loadMemoryPrompt(owner?: ResolveAutoMemoryDirectoryOptions): Promise<MemoryPromptSections | null> {
+  const resolved = owner === undefined ? undefined : await resolveAutoMemoryDirectory(owner)
+  if (resolved === undefined ? !isAutoMemoryEnabled() : !resolved.enabled || resolved.path === undefined) return null
+  const autoDir = owner === undefined ? getAutoMemPath() : resolved?.path
+  const globalDir = owner === undefined ? getGlobalMemoryPath() : await resolveGlobalMemoryDirectory(owner)
+  if (autoDir === undefined || globalDir === undefined) return null
+  await ensureMemoryDirExists(globalDir)
+  await ensureMemoryDirExists(autoDir)
 
   const skipIndex = false
 
@@ -382,26 +388,26 @@ export async function loadMemoryPrompt(): Promise<MemoryPromptSections | null> {
   if (feature('KAIROS') && getKairosActive()) {
     return {
       instructions: '',
-      directories: buildAssistantDailyLogPrompt(skipIndex),
+      directories: buildAssistantDailyLogPrompt(skipIndex, autoDir, globalDir,
+        owner?.configStore === undefined || owner.cwd === undefined ? undefined : {
+          projectInstructionPath: join(owner.configStore.projectRoot, 'AGENC.md'),
+          transcriptDir: getCanonicalProjectDir(owner.cwd, undefined, owner.configStore.homeContext.path),
+        }),
     }
   }
 
   // Cowork injects memory-policy text via env var; it is per-session, so it
   // rides with the directory block.
-  const coworkExtraGuidelines = getSessionCoworkMemoryExtraGuidelines()
+  const coworkExtraGuidelines = owner === undefined ? getSessionCoworkMemoryExtraGuidelines() : owner.runtimeOptions?.coworkMemoryExtraGuidelines
   const extraGuidelines =
     coworkExtraGuidelines && coworkExtraGuidelines.trim().length > 0
       ? [coworkExtraGuidelines]
       : undefined
 
-  const autoDir = getAutoMemPath()
-  const globalDir = getGlobalMemoryPath()
   // Harness guarantees the directories exist so the model can write without
   // checking. The prompt text reflects this ("already exist").
-  await ensureMemoryDirExists(globalDir)
-  await ensureMemoryDirExists(autoDir)
   return {
     instructions: buildMemoryInstructionLines().join('\n'),
-    directories: buildMemoryDirectoryLines(autoDir, extraGuidelines).join('\n'),
+    directories: buildMemoryDirectoryLines(autoDir, extraGuidelines, globalDir).join('\n'),
   }
 }

--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -71,6 +71,7 @@ import {
   unattendedPolicyForContext,
 } from "./unattended-policy.js";
 import type { Session } from "../session/session.js";
+import { isSessionPlanMutation } from "../planning/session-plan-authority.js";
 import {
   classifyYoloAction,
   isAutoModeAllowlistedTool,
@@ -298,7 +299,8 @@ export async function checkRuleBasedPermissions(
     appState.autoModeActive !== true &&
     !toolDoesNotRequireApproval(tool) &&
     !SAFE_YOLO_ALLOWLISTED_TOOLS.has(tool.name) &&
-    !planModeReadOnlyShellCommand(tool, input)
+    !planModeReadOnlyShellCommand(tool, input) &&
+    !isSessionPlanMutation(tool, input, context.session)
   ) {
     const message = planModeDenyMessage(tool.name);
     return Object.freeze({

--- a/runtime/src/permissions/path-validation.ts
+++ b/runtime/src/permissions/path-validation.ts
@@ -33,6 +33,7 @@ import {
 import {
   withSignedAllowedRoots,
 } from "../agents/_deps/filesystem-args.js";
+import { matchesSessionPlanFile, type SessionPlanFileAuthority } from "../planning/session-plan-authority.js";
 import type {
   PermissionDecisionReason,
   PermissionResult,
@@ -61,6 +62,7 @@ export interface ResolvedPathCheckResult extends PathCheckResult {
 
 export interface ValidatePathOptions {
   readonly extraWorkingDirectories?: readonly string[];
+  readonly planFileAuthority?: SessionPlanFileAuthority | null;
 }
 
 export interface ToolPathPermissionOptions {
@@ -71,6 +73,7 @@ export interface ToolPathPermissionOptions {
   readonly context: ToolPermissionContext;
   readonly operationType: FileOperationType;
   readonly extraWorkingDirectories?: readonly string[];
+  readonly planFileAuthority?: SessionPlanFileAuthority | null;
 }
 
 export function formatDirectoryList(directories: string[]): string {
@@ -377,6 +380,18 @@ export function isPathAllowed(
     };
   }
 
+  if (matchesSessionPlanFile(resolvedPath, options.planFileAuthority)) {
+    const askRule = matchingRuleForPath(
+      resolvedPath, context, operationType, "ask",
+    );
+    return askRule === null
+      ? {
+          allowed: true,
+          decisionReason: { type: "other", reason: "owning session plan file" },
+        }
+      : { allowed: false, decisionReason: { type: "rule", rule: askRule } };
+  }
+
   if (operationType !== "read") {
     const safetyCheck = checkPathSafetyForAutoEdit(
       resolvedPath,
@@ -646,7 +661,12 @@ export function checkToolPathPermission(
     opts.cwd,
     opts.context,
     opts.operationType,
-    { extraWorkingDirectories: opts.extraWorkingDirectories },
+    {
+      extraWorkingDirectories: opts.extraWorkingDirectories,
+      planFileAuthority: matchesSessionPlanFile(
+        opts.path, opts.planFileAuthority, opts.cwd,
+      ) ? opts.planFileAuthority : null,
+    },
   );
   if (result.allowed) {
     return {
@@ -686,7 +706,10 @@ export function checkToolPathPermission(
   // bypass.
   if (
     opts.context.mode === "bypassPermissions" &&
-    decisionReason?.type !== "safetyCheck"
+    decisionReason?.type !== "safetyCheck" &&
+    !(decisionReason?.type === "rule" &&
+      decisionReason.rule.ruleBehavior === "ask" &&
+      matchesSessionPlanFile(opts.path, opts.planFileAuthority, opts.cwd))
   ) {
     return {
       behavior: "allow",

--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -33,6 +33,8 @@
 
 import { dirname, isAbsolute, resolve } from "node:path";
 import type { LLMToolCall } from "../../llm/types.js";
+import { signedSessionPlanFileArgs } from "../../agents/_deps/filesystem-args.js";
+import { sessionPlanFileAuthority } from "../../planning/session-plan-authority.js";
 import {
   getPlan,
   getPlanFilePath,
@@ -977,6 +979,7 @@ export class StreamingToolExecutor {
                 arguments: JSON.stringify(dispatchArgs),
               };
               return dispatchWithInjectedArgs(this.registry, dispatchCall, {
+                ...signedSessionPlanFileArgs(sessionPlanFileAuthority(session)),
                 __onProgress: onProgress,
                 __abortSignal: this.abortSignal,
                 __callId: tool.toolCall.id,

--- a/runtime/src/planning/plan-files.ts
+++ b/runtime/src/planning/plan-files.ts
@@ -97,7 +97,7 @@ function cacheKey(key: PlanKey): string {
 }
 
 function slugIndexPath(ctx: PlanFileContext): string {
-  return join(getPlansDirectory(ctx), ".slugs.json");
+  return join(resolveAgencHome(ctx), "plans", ".slugs.json");
 }
 
 function readSlugIndex(ctx: PlanFileContext): Record<string, string> {
@@ -205,30 +205,16 @@ export function getPlanFilePath(ctx: PlanFileContext = {}): string {
   return pathForSlug(ctx, getPlanSlug(ctx));
 }
 
-/**
- * Does `absolutePath` belong to the current session's plan-file family?
- *
- * Mirrors reference `isSessionPlanFile`
- * (`/home/tetsuo/git/AgenC/src/utils/permissions/filesystem.ts:254`):
- *
- *     const expectedPrefix = join(getPlansDirectory(), getPlanSlug())
- *     return path.startsWith(expectedPrefix) && path.endsWith('.md')
- *
- * The prefix match (rather than exact equality) covers both the main
- * plan file `<plansDir>/<slug>.md` and per-agent plans
- * `<plansDir>/<slug>-agent-<agentId>.md`. The `.md` suffix guards
- * against directory-traversal corner cases like `<slug>../../etc/passwd`.
- *
- * The `.slugs.json` index itself is NOT a plan file — its name does not
- * end in `.md` so the suffix check excludes it.
- *
- * Used by the filesystem tools to allowlist plan-file writes regardless
- * of the workspace allowlist, matching AgenC's
- * `checkEditableInternalPath` carve-out (filesystem.ts:1488-1506) which
- * fires before the workspace-write check and bypasses dangerous-path
- * heuristics (the plan dir lives under the AgenC home, which is normally
- * treated as dangerous).
- */
+export function getExistingPlanFilePath(ctx: PlanFileContext): string | null {
+  const key = baseKey(ctx);
+  const slug = planSlugs.get(cacheKey(key)) ?? readSlugIndex(ctx)[key.sessionId];
+  if (typeof slug !== "string" || slug.length === 0) return null;
+  const agentSuffix = ctx.agentId?.trim()
+    ? `-agent-${sanitizeAgentId(ctx.agentId)}`
+    : "";
+  return join(key.agencHome, "plans", `${slug}${agentSuffix}.md`);
+}
+
 export function isSessionPlanFile(
   absolutePath: string,
   ctx: PlanFileContext = {},
@@ -236,8 +222,7 @@ export function isSessionPlanFile(
   if (typeof absolutePath !== "string" || absolutePath.length === 0) {
     return false;
   }
-  const expectedPrefix = join(getPlansDirectory(ctx), getPlanSlug(ctx));
-  return absolutePath.startsWith(expectedPrefix) && absolutePath.endsWith(".md");
+  return absolutePath === getExistingPlanFilePath(ctx);
 }
 
 export function getPlan(ctx: PlanFileContext = {}): string | null {

--- a/runtime/src/planning/session-plan-authority.ts
+++ b/runtime/src/planning/session-plan-authority.ts
@@ -1,0 +1,128 @@
+import { lstatSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { getExistingPlanFilePath, type PlanFileContext } from "./plan-files.js";
+import { asRecord } from "../utils/record.js";
+import { resolveHomeContext } from "../config/home.js";
+
+export interface SessionPlanFileAuthority {
+  readonly sessionId: string;
+  readonly agencHome: string;
+  readonly planFilePath: string;
+  readonly agentId?: string;
+}
+
+const sessionAuthorities = new WeakMap<object, SessionPlanFileAuthority>();
+
+export function sessionFilesystemContext(
+  session: unknown,
+): { readonly sessionId: string; readonly agencHome: string } | null {
+  const owner = asRecord(session);
+  const configStore = asRecord(asRecord(owner?.services)?.configStore);
+  const homeContext = asRecord(configStore?.homeContext);
+  if (typeof owner?.conversationId !== "string" ||
+      !owner.conversationId.trim() || typeof homeContext?.path !== "string" ||
+      !homeContext.path.trim()) return null;
+  return {
+    sessionId: owner.conversationId,
+    agencHome: resolveHomeContext({ AGENC_HOME: homeContext.path }).path,
+  };
+}
+
+export function planFileAuthorityFromContext(
+  context: PlanFileContext,
+): SessionPlanFileAuthority | null {
+  if (!context.sessionId?.trim() || !context.agencHome?.trim()) return null;
+  try {
+    const planFilePath = getExistingPlanFilePath(context);
+    if (planFilePath === null) return null;
+    const agencHome = realpathSync(context.agencHome);
+    if (agencHome.split(/[\\/]/).some((segment) =>
+      [".git", ".agents"].includes(segment.toLowerCase())
+    )) return null;
+    const plansDirectory = join(agencHome, "plans");
+    if (realpathSync(dirname(planFilePath)) !== plansDirectory) return null;
+    return Object.freeze({
+      sessionId: context.sessionId,
+      agencHome,
+      planFilePath: join(plansDirectory, basename(planFilePath)),
+      ...(context.agentId !== undefined ? { agentId: context.agentId } : {}),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function sessionPlanFileAuthority(
+  session: unknown,
+): SessionPlanFileAuthority | null {
+  const owner = asRecord(session);
+  const services = asRecord(owner?.services);
+  const configStore = asRecord(services?.configStore);
+  const homeContext = asRecord(configStore?.homeContext);
+  const sessionId = owner?.conversationId;
+  const agencHome = homeContext?.path;
+  if (owner === null || typeof sessionId !== "string" ||
+      typeof agencHome !== "string") return null;
+  const existing = sessionAuthorities.get(owner);
+  if (existing !== undefined) {
+    try {
+      return existing.sessionId === sessionId &&
+        existing.agencHome === realpathSync(agencHome) ? existing : null;
+    } catch {
+      return null;
+    }
+  }
+  const authority = planFileAuthorityFromContext({ sessionId, agencHome });
+  if (authority !== null) sessionAuthorities.set(owner, authority);
+  return authority;
+}
+
+export function matchesSessionPlanFile(
+  target: string,
+  authority: SessionPlanFileAuthority | null | undefined,
+  cwd?: string,
+): boolean {
+  if (
+    authority == null || !target || target.length > 4096 ||
+    target.includes("\0") || target.split(/[\\/]/).includes("..") ||
+    /[*?\[\]{}$%]/.test(target)
+  ) return false;
+  if (!isAbsolute(target) && cwd === undefined) return false;
+  try {
+    const absolute = cwd === undefined ? target : resolve(cwd, target);
+    if (basename(absolute) !== basename(authority.planFilePath) ||
+        realpathSync(dirname(absolute)) !== dirname(authority.planFilePath)) return false;
+    try {
+      const stat = lstatSync(absolute);
+      if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) return false;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isSessionPlanMutation(
+  tool: unknown,
+  input: unknown,
+  session: unknown,
+): boolean {
+  const descriptor = asRecord(tool);
+  const metadata = asRecord(descriptor?.metadata);
+  const args = asRecord(input);
+  if (
+    metadata?.source !== "builtin" || metadata.family !== "filesystem" ||
+    !["Write", "Edit", "MultiEdit"].includes(String(descriptor?.name)) ||
+    typeof args?.file_path !== "string"
+  ) return false;
+  const owner = asRecord(session);
+  const configuration = asRecord(owner?.sessionConfiguration);
+  const cwd = typeof args.cwd === "string" ? args.cwd : configuration?.cwd;
+  return matchesSessionPlanFile(
+    args.file_path,
+    sessionPlanFileAuthority(session),
+    typeof cwd === "string" ? cwd : undefined,
+  );
+}

--- a/runtime/src/prompts/system-prompt.ts
+++ b/runtime/src/prompts/system-prompt.ts
@@ -41,6 +41,8 @@ import { spawnSync } from "node:child_process";
 import { platform as osPlatform, type as osType, release as osRelease } from "node:os";
 
 import type { ToolPermissionContext } from "../permissions/types.js";
+import type { ConfigStore } from "../config/store.js";
+import type { AgentRuntimeOptions } from "../session/runtime-options.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import { gitChildEnvironment } from "../sandbox/git-environment.js";
 import { hardenGitWorktreeMutationArgs } from "../sandbox/worktree-permissions.js";
@@ -412,12 +414,19 @@ function getMemoryInstructionsSection(
  * when the memory directories or settings authority cannot be resolved, so a
  * memory misconfiguration never blocks prompt assembly.
  */
-export async function resolveMemoryPromptInputs(): Promise<{
+export async function resolveMemoryPromptInputs(session: SystemPromptSessionSnapshot, cwd: string): Promise<{
   readonly memoryInstructions: string;
   readonly memoryPrompt: string;
 }> {
   try {
-    const prompt = await loadMemoryPrompt();
+    const configStore = session.services?.configStore;
+    if (configStore === undefined) return { memoryInstructions: "", memoryPrompt: "" };
+    const prompt = await loadMemoryPrompt({
+      cwd,
+      configStore,
+      env: session.services?.userShell?.childEnvironment ?? session.services?.providerEnvironment ?? {},
+      runtimeOptions: { remoteMode: false, ...session.services?.runtimeOptions },
+    });
     return {
       memoryInstructions: prompt?.instructions ?? "",
       memoryPrompt: prompt?.directories ?? "",
@@ -659,7 +668,9 @@ Do not narrate each step, list every file you read, or explain routine actions. 
 
 export interface SystemPromptSessionSnapshot {
   readonly services?: {
-    readonly runtimeOptions?: { readonly simpleMode?: boolean };
+    readonly runtimeOptions?: Partial<AgentRuntimeOptions>;
+    readonly configStore?: ConfigStore;
+    readonly userShell?: { readonly childEnvironment: NodeJS.ProcessEnv };
     readonly sandboxExecutionBroker?: SandboxExecutionBrokerLike;
     readonly providerEnvironment?: ProviderEnvironment;
   };
@@ -827,7 +838,7 @@ export async function assembleBaseInstructionsForModel(params: {
   const enabledToolNames = new Set(
     params.registry.tools.map((tool) => tool.name),
   );
-  const memory = await resolveMemoryPromptInputs();
+  const memory = await resolveMemoryPromptInputs(params.session, params.ctx.cwd);
   const snapshot = await assembleSystemPromptSnapshot({
     profile: params.profile,
     session: params.session,

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -1010,7 +1010,7 @@ export function initExtractMemories(
       ...(appendSavedMemories !== undefined ? { appendSavedMemories } : {}),
     };
     const pathResult = await (deps.resolveMemoryDirectory ?? resolveAutoMemoryDirectory)({
-      env: deps.env,
+      env: queued.context.session.services.userShell?.childEnvironment ?? deps.env,
       cwd: queued.context.ctx.cwd,
       configStore: queued.context.session.services?.configStore,
       runtimeOptions: queued.context.session.services.runtimeOptions,
@@ -1021,7 +1021,7 @@ export function initExtractMemories(
     // duplicating what is already there; it still writes only to this
     // session's project root.
     const globalMemoryRoot = await resolveGlobalMemoryDirectory({
-      env: deps.env,
+      env: queued.context.session.services.userShell?.childEnvironment ?? deps.env,
       cwd: queued.context.ctx.cwd,
       configStore: queued.context.session.services?.configStore,
       runtimeOptions: queued.context.session.services.runtimeOptions,

--- a/runtime/src/services/extractMemories/memory-paths.ts
+++ b/runtime/src/services/extractMemories/memory-paths.ts
@@ -70,7 +70,7 @@ export interface ResolveAutoMemoryDirectoryOptions {
   readonly runtimeOptions?: Pick<
     AgentRuntimeOptions,
     "coworkMemoryPathOverride" | "remoteMode" | "remoteMemoryRoot"
-  >;
+  > & Partial<Pick<AgentRuntimeOptions, "simpleMode" | "coworkMemoryExtraGuidelines">>;
   readonly settings?: {
     readonly [K in PermissionRuleSource]?: AgenCConfig | null;
   };
@@ -100,7 +100,7 @@ function effectiveCwd(opts: ResolveAutoMemoryDirectoryOptions): string {
 }
 
 function effectiveHome(opts: ResolveAutoMemoryDirectoryOptions): string {
-  return opts.homeDir ?? homedir();
+  return opts.homeDir ?? (opts.env === undefined ? homedir() : opts.env.HOME ?? opts.env.USERPROFILE ?? "");
 }
 
 function resolveConfigHome(opts: ResolveAutoMemoryDirectoryOptions): string {
@@ -229,7 +229,7 @@ export async function resolveAutoMemoryDirectory(
 ): Promise<AutoMemoryPathResult> {
   const env = effectiveEnv(opts.env);
   const runtimeOptions = opts.runtimeOptions ?? getActiveAgentRuntimeOptions();
-  if (isBareMode()) {
+  if (opts.runtimeOptions === undefined ? isBareMode() : opts.runtimeOptions.simpleMode === true) {
     return { enabled: false, reason: "simple_mode" };
   }
   if (runtimeOptions?.remoteMode && !runtimeOptions.remoteMemoryRoot) {

--- a/runtime/src/session/child-run-journal.ts
+++ b/runtime/src/session/child-run-journal.ts
@@ -82,6 +82,15 @@ export function recordUnconstructedChildRunTerminal(
       agencVersion: parentRollout.store.agencVersion,
       model: options.model,
       modelProvider: options.modelProvider,
+      ...(services?.executionAdmission !== undefined
+        ? {
+            admissionOwner: {
+              workspaceId: services.executionAdmission.scope.workspaceId,
+              runId: options.childRunId,
+              parentRunId: services.executionAdmission.scope.runId,
+            },
+          }
+        : {}),
     });
     let lastSequenceBeforeTerminal = store
       .readAll()
@@ -168,6 +177,9 @@ export function mountChildRunJournal(
   const { parent, child } = options;
   const parentRollout = parent.rolloutStore;
   const admission = child.services.executionAdmission;
+  if (admission !== undefined && admission.scope.runId !== child.conversationId) {
+    throw new AdmissionDeniedError("child_run_journal_identity_conflict");
+  }
   const requiresCanonicalJournal =
     admission !== undefined || child.services.admissionRequired !== false;
   if (parentRollout === null) {
@@ -198,6 +210,17 @@ export function mountChildRunJournal(
     modelProvider:
       readProviderIdentity(child.services.provider) ??
       child.services.provider.name,
+    ...(admission !== undefined
+      ? {
+          admissionOwner: {
+            workspaceId: admission.scope.workspaceId,
+            runId: admission.scope.runId,
+            ...(admission.scope.parentRunId !== undefined
+              ? { parentRunId: admission.scope.parentRunId }
+              : {}),
+          },
+        }
+      : {}),
   });
 
   try {

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -121,6 +121,11 @@ export interface SessionMetaLine {
   readonly modelProvider?: string;
   /** Upstream thread memory mode persisted by metadata-update rows. */
   readonly memoryMode?: string;
+  readonly admissionOwner?: {
+    readonly workspaceId: string;
+    readonly runId: string;
+    readonly parentRunId?: string;
+  };
 }
 
 export interface TurnStartedEvent {

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -687,6 +687,9 @@ const isSessionUsage: Validator<
   AllKeys<EventPayload<"session_usage">>
 > = isAdmissionUsageSummary;
 
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
 const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
   session_meta: objectShape(
     {
@@ -703,6 +706,10 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
       model: isString,
       modelProvider: isString,
       memoryMode: isString,
+      admissionOwner: objectShape(
+        { workspaceId: isNonEmptyString, runId: isNonEmptyString },
+        { parentRunId: isNonEmptyString },
+      ),
     },
   ),
   session_configured: objectShape(

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -2073,9 +2073,10 @@ export async function runToolUse(
     argsForTool = { ...inputForTool };
     const filesystemContext = sessionFilesystemContext(invocation.session);
     const planAuthority = sessionPlanFileAuthority(invocation.session);
+    if (filesystemContext === null) delete argsForTool.__agencHome;
     for (const [key, value] of Object.entries({
       ...signedSessionPlanFileArgs(planAuthority),
-      __agencHome: filesystemContext?.agencHome ?? null,
+      ...(filesystemContext !== null ? { __agencHome: filesystemContext.agencHome } : {}),
     })) {
       Object.defineProperty(argsForTool, key, {
         value,

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -85,6 +85,8 @@ import {
   toolNameDisplay,
 } from "./context.js";
 import type { Tool } from "./types.js";
+import { signedSessionPlanFileArgs } from "../agents/_deps/filesystem-args.js";
+import { sessionFilesystemContext, sessionPlanFileAuthority } from "../planning/session-plan-authority.js";
 import {
   SESSION_ID_SIG_ARG,
   signSessionId,
@@ -2069,6 +2071,18 @@ export async function runToolUse(
   let argsForTool: Record<string, unknown> = inputForTool;
   if (progressCallback || effectiveSignal || invocation.callId.length > 0) {
     argsForTool = { ...inputForTool };
+    const filesystemContext = sessionFilesystemContext(invocation.session);
+    const planAuthority = sessionPlanFileAuthority(invocation.session);
+    for (const [key, value] of Object.entries({
+      ...signedSessionPlanFileArgs(planAuthority),
+      __agencHome: filesystemContext?.agencHome ?? null,
+    })) {
+      Object.defineProperty(argsForTool, key, {
+        value,
+        enumerable: false,
+        configurable: true,
+      });
+    }
     if (progressCallback) {
       Object.defineProperty(argsForTool, "__onProgress", {
         value: progressCallback,

--- a/runtime/src/tools/runtimes/sandboxing.ts
+++ b/runtime/src/tools/runtimes/sandboxing.ts
@@ -25,10 +25,9 @@ import {
   type SandboxPolicy,
 } from "../../permissions/sandbox.js";
 import {
-  getPlansDirectory,
-  isSessionPlanFile,
-  type PlanFileContext,
-} from "../../planning/plan-files.js";
+  matchesSessionPlanFile,
+  sessionPlanFileAuthority,
+} from "../../planning/session-plan-authority.js";
 import type { SandboxMode } from "../orchestrator.js";
 import type { Tool } from "../types.js";
 import type { ToolRuntimeAttemptContext } from "./context.js";
@@ -442,7 +441,9 @@ export function enforceRuntimeSandboxAttempt(
         cwd,
         sessionTempRoot,
       ) &&
-      !(shellAccess === null && isActiveSessionPlanFile(input.context, target))
+      !(shellAccess === null &&
+        isActiveSessionPlanFile(input.context, target) &&
+        planFilePolicyAllowsWrite(profile.fileSystem, target, cwd, sessionTempRoot))
     ) {
       throw new SandboxDeniedError(
         `sandbox workspace_write blocked write outside workspace: ${target}`,
@@ -456,63 +457,29 @@ export function enforceRuntimeSandboxAttempt(
   }
 }
 
-/**
- * The active session's plan file is the one write target outside the
- * workspace that the runtime itself hands to the model: the plan-mode
- * attachment advertises `<AGENC_HOME>/plans/<slug>.md`, and the filesystem
- * tools carve that family out of their workspace allowlist
- * (coding-common.ts, filesystem.ts). This preflight runs before any tool
- * code, so without the same allowance every Write or Edit to the plan file
- * dies here as "outside workspace" on any machine where the plans directory
- * is not lexically inside the turn cwd, which is every real installation.
- *
- * Authority never comes from model args: the session id is read from the
- * runtime's own session object and the home from that session's bound
- * ConfigStore, falling back to the same resolver the plan attachment uses.
- * Only the session's own plan-file family (`<slug>*.md` directly inside the
- * plans directory) is admitted; `.slugs.json` and other sessions' plans stay
- * denied, and shell tools get no carve-out because the platform sandbox
- * cannot honor it. The plans directory is compared canonically as well as
- * lexically so a symlinked home or temp directory (macOS `/tmp` resolving to
- * `/private/tmp`) cannot turn the path the runtime advertised into a denial.
- */
+function planFilePolicyAllowsWrite(
+  policy: EngineFileSystemSandboxPolicy,
+  target: string,
+  cwd: string,
+  sessionTempRoot: string,
+): boolean {
+  if (policy.kind !== "restricted") return false;
+  return canWritePathWithCwd({
+    ...policy,
+    entries: policy.entries.map((entry) =>
+      entry.access === "read" && entry.path.kind === "special" &&
+        entry.path.value.kind === "root"
+        ? { ...entry, access: "write" as const }
+        : entry,
+    ),
+  }, target, cwd, sessionTempRoot);
+}
+
 function isActiveSessionPlanFile(
   context: ToolRuntimeAttemptContext,
   target: string,
 ): boolean {
-  const session = context.invocation.session as {
-    readonly conversationId?: unknown;
-    readonly services?: {
-      readonly configStore?: {
-        readonly homeContext?: { readonly path?: unknown };
-      };
-    };
-  };
-  const sessionId = session.conversationId;
-  if (typeof sessionId !== "string" || sessionId.length === 0) return false;
-  const boundHome = session.services?.configStore?.homeContext?.path;
-  const planContext: PlanFileContext =
-    typeof boundHome === "string" && boundHome.length > 0
-      ? { sessionId, agencHome: boundHome }
-      : { sessionId };
-  try {
-    const plansDirectory = path.normalize(getPlansDirectory(planContext));
-    const targetDirectory = path.dirname(target);
-    if (
-      path.normalize(targetDirectory) !== plansDirectory &&
-      safeRealpath(targetDirectory) !== safeRealpath(plansDirectory)
-    ) {
-      return false;
-    }
-    return isSessionPlanFile(
-      path.join(plansDirectory, path.basename(target)),
-      planContext,
-    );
-  } catch {
-    // Home resolution can refuse an ambiguous session binding; the plan
-    // carve-out then stays closed and the ordinary denial applies.
-    return false;
-  }
+  return matchesSessionPlanFile(target, sessionPlanFileAuthority(context.invocation.session));
 }
 
 function canDeferIndeterminateWritesToPlatformSandbox(

--- a/runtime/src/tools/system/coding-common.ts
+++ b/runtime/src/tools/system/coding-common.ts
@@ -7,8 +7,8 @@ import {
 } from "node:path";
 
 import {
-  isSessionPlanFile,
-} from "../../planning/plan-files.js";
+  matchesSessionPlanFile,
+} from "../../planning/session-plan-authority.js";
 import type { Logger } from "../../utils/logger.js";
 import type { RunCommandResult } from "../../utils/process.js";
 import { runSupervisedProcess } from "../../utils/supervisedProcess.js";
@@ -28,34 +28,13 @@ import {
   verifiedPlanFileContextFromArgs,
 } from "./filesystem.js";
 
-/**
- * Optional plan-file allowlist context derived from injected tool args.
- * When the dispatcher injects `__agencSessionId`, the filesystem tools
- * can resolve the active session's plan file path via plan-files.ts and
- * allowlist it regardless of the workspace allowlist — mirrors
- * AgenC's `checkEditableInternalPath` carve-out
- * (utils/permissions/filesystem.ts:1488-1506).
- *
- * SECURITY: this carve-out grants a WRITE target outside the workspace
- * allowlist, so the session id must come from a TRUSTED source. We verify
- * the HMAC signature the runtime attaches via
- * `withSignedSessionId`; an unsigned/forged `__agencSessionId` (e.g. a
- * model-supplied value) verifies as absent and yields no carve-out.
- */
-/**
- * True when `targetPath` belongs to the active session's plan-file
- * family AND the request carries enough session context to identify it.
- * Centralises the "is this a plan-file write that bypasses the
- * workspace allowlist" decision so writeFile / appendFile / editFile /
- * mkdir / delete / move all stay in sync.
- */
 function isPlanFileWriteAllowed(
   args: Record<string, unknown>,
   targetPath: string,
 ): boolean {
   const ctx = verifiedPlanFileContextFromArgs(args);
   if (ctx === null) return false;
-  return isSessionPlanFile(targetPath, ctx);
+  return matchesSessionPlanFile(targetPath, ctx);
 }
 
 export const SESSION_ADVERTISED_TOOL_NAMES_ARG = "__agencAdvertisedToolNames";

--- a/runtime/src/tools/system/file-edit.ts
+++ b/runtime/src/tools/system/file-edit.ts
@@ -43,6 +43,9 @@ import { plainTextErrorToolResult as errorResult } from "../results.js";
 import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 import { buildFileMutationMetadata } from "../result-metadata.js";
 import {
+  sessionPlanFileAuthority,
+} from "../../planning/session-plan-authority.js";
+import {
   getSessionReadSnapshot,
   recordSessionRead,
   resolveSessionId,
@@ -875,6 +878,7 @@ export function createFileEditTool(config: FileEditToolConfig): Tool {
         context: context.getAppState().toolPermissionContext,
         operationType: asString(args.old_string) === "" ? "create" : "write",
         extraWorkingDirectories: config.allowedPaths,
+        planFileAuthority: sessionPlanFileAuthority(context.session),
       });
     },
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
@@ -1250,6 +1254,7 @@ export function createFileMultiEditTool(config: FileEditToolConfig): Tool {
         context: context.getAppState().toolPermissionContext,
         operationType: firstOldString === "" ? "create" : "write",
         extraWorkingDirectories: config.allowedPaths,
+        planFileAuthority: sessionPlanFileAuthority(context.session),
       });
     },
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {

--- a/runtime/src/tools/system/file-write.ts
+++ b/runtime/src/tools/system/file-write.ts
@@ -47,6 +47,9 @@ import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
 import { plainTextErrorToolResult as errorResult } from "../results.js";
 import { buildFileMutationMetadata } from "../result-metadata.js";
 import {
+  sessionPlanFileAuthority,
+} from "../../planning/session-plan-authority.js";
+import {
   getSessionReadSnapshot,
   hasSessionRead,
   recordSessionRead,
@@ -352,6 +355,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
         context: context.getAppState().toolPermissionContext,
         operationType: "write",
         extraWorkingDirectories: allowedPaths,
+        planFileAuthority: sessionPlanFileAuthority(context.session),
       });
     },
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -44,7 +44,6 @@ import {
   writeFileSync,
 } from "node:fs";
 import { resolve, dirname, basename, join } from "node:path";
-import { resolveHomeContext } from "../../config/home.js";
 // Imported from the defining module rather than the `memory/index.js` barrel.
 // The barrel re-exports the recall pipeline, which reaches `utils/ide.ts` and
 // `utils/envDynamic.ts`; that module calls `stat` at import time on Linux, so
@@ -64,9 +63,11 @@ function resolveSessionWorkspaceRoot(entry?: string): string {
   return getCurrentRuntimeSession()?.sessionConfiguration.cwd ?? getCwd();
 }
 import {
-  isSessionPlanFile,
-  type PlanFileContext,
-} from "../../planning/plan-files.js";
+  matchesSessionPlanFile,
+  planFileAuthorityFromContext,
+  type SessionPlanFileAuthority,
+} from "../../planning/session-plan-authority.js";
+import { resolveHomeContext } from "../../config/home.js";
 import {
   SESSION_ALLOWED_ROOTS_ARG,
   SESSION_ALLOWED_ROOTS_SIG_ARG,
@@ -75,6 +76,7 @@ import {
   signSessionId,
   verifyAllowedRoots,
   verifySessionId,
+  verifySessionPlanFileArgs,
   withSignedAllowedRoots,
   withSignedSessionId,
 } from "../../agents/_deps/filesystem-args.js";
@@ -1178,7 +1180,22 @@ function normalizeFilesystemUnicodeIdentity(path: string): string {
  */
 export function verifiedPlanFileContextFromArgs(
   args: Record<string, unknown> | undefined,
-): PlanFileContext | null {
+): SessionPlanFileAuthority | null {
+  const context = verifiedSessionContextFromArgs(args);
+  if (context === null || args === undefined) return null;
+  const authority = verifySessionPlanFileArgs(args);
+  if (authority === null || authority.sessionId !== context.sessionId) return null;
+  const current = planFileAuthorityFromContext({
+    ...context,
+    ...(authority.agentId !== undefined ? { agentId: authority.agentId } : {}),
+  });
+  return current !== null && current.agencHome === authority.agencHome &&
+    current.planFilePath === authority.planFilePath ? authority : null;
+}
+
+export function verifiedSessionContextFromArgs(
+  args: Record<string, unknown> | undefined,
+): { readonly sessionId: string; readonly agencHome: string } | null {
   if (!args) return null;
   // SECURITY: honor the session id (which unlocks the plan-file carve-out
   // OUTSIDE the workspace allowlist) ONLY when it carries a valid
@@ -1194,14 +1211,13 @@ export function verifiedPlanFileContextFromArgs(
       ? verified
       : null;
   if (sessionId === null) return null;
-  const ctx: PlanFileContext = { sessionId };
   const injectedAgencHome = args[SESSION_AGENC_HOME_ARG];
   if (
     typeof injectedAgencHome !== "string" ||
     injectedAgencHome.trim().length === 0
   ) return null;
   return {
-    ...ctx,
+    sessionId,
     agencHome: resolveHomeContext({ AGENC_HOME: injectedAgencHome }).path,
   };
 }
@@ -1221,7 +1237,7 @@ export async function safePathAllowingSessionPlanFile(
   if (planCtx !== null && !hasUnsafeShape(targetPath)) {
     try {
       const canonical = await canonicalize(targetPath);
-      if (isSessionPlanFile(canonical, planCtx)) {
+      if (matchesSessionPlanFile(targetPath, planCtx) && canonical === planCtx.planFilePath) {
         return { safe: true, resolved: canonical };
       }
     } catch {
@@ -1256,7 +1272,7 @@ async function validatePath(
   if (planCtx !== null && !hasUnsafeShape(input)) {
     try {
       const canonical = await canonicalize(input);
-      if (isSessionPlanFile(canonical, planCtx)) {
+      if (matchesSessionPlanFile(input, planCtx) && canonical === planCtx.planFilePath) {
         return [canonical, null];
       }
     } catch {

--- a/runtime/src/tools/system/worktree.ts
+++ b/runtime/src/tools/system/worktree.ts
@@ -59,7 +59,7 @@ import {
   validationErrorToolResult,
 } from "../results.js";
 import { runSandboxedToolCommand } from "./coding-common.js";
-import { verifiedPlanFileContextFromArgs } from "./filesystem.js";
+import { verifiedSessionContextFromArgs } from "./filesystem.js";
 import {
   hardenGitWorktreeMutationArgs,
   worktreeCheckoutPermissions,
@@ -376,7 +376,7 @@ export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
     },
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
       const args = rawArgs as ToolExecutionInjectedArgs & { name?: unknown };
-      const planContext = verifiedPlanFileContextFromArgs(rawArgs);
+      const planContext = verifiedSessionContextFromArgs(rawArgs);
       if (planContext === null || planContext.sessionId === undefined) {
         return refuse(
           "EnterWorktree",
@@ -643,7 +643,7 @@ export function createExitWorktreeTool(_config: WorktreeToolConfig): Tool {
         action?: unknown;
         discard_changes?: unknown;
       };
-      const planContext = verifiedPlanFileContextFromArgs(rawArgs);
+      const planContext = verifiedSessionContextFromArgs(rawArgs);
       if (planContext === null || planContext.sessionId === undefined) {
         return refuse(
           "ExitWorktree",

--- a/runtime/src/tui/ink/native-ts/yoga-layout/index.ts
+++ b/runtime/src/tui/ink/native-ts/yoga-layout/index.ts
@@ -1111,7 +1111,7 @@ function layoutNode(
     // Same-generation check covers fresh-mounted (dirty) nodes during
     // virtual scroll — the dirty chain invokes them ≥2^depth times, first
     // call writes cache, rest hit: 105k visits → ~10k for 1593-node tree.
-    if (node._cN > 0 && (sameGen || !node.isDirty_)) {
+    if (!performLayout && node._cN > 0 && (sameGen || !node.isDirty_)) {
       const cIn = node._cIn!
       for (let i = 0; i < node._cN; i++) {
         const o = i * 8
@@ -1184,13 +1184,7 @@ function layoutNode(
     node._mOW = ownerWidth
     node._mOH = ownerHeight
     node._hasM = true
-    // Don't clear isDirty_. For DIRTY nodes, invalidate _hasL so the upcoming
-    // performLayout=true call recomputes with the new child set (otherwise
-    // sticky-scroll never follows new content — the bug from 4557bc9f9c).
-    // Clean nodes keep _hasL: their layout from the previous generation is
-    // still valid, they're only here because an ancestor is dirty and called
-    // with different inputs than cached.
-    if (wasDirty) node._hasL = false
+    node._hasL = false
   }
 
   // Resolve padding/border/margin against ownerWidth (yoga uses ownerWidth for %)
@@ -1356,8 +1350,8 @@ function layoutNode(
   // values. Per CSS, a % width resolves against the parent's content-box
   // width. If this node's width is indefinite, children's % widths are also
   // indefinite — do NOT fall through to the grandparent's size.
-  const ownerW = isDefined(width) ? width : NaN
-  const ownerH = isDefined(height) ? height : NaN
+  const ownerW = isDefined(width) ? Math.max(0, width - paddingBorderWidth) : NaN
+  const ownerH = isDefined(height) ? Math.max(0, height - paddingBorderHeight) : NaN
   const isWrap = style.flexWrap !== Wrap.NoWrap
   const gapCross = resolveGap(
     style,

--- a/runtime/src/tui/ink/styles.ts
+++ b/runtime/src/tui/ink/styles.ts
@@ -668,7 +668,7 @@ const applyDimensionStyles = (node: LayoutNode, style: Styles): void => {
     if (typeof style.maxWidth === 'string') {
       node.setMaxWidthPercent(Number.parseInt(style.maxWidth, 10))
     } else {
-      node.setMaxWidth(style.maxWidth ?? 0)
+      node.setMaxWidth(style.maxWidth ?? Number.NaN)
     }
   }
 
@@ -676,7 +676,7 @@ const applyDimensionStyles = (node: LayoutNode, style: Styles): void => {
     if (typeof style.maxHeight === 'string') {
       node.setMaxHeightPercent(Number.parseInt(style.maxHeight, 10))
     } else {
-      node.setMaxHeight(style.maxHeight ?? 0)
+      node.setMaxHeight(style.maxHeight ?? Number.NaN)
     }
   }
 }

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ApprovalCtx } from "../tools/orchestrator.js";
 import type { ReviewDecision } from "../permissions/review-decision.js";
@@ -416,6 +416,7 @@ function PlanApprovalContainer({
   readonly request: PendingRequest;
 }) {
   useRegisterKeybindingContext("Confirmation");
+  const settled = useRef(false);
 
   const planContent =
     request.ctx.planContent ??
@@ -428,6 +429,8 @@ function PlanApprovalContainer({
 
   const onApprove = useCallback(
     (mode: "acceptEdits" | "default") => {
+      if (settled.current) return;
+      settled.current = true;
       setPlanApprovalChoice(request.id, {
         action: "approve",
         mode,
@@ -439,6 +442,8 @@ function PlanApprovalContainer({
   );
 
   const onKeepPlanning = useCallback(() => {
+    if (settled.current) return;
+    settled.current = true;
     setPlanApprovalChoice(request.id, { action: "revise" });
     request.resolve(APPROVED);
   }, [request]);
@@ -446,6 +451,8 @@ function PlanApprovalContainer({
   useKeybindings(
     {
       "app:interrupt": () => {
+        if (settled.current) return;
+        settled.current = true;
         request.resolve(ABORT);
       },
     },

--- a/runtime/src/tui/startup/StatusLine.tsx
+++ b/runtime/src/tui/startup/StatusLine.tsx
@@ -145,6 +145,8 @@ async function executeDaemonStatusLineWhenReady(
 }
 
 function daemonStatusLineNotice(result: SessionStatusLineExecuteResult): string | undefined {
+  if (result.status === 'blocked' && result.reason === 'sandbox_policy_unexpressible') return 'status line command blocked: the session sandbox cannot represent this policy; on Linux, provide a trusted bubblewrap directory in the session PATH and run agenc doctor';
+  if (result.status === 'blocked' && result.reason?.startsWith('sandbox_')) return 'status line command blocked: session sandbox unavailable; run agenc doctor';
   if (result.status === 'blocked') return 'status line command blocked by session hook policy';
   if (result.reason === 'unsupported_method') return 'status line command is not supported by this daemon';
   if (result.reason === 'timeout') return 'status line command timed out';

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -29,6 +29,7 @@ import { WorkbenchComposerFocusProvider } from "./composerFocusContext.js";
 import { visibleWorkbenchPane } from "./reducer.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "./state.js";
 import { WorkbenchTranscriptLayoutProvider } from "./transcriptLayoutContext.js";
+import { workbenchSurfacePadding } from "./surfaceGeometry.js";
 import type {
   WorkbenchLayoutSize,
   WorkbenchPane,
@@ -182,7 +183,10 @@ export function WorkbenchLayout({
       (showAgents ? agentsWidth : 0) -
       (showRail ? railWidth : 0),
   );
-  const surfaceContentWidth = Math.max(1, surfaceWidth - 2);
+  const surfaceContentWidth = Math.max(
+    1,
+    surfaceWidth - 2 * workbenchSurfacePadding(workbench.activeSurfaceMode),
+  );
   const visiblePanes = useMemo(
     () => visiblePaneList(showExplorer, showAgents, railAvailable),
     [railAvailable, showAgents, showExplorer],

--- a/runtime/src/tui/workbench/surfaceGeometry.ts
+++ b/runtime/src/tui/workbench/surfaceGeometry.ts
@@ -1,0 +1,5 @@
+import type { ActiveSurfaceMode } from "./types.js";
+
+export function workbenchSurfacePadding(mode: ActiveSurfaceMode): number {
+  return mode === "transcript" ? 3 : 1;
+}

--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -11,6 +11,7 @@ import { useWorkbenchState } from "../state.js";
 import { useBufferStore } from "../buffer/useBufferStore.js";
 import { bufferKeybindingContext } from "../buffer/keybindingContext.js";
 import { WorkbenchTranscriptLayoutProvider } from "../transcriptLayoutContext.js";
+import { workbenchSurfacePadding } from "../surfaceGeometry.js";
 import type { ActiveSurfaceMode, WorkbenchState } from "../types.js";
 import { AgentSurface } from "./AgentSurface.js";
 import {
@@ -240,7 +241,7 @@ export function ActiveWorkSurface({
         flexBasis={0}
         minHeight={0}
         overflow="hidden"
-        paddingX={isTranscript ? 3 : 1}
+        paddingX={workbenchSurfacePadding(descriptor.mode)}
         paddingTop={isTranscript ? 1 : 0}
       >
         {isTranscript ? (

--- a/runtime/src/utils/permissions/filesystem.ts
+++ b/runtime/src/utils/permissions/filesystem.ts
@@ -40,7 +40,7 @@ import {
   expandPath,
   getDirectoryForPath,
 } from '../path.js'
-import { getPlanSlug, getPlansDirectory } from '../plans.js'
+import { matchesSessionPlanFile, sessionPlanFileAuthority } from '../../planning/session-plan-authority.js'
 import { getPlatform } from '../platform.js'
 import { getProjectDir } from '../sessionStorage.js'
 import { projectStorageKey } from '../project-storage-key.js'
@@ -268,15 +268,7 @@ function isAgenCConfigFilePath(filePath: string): boolean {
 
 // Check if file is the plan file for the current session
 function isSessionPlanFile(absolutePath: string): boolean {
-  // Check if path is a plan file for this session (main or agent-specific)
-  // Main plan file: {plansDir}/{planSlug}.md
-  // Agent plan file: {plansDir}/{planSlug}-agent-{agentId}.md
-  const expectedPrefix = join(getPlansDirectory(), getPlanSlug())
-  // SECURITY: Normalize to prevent path traversal bypasses via .. segments
-  const normalizedPath = normalize(absolutePath)
-  return (
-    normalizedPath.startsWith(expectedPrefix) && normalizedPath.endsWith('.md')
-  )
+  return matchesSessionPlanFile(absolutePath, sessionPlanFileAuthority(peekAmbientRuntimeSession()))
 }
 
 /**

--- a/runtime/src/utils/subprocessEnv.ts
+++ b/runtime/src/utils/subprocessEnv.ts
@@ -2,12 +2,14 @@ import { isEnvTruthy } from './envBoolean.js'
 import { isSecretEnvKey } from './secretEnv.js'
 import { assertNoObsoleteConfigEnvironment } from '../config/env.js'
 import { isAbsolute, normalize } from 'node:path'
+import { convertWindowsPathToPosix } from './windows-path-conversion.js'
 
 const CHILD_TEMP_AUTHORITY_KEYS = new Set([
   'AGENC_TMPDIR',
   'TMPDIR',
   'TEMP',
   'TMP',
+  'TMPPREFIX',
 ])
 
 /** True when an environment key can select a child process's temp root. */
@@ -38,6 +40,8 @@ export function withChildTempAuthority(
   childEnvironment.TMPDIR = root
   childEnvironment.TEMP = root
   childEnvironment.TMP = root
+  const shellRoot = process.platform === 'win32' ? convertWindowsPathToPosix(root) : root
+  childEnvironment.TMPPREFIX = `${shellRoot.replace(/\/+$/u, '')}/zsh`
   return childEnvironment
 }
 

--- a/runtime/src/utils/windows-path-conversion.ts
+++ b/runtime/src/utils/windows-path-conversion.ts
@@ -1,0 +1,11 @@
+export function convertWindowsPathToPosix(windowsPath: string): string {
+  if (windowsPath.startsWith('\\\\')) {
+    return windowsPath.replace(/\\/g, '/')
+  }
+  const driveMatch = windowsPath.match(/^([A-Za-z]):[/\\]/)
+  if (driveMatch) {
+    const driveLetter = driveMatch[1]!.toLowerCase()
+    return '/' + driveLetter + windowsPath.slice(2).replace(/\\/g, '/')
+  }
+  return windowsPath.replace(/\\/g, '/')
+}

--- a/runtime/src/utils/windowsPaths.ts
+++ b/runtime/src/utils/windowsPaths.ts
@@ -1,21 +1,9 @@
 import { memoizeWithLRU } from './memoize.js'
+import { convertWindowsPathToPosix } from './windows-path-conversion.js'
 
 /** Convert a Windows path to a POSIX path using pure JS. */
 export const windowsPathToPosixPath = memoizeWithLRU(
-  (windowsPath: string): string => {
-    // Handle UNC paths: \\server\share -> //server/share
-    if (windowsPath.startsWith('\\\\')) {
-      return windowsPath.replace(/\\/g, '/')
-    }
-    // Handle drive letter paths: C:\Users\foo -> /c/Users/foo
-    const match = windowsPath.match(/^([A-Za-z]):[/\\]/)
-    if (match) {
-      const driveLetter = match[1]!.toLowerCase()
-      return '/' + driveLetter + windowsPath.slice(2).replace(/\\/g, '/')
-    }
-    // Already POSIX or relative — just flip slashes
-    return windowsPath.replace(/\\/g, '/')
-  },
+  convertWindowsPathToPosix,
   (p: string) => p,
   500,
 )

--- a/runtime/tests/agents/delegate-worktree.test.ts
+++ b/runtime/tests/agents/delegate-worktree.test.ts
@@ -26,6 +26,7 @@ import { runAgent } from "./run-agent.js";
 import type { LiveAgent } from "./control.js";
 import type { AgentMetadata } from "./registry.js";
 import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
+import * as worktreeModule from "./worktree.js";
 
 const mockRunAgent = vi.mocked(runAgent);
 const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
@@ -118,6 +119,58 @@ function gatedRun(): {
 }
 
 describe("delegate worktree isolation (real git)", () => {
+  it.each([false, true])("keeps post-creation failures uncertain even when cleanup fails: %s", async (cleanupFails) => {
+    const repo = initRepo();
+    const cleanup = vi.spyOn(worktreeModule, "removeAgentWorktree");
+    if (cleanupFails) cleanup.mockRejectedValueOnce(new Error("cleanup unavailable"));
+    try {
+      const result = await delegate({
+        parent: makeParentSession(repo) as never,
+        parentPath: "/root",
+        control: { spawn: vi.fn(async () => { throw new Error("child creation failed"); }) } as never,
+        registry: {} as never,
+        taskPrompt: "write files",
+        isolation: "worktree",
+        worktreeSlug: "failed_worker",
+      });
+      expect(result).toMatchObject({ kind: "rejected", code: "AGENT_SPAWN_REJECTED" });
+      expect(result).not.toHaveProperty("effectDisposition");
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(existsSync(join(repo, ".agenc-worktrees", "failed_worker"))).toBe(cleanupFails);
+    } finally {
+      cleanup.mockRestore();
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an unborn base before mutations and preserves the no-effect evidence", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "agenc-unborn-worktree-"));
+    git(repo, "init", "-b", "main");
+    const control = { spawn: vi.fn() };
+    try {
+      const result = await delegate({
+        parent: makeParentSession(repo) as never,
+        parentPath: "/root",
+        control: control as never,
+        registry: {} as never,
+        taskPrompt: "write files",
+        isolation: "worktree",
+        worktreeSlug: "unborn_worker",
+      });
+      expect(result).toMatchObject({
+        kind: "rejected",
+        code: "WORKTREE_UNAVAILABLE",
+        effectDisposition: { disposition: "confirmed_no_effect", evidenceKind: "boundary_not_crossed" },
+      });
+      expect(control.spawn).not.toHaveBeenCalled();
+      expect(existsSync(join(repo, ".agenc-worktrees"))).toBe(false);
+      expect(git(repo, "for-each-ref", "--format=%(refname)")).toBe("");
+      expect(git(repo, "status", "--porcelain")).toBe("");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("gives two agents distinct worktrees; unchanged ones are removed, dirty ones kept", async () => {
     const repo = initRepo();
     try {

--- a/runtime/tests/agents/v2/spawn-isolation.test.ts
+++ b/runtime/tests/agents/v2/spawn-isolation.test.ts
@@ -13,6 +13,7 @@ import { AgentRoleCatalog } from "../role-catalog.js";
 import { signSessionId } from "../_deps/filesystem-args.js";
 import { StaticModelsManager } from "../../../src/llm/models-manager.js";
 import { defaultConfig } from "../../../src/config/schema.js";
+import { validationErrorToolResult } from "../../../src/tools/results.js";
 
 const ROLE_WORKSPACE = createAgentRoleWorkspace("/repo");
 const ROLE_CATALOG = new AgentRoleCatalog(ROLE_WORKSPACE);
@@ -107,6 +108,24 @@ function makeOptions(
 describe("spawn_agent isolation", () => {
   beforeEach(() => {
     mockDelegate.mockReset();
+  });
+
+  it.each([true, false])("preserves only authoritative delegate refusal evidence: %s", async (confirmed) => {
+    const evidence = validationErrorToolResult("worktree:precondition", "invalid HEAD").effectDisposition;
+    mockDelegate.mockResolvedValue({
+      kind: "rejected",
+      code: "WORKTREE_UNAVAILABLE",
+      category: "environment",
+      reason: "invalid HEAD",
+      ...(confirmed ? { effectDisposition: evidence } : {}),
+    });
+    const result = await createSpawnAgentTool(makeOptions(makeSession())).execute({
+      message: "write files",
+      task_name: "worker",
+      __callId: "spawn-precondition",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.effectDisposition).toEqual(confirmed ? evidence : undefined);
   });
 
   it.each(["override", "role"] as const)("validates Gemini %s effort against real model metadata", async (source) => {

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -5958,6 +5958,43 @@ describe("AgenC background agent lifecycle", () => {
     }
   });
 
+  it("resolves legacy review rows only in the manager's captured home", async () => {
+    const { cwd, home, restoreEnv } = createThreadStoreTestDirs();
+    const otherHome = mkdtempSync(join(tmpdir(), "agenc-review-other-home-"));
+    const sessionId = "session_same_workspace_review";
+    const sessions = new AgenCDaemonSessionManager({ createSessionId: () => sessionId });
+    const ownerDriver = openStateDatabases({ cwd, agencHome: home });
+    const otherDriver = openStateDatabases({ cwd, agencHome: otherHome });
+    try {
+      await sessions.createSession({ cwd, agentId: "agent_review_owner" });
+      const agents = new AgenCDaemonAgentManager({ sessionManager: sessions, agencHome: home });
+      for (const driver of [ownerDriver, otherDriver]) {
+        recordInFlightToolCallUnknownOutcome(driver, {
+          sessionId,
+          agentId: "agent_review_owner",
+          toolCallId: "same_call_id",
+          toolName: "LegacyWrite",
+          observedAt: "2026-09-10T00:00:00.000Z",
+          recoveryCategory: "side-effecting",
+        });
+      }
+      process.env.AGENC_HOME = otherHome;
+      await expect(agents.resolveSessionToolCall({ sessionId, reviewer: "owner" }))
+        .resolves.toMatchObject({ resolved: [{ toolCallId: "same_call_id" }], remaining: 0 });
+      expect(listUnresolvedUnknownOutcomeEffects(ownerDriver, sessionId)).toHaveLength(0);
+      expect(listUnresolvedUnknownOutcomeEffects(otherDriver, sessionId)).toHaveLength(1);
+      await expect(agents.resolveSessionToolCall({ sessionId, reviewer: "owner" }))
+        .resolves.toMatchObject({ resolved: [], remaining: 0 });
+    } finally {
+      ownerDriver.close();
+      otherDriver.close();
+      restoreEnv();
+      rmSync(home, { recursive: true, force: true });
+      rmSync(otherHome, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("stops a launched agent when lifecycle session creation fails", async () => {
     const stopAgent = vi.fn(async () => {});
     const agents = new AgenCDaemonAgentManager({

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -67,10 +67,17 @@ import {
 import {
   clearCurrentRuntimeSession,
   peekScopedRuntimeSession,
+  runWithCurrentRuntimeSession,
   setCurrentRuntimeSession,
 } from "../session/current-session.js";
 import type { Session } from "../session/session.js";
-import { EventLog } from "../../src/session/event-log.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
+import { openStateDatabases } from "../../src/state/sqlite-driver.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
+import { createOperatorEffectReviewResolution } from "../../src/state/effect-review.js";
+import { listUnresolvedUnknownOutcomeEffects } from "../../src/state/unknown-outcome-gate.js";
+import { recordInFlightToolCallUnknownOutcome } from "../../src/state/tool-output-rotation.js";
+import { seedPendingEffectReview } from "../state/helpers/effect-review-fixture.js";
 import { registerChildApprovalSession, revokeChildApprovalSession } from "../../src/agents/child-approval-context.js";
 import type { ApprovalResolver } from "../../src/permissions/guardian/arbiter.js";
 import type { TurnContext } from "../session/turn-context.js";
@@ -2385,6 +2392,72 @@ describe("AgenC delegate background-agent runner", () => {
     } finally {
       releaseSendInput.resolve();
       clearCurrentRuntimeSession();
+    }
+  });
+
+  it("resolves live effect evidence under its owning session and home across ambiguous or conflicting scopes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-live-review-owner-"));
+    const cwd = join(root, "workspace");
+    const home = join(root, "owner");
+    const otherHome = join(root, "other");
+    mkdirSync(cwd);
+    const sessionId = "live-review-shared-session";
+    const recordedAt = "2026-09-10T00:00:00.000Z";
+    const target = makeTopLevelRunner({ conversationId: sessionId, workspaceRoot: cwd,
+      rolloutItems: [{ type: "event_msg", timestamp: recordedAt, payload: {
+        eventId: "unknown-1", id: "unknown-1", seq: 2, msg: { type: "effect_unknown_outcome", payload: {
+          runId: sessionId, stepId: "tool:step-1", callId: "call-1", toolName: "exec_command",
+          recoveryCategory: "side-effecting", reason: "tool_error_result_without_authoritative_effect_disposition",
+          requiresReview: true, recordedAt,
+        } },
+      } }],
+    });
+    const other = makeTopLevelRunner({ conversationId: sessionId, workspaceRoot: cwd });
+    Object.assign(target.configStore, { homeContext: { path: home } });
+    Object.assign(other.configStore, { homeContext: { path: otherHome } });
+    const driver = openStateDatabases({ cwd, agencHome: home });
+    const otherDriver = openStateDatabases({ cwd, agencHome: otherHome });
+    const effects = new StateRunDurabilityRepository(driver);
+    const projectedScopes: Array<Session | null> = [];
+    Object.assign(target.rolloutStore, { recordEffectEvent: (event: Event) => {
+      projectedScopes.push(peekScopedRuntimeSession());
+      if (event.msg.type !== "effect_review_resolved") throw new Error("unexpected review event");
+      effects.resolveEffectReview({ ...event.msg.payload, eventId: event.eventId! });
+    } });
+    const resolution = createOperatorEffectReviewResolution({
+      disposition: "confirmed_no_effect", actorId: "operator", evidenceRef: "test:verified-no-effect",
+      evidenceSha256: "a".repeat(64), reviewedAt: recordedAt,
+    });
+    clearCurrentRuntimeSession();
+    try {
+      for (const database of [driver, otherDriver]) {
+        seedPendingEffectReview(database, sessionId, recordedAt);
+        recordInFlightToolCallUnknownOutcome(database, { sessionId, agentId: sessionId,
+          toolCallId: "call-1", toolName: "exec_command", observedAt: recordedAt, recoveryCategory: "side-effecting" });
+      }
+      await target.runner.startAgent({ objective: "idle review owner", deferInitialTurn: true });
+      await other.runner.startAgent({ objective: "idle other owner", deferInitialTurn: true });
+      setCurrentRuntimeSession(target.session as unknown as Session);
+      setCurrentRuntimeSession(other.session as unknown as Session);
+      const params = { sessionId, toolCallId: "call-1", resolution };
+      await expect(target.runner.resolveLiveEffectReview(sessionId, params))
+        .resolves.toMatchObject({ kind: "resolved", durable: true });
+      await expect(runWithCurrentRuntimeSession(other.session as unknown as Session,
+        () => target.runner.resolveLiveEffectReview(sessionId, params)))
+        .resolves.toMatchObject({ kind: "already_resolved", durable: true });
+      expect(projectedScopes).toEqual([target.session, target.session]);
+      expect(listUnresolvedUnknownOutcomeEffects(driver, sessionId)).toHaveLength(0);
+      expect(listUnresolvedUnknownOutcomeEffects(otherDriver, sessionId)).toHaveLength(1);
+      expect(new StateRunDurabilityRepository(otherDriver).getEffect(sessionId, "tool:step-1")?.reviewStatus).toBe("pending");
+      expect(target.rolloutItems.filter((item) => (item as { payload?: { msg?: { type?: string } } }).payload?.msg?.type === "effect_review_resolved")).toHaveLength(1);
+      await expect(target.runner.resolveLiveEffectReview(sessionId, { ...params, sessionId: "wrong-owner" })).rejects.toThrow("does not own session");
+    } finally {
+      clearCurrentRuntimeSession();
+      await target.runner.stopAgent(sessionId);
+      await other.runner.stopAgent(sessionId);
+      driver.close();
+      otherDriver.close();
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/runtime/tests/app-server/run-inspection.split-authority.test.ts
+++ b/runtime/tests/app-server/run-inspection.split-authority.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgenCDaemonRunInspectionService } from "../../src/app-server/run-inspection.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import type { ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
+
+const RUN_ID = "split-child";
+let root: string;
+let home: string;
+let parent: StateSqliteDriver;
+let child: StateSqliteDriver;
+let kernel: ExecutionAdmissionKernel;
+let client: ExecutionAdmissionClient;
+let service: AgenCDaemonRunInspectionService;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "agenc-split-authority-"));
+  home = join(root, "home");
+  const parentCwd = join(root, "parent");
+  const childCwd = join(root, "worktree");
+  mkdirSync(join(parentCwd, ".git"), { recursive: true });
+  mkdirSync(join(childCwd, ".git"), { recursive: true });
+  parent = openStateDatabases({ cwd: parentCwd, agencHome: home });
+  child = openStateDatabases({ cwd: childCwd, agencHome: home });
+  kernel = new ExecutionAdmissionKernel({ agencHome: home, ownerId: "split-test", ownerPid: process.pid });
+  client = kernel.bindClient({
+    cwd: parentCwd,
+    scope: { runId: "parent-run", sessionId: "parent-run", autonomous: false },
+    budget: { runMaxCostUsd: 1 },
+  }).forSession({ runId: RUN_ID, sessionId: RUN_ID });
+  service = new AgenCDaemonRunInspectionService({ agencHome: home, stateDatabasePaths: () => [parent, child] });
+});
+
+afterEach(() => {
+  kernel.close();
+  parent.close();
+  child.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function seedSplitRun(options: { legacy?: boolean; owner?: string; corruptEvent?: boolean; omitEvents?: boolean; beforeAdmission?: boolean } = {}): Promise<void> {
+  if (!options.beforeAdmission) {
+    const lease = await client.acquire({ stepId: "model:1", kind: "model_turn", maxInputTokens: 10, maxOutputTokens: 5, maxCostUsd: 0.1 });
+    client.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    client.reconcile(lease.reservation.reservationId, { inputTokens: 4, outputTokens: 2, costUsd: 0.03 });
+  }
+  const store = new RolloutStore({ cwd: join(root, "worktree"), agencHome: home, sessionId: RUN_ID, agencVersion: "0.17.0", sessionTempRoot: join(root, "session-tmp") });
+  store.open({
+    sessionId: RUN_ID, cwd: join(root, "worktree"), timestamp: new Date().toISOString(), originator: "agenc-subagent", agencVersion: "0.17.0",
+    ...(options.legacy ? {} : { admissionOwner: { workspaceId: options.owner ?? parent.projectDir, runId: RUN_ID, parentRunId: "parent-run" } }),
+  });
+  let sequence = 0;
+  for (const event of options.omitEvents ? [] : client.replayJournal?.() ?? []) {
+    sequence += 1;
+    store.append({ id: event.eventId, eventId: event.eventId, seq: sequence, msg: { type: "execution_admission", payload: options.corruptEvent ? { ...event, stepId: "forged-step" } : event } }, { durable: true });
+  }
+  store.append({ id: "split-terminal", eventId: "split-terminal", seq: sequence + 1, msg: { type: "run_terminal", payload: {
+    runId: RUN_ID, epoch: store.runEpoch, status: "failed", exitCode: 1, stopReason: "budget_exhausted", finalMessage: "child failed truthfully", usage: null,
+    lastSequenceBeforeTerminal: sequence || null, finishedAt: new Date().toISOString(),
+  } } }, { durable: true });
+  store.close();
+}
+
+describe("split canonical journal and admission ownership", () => {
+  it("advances admission provenance with a later descendant settlement", async () => {
+    const rootClient = kernel.bindClient({
+      cwd: join(root, "parent"),
+      scope: { runId: "parent-run", sessionId: "parent-run", autonomous: false },
+      budget: { runMaxCostUsd: 1 },
+    });
+    const rootLease = await rootClient.acquire({ stepId: "root", kind: "spawn", maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 });
+    rootClient.markDispatched(rootLease.reservation.reservationId, { boundary: "child_agent" });
+    rootClient.reconcile(rootLease.reservation.reservationId, { inputTokens: 0, outputTokens: 0, costUsd: 0 });
+    await seedSplitRun();
+    const before = service.status({ runId: RUN_ID });
+    const descendant = client.forSession({ runId: "split-grandchild", sessionId: "split-grandchild" });
+    const lease = await descendant.acquire({ stepId: "model:grandchild", kind: "model_turn", maxInputTokens: 10, maxOutputTokens: 5, maxCostUsd: 0.1 });
+    descendant.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    descendant.reconcile(lease.reservation.reservationId, { inputTokens: 3, outputTokens: 1, costUsd: 0.02 });
+    const after = service.status({ runId: RUN_ID });
+    expect(after.admission.actualCostUsd).toBeCloseTo(0.05);
+    expect(after.source.admissionLastSequence).toBeGreaterThan(before.source.admissionLastSequence!);
+    const latest = parent.state.prepare("SELECT MAX(sequence) AS sequence FROM execution_admission_journal WHERE run_id = ?").get("split-grandchild") as { sequence: number };
+    expect(after.source.admissionLastSequence).toBe(latest.sequence);
+    expect(service.evidence({ runId: RUN_ID }).source.admissionLastSequence).toBe(latest.sequence);
+  });
+  it("resolves a declared discovered owner before the child's first admission", async () => {
+    await seedSplitRun({ beforeAdmission: true });
+    expect(service.status({ runId: RUN_ID })).toMatchObject({ status: "failed", admission: { actualCostUsd: 0, reservationCount: 0 }, source: { projectDir: child.projectDir, admissionProjectDir: parent.projectDir } });
+    expect(service.replay({ runId: RUN_ID }).events).toHaveLength(1);
+  });
+  it.each([false, true])("reads the exact child and parent admission without double counting (legacy=%s)", async (legacy) => {
+    await seedSplitRun({ legacy });
+    child.state.prepare("DELETE FROM thread_rollout_items WHERE thread_id = ?").run(RUN_ID);
+    const status = service.status({ runId: RUN_ID });
+    expect(status).toMatchObject({ status: "failed", terminal: true, admission: { actualCostUsd: 0.03, actualTokens: 6, reservationCount: 1 }, source: { projectDir: child.projectDir, admissionProjectDir: parent.projectDir } });
+    const replay = service.replay({ runId: RUN_ID, limit: 2 });
+    expect(replay.source).toMatchObject({ kind: "run_journal", sequenceScope: "run", projectDir: child.projectDir });
+    expect(replay.events.map((event) => event.sequence)).toEqual([1, 2]);
+    const next = service.replay({ runId: RUN_ID, afterSequence: replay.nextAfterSequence });
+    expect(next.events.at(-1)).toMatchObject({ event: "run_terminal", payload: { finalMessage: "child failed truthfully" } });
+    expect(service.result({ runId: RUN_ID })).toMatchObject({ status: "failed", output: { available: true, finalMessage: "child failed truthfully" } });
+    expect(service.evidence({ runId: RUN_ID }).source).toMatchObject({ completeness: "partial", admissionProjectDir: parent.projectDir, admissionLastSequence: status.source.admissionLastSequence });
+    const reverse = new AgenCDaemonRunInspectionService({ stateDatabasePaths: () => [child, parent] });
+    expect(reverse.status({ runId: RUN_ID })).toEqual(status);
+  });
+
+  it.each([
+    { owner: "/outside/owner" },
+    { corruptEvent: true },
+    { legacy: true, omitEvents: true },
+  ])("refuses unproved or conflicting ownership %j", async (options) => {
+    await seedSplitRun(options);
+    expect(() => service.replay({ runId: RUN_ID })).toThrow(expect.objectContaining({ code: "RUN_ID_AMBIGUOUS" }));
+  });
+
+  it("does not treat a distinct journal with the same run ID as an admission mirror", async () => {
+    await seedSplitRun();
+    const store = new RolloutStore({ cwd: join(root, "parent"), agencHome: home, sessionId: RUN_ID, agencVersion: "0.17.0", sessionTempRoot: join(root, "session-tmp") });
+    store.open({ sessionId: RUN_ID, cwd: join(root, "parent"), timestamp: new Date().toISOString(), originator: "agenc-subagent", agencVersion: "0.17.0" });
+    store.close();
+    expect(() => service.status({ runId: RUN_ID })).toThrow(expect.objectContaining({ code: "RUN_ID_AMBIGUOUS" }));
+  });
+});

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -13,7 +13,8 @@
  * provider + rollout on disk). These tests cover the extracted units
  * that back the integration.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import * as memoryPrompt from "../../src/memory/memdir.js";
 import { VERSION } from "../../src/version.js";
 import { lstat, mkdtemp, rm, writeFile, mkdir, rename } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -1435,8 +1436,15 @@ describe("prepareTurnRuntimeInputs", () => {
     await writeFile(memoryMdPath, "MEMORY-ONE\n", "utf8");
 
     let instructionText = "MCP-ONE";
+    const home = join(repoRoot, "session-home");
+    const store = new ConfigStore({ home, cwd: nested, env: { HOME: repoRoot, AGENC_HOME: home } });
+    await store.reload();
+    const load = vi.spyOn(memoryPrompt, "loadMemoryPrompt");
+    onTestFinished(() => load.mockRestore());
     const session = {
       services: {
+        configStore: store,
+        runtimeOptions: { simpleMode: false, remoteMode: false },
         mcpManager: {
           effectiveServers: vi.fn(
             async () =>
@@ -1450,9 +1458,6 @@ describe("prepareTurnRuntimeInputs", () => {
         },
       },
     } as unknown as Session;
-    const store = new ConfigStore({ env: {} });
-    await store.reload();
-
     const first = await prepareTurnRuntimeInputs({
       session,
       configStore: store,
@@ -1466,6 +1471,8 @@ describe("prepareTurnRuntimeInputs", () => {
     // per-session directory block both come out of the turn inputs.
     expect(first.memoryInstructionsText).toContain("# auto memory");
     expect(first.memoryPromptText).toContain("# Memory directories");
+    expect(first.memoryPromptText).toContain(join(home, "memory"));
+    expect(load).toHaveBeenLastCalledWith(expect.objectContaining({ cwd: nested, configStore: store }));
     expect(first.mcpServers).toEqual([
       { name: "alpha", instructions: "MCP-ONE" },
     ]);
@@ -1485,6 +1492,7 @@ describe("prepareTurnRuntimeInputs", () => {
     expect(second).not.toHaveProperty("projectInstructions");
     expect(second.memoryInstructionsText).toContain("# auto memory");
     expect(second.memoryPromptText).toContain("# Memory directories");
+    expect(second.memoryPromptText).toContain(join(home, "memory"));
     expect(second.mcpServers).toEqual([
       { name: "alpha", instructions: "MCP-TWO" },
     ]);

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -9,6 +9,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExecutionAdmissionKernel } from "../budget/execution-admission-kernel.js";
+import { runAdmittedToolCall } from "../budget/admitted-tool-call.js";
+import { EventLog, type Event } from "../session/event-log.js";
+import { resetCronSchedulerForTests } from "../utils/cronScheduler.js";
 import type { ProviderFactoryOptions } from "../llm/provider.js";
 import type { LLMProvider, LLMResponse } from "../llm/types.js";
 import type { ToolEvaluatorContext } from "../permissions/evaluator.js";
@@ -759,6 +763,43 @@ describe("model-facing tools", () => {
     expect(JSON.parse(removedAlias.content).error).toContain(
       "unknown field `max_workers`",
     );
+  });
+
+  it("admits local Skill and Cron effects under a hard cap without pricing remote tools as free", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agenc-local-priced-tools-"));
+    const home = join(root, "home");
+    const kernel = new ExecutionAdmissionKernel({ agencHome: home, ownerId: "local-pricing", ownerPid: process.pid });
+    try {
+      const session = fakeSession(root);
+      const admission = kernel.bindClient({ cwd: root, scope: { runId: session.conversationId, sessionId: session.conversationId, autonomous: false }, budget: { runMaxCostUsd: 0.01 } });
+      const eventLog = new EventLog();
+      Object.assign(session, { eventLog, emit: (event: Event) => eventLog.emit(event), rolloutStore: { assertToolAdmissionAllowed: vi.fn() } });
+      Object.assign(session.services, { executionAdmission: admission, admissionRequired: true });
+      const registry = buildBootstrapToolRegistry({ workspaceRoot: root, agencHome: home, mcpManager: fakeMcpManager() as never, csvAgentJobsRepositories: UNUSED_CSV_AGENT_JOBS_REPOSITORIES, getSession: () => session, emitWarning: () => {} });
+      let callSequence = 0;
+      const call = async (name: string, args: Record<string, unknown>) => {
+        const tool = registry.tools.find((candidate) => candidate.name === name)!;
+        callSequence += 1;
+        return runAdmittedToolCall({ session, turnId: "turn-1", callId: `local-${callSequence}`, tool, args, invoke: async ({ crossEffectBoundary }) => { crossEffectBoundary(); return tool.execute(args); } });
+      };
+      expect((await call("Skill", { skill: "demo-skill" })).isError).not.toBe(true);
+      const created = await call("CronCreate", { cron: "0 0 1 1 *", prompt: "check the workspace", recurring: false, durable: false });
+      expect(created.isError).not.toBe(true);
+      const createdId = JSON.parse(created.content).cron.id;
+      expect(JSON.parse((await call("CronList", {})).content).crons).toEqual(expect.arrayContaining([expect.objectContaining({ id: createdId })]));
+      expect(JSON.parse((await call("CronDelete", { id: createdId })).content).deleted).toBe(true);
+      expect(admission.getUsageSummary?.()).toMatchObject({ costUsd: 0, heldCostUsd: 0, hasUnknownCost: false });
+      const unknown = registry.tools.find((tool) => tool.name === "WorkflowTool")!;
+      expect(unknown.admissionEstimate?.({})).toMatchObject({ maxCostUsd: null });
+      const invoke = vi.fn(async () => ({ content: "must not run" }));
+      await expect(runAdmittedToolCall({ session, turnId: "turn-1", callId: "unknown-priced", tool: unknown, args: {}, invoke })).rejects.toMatchObject({ reason: "unpriced_under_hard_cap" });
+      expect(invoke).not.toHaveBeenCalled();
+      await expect(admission.acquire({ stepId: "scheduled-model", kind: "model_turn", maxInputTokens: 10, maxOutputTokens: 10, maxCostUsd: 0.02 })).rejects.toMatchObject({ reason: "budget_exceeded" });
+    } finally {
+      await resetCronSchedulerForTests();
+      kernel.close();
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps CSV review reads bounded and resolution approval-gated", () => {

--- a/runtime/tests/bin/unknown-startup-options.test.ts
+++ b/runtime/tests/bin/unknown-startup-options.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { classifyCLI, routeCLI, stripRoutingFlags } from "../../src/bin/route.js";
+
+const executable = ["/usr/bin/node", "/opt/agenc/agenc.js"];
+
+describe("unknown startup options", () => {
+  it("does not call any startup implementation for an unsupported flag", async () => {
+    const start = vi.fn(async () => 0);
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(await routeCLI({
+        argv: [...executable, "-p", "--max-budget-usd", "2", "write code"],
+        isTTY: false,
+        isStdoutTTY: false,
+        bootTUI: start,
+        oneShotCLI: start,
+        resumeTUI: start,
+        continueTUI: start,
+      })).toBe(2);
+      expect(start).not.toHaveBeenCalled();
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining("unknown option '--max-budget-usd'"));
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it.each([true, false])("rejects options before routing when tty=%s", (isTTY) => {
+    for (const option of ["--max-budget-usd", "--max-budget-usd=2", "--sandbox", "--fork", "-unknown", "--print=yes"]) {
+      expect(classifyCLI({ argv: [...executable, option, "2", "build something"], isTTY, isStdoutTTY: isTTY })).toEqual({
+        kind: "errorAndExit",
+        message: `agenc: unknown option '${option}'. Use '--' before literal prompt text that starts with '-'.`,
+        exitCode: 2,
+      });
+    }
+  });
+
+  it("preserves literal options after either prompt boundary", () => {
+    for (const prompt of [["--", "--max-budget-usd", "2"], ["explain", "--max-budget-usd", "2"]]) {
+      expect(classifyCLI({ argv: [...executable, "-p", ...prompt], isTTY: false, isStdoutTTY: false })).toMatchObject({
+        kind: "oneShotCLI",
+        userMessage: prompt.filter((token) => token !== "--").join(" "),
+      });
+    }
+  });
+
+  it.each(["--debug", "-d", "--debug=permissions", "--debug-to-stderr", "-d2e", "--debug-file=/tmp/debug.log"])("preserves supported debug option %s without sending it to the model", (option) => {
+    expect(classifyCLI({ argv: [...executable, "-p", option, "hello"], isTTY: false, isStdoutTTY: false })).toEqual({ kind: "oneShotCLI", userMessage: "hello" });
+    expect(stripRoutingFlags([option, "hello"])).toEqual(["hello"]);
+  });
+
+  it("consumes debug-file values before validating the next option", () => {
+    expect(classifyCLI({ argv: [...executable, "-p", "--debug-file", "/tmp/debug.log", "--wrong"], isTTY: false, isStdoutTTY: false })).toMatchObject({ kind: "errorAndExit", exitCode: 2 });
+    expect(stripRoutingFlags(["--debug-file", "/tmp/debug.log", "hello"])).toEqual(["hello"]);
+  });
+});

--- a/runtime/tests/budget/failed-spawn-admission.integration.test.ts
+++ b/runtime/tests/budget/failed-spawn-admission.integration.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it, vi } from "vitest";
+import { createSpawnAgentTool } from "../../src/agents/v2/spawn.js";
+import type { MultiAgentV2Options } from "../../src/agents/v2/common.js";
+import { createAgentRoleWorkspace } from "../../src/agents/role.js";
+import { AgentRoleCatalog } from "../../src/agents/role-catalog.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
+import type { Session } from "../../src/session/session.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import type { Tool } from "../../src/tools/types.js";
+import { explicitDangerBroker } from "../helpers/explicit-danger-boundary.js";
+
+it("a real unborn-worktree refusal does not poison the next admitted mutation", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agenc-spawn-admission-"));
+  const home = join(root, "home");
+  const cwd = join(root, "workspace");
+  execFileSync("git", ["init", "-b", "main", cwd], { stdio: "ignore" });
+  const workspace = createAgentRoleWorkspace(cwd);
+  const kernel = new ExecutionAdmissionKernel({ agencHome: home, ownerId: "spawn-test", ownerPid: process.pid });
+  const admission = kernel.bindClient({ cwd, scope: { runId: "spawn-parent", sessionId: "spawn-parent", autonomous: false }, budget: { runMaxCostUsd: 1 } });
+  const rolloutStore = new RolloutStore({ cwd, agencHome: home, sessionId: "spawn-parent", agencVersion: "0.17.0", sessionTempRoot: root });
+  rolloutStore.open({ sessionId: "spawn-parent", cwd, timestamp: new Date().toISOString(), originator: "agenc", agencVersion: "0.17.0" });
+  const eventLog = new EventLog();
+  const events: Event[] = [];
+  eventLog.subscribe((event) => {
+    events.push(event);
+    rolloutStore.append(event, { durable: true });
+  });
+  const control = {
+    roleWorkspace: workspace,
+    assertRoleWorkspace: () => {},
+    getLive: () => undefined,
+    spawn: vi.fn(),
+    shutdownAgentTree: vi.fn(),
+  };
+  const session = {
+    conversationId: "spawn-parent",
+    abortController: new AbortController(),
+    roleWorkspace: workspace,
+    eventLog,
+    rolloutStore,
+    emit: (event: Event) => eventLog.emit(event),
+    nextInternalSubId: () => `spawn-event-${events.length}`,
+    snapshotHistoryMessages: () => [],
+    modelInfo: { slug: "test-model" },
+    sessionConfiguration: { cwd, collaborationMode: { model: "test-model" } },
+    config: { cwd, multiAgentV2: { hideSpawnAgentMetadata: false } },
+    services: {
+      executionAdmission: admission,
+      admissionRequired: true,
+      agentControl: control,
+      sandboxExecutionBroker: explicitDangerBroker.forkForCwd(cwd),
+      modelsManager: {
+        tryListModels: () => undefined,
+        listModels: async () => [],
+        getModelInfo: async () => ({ slug: "test-model" }),
+      },
+    },
+    abortTerminal: vi.fn(),
+  } as unknown as Session;
+  const spawnTool = createSpawnAgentTool({
+    getSession: () => session,
+    workspace,
+    roleCatalog: new AgentRoleCatalog(workspace),
+    ensureAgentControl: () => ({ control, registry: {} }),
+  } as unknown as MultiAgentV2Options);
+  const spawnArgs = { message: "implement a feature", task_name: "worker", isolation: "worktree", __callId: "spawn-unborn" };
+  try {
+    const refused = await runAdmittedToolCall({
+      session, turnId: "turn-1", callId: "spawn-unborn", tool: spawnTool, args: spawnArgs,
+      invoke: async ({ crossEffectBoundary }) => {
+        crossEffectBoundary();
+        return spawnTool.execute(spawnArgs);
+      },
+    });
+    expect(refused).toMatchObject({ isError: true, effectDisposition: { disposition: "confirmed_no_effect" } });
+    expect(control.spawn).not.toHaveBeenCalled();
+    const file = join(cwd, "follow-up.txt");
+    const writeTool = {
+      name: "write.follow-up",
+      recoveryCategory: "side-effecting",
+      admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
+    } as unknown as Tool;
+    await expect(runAdmittedToolCall({
+      session, turnId: "turn-1", callId: "write-after-refusal", tool: writeTool, args: {},
+      invoke: async ({ crossEffectBoundary }) => {
+        crossEffectBoundary();
+        writeFileSync(file, "completed");
+        return { content: "completed" };
+      },
+    })).resolves.toMatchObject({ content: "completed" });
+    expect(readFileSync(file, "utf8")).toBe("completed");
+    expect(existsSync(join(cwd, ".agenc-worktrees"))).toBe(false);
+    expect(admission.getUsageSummary?.()).toMatchObject({ costUsd: 0, hasUnknownCost: false });
+    expect(events.some((event) => event.msg.type === "effect_result" && event.msg.payload.outcome === "unknown")).toBe(false);
+  } finally {
+    rolloutStore.close();
+    kernel.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/runtime/tests/commands/session-compact-context.test.ts
+++ b/runtime/tests/commands/session-compact-context.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ConfigStore } from "../../src/config/store.js";
+import * as memoryPrompt from "../../src/memory/memdir.js";
+import * as outputStyles from "../../src/constants/outputStyles.js";
 
 const { loadTieredInstructionsMock } = vi.hoisted(() => ({
   loadTieredInstructionsMock: vi.fn(async () => ({
@@ -424,6 +430,37 @@ describe("/context display: computeContextUsageBreakdown", () => {
 });
 
 describe("/context TUI bridge", () => {
+  test("counts memory from the captured session home and working directory", async () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-context-memory-owner-"));
+    const configStore = new ConfigStore({ home, cwd: home, env: { HOME: home, AGENC_HOME: home } });
+    await configStore.reload();
+    const load = vi.spyOn(memoryPrompt, "loadMemoryPrompt");
+    const style = vi.spyOn(outputStyles, "getOutputStyleConfig").mockResolvedValue(null);
+    const session = {
+      abortController: new AbortController(), conversationId: "context-memory-owner",
+      newDefaultTurnWithSubId: () => ({ cwd: home, config: {},
+        modelInfo: { slug: "grok-4", contextWindow: 200_000, effectiveContextWindowPercent: 100 },
+        modelProviderId: "grok", dynamicTools: [], options: {} }),
+      nextInternalSubId: () => "context-memory-1", snapshotHistoryMessages: () => [],
+      state: { unsafePeek: () => ({ totalTokenUsage: { promptTokens: 0 } }) },
+      permissionModeRegistry: { current: () => undefined },
+      services: { configStore, registry: { toLLMTools: () => [], allSpecs: () => [] },
+        permissionModeRegistry: { current: () => undefined }, providerEnvironment: {}, provider: {},
+        runtimeOptions: { simpleMode: false, remoteMode: false } },
+      emit: vi.fn(), clearProviderResponseId: vi.fn(),
+    };
+    try {
+      await contextCommand.execute({ session: session as never, argsRaw: "", cwd: home, home,
+        appState: { setToolJSX: vi.fn() } });
+      expect(load).toHaveBeenCalledWith(expect.objectContaining({ cwd: home, configStore }));
+      expect((await load.mock.results[0]?.value)?.directories).toContain(join(home, "memory"));
+    } finally {
+      load.mockRestore();
+      style.mockRestore();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("loads managed policy from the session's captured authority", async () => {
     const capturedManagedPath = "/captured/policy/AGENC.md";
     const ambientManagedPath = "/ambient/policy/AGENC.md";

--- a/runtime/tests/config/session-home-authority.architecture.test.ts
+++ b/runtime/tests/config/session-home-authority.architecture.test.ts
@@ -306,8 +306,9 @@ describe("session home authority architecture", () => {
 
     expect(filesystem).toContain("verifiedPlanFileContextFromArgs")
     expect(filesystem).toContain("SESSION_AGENC_HOME_ARG")
+    expect(codingCommon).toContain("verifiedPlanFileContextFromArgs")
+    expect(worktree).toContain("verifiedSessionContextFromArgs")
     for (const consumer of [codingCommon, worktree]) {
-      expect(consumer).toContain("verifiedPlanFileContextFromArgs")
       expect(consumer).not.toContain("resolveHomeContext(process.env)")
     }
   });

--- a/runtime/tests/gaphunt3/bin-route.test.ts
+++ b/runtime/tests/gaphunt3/bin-route.test.ts
@@ -4,10 +4,7 @@
  * --approval-policy). Previously stripRoutingFlags removed each such flag AND
  * its following value before the residue became the prompt, so the user's
  * intent (e.g. the fork target) silently vanished with no behavior change and
- * no feedback. After the fix these flags fall through as visible prompt text.
- *
- * Each test below fails if the fix is reverted (the flag+value is swallowed,
- * leaving an empty prompt) and passes with it (the flag text is preserved).
+ * no feedback.
  */
 
 import { describe, expect, it } from "vitest";
@@ -34,29 +31,22 @@ describe("gaphunt3 #37: unconsumed value flags are no longer silently swallowed"
     expect(stripRoutingFlags([flag, value])).toEqual([flag, value]);
   });
 
-  it("classifyCLI('agenc --fork <id>') preserves the fork id as prompt text instead of dropping it", () => {
+  it("classifyCLI rejects unsupported fork options instead of sending a prompt", () => {
     const plan = classifyCLI({
       argv: [NODE, SCRIPT, "--fork", "conv-abc123"],
       isTTY: true,
       isStdoutTTY: true,
     });
-    // Must be a bootTUI plan that still carries the user's intent. Before the
-    // fix this was a bootTUI plan with NO initialPrompt (fork id swallowed).
-    expect(plan.kind).toBe("bootTUI");
-    if (plan.kind !== "bootTUI") throw new Error("expected bootTUI plan");
-    expect(plan.args.initialPrompt).toBe("--fork conv-abc123");
+    expect(plan).toMatchObject({ kind: "errorAndExit", exitCode: 2 });
   });
 
-  it("classifyCLI('agenc --sandbox strict \"do X\"') keeps both the flag/value and the real prompt", () => {
+  it("classifyCLI rejects unsupported sandbox options instead of sending a prompt", () => {
     const plan = classifyCLI({
       argv: [NODE, SCRIPT, "--sandbox", "strict", "do", "X"],
       isTTY: true,
       isStdoutTTY: true,
     });
-    expect(plan.kind).toBe("bootTUI");
-    if (plan.kind !== "bootTUI") throw new Error("expected bootTUI plan");
-    // Before the fix "--sandbox strict" was swallowed, leaving "do X".
-    expect(plan.args.initialPrompt).toBe("--sandbox strict do X");
+    expect(plan).toMatchObject({ kind: "errorAndExit", exitCode: 2 });
   });
 
   it("still strips genuinely-consumed value flags (--model, --provider, --config, --resume)", () => {

--- a/runtime/tests/hooks/engine/command-runner.lifecycle.test.ts
+++ b/runtime/tests/hooks/engine/command-runner.lifecycle.test.ts
@@ -1,10 +1,31 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { runHookCommand } from "../../../src/hooks/engine/command-runner.js";
 import { SandboxExecutionBroker } from "../../../src/sandbox/execution-broker.js";
 import { transitionSandboxExecutionBrokerMode } from "../../../src/sandbox/execution-lifecycle.js";
 
 describe("configured hook sandbox lifecycle", () => {
+  test.skipIf(process.platform === "win32")("enters the broker lease before the dispatch callback", async () => {
+    const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd: process.cwd() });
+    const dispatch = vi.fn();
+    const begin = vi.spyOn(broker, "beginOneShotSpawnLease");
+    const result = await runHookCommand({
+      command: "printf callback-order",
+      cwd: process.cwd(),
+      env: process.env,
+      shellPath: "/bin/sh",
+      stdin: "",
+      timeoutMs: 5_000,
+      sandboxExecutionBroker: broker,
+      beforeSpawn: () => {
+        expect(begin).toHaveBeenCalledOnce();
+        dispatch();
+      },
+    });
+    expect(result).toMatchObject({ status: "success", stdout: "callback-order" });
+    expect(dispatch).toHaveBeenCalledOnce();
+  });
+
   test.skipIf(process.platform === "win32")(
     "applies the captured command wrapper",
     async () => {

--- a/runtime/tests/hooks/status-line-executor.test.ts
+++ b/runtime/tests/hooks/status-line-executor.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -155,6 +155,72 @@ describe.skipIf(process.platform === "win32")("daemon-owned status-line executor
     Object.assign(second.session.services.userShell, { commandWrapperArgv: ["env", "AGENC_STATUS_WRAPPER=second", "/bin/sh", "-c"] });
     expect(await Promise.all([executeSessionStatusLine(first.session), executeSessionStatusLine(second.session)]))
       .toEqual([{ status: "rendered", text: `${first.configStore.projectRoot}:first` }, { status: "rendered", text: `${second.configStore.projectRoot}:second` }]);
+  });
+
+  test("does not dispatch or retain an unknown hold when sandbox preparation refuses", async () => {
+    const owner = await fixture();
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd: owner.cwd,
+      env: { HOME: owner.home, AGENC_HOME: owner.home, PATH: "" },
+      sessionTempRoot: owner.home,
+      probe: () => ({
+        kind: "ready",
+        mode: "workspace_write",
+        platform: "linux",
+        landlock: "full",
+        landlockFallback: {
+          reason: "bubblewrap was not found in a trusted system directory",
+          remediation: "Provide a trusted bubblewrap directory in the session PATH.",
+        },
+      }),
+      platform: "linux",
+    });
+    Object.assign(owner.session.services, { sandboxExecutionBroker: broker });
+    const dispatched = vi.spyOn(owner.admission, "markDispatched");
+    const held = vi.spyOn(owner.admission, "holdUnknown");
+    const voided = vi.spyOn(owner.admission, "void");
+    const result = await executeSessionStatusLine(owner.session);
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toContain("sandbox_policy_unexpressible");
+    expect(dispatched).not.toHaveBeenCalled();
+    expect(held).not.toHaveBeenCalled();
+    expect(voided).toHaveBeenCalledOnce();
+    expect(owner.admission.replayJournal?.().map((event) => event.event)).toContain("voided");
+  });
+
+  test("marks dispatch only after successful sandbox preparation", async () => {
+    const owner = await fixture();
+    const order: string[] = [];
+    const prepare = owner.broker.prepareSpawn.bind(owner.broker);
+    vi.spyOn(owner.broker, "prepareSpawn").mockImplementation((...args) => {
+      order.push("prepare");
+      return prepare(...args);
+    });
+    const dispatch = owner.admission.markDispatched.bind(owner.admission);
+    vi.spyOn(owner.admission, "markDispatched").mockImplementation((...args) => {
+      order.push("dispatch");
+      return dispatch(...args);
+    });
+    expect(await executeSessionStatusLine(owner.session)).toMatchObject({ status: "rendered" });
+    expect(order).toEqual(["prepare", "dispatch"]);
+  });
+
+  test("settles confirmed spawn failure as zero usage without an unknown hold", async () => {
+    const owner = await fixture();
+    const shellPath = join(owner.home, "removed-shell");
+    copyFileSync("/bin/sh", shellPath);
+    Object.assign(owner.session.services.userShell, { path: shellPath });
+    const dispatch = owner.admission.markDispatched.bind(owner.admission);
+    vi.spyOn(owner.admission, "markDispatched").mockImplementation((...args) => {
+      dispatch(...args);
+      rmSync(shellPath);
+    });
+    const held = vi.spyOn(owner.admission, "holdUnknown");
+    const reconcile = vi.spyOn(owner.admission, "reconcile");
+    expect(await executeSessionStatusLine(owner.session)).toEqual({ status: "error", reason: "command_failed" });
+    expect(held).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledWith(expect.any(String), { inputTokens: 0, outputTokens: 0, costUsd: 0 });
   });
 
   test("returns busy without cancelling another request and tracks physical work", async () => {

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -326,10 +326,10 @@ describe("reproducible install and release contract", () => {
       "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
     );
     expect(linuxKernelJob).toContain("numTotalTestSuites: 3");
-    expect(linuxKernelJob).toContain("numTotalTests: 15");
-    expect(linuxKernelJob).toContain("numPassedTests: 15");
+    expect(linuxKernelJob).toContain("numTotalTests: 17");
+    expect(linuxKernelJob).toContain("numPassedTests: 17");
     expect(linuxKernelJob).toContain(
-      "real-kernel sandbox lane passed 15 tests in 2 files with zero skipped",
+      "real-kernel sandbox lane passed 17 tests in 2 files with zero skipped",
     );
     expect(linuxKernelJob).toContain('bwrap_help="$(bwrap --help)"');
     expect(linuxKernelJob).toContain("grep -Fq -- '--ro-bind-fd'");

--- a/runtime/tests/permissions/session-plan-mutation.test.ts
+++ b/runtime/tests/permissions/session-plan-mutation.test.ts
@@ -1,0 +1,272 @@
+import { existsSync, linkSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getPlanFilePath, setPlanSlug, clearAllPlanSlugs } from "../../src/planning/plan-files.js";
+import { createFileWriteTool } from "../../src/tools/system/file-write.js";
+import { createFileEditTool, createFileMultiEditTool } from "../../src/tools/system/file-edit.js";
+import { attachContextDefaults, hasPermissionsToUseTool, type ToolEvaluatorContext } from "../../src/permissions/evaluator.js";
+import { createEmptyToolPermissionContext, type PermissionMode } from "../../src/permissions/types.js";
+import { applyPermissionUpdate } from "../../src/permissions/permission-updates.js";
+import { runToolUse } from "../../src/tools/execution.js";
+import { StreamingToolExecutor } from "../../src/phases/_deps/tool-runtime.js";
+import type { ToolRegistry } from "../../src/tool-registry.js";
+import type { ToolInvocation } from "../../src/tools/context.js";
+import { ConfigStore } from "../../src/config/store.js";
+import { mkCtx, mkSession } from "../fixtures.js";
+import { buildFilteredRegistry } from "../../src/agents/run-agent.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { planModeProducer } from "../../src/prompts/attachments/plan-mode.js";
+import { getAttachmentTrackingState } from "../../src/session/attachment-state.js";
+import { signSessionId } from "../../src/tools/system/filesystem.js";
+import { enforceRuntimeSandboxAttempt } from "../../src/tools/runtimes/sandboxing.js";
+import { createEnterWorktreeTool } from "../../src/tools/system/worktree.js";
+
+let root: string;
+let cwd: string;
+let home: string;
+let planPath: string;
+let session: ReturnType<typeof mkSession>["session"];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "agenc-plan-permission-"));
+  cwd = join(root, "project");
+  home = join(root, "home");
+  mkdirSync(cwd);
+  const configStore = new ConfigStore({ home, env: { AGENC_HOME: home }, cwd });
+  session = mkSession({ cwd, services: { configStore } }).session;
+  setPlanSlug({ sessionId: session.conversationId, agencHome: home }, "exact-own-plan");
+  planPath = getPlanFilePath({ sessionId: session.conversationId, agencHome: home });
+});
+
+afterEach(async () => {
+  await session.shutdown();
+  clearAllPlanSlugs();
+  rmSync(root, { recursive: true, force: true });
+});
+
+function context(mode: PermissionMode = "plan", behavior?: "ask" | "deny", ruleContent?: string): ToolEvaluatorContext {
+  let permissions = createEmptyToolPermissionContext({ mode });
+  if (behavior !== undefined) permissions = applyPermissionUpdate(permissions, {
+    type: "addRules", destination: "session", behavior,
+    rules: [{ toolName: "Write", ...(ruleContent !== undefined ? { ruleContent } : {}) }],
+  });
+  return attachContextDefaults({ session, getAppState: () => ({ toolPermissionContext: permissions }) });
+}
+
+describe("exact owning plan-file mutation authority", () => {
+  it.each(["native", "child-wrapped", "child-direct"])("keeps no-plan session identity available to %s worktree dispatch", async (pipeline) => {
+    rmSync(dirname(planPath), { recursive: true, force: true });
+    clearAllPlanSlugs();
+    const kernel = new ExecutionAdmissionKernel({ agencHome: home, ownerId: "worktree-identity-test", ownerPid: process.pid });
+    Object.assign(session.services, { executionAdmission: kernel.bindClient({ cwd, scope: { runId: session.conversationId, sessionId: session.conversationId, autonomous: false } }) });
+    try {
+      const native = {
+        ...createEnterWorktreeTool({ cwd }),
+        admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
+      };
+      const base: ToolRegistry = { tools: [native], toLLMTools: () => [], dispatch: async () => { throw new Error("unexpected fallback"); } };
+      const registry = buildFilteredRegistry(base, { childConversationId: session.conversationId, getSession: () => session });
+      const args = { name: "invalid name!" };
+      let content: string;
+      if (pipeline === "child-direct") {
+        const result = await registry.dispatch({ id: "worktree-no-plan-direct", name: native.name, arguments: JSON.stringify(args) });
+        content = String(result.content);
+      } else {
+        const tool = pipeline === "native" ? native : registry.tools[0]!;
+        const turn = mkCtx({ cwd });
+        const result = await runToolUse(JSON.stringify(args), {
+          tool, currentTurnId: turn.subId,
+          invocation: { session, turn, tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} }, callId: "worktree-no-plan", toolName: { name: tool.name }, payload: { kind: "function", arguments: "" }, source: "direct" },
+          requestApproval: async () => ({ behavior: "allow", decisionAtTurnId: turn.subId }),
+        });
+        content = result.content;
+      }
+      expect(content).not.toContain("requires signed session");
+      expect(content).toMatch(/name.*(?:letters|characters|segments)|invalid.*name/i);
+      expect(existsSync(dirname(planPath))).toBe(false);
+    } finally {
+      kernel.close();
+    }
+  });
+
+  it.each([".git", ".agents"])("does not waive unrelated %s metadata protection for a nested home", async (directory) => {
+    const protectedHome = join(cwd, directory, "home");
+    const configStore = new ConfigStore({ home: protectedHome, env: { AGENC_HOME: protectedHome }, cwd });
+    Object.assign(session.services, { configStore });
+    setPlanSlug({ sessionId: session.conversationId, agencHome: protectedHome }, "protected-plan");
+    const protectedPath = getPlanFilePath({ sessionId: session.conversationId, agencHome: protectedHome });
+    expect((await hasPermissionsToUseTool(createFileWriteTool({ allowedPaths: [cwd] }), { file_path: protectedPath, content: "bad" }, context())).behavior).toBe("deny");
+  });
+
+  it("does not grant native home access from a signed session ID alone", async () => {
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    const result = await tool.execute({
+      file_path: planPath, content: "forged capability", __agencHome: home,
+      __agencSessionId: session.conversationId,
+      __agencSessionIdSig: signSessionId(session.conversationId),
+    });
+    expect(result.isError).toBe(true);
+    expect(existsSync(planPath)).toBe(false);
+  });
+
+  it("pins the previously authorized owner instead of adopting another slug", async () => {
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    expect((await hasPermissionsToUseTool(tool, { file_path: planPath, content: "# Plan" }, context())).behavior).toBe("allow");
+    setPlanSlug({ sessionId: session.conversationId, agencHome: home }, "replacement-slug");
+    const changedPath = getPlanFilePath({ sessionId: session.conversationId, agencHome: home });
+    expect((await hasPermissionsToUseTool(tool, { file_path: changedPath, content: "bad" }, context())).behavior).toBe("deny");
+  });
+
+  it.each(["default", "deny-exact", "deny-parent", "read-only"])("preserves the %s filesystem sandbox restriction", (restriction) => {
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    const mode = restriction === "read-only" ? "read_only" : "workspace_write";
+    const turn = mkCtx({ cwd, fileSystemSandboxPolicy: {
+      allowWrite: restriction === "read-only" ? [] : [cwd], allowRead: [], denyRead: [],
+      denyWrite: restriction === "deny-exact" ? [planPath] : restriction === "deny-parent" ? [dirname(planPath)] : [],
+    } } as never);
+    const attempt = () => enforceRuntimeSandboxAttempt({ tool, args: { file_path: planPath, content: "# Plan" }, context: {
+      callId: "plan-sandbox", toolName: tool.name, runtimeKind: "function", classification: { kind: "exclusive" },
+      supportsParallelToolCalls: false, source: "direct", submittedAtMs: 0,
+      approvalPolicy: "never", requestedSandboxMode: mode, sandboxMode: mode, approvalResolved: false, rawArgs: "{}",
+      invocation: { session, turn, tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} }, callId: "plan-sandbox", toolName: { name: tool.name }, payload: { kind: "function", arguments: "{}" }, source: "direct" },
+    } as never });
+    if (restriction === "default") expect(attempt).not.toThrow();
+    else expect(attempt).toThrow(/blocked/);
+  });
+
+  it("authorizes the actual advertised attachment path after cold slug-cache reconstruction", async () => {
+    clearAllPlanSlugs();
+    const attachments = await planModeProducer({
+      sessionKey: session, agencHome: home, cwd, loadedTools: [], messages: [],
+      getSession: () => session, permissionContext: createEmptyToolPermissionContext({ mode: "plan" }),
+      subagentDepth: 0, signal: new AbortController().signal,
+    }, getAttachmentTrackingState(session));
+    expect(attachments).toContainEqual(expect.objectContaining({ kind: "plan_mode", planFilePath: planPath }));
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    expect((await hasPermissionsToUseTool(tool, { file_path: planPath, content: "# Plan" }, context())).behavior).toBe("allow");
+  });
+
+  it.each(["wrapped", "direct"])("re-derives child authority through the real %s filtered registry", async (dispatch) => {
+    const kernel = new ExecutionAdmissionKernel({ agencHome: home, ownerId: "plan-child-test", ownerPid: process.pid });
+    const admission = kernel.bindClient({ cwd, scope: { runId: session.conversationId, sessionId: session.conversationId, autonomous: false }, budget: { runMaxCostUsd: 1 } });
+    Object.assign(session.services, { executionAdmission: admission });
+    try {
+      const native = {
+        ...createFileWriteTool({ allowedPaths: [cwd] }),
+        admissionEstimate: () => ({ maxInputTokens: 0, maxOutputTokens: 0, maxCostUsd: 0 }),
+      };
+      const base: ToolRegistry = { tools: [native], toLLMTools: () => [], dispatch: async () => { throw new Error("unexpected fallback"); } };
+      const registry = buildFilteredRegistry(base, {
+        childConversationId: session.conversationId, getSession: () => session,
+        childToolPolicy: async (_tool, args) => {
+          const decision = await hasPermissionsToUseTool(native, args, context());
+          return decision.behavior === "allow" ? { behavior: "allow", updatedInput: args } : { behavior: "deny", message: "child plan denied" };
+        },
+      });
+      const input = { file_path: planPath, content: "# Child plan", __agencSessionId: "forged-parent", __agencHome: join(root, "forged") };
+      if (dispatch === "direct") {
+        const result = await registry.dispatch({ id: "child-plan-direct", name: native.name, arguments: JSON.stringify(input) });
+        expect(result.isError, String(result.content)).not.toBe(true);
+        expect(admission.getUsageSummary?.().hasUnknownCost).toBe(false);
+      } else {
+        const tool = registry.tools[0]!;
+        const turn = mkCtx({ cwd });
+        const invocation: ToolInvocation = { session, turn, tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} }, callId: "child-plan-wrapped", toolName: { name: tool.name }, payload: { kind: "function", arguments: "" }, source: "direct" };
+        const result = await runToolUse(JSON.stringify(input), { tool, invocation, currentTurnId: turn.subId, canUseTool: hasPermissionsToUseTool, permissionContext: context() });
+        expect(result.isError, result.content).toBe(false);
+      }
+      expect(readFileSync(planPath, "utf8")).toBe(input.content);
+      const denied = await registry.dispatch({ id: "child-plan-sibling", name: native.name, arguments: JSON.stringify({ ...input, file_path: planPath.replace(".md", "-agent-parent.md") }) });
+      expect(denied.isError).toBe(true);
+    } finally {
+      kernel.close();
+    }
+  });
+
+  it("keeps a descriptor-bound plan write from following a late parent exchange", async () => {
+    const outside = join(root, "outside");
+    mkdirSync(outside);
+    const tool = createFileWriteTool({ allowedPaths: [cwd], __testAfterPreWriteCheck: async () => {
+      renameSync(dirname(planPath), `${dirname(planPath)}-old`);
+      symlinkSync(outside, dirname(planPath), "junction");
+    } });
+    const turn = mkCtx({ cwd });
+    const invocation: ToolInvocation = { session, turn, tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} }, callId: "plan-race", toolName: { name: tool.name }, payload: { kind: "function", arguments: "" }, source: "direct" };
+    const result = await runToolUse(JSON.stringify({ file_path: planPath, content: "# Race plan" }), { tool, invocation, currentTurnId: turn.subId, canUseTool: hasPermissionsToUseTool, permissionContext: context() });
+    expect(result.isError).toBe(true);
+    expect(existsSync(join(outside, basename(planPath)))).toBe(false);
+    expect(readFileSync(join(`${dirname(planPath)}-old`, basename(planPath)), "utf8")).toBe("# Race plan");
+  });
+
+  it.each(["Write", "Edit", "MultiEdit"])("permits unsigned owning %s input before dispatch, not sibling or workspace writes", async (name) => {
+    const tool = name === "Write" ? createFileWriteTool({ allowedPaths: [cwd] }) : name === "Edit" ? createFileEditTool({ allowedPaths: [cwd] }) : createFileMultiEditTool({ allowedPaths: [cwd] });
+    expect((await hasPermissionsToUseTool(tool, { file_path: planPath, content: "# Plan" }, context())).behavior).toBe("allow");
+    for (const filePath of [join(cwd, "app.mjs"), planPath.replace(".md", "-other.md"), planPath.replace(".md", "-agent-other.md"), join(dirname(planPath), ".slugs.json")]) {
+      expect((await hasPermissionsToUseTool(tool, { file_path: filePath, content: "not allowed" }, context())).behavior).toBe("deny");
+    }
+  });
+
+  it.each(["default", "plan", "acceptEdits", "bypassPermissions"] as const)("preserves explicit exact-path asks and denies in %s mode", async (mode) => {
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    for (const behavior of ["ask", "deny"] as const) {
+      expect((await hasPermissionsToUseTool(tool, { file_path: planPath, content: "# Plan" }, context(mode, behavior, planPath))).behavior).toBe(behavior);
+      expect((await hasPermissionsToUseTool(tool, { file_path: planPath, content: "# Plan" }, context(mode, behavior))).behavior).toBe(behavior);
+    }
+  });
+
+  it("rejects forged owner fields, foreign homes, plugin writes and shell writes", async () => {
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    const foreignHome = join(root, "foreign");
+    setPlanSlug({ sessionId: session.conversationId, agencHome: foreignHome }, "foreign-plan");
+    const foreignPath = getPlanFilePath({ sessionId: session.conversationId, agencHome: foreignHome });
+    const input = { file_path: foreignPath, content: "bad", __agencHome: foreignHome, __agencSessionId: session.conversationId };
+    expect((await hasPermissionsToUseTool(tool, input, context())).behavior).toBe("deny");
+    for (const untrustedTool of [
+      { ...tool, metadata: { ...tool.metadata, source: "plugin" as const } },
+      { ...tool, name: "system.bash" },
+      { ...tool, name: "mcp.server.Write" },
+    ]) expect((await hasPermissionsToUseTool(untrustedTool, { file_path: planPath, content: "bad" }, context())).behavior).toBe("deny");
+    expect((await hasPermissionsToUseTool(tool, { file_path: planPath, content: "bad" }, { ...context(), session: { conversationId: session.conversationId, services: {} } as never })).behavior).toBe("deny");
+  });
+
+  it.each(["symlink", "hardlink", "parent-symlink", "traversal"])("rejects %s plan targets before approval", async (variant) => {
+    const outside = join(root, "outside.md");
+    writeFileSync(outside, "untouched");
+    let target = planPath;
+    if (variant === "symlink") symlinkSync(outside, planPath);
+    if (variant === "hardlink") linkSync(outside, planPath);
+    if (variant === "parent-symlink") {
+      const original = `${dirname(planPath)}-old`;
+      renameSync(dirname(planPath), original);
+      symlinkSync(original, dirname(planPath), "junction");
+    }
+    if (variant === "traversal") target = `${dirname(planPath)}/../plans/${basename(planPath)}`;
+    expect((await hasPermissionsToUseTool(createFileWriteTool({ allowedPaths: [cwd] }), { file_path: target, content: "bad" }, context())).behavior).toBe("deny");
+    expect(readFileSync(outside, "utf8")).toBe("untouched");
+  });
+
+  it.each(["native", "streaming"])("executes the actual Write sink through %s with trusted exact args", async (pipeline) => {
+    const tool = createFileWriteTool({ allowedPaths: [cwd] });
+    const input = { file_path: planPath, content: "# Canonical plan\n" };
+    const turn = mkCtx({ cwd, sandboxPolicy: { value: "workspace_write" }, approvalPolicy: { value: "on_request" } } as never);
+    const approval = vi.fn(async () => ({ kind: "denied" as const }));
+    if (pipeline === "native") {
+      const invocation: ToolInvocation = { session, turn, tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} }, callId: "plan-native", toolName: { name: tool.name }, payload: { kind: "function", arguments: JSON.stringify(input) }, source: "direct" };
+      const result = await runToolUse(JSON.stringify(input), { tool, invocation, currentTurnId: turn.subId, canUseTool: hasPermissionsToUseTool, permissionContext: context(), approvalResolver: { request: approval } });
+      expect(result.isError, result.content).toBe(false);
+    } else {
+      const registry: ToolRegistry = { tools: [tool], toLLMTools: () => [], dispatch: async (call) => tool.execute(JSON.parse(call.arguments)) };
+      const executor = new StreamingToolExecutor({ registry, liveToolDispatch: { router: { registry }, options: { session, turn, agencHome: home, approvalPolicy: "on_request", canUseTool: hasPermissionsToUseTool, permissionContext: context(), approvalResolver: { request: approval } } } });
+      executor.addTool({}, { id: "plan-streaming", name: tool.name, arguments: JSON.stringify(input) });
+      executor.close();
+      const results = [];
+      for await (const result of executor.getRemainingResults()) results.push(result.result);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.isError, String(results[0]?.content)).not.toBe(true);
+    }
+    expect(approval).not.toHaveBeenCalled();
+    expect(existsSync(planPath)).toBe(true);
+    expect(readFileSync(planPath, "utf8")).toBe(input.content);
+  });
+});

--- a/runtime/tests/planning/plan-files.test.ts
+++ b/runtime/tests/planning/plan-files.test.ts
@@ -1,16 +1,3 @@
-/**
- * Tests for `isSessionPlanFile` — the AgenC-compatible carve-out used
- * by `tools/system/filesystem.ts:validatePath` and
- * `tools/system/coding-common.ts:resolveWorkspacePath` to allow writes
- * to the active session's plan-file family even when the path is
- * outside the workspace allowlist.
- *
- * Mirrors reference `isSessionPlanFile`
- * (`src/utils/permissions/filesystem.ts:254`):
- *
- *     const expectedPrefix = join(getPlansDirectory(), getPlanSlug())
- *     return path.startsWith(expectedPrefix) && path.endsWith('.md')
- */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -54,11 +41,7 @@ describe("isSessionPlanFile", () => {
     expect(isSessionPlanFile(planPath, { sessionId, agencHome })).toBe(true);
   });
 
-  test("matches the per-agent variant `<slug>-agent-<agentId>.md`", () => {
-    // AgenC allows both the main plan and per-agent plan files for
-    // the same session — the prefix is `getPlansDirectory()/<slug>` and
-    // the suffix is `.md`. The agent-id segment fits between the slug
-    // and the `.md` suffix.
+  test("requires exact per-agent ownership rather than a slug prefix", () => {
     const sessionId = "session-B";
     const slug = "ember-bridge-cafef00d";
     setPlanSlug({ sessionId, agencHome }, slug);
@@ -67,8 +50,10 @@ describe("isSessionPlanFile", () => {
       `${slug}-agent-explorer-1.md`,
     );
     expect(isSessionPlanFile(agentPlanPath, { sessionId, agencHome })).toBe(
-      true,
+      false,
     );
+    expect(isSessionPlanFile(agentPlanPath, { sessionId, agencHome, agentId: "explorer-1" })).toBe(true);
+    expect(isSessionPlanFile(join(agencHome, "plans", `${slug}-other.md`), { sessionId, agencHome })).toBe(false);
   });
 
   test("rejects another session's plan file (slug mismatch)", () => {

--- a/runtime/tests/planning/session-plan-authority.test.ts
+++ b/runtime/tests/planning/session-plan-authority.test.ts
@@ -1,0 +1,36 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getExistingPlanFilePath, getPlanFilePath, setPlanSlug, clearAllPlanSlugs } from "../../src/planning/plan-files.js";
+import { matchesSessionPlanFile, planFileAuthorityFromContext } from "../../src/planning/session-plan-authority.js";
+import { signedSessionPlanFileArgs, verifySessionPlanFileArgs, SESSION_PLAN_FILE_ARG, SESSION_PLAN_FILE_SIG_ARG } from "../../src/agents/_deps/filesystem-args.js";
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "agenc-plan-capability-")); });
+afterEach(() => { clearAllPlanSlugs(); rmSync(root, { recursive: true, force: true }); });
+
+describe("signed exact plan capability", () => {
+  it("does not allocate a slug or create a directory during a permission lookup", () => {
+    const context = { agencHome: join(root, "missing"), sessionId: "missing-plan" };
+    expect(getExistingPlanFilePath(context)).toBeNull();
+    expect(planFileAuthorityFromContext(context)).toBeNull();
+    expect(existsSync(context.agencHome)).toBe(false);
+  });
+
+  it("binds every authority field across a JSON roundtrip and rejects tampering", () => {
+    const context = { agencHome: root, sessionId: "own-session", agentId: "own-agent" };
+    setPlanSlug(context, "own-plan");
+    const authority = planFileAuthorityFromContext(context)!;
+    const args = JSON.parse(JSON.stringify(signedSessionPlanFileArgs(authority)));
+    expect(verifySessionPlanFileArgs(args)).toEqual(authority);
+    for (const key of ["sessionId", "agentId", "agencHome", "planFilePath"]) {
+      expect(verifySessionPlanFileArgs({ ...args, [SESSION_PLAN_FILE_ARG]: { ...args[SESSION_PLAN_FILE_ARG], [key]: "forged" } })).toBeNull();
+    }
+    expect(verifySessionPlanFileArgs({ ...args, [SESSION_PLAN_FILE_SIG_ARG]: "00".repeat(32) })).toBeNull();
+    expect(verifySessionPlanFileArgs(signedSessionPlanFileArgs(null))).toBeNull();
+    expect(matchesSessionPlanFile(getPlanFilePath(context), authority)).toBe(true);
+    expect(matchesSessionPlanFile(getPlanFilePath({ ...context, agentId: "other-agent" }), authority)).toBe(false);
+    expect(matchesSessionPlanFile(getPlanFilePath({ ...context, agentId: undefined }), authority)).toBe(false);
+  });
+});

--- a/runtime/tests/prompts/memory-owner-context.test.ts
+++ b/runtime/tests/prompts/memory-owner-context.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { ConfigStore } from "../../src/config/store.js";
+import { getProjectRoot, setProjectRoot } from "../../src/bootstrap/state.js";
+import { resolveMemoryPromptInputs } from "../../src/prompts/system-prompt.js";
+import { resolveAutoMemoryDirectory, resolveGlobalMemoryDirectory } from "../../src/services/extractMemories/memory-paths.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import { clearCurrentRuntimeSession, setCurrentRuntimeSession } from "../../src/session/current-session.js";
+import type { Session } from "../../src/session/session.js";
+import { runWithCanonicalSettingsAuthority } from "../../src/utils/settings/canonicalAuthority.js";
+
+const roots: string[] = [];
+const originalProjectRoot = getProjectRoot();
+afterEach(() => {
+  clearCurrentRuntimeSession();
+  setProjectRoot(originalProjectRoot);
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+async function owner(name: string, configText = "", runtime = {}) {
+  const root = mkdtempSync(join(tmpdir(), `agenc-memory-${name}-`));
+  roots.push(root);
+  const home = join(root, "home");
+  const cwd = join(root, "workspace");
+  mkdirSync(home);
+  mkdirSync(cwd);
+  writeFileSync(join(home, "config.toml"), `config_version = 2\n${configText}\n`);
+  const env = { HOME: root, AGENC_HOME: home };
+  const configStore = new ConfigStore({ home, cwd, env });
+  await configStore.reload();
+  const runtimeOptions = resolveAgentRuntimeOptions({}, runtime);
+  const session = { services: { configStore, runtimeOptions, providerEnvironment: env,
+    userShell: { childEnvironment: env } } };
+  return { root, home, cwd, session, options: { cwd, configStore, env, runtimeOptions } };
+}
+
+describe("memory prompt owner context", () => {
+  test("matches extraction roots across concurrent sessions despite daemon-global project state", async () => {
+    const first = await owner("first");
+    const second = await owner("second");
+    setCurrentRuntimeSession(first.session as unknown as Session);
+    setCurrentRuntimeSession(second.session as unknown as Session);
+    setProjectRoot(second.home);
+    const prompts = await runWithCanonicalSettingsAuthority(second.session.services.configStore, () =>
+      Promise.all([resolveMemoryPromptInputs(first.session, first.cwd), resolveMemoryPromptInputs(second.session, second.cwd)]));
+    for (const [index, target] of [first, second].entries()) {
+      const project = await resolveAutoMemoryDirectory(target.options);
+      const global = await resolveGlobalMemoryDirectory(target.options);
+      expect(prompts[index]!.memoryPrompt).toContain(project.path);
+      expect(prompts[index]!.memoryPrompt).toContain(global);
+      expect(existsSync(project.path!)).toBe(true);
+      expect(prompts[index]!.memoryPrompt).not.toContain(index === 0 ? second.home : first.home);
+    }
+  });
+
+  test.each([
+    ["autoMemoryEnabled = false", {}],
+    ["", { simpleMode: true }],
+    ["", { remoteMode: true }],
+  ])("honors the owner's memory disable gate", async (config, runtime) => {
+    const target = await owner("disabled", config, runtime);
+    expect(await resolveMemoryPromptInputs(target.session, target.cwd))
+      .toEqual({ memoryInstructions: "", memoryPrompt: "" });
+    expect(existsSync(join(target.home, "memory"))).toBe(false);
+  });
+
+  test("uses the owner's tilde expansion and keeps the global root separate", async () => {
+    const target = await owner("override", 'autoMemoryDirectory = "~/saved-project-memory"');
+    const prompt = await resolveMemoryPromptInputs(target.session, target.cwd);
+    expect(prompt.memoryPrompt).toContain(join(target.root, "saved-project-memory"));
+    expect(prompt.memoryPrompt).toContain(join(target.home, "memory"));
+  });
+
+  test("fails closed without an owning configuration store", async () => {
+    expect(await resolveMemoryPromptInputs({ services: {} }, originalProjectRoot))
+      .toEqual({ memoryInstructions: "", memoryPrompt: "" });
+  });
+});

--- a/runtime/tests/prompts/system-prompt.test.ts
+++ b/runtime/tests/prompts/system-prompt.test.ts
@@ -29,7 +29,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, onTestFinished, test } from "vitest";
+import { ConfigStore } from "../../src/config/store.js";
 
 import type { TurnContext } from "../session/turn-context.js";
 import type { Session } from "../session/session.js";
@@ -764,10 +765,13 @@ describe("assembleSystemPrompt", () => {
   });
 
   test("base instructions carry the memory prompt when auto memory is enabled and drop it in simple mode", async () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-base-memory-owner-"));
+    onTestFinished(() => rmSync(home, { recursive: true, force: true }));
+    const configStore = new ConfigStore({ home, cwd: home, env: { HOME: home, AGENC_HOME: home } });
     const registry = { tools: [{ name: "FileRead" }, { name: "Write" }] };
     const standard = await assembleBaseInstructionsForModel({
-      session: { services: { runtimeOptions: { simpleMode: false } } },
-      ctx: fakeCtx(),
+      session: { services: { configStore, runtimeOptions: { simpleMode: false } } },
+      ctx: fakeCtx({ cwd: home }),
       registry,
       provider: "grok",
       permissionContext: null,
@@ -775,6 +779,7 @@ describe("assembleSystemPrompt", () => {
     });
     expect(standard).toContain("# auto memory");
     expect(standard).toContain("# Memory directories");
+    expect(standard).toContain(join(home, "memory"));
     expect(standard.indexOf("# auto memory")).toBeLessThan(
       standard.indexOf(SYSTEM_PROMPT_DYNAMIC_BOUNDARY),
     );
@@ -783,8 +788,8 @@ describe("assembleSystemPrompt", () => {
     );
 
     const simple = await assembleBaseInstructionsForModel({
-      session: { services: { runtimeOptions: { simpleMode: true } } },
-      ctx: fakeCtx(),
+      session: { services: { configStore, runtimeOptions: { simpleMode: true } } },
+      ctx: fakeCtx({ cwd: home }),
       registry,
       provider: "grok",
       permissionContext: null,

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
@@ -24,9 +24,15 @@ import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
 
 import { SandboxExecutionBroker } from "../../../src/sandbox/execution-broker.js";
+import { ExecutionAdmissionKernel } from "../../../src/budget/execution-admission-kernel.js";
+import { createHookExecutionAuthority } from "../../../src/hooks/execution-authority.js";
+import { executeSessionStatusLine } from "../../../src/hooks/status-line-executor.js";
+import { UnifiedExecProcessManager } from "../../../src/unified-exec/process-manager.js";
 import { INHERITED_CWD_SANDBOX_PATH } from "../../../src/sandbox/linux-launcher/config.js";
 import { findSystemBubblewrapInPath } from "../../../src/sandbox/linux-launcher/launcher.js";
 import { bindWorkspaceDirectoryReadCapability } from "../../../src/workspace/file-mutation-transaction.js";
+import { workspaceMutationCoordinators } from "../../../src/workspace/mutation-coordinator.js";
+import { createTestConfigStore, mkSession } from "../../fixtures.js";
 
 const runtimeRoot = fileURLToPath(new URL("../../../", import.meta.url));
 const launcherEntry = join(runtimeRoot, "bin", "agenc-linux-sandbox");
@@ -37,6 +43,97 @@ const builtLauncher = join(
   "linux-launcher",
   "main.js",
 );
+
+test("renders a status command with ordinary workspace-write isolation and a captured system PATH", { timeout: 30_000 }, async () => {
+  expect(process.platform).toBe("linux");
+  const home = realpathSync(mkdtempSync(join("/var/tmp", "agenc-status-kernel-")));
+  const cwd = join(home, "project");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  const environment = { PATH: "/usr/bin:/bin", HOME: home, AGENC_HOME: home };
+  const kernel = new ExecutionAdmissionKernel({ agencHome: home });
+  try {
+    expect(findSystemBubblewrapInPath(environment.PATH)).toBe("/usr/bin/bwrap");
+    const admission = kernel.bindClient({ cwd, scope: { runId: "conv-test", sessionId: "conv-test", autonomous: false } });
+    const configStore = createTestConfigStore({ cwd, base: {
+      statusLine: { type: "command", command: "printf ordinary-sandbox-status" },
+    } });
+    await configStore.reload();
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd,
+      env: environment,
+      sessionTempRoot: home,
+      agencLinuxSandboxExe: launcherEntry,
+    });
+    expect(broker.status().kind).toBe("ready");
+    const { session } = mkSession({
+      cwd,
+      services: {
+        configStore,
+        executionAdmission: admission,
+        sandboxExecutionBroker: broker,
+        hookExecutionAuthority: createHookExecutionAuthority({
+          runtimeOptions: { simpleMode: false, allowUntrustedHooks: false },
+          isWorkspaceTrusted: () => true,
+        }),
+        userShell: {
+          path: "/bin/sh",
+          commandWrapperArgv: [],
+          childEnvironment: environment,
+          deriveExecArgs: (command) => ["-c", command],
+        },
+      },
+    });
+    expect(await executeSessionStatusLine(session))
+      .toEqual({ status: "rendered", text: "ordinary-sandbox-status" });
+    expect(admission.replayJournal?.().map((event) => event.event)).not.toContain("held_unknown");
+  } finally {
+    kernel.close();
+    workspaceMutationCoordinators.clearForTests();
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("sandboxed zsh heredocs use captured temp authority while general tmp stays read-only", { timeout: 30_000 }, async () => {
+  const root = realpathSync(mkdtempSync(join("/var/tmp", "agenc-zsh-kernel-")));
+  const workspace = join(root, "workspace");
+  const sessionTempRoot = join(root, "temporary files");
+  mkdirSync(workspace);
+  mkdirSync(sessionTempRoot);
+  const environment = {
+    ...stringEnvironment(process.env),
+    TMPPREFIX: "/tmp/untrusted-zsh",
+    TmPpReFiX: "/tmp/mixed-zsh",
+  };
+  const broker = new SandboxExecutionBroker({
+    mode: "workspace_write",
+    cwd: workspace,
+    env: environment,
+    sessionTempRoot,
+    agencLinuxSandboxExe: launcherEntry,
+  });
+  const manager = new UnifiedExecProcessManager({ cwd: workspace, baseEnv: environment, sessionTempRoot });
+  const blockedPath = `/tmp/agenc-zsh-denied-${randomUUID()}`;
+  try {
+    expect(broker.status().kind).toBe("ready");
+    const payload = "heredoc-data-".repeat(1000);
+    const result = await manager.execCommand({
+      shell: "/bin/zsh",
+      login: false,
+      cmd: `printf '%s\\n' "$TMPPREFIX"\ncat <<'AGENC_DATA'\n${payload}\nAGENC_DATA\nif printf forbidden > '${blockedPath}'; then exit 91; fi`,
+      runtimeSandbox: broker.runtimeSandbox("tool"),
+      yield_time_ms: 10_000,
+    });
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`${sessionTempRoot}/zsh\n${payload}\n`);
+    expect(result.stderr).toMatch(/read-only file system|read-only filesystem|permission denied/iu);
+    expect(existsSync(blockedPath)).toBe(false);
+  } finally {
+    await manager.closeAll("test_cleanup");
+    rmSync(root, { recursive: true, force: true });
+    rmSync(blockedPath, { force: true });
+  }
+});
 
 test("protects custom Desktop authority records and their ancestor namespace with the real Linux kernel", { timeout: 30_000 }, async () => {
   expect(process.platform).toBe("linux");

--- a/runtime/tests/services/mcp/client-transports.test.ts
+++ b/runtime/tests/services/mcp/client-transports.test.ts
@@ -559,6 +559,7 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
     TMPDIR: '/ambient/posix',
     TEMP: 'C:\\ambient\\temp',
     TMP: 'C:\\ambient\\tmp',
+    TMPPREFIX: '/ambient/zsh',
   })
   const runtimeOptions = (sessionTempRoot: string) => ({
     simpleMode: false,
@@ -586,6 +587,7 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
     TMPDIR: '/tmp/agenc-mcp-session-a',
     TEMP: '/tmp/agenc-mcp-session-a',
     TMP: '/tmp/agenc-mcp-session-a',
+    TMPPREFIX: '/tmp/agenc-mcp-session-a/zsh',
   })
   assert.deepEqual(fakeStdioTransports[1]?.env, {
     PATH: '/usr/bin',
@@ -593,6 +595,7 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
     TMPDIR: '/tmp/agenc-mcp-session-b',
     TEMP: '/tmp/agenc-mcp-session-b',
     TMP: '/tmp/agenc-mcp-session-b',
+    TMPPREFIX: '/tmp/agenc-mcp-session-b/zsh',
   })
 
   if (first.type === 'connected') await first.cleanup()

--- a/runtime/tests/session/agenc-delegate.test.ts
+++ b/runtime/tests/session/agenc-delegate.test.ts
@@ -678,6 +678,9 @@ describe("review delegate spawn admission", () => {
       { cwd },
     );
     mountTestRollout(session);
+    const workspaceId = resolveStateDatabasePaths({ cwd, agencHome: requireTestConfigHome(session) }).projectDir;
+    Object.assign(admission.client.scope, { workspaceId });
+    Object.assign(admission.child.scope, { workspaceId });
     const req = mkOneShotRequest(session);
 
     await expect(

--- a/runtime/tests/session/child-run-journal.authority.test.ts
+++ b/runtime/tests/session/child-run-journal.authority.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { mountChildRunJournal, recordUnconstructedChildRunTerminal } from "../../src/session/child-run-journal.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import type { Session } from "../../src/session/session.js";
+import { isCanonicalRolloutPayload } from "../../src/state/recovery-journal-schema.js";
+
+let root: string;
+let kernel: ExecutionAdmissionKernel;
+let parent: Session;
+let parentStore: RolloutStore;
+const children: RolloutStore[] = [];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "agenc-child-journal-authority-"));
+  const cwd = join(root, "parent");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  kernel = new ExecutionAdmissionKernel({ agencHome: join(root, "home"), ownerId: "child-journal-test", ownerPid: process.pid });
+  const executionAdmission = kernel.bindClient({ cwd, scope: { runId: "parent", sessionId: "parent", autonomous: false } });
+  parentStore = new RolloutStore({ cwd, agencHome: join(root, "home"), sessionId: "parent", agencVersion: "0.17.0", sessionTempRoot: join(root, "session-tmp") });
+  parentStore.open({ cwd, sessionId: "parent", timestamp: new Date().toISOString(), originator: "agenc", agencVersion: "0.17.0" });
+  parent = { rolloutStore: parentStore, services: { executionAdmission } } as unknown as Session;
+});
+
+afterEach(() => {
+  for (const store of children.splice(0)) store.close();
+  parentStore.close();
+  kernel.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("child journal admission-owner metadata", () => {
+  it("binds a constructed child to its parent's admitted workspace before events", () => {
+    const cwd = join(root, "child");
+    mkdirSync(join(cwd, ".git"), { recursive: true });
+    const admission = parent.services.executionAdmission!.forSession({ runId: "child", sessionId: "child" });
+    const eventLog = new EventLog();
+    let mounted: RolloutStore | null = null;
+    const child = {
+      conversationId: "child", eventLog,
+      sessionConfiguration: { cwd, collaborationMode: { model: "test-model" } },
+      services: { executionAdmission: admission, provider: { name: "test-provider" } },
+      mountRolloutStore: (store: RolloutStore | null) => { mounted = store; },
+      get rolloutStore() { return mounted; },
+      emit: (input: Event) => { const event = eventLog.emit(input); mounted?.append(event, { durable: true }); return event; },
+      onBeforeDurableClose: () => {},
+    } as unknown as Session;
+    const store = mountChildRunJournal({ parent, child, originator: "agenc-subagent", terminalResult: () => ({ status: "completed", stopReason: "completed" }) })!;
+    children.push(store);
+    const metadata = store.readAll().find((item) => item.type === "session_meta");
+    expect(metadata).toMatchObject({ payload: { sessionId: "child", cwd, admissionOwner: { workspaceId: parent.services.executionAdmission!.scope.workspaceId, runId: "child", parentRunId: "parent" } } });
+    expect(store.store.agencHome).toBe(parentStore.store.agencHome);
+    store.store.rewriteRolloutItemsAtomically(store.readAll());
+    expect(store.readAll().find((item) => item.type === "session_meta")).toEqual(metadata);
+    const wrongChild = { ...child, conversationId: "wrong-child" } as Session;
+    expect(() => mountChildRunJournal({ parent, child: wrongChild, originator: "agenc-subagent", terminalResult: () => ({ status: "failed", stopReason: "failed" }) })).toThrow(/child_run_journal_identity_conflict/);
+  });
+
+  it("records the same authority when construction fails before a child exists", () => {
+    const cwd = join(root, "unconstructed");
+    mkdirSync(join(cwd, ".git"), { recursive: true });
+    const path = recordUnconstructedChildRunTerminal({ parent, childRunId: "unconstructed", cwd, model: "test-model", modelProvider: "test-provider", originator: "agenc-subagent", result: { status: "failed", stopReason: "construction_failed" } })!;
+    const metadata = JSON.parse(readFileSync(path, "utf8").split("\n")[0]!).payload;
+    expect(metadata.admissionOwner).toEqual({ workspaceId: parent.services.executionAdmission!.scope.workspaceId, runId: "unconstructed", parentRunId: "parent" });
+    expect(isCanonicalRolloutPayload("session_meta", metadata)).toBe(true);
+    expect(isCanonicalRolloutPayload("session_meta", { ...metadata, admissionOwner: { ...metadata.admissionOwner, runId: "" } })).toBe(false);
+    const { admissionOwner: omittedOwner, ...legacyMetadata } = metadata;
+    expect(isCanonicalRolloutPayload("session_meta", legacyMetadata)).toBe(true);
+  });
+});

--- a/runtime/tests/session/runtime-options.test.ts
+++ b/runtime/tests/session/runtime-options.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import { windowsPathToPosixPath } from "../../src/utils/windowsPaths.js";
 
 import {
   AgentRuntimeOptionsError,
@@ -93,6 +94,7 @@ describe("agent runtime options", () => {
         TMPDIR: "/ambient/posix",
         TEMP: "C:\\ambient\\temp",
         TMP: "C:\\ambient\\tmp",
+        TMPPREFIX: "/ambient/zsh",
       },
     );
 
@@ -105,6 +107,7 @@ describe("agent runtime options", () => {
         TMPDIR: sessionTempRoot,
         TEMP: sessionTempRoot,
         TMP: sessionTempRoot,
+        TMPPREFIX: `${process.platform === "win32" ? windowsPathToPosixPath(sessionTempRoot) : sessionTempRoot}/zsh`,
       },
     });
     expect(Object.isFrozen(authority)).toBe(true);

--- a/runtime/tests/tools/runtimes/runtime.test.ts
+++ b/runtime/tests/tools/runtimes/runtime.test.ts
@@ -1098,16 +1098,12 @@ describe("tools/runtimes", () => {
           args,
         });
 
-      // The session's own plan-file family is admitted, including the
-      // per-agent spelling and a canonical alias of the plans directory.
       expect(attempt({ file_path: planPath })).not.toThrow();
-      expect(attempt({ file_path: agentPlanPath })).not.toThrow();
+      expect(attempt({ file_path: agentPlanPath })).toThrow(/workspace_write blocked/);
       expect(
         attempt({ file_path: join(aliasHome, "plans", basename(planPath)) }),
       ).not.toThrow();
 
-      // Without a bound home the preflight falls back to the runtime's own
-      // home resolver, the same one the plan attachment uses.
       const fallbackSessionId = "runtime-plan-fallback-session";
       const fallbackPlanPath = getPlanFilePath({ sessionId: fallbackSessionId });
       expect(
@@ -1115,9 +1111,8 @@ describe("tools/runtimes", () => {
           { file_path: fallbackPlanPath },
           { conversationId: fallbackSessionId, services: TEST_RUNTIME_SERVICES },
         ),
-      ).not.toThrow();
+      ).toThrow(/workspace_write blocked/);
 
-      // Everything else in the plans directory stays outside the workspace.
       expect(attempt({ file_path: join(plansDirectory, "other-plan.md") })).toThrow(
         /workspace_write blocked/,
       );

--- a/runtime/tests/tools/system/coding-common.test.ts
+++ b/runtime/tests/tools/system/coding-common.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { resolveWorkspacePath } from "src/tools/system/coding-common.js";
 import { SESSION_AGENC_HOME_ARG } from "src/tools/system/filesystem.js";
+import { signedSessionPlanFileArgs } from "src/agents/_deps/filesystem-args.js";
+import { planFileAuthorityFromContext } from "src/planning/session-plan-authority.js";
 import {
   SESSION_ID_ARG,
   SESSION_ID_SIG_ARG,
@@ -130,6 +132,7 @@ describe("HMAC-signed session id (plan-file carve-out)", () => {
           {
             file_path: planFile,
             [SESSION_AGENC_HOME_ARG]: agencHome,
+            ...signedSessionPlanFileArgs(planFileAuthorityFromContext({ agencHome, sessionId: SESSION_ID })),
           },
           SESSION_ID,
         ),

--- a/runtime/tests/tools/system/file-edit.test.ts
+++ b/runtime/tests/tools/system/file-edit.test.ts
@@ -26,6 +26,8 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { signedSessionPlanFileArgs } from "../../../src/agents/_deps/filesystem-args.js";
+import { planFileAuthorityFromContext } from "../../../src/planning/session-plan-authority.js";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -231,6 +233,7 @@ describe("Edit tool", () => {
         file_path: planPath,
         old_string: "Verify allowlist",
         new_string: "Verify plan edits",
+        ...signedSessionPlanFileArgs(planFileAuthorityFromContext({ agencHome, sessionId: SESSION_ID })),
         [SESSION_ID_ARG]: SESSION_ID,
         [SESSION_ID_SIG_ARG]: signSessionId(SESSION_ID),
         [SESSION_AGENC_HOME_ARG]: agencHome,

--- a/runtime/tests/tools/system/file-read.test.ts
+++ b/runtime/tests/tools/system/file-read.test.ts
@@ -9,6 +9,8 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { signedSessionPlanFileArgs } from "../../../src/agents/_deps/filesystem-args.js";
+import { planFileAuthorityFromContext } from "../../../src/planning/session-plan-authority.js";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -881,6 +883,7 @@ describe("FileRead tool", () => {
         __agencSessionId: sessionId,
         __agencSessionIdSig: signSessionId(sessionId),
         [SESSION_AGENC_HOME_ARG]: agencHome,
+        ...signedSessionPlanFileArgs(planFileAuthorityFromContext({ agencHome, sessionId })),
       });
 
       expect(result.isError).toBeUndefined();

--- a/runtime/tests/tools/system/file-write.test.ts
+++ b/runtime/tests/tools/system/file-write.test.ts
@@ -20,6 +20,8 @@ vi.mock("../../services/lsp/fileNotifications.js", () => ({
 }));
 
 import type { ToolResult } from "../types.js";
+import { signedSessionPlanFileArgs } from "../../../src/agents/_deps/filesystem-args.js";
+import { planFileAuthorityFromContext } from "../../../src/planning/session-plan-authority.js";
 import { createFileWriteTool } from "./file-write.js";
 import {
   clearSessionReadState,
@@ -97,6 +99,7 @@ describe("Write tool", () => {
       const result = await tool.execute({
         file_path: planPath,
         content: "# Plan\n\n- [ ] Fix plan file writes\n",
+        ...signedSessionPlanFileArgs(planFileAuthorityFromContext({ agencHome, sessionId })),
         __agencSessionId: sessionId,
         __agencSessionIdSig: signSessionId(sessionId),
         [SESSION_AGENC_HOME_ARG]: agencHome,

--- a/runtime/tests/tui/ink/native-ts/yoga-layout/content-box-cache.test.ts
+++ b/runtime/tests/tui/ink/native-ts/yoga-layout/content-box-cache.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import Yoga, { Edge, FlexDirection } from "../../../../../src/tui/ink/native-ts/yoga-layout/index.js";
+
+describe("content-box and descendant layout authority", () => {
+  test("resolves flow-child percentage dimensions inside padding and borders", () => {
+    const root = Yoga.Node.create();
+    const child = Yoga.Node.create();
+    root.setWidth(96);
+    root.setHeight(40);
+    root.setPadding(Edge.Horizontal, 3);
+    root.setPadding(Edge.Vertical, 2);
+    root.setBorder(Edge.All, 1);
+    child.setWidthPercent(100);
+    child.setHeightPercent(50);
+    root.insertChild(child, 0);
+    try {
+      root.calculateLayout(96, 40);
+      expect(child.getComputedWidth()).toBe(88);
+      expect(child.getComputedHeight()).toBe(17);
+      expect(child.getComputedLeft()).toBe(4);
+      expect(child.getComputedTop()).toBe(3);
+    } finally {
+      root.freeRecursive();
+    }
+  });
+
+  test("restores complete descendant geometry after intrinsic measure and persistent resizing", () => {
+    const root = Yoga.Node.create();
+    const row = Yoga.Node.create();
+    const label = Yoga.Node.create();
+    const column = Yoga.Node.create();
+    const content = Yoga.Node.create();
+    const text = Yoga.Node.create();
+    root.setFlexDirection(FlexDirection.Column);
+    root.setHeight(48);
+    row.setFlexDirection(FlexDirection.Row);
+    row.setWidthPercent(100);
+    label.setWidth(7);
+    label.setFlexShrink(0);
+    column.setFlexGrow(1);
+    column.setFlexShrink(1);
+    column.setMinWidth(0);
+    column.setFlexDirection(FlexDirection.Column);
+    content.setFlexDirection(FlexDirection.Column);
+    text.setMeasureFunc((width) => ({ width, height: Math.ceil(200 / width) }));
+    root.insertChild(row, 0);
+    row.insertChild(label, 0);
+    row.insertChild(column, 1);
+    column.insertChild(content, 0);
+    content.insertChild(text, 0);
+    try {
+      for (const width of [90, 114, 90]) {
+        root.setWidth(width);
+        root.calculateLayout(width, 48);
+        expect(column.getComputedWidth()).toBe(width - 7);
+        expect(content.getComputedWidth()).toBe(width - 7);
+        expect(text.getComputedWidth()).toBe(width - 7);
+        expect(text.getComputedHeight()).toBe(Math.ceil(200 / (width - 7)));
+      }
+    } finally {
+      root.freeRecursive();
+    }
+  });
+});

--- a/runtime/tests/tui/ink/native-ts/yoga-layout/index.test.ts
+++ b/runtime/tests/tui/ink/native-ts/yoga-layout/index.test.ts
@@ -122,7 +122,7 @@ describe("yoga-layout TypeScript shim", () => {
       expect(root.getComputedBorder(Edge.Left)).toBe(4);
       expect(root.getComputedBorder(Edge.Bottom)).toBe(3);
       expect(child.getComputedMargin(Edge.Left)).toBe(3);
-      expect(child.getComputedMargin(Edge.End)).toBe(20);
+      expect(child.getComputedMargin(Edge.End)).toBeCloseTo(15.6);
       expect(child.getComputedMargin(99 as Edge)).toBe(3);
     } finally {
       root.freeRecursive();

--- a/runtime/tests/tui/ink/styles.wave200-051.coverage.test.ts
+++ b/runtime/tests/tui/ink/styles.wave200-051.coverage.test.ts
@@ -189,10 +189,10 @@ test('maps less common style branches to layout node setters', () => {
   expect(node.setHeightAuto).toHaveBeenCalled()
   expect(node.setMinWidthPercent).toHaveBeenCalledWith(25)
   expect(node.setMinHeightPercent).toHaveBeenCalledWith(30)
-  expect(node.setMaxWidth).toHaveBeenCalledWith(0)
+  expect(node.setMaxWidth).toHaveBeenCalledWith(Number.NaN)
   expect(node.setMaxWidthPercent).toHaveBeenCalledWith(70)
   expect(node.setMaxHeightPercent).toHaveBeenCalledWith(80)
-  expect(node.setMaxHeight).toHaveBeenCalledWith(0)
+  expect(node.setMaxHeight).toHaveBeenCalledWith(Number.NaN)
   expect(node.setDisplay).toHaveBeenCalledWith(LayoutDisplay.Flex)
   expect(node.setDisplay).toHaveBeenCalledWith(LayoutDisplay.None)
 

--- a/runtime/tests/tui/permission-requests-plan-routing.test.tsx
+++ b/runtime/tests/tui/permission-requests-plan-routing.test.tsx
@@ -6,10 +6,13 @@ import { afterEach, describe, expect, test } from "vitest";
 
 import type { ApprovalCtx } from "../../src/tools/orchestrator.js";
 import type { ReviewDecision } from "../../src/permissions/review-decision.js";
-import { APPROVED } from "../../src/permissions/review-decision.js";
+import { ABORT, APPROVED } from "../../src/permissions/review-decision.js";
 import { createRoot } from "../../src/tui/ink.js";
 import type { PendingRequest } from "../../src/tui/permission-requests.js";
 import { AgenCPermissionOverlay } from "../../src/tui/permission-requests.js";
+import { KeybindingProvider } from "../../src/tui/keybindings/KeybindingContext.js";
+import { parseBindings } from "../../src/tui/keybindings/parser.js";
+import type { KeybindingContextName } from "../../src/tui/keybindings/types.js";
 import {
   AppStateProvider,
   getDefaultAppState,
@@ -94,6 +97,64 @@ function createExitPlanRequest(
 
 describe("permission-requests routes ExitPlanMode to PlanApprovalOverlay (contract #7)", () => {
   afterEach(() => clearPlanApprovalChoicesForTest());
+
+  test.each([
+    ["2\r", { action: "approve", mode: "default" }, APPROVED],
+    ["1\r", { action: "approve", mode: "acceptEdits", applyAllowedPrompts: true }, APPROVED],
+    ["3\r", { action: "revise" }, APPROVED],
+    ["\x1b", { action: "revise" }, APPROVED],
+    ["\x03", undefined, ABORT],
+  ])("settles only once for batched input %j", async (input, choice, decision) => {
+    const resolved: ReviewDecision[] = [];
+    const request = createExitPlanRequest((value) => resolved.push(value));
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      exitOnCtrlC: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    try {
+      const activeContexts = new Set<KeybindingContextName>();
+      const renderRequest = (pending: PendingRequest) => root.render(
+        <AppStateProvider initialState={getDefaultAppState()}>
+          <KeybindingProvider
+            bindings={parseBindings([{ context: "Global", bindings: { "ctrl+c": "app:interrupt" } }])}
+            pendingChordRef={{ current: null }}
+            pendingChord={null}
+            setPendingChord={() => {}}
+            activeContexts={activeContexts}
+            registerActiveContext={(context) => { activeContexts.add(context); }}
+            unregisterActiveContext={(context) => { activeContexts.delete(context); }}
+            handlerRegistryRef={{ current: new Map() }}
+          >
+            <AgenCPermissionOverlay request={pending} tools={[]} />
+          </KeybindingProvider>
+        </AppStateProvider>,
+      );
+      renderRequest(request);
+      await sleep();
+      stdin.write(input);
+      await sleep(75);
+      stdin.write("\r1\r");
+      await sleep();
+      expect(resolved).toEqual([decision]);
+      expect(takePlanApprovalChoice(request.id)).toEqual(choice);
+
+      const nextRequest = { ...request, id: "call-next-plan" };
+      renderRequest(nextRequest);
+      await sleep();
+      stdin.write("2\r");
+      await sleep();
+      expect(resolved).toEqual([decision, APPROVED]);
+      expect(takePlanApprovalChoice(nextRequest.id)).toEqual({ action: "approve", mode: "default" });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
 
   test("renders the plan overlay (not ApprovalCard) and auto-accept sets the choice + resolves APPROVED", async () => {
     const resolved: ReviewDecision[] = [];

--- a/runtime/tests/tui/startup/StatusLine.test.tsx
+++ b/runtime/tests/tui/startup/StatusLine.test.tsx
@@ -493,6 +493,8 @@ describe('StatusLine vim mode display', () => {
 
   test.each([
     [{ status: 'blocked', reason: 'untrusted_workspace' }, 'status line command blocked by session hook policy'],
+    [{ status: 'blocked', reason: 'sandbox_policy_unexpressible' }, 'status line command blocked: the session sandbox cannot represent this policy; on Linux, provide a trusted bubblewrap directory in the session PATH and run agenc doctor'],
+    [{ status: 'blocked', reason: 'sandbox_probe_failed' }, 'status line command blocked: session sandbox unavailable; run agenc doctor'],
     [{ status: 'error', reason: 'timeout' }, 'status line command timed out'],
     [{ status: 'unavailable', reason: 'unsupported_method' }, 'status line command is not supported by this daemon'],
   ] as const)('shows a static notice for daemon result %j', async (result, text) => {

--- a/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-workbench-rendering.contract.test.tsx
@@ -319,7 +319,7 @@ describe("BUFFER workbench rendering", () => {
     expect(allRenderedLinesFit(output, 148)).toBe(true);
     expect(provider.resize).toHaveBeenLastCalledWith({
       rows: 13,
-      columns: 116,
+      columns: 114,
     });
   });
 

--- a/runtime/tests/tui/workbench/layout-cell-regressions.test.tsx
+++ b/runtime/tests/tui/workbench/layout-cell-regressions.test.tsx
@@ -1,0 +1,220 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { agentsCommand } from "../../../src/commands/agent-management.js";
+import type { SlashCommandContext } from "../../../src/commands/types.js";
+import type { AgentDefinition } from "../../../src/tools/AgentTool/loadAgentsDir.js";
+import { Box, Text, createRoot } from "../../../src/tui/ink.js";
+import { getInkInstance } from "../../../src/tui/ink/instances.js";
+import { cellAt, type Screen } from "../../../src/tui/ink/screen.js";
+import type { DOMElement } from "../../../src/tui/ink/dom.js";
+import type { ScrollBoxHandle } from "../../../src/tui/ink/components/ScrollBox.js";
+import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { useContentWidth } from "../../../src/tui/context/contentWidthContext.js";
+import { MessageRow } from "../../../src/tui/components/MessageRow.js";
+import { VirtualMessageList } from "../../../src/tui/components/VirtualMessageList.js";
+import { buildMessageLookups, createUserMessage, normalizeMessages } from "../../../src/utils/messages.js";
+import { WorkbenchLayout } from "../../../src/tui/workbench/WorkbenchLayout.js";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Expected terminal frame did not arrive");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function createTerminal(columns = 160, rows = 48) {
+  const stdin = Object.assign(new PassThrough(), {
+    isTTY: true,
+    setRawMode: () => {},
+    ref: () => {},
+    unref: () => {},
+  });
+  const stdout = Object.assign(new PassThrough(), { columns, rows, isTTY: true });
+  stdout.resume();
+  const root = await createRoot({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  });
+  const instance = getInkInstance(stdout as unknown as NodeJS.WriteStream);
+  if (!instance) throw new Error("Expected live Ink instance");
+  const frameOwner = instance as unknown as { frontFrame: { screen: Screen }; rootNode: DOMElement };
+  instance.setAltScreenActive(true);
+  return {
+    root,
+    stdin,
+    node: frameOwner.rootNode,
+    screenRows: () => {
+      const screen = frameOwner.frontFrame.screen;
+      return Array.from({ length: screen.height }, (_, row) =>
+        Array.from({ length: screen.width }, (_, column) =>
+          cellAt(screen, column, row)?.char ?? " ",
+        ).join(""),
+      );
+    },
+    resize: async (nextColumns: number) => {
+      stdout.columns = nextColumns;
+      stdout.emit("resize");
+      await waitFor(() => frameOwner.frontFrame.screen.width === nextColumns);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    },
+    close: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    },
+  };
+}
+
+const prompt = "START " + Array.from({ length: 32 }, (_, index) => `word${index.toString().padStart(2, "0")}`).join(" ") + " END";
+const rawMessages = Array.from({ length: 60 }, (_, index) =>
+  createUserMessage({ content: index === 59 ? prompt : `history-${index}`, timestamp: "", uuid: `message-${index}` }),
+);
+const messages = normalizeMessages(rawMessages);
+const lookups = buildMessageLookups(messages, rawMessages);
+
+function TranscriptRows({ scrollRef }: { readonly scrollRef: React.RefObject<ScrollBoxHandle | null> }) {
+  const columns = useContentWidth();
+  if (columns === null) throw new Error("Expected workbench content width");
+  return <VirtualMessageList
+    messages={messages}
+    scrollRef={scrollRef}
+    columns={columns}
+    itemKey={(message) => message.uuid}
+    renderItem={(message) => <MessageRow
+      message={message}
+      columns={columns}
+      lookups={lookups}
+      tools={[]}
+      commands={[]}
+      verbose={false}
+      inProgressToolUseIDs={new Set()}
+      streamingToolUseIDs={new Set()}
+      screen="prompt"
+      canAnimate={false}
+      lastThinkingBlockId={null}
+      latestBashOutputUUID={null}
+      isLoading={false}
+      isUserContinuation={false}
+      hasContentAfter={false}
+    />}
+  />;
+}
+
+function promptGeometry(node: DOMElement): unknown[] | null {
+  if (node.childNodes.some((child) => child.nodeName === "#text" && child.nodeValue.includes("START"))) {
+    return [{ name: node.nodeName, style: node.style, width: node.yogaNode?.getComputedWidth() }];
+  }
+  for (const child of node.childNodes) {
+    if (child.nodeName === "#text") continue;
+    const found = promptGeometry(child);
+    if (found) return [{ name: node.nodeName, style: node.style, width: node.yogaNode?.getComputedWidth() }, ...found];
+  }
+  return null;
+}
+
+describe("persistent workbench terminal cells", () => {
+  test("wraps every prompt character inside both sidebars through resize and virtual scrolling", async () => {
+    const terminal = await createTerminal();
+    const scrollRef = React.createRef<ScrollBoxHandle>();
+    try {
+      terminal.root.render(<AppStateProvider initialState={getDefaultAppState()}>
+        <WorkbenchLayout transcript={<TranscriptRows scrollRef={scrollRef} />} composer={<Text>composer-marker</Text>} scrollRef={scrollRef} />
+      </AppStateProvider>);
+      await waitFor(() => terminal.screenRows().some((row) => row.includes("START")));
+      for (const columns of [160, 200, 160]) {
+        await terminal.resize(columns);
+        scrollRef.current?.scrollTo(0);
+        await waitFor(() => terminal.screenRows().some((row) => row.includes("history-0")));
+        scrollRef.current?.scrollToBottom();
+        await waitFor(() => terminal.screenRows().some((row) => row.includes("START")));
+        const rows = terminal.screenRows();
+        expect(rows.some((row) => row.includes("WORKSPACE")), rows.join("\n")).toBe(true);
+        expect(rows.some((row) => row.includes("AGENTS"))).toBe(true);
+        const startRow = rows.findIndex((row) => row.includes("START"));
+        const endRow = rows.findIndex((row, index) => index >= startRow && row.includes("END"));
+        expect(endRow).toBeGreaterThanOrEqual(startRow);
+        const contentColumn = rows[startRow]!.indexOf("START");
+        const frameColumns = columns - 4;
+        const rightEdge = 2 + frameColumns - Math.max(24, Math.floor(frameColumns * 0.19)) - 3;
+        const visiblePrompt = rows.slice(startRow, endRow + 1).map((row) => row.slice(contentColumn, rightEdge).trim()).join(" ");
+        expect(visiblePrompt, JSON.stringify(promptGeometry(terminal.node))).toBe(prompt);
+      }
+    } finally {
+      await terminal.close();
+    }
+  });
+
+  test("keeps every agents row and detail on distinct cells through 160 to 200 to 160 resizing", async () => {
+    const terminal = await createTerminal();
+    const agents = ["default", "runner", "reviewer", "Plan", "scanner"].map((agentType): AgentDefinition => ({
+      agentType,
+      source: "built-in",
+      baseDir: "built-in",
+      whenToUse: "Review code and report findings.",
+      tools: ["Read", "Grep"],
+      getSystemPrompt: () => "Review code and report concrete findings in the current checkout.",
+    }));
+    const setToolJSX = vi.fn();
+    await agentsCommand.execute({
+      session: { services: {} } as SlashCommandContext["session"],
+      argsRaw: "",
+      cwd: "/tmp/project",
+      home: "/tmp",
+      appState: { setToolJSX },
+    });
+    const modal = setToolJSX.mock.calls[0]?.[0].jsx as React.ReactNode;
+    try {
+      terminal.root.render(<AppStateProvider initialState={{ ...getDefaultAppState(), agentDefinitions: { activeAgents: agents, allAgents: agents } }}>
+        <WorkbenchLayout transcript={<Text>transcript-marker</Text>} composer={<Text>composer-marker</Text>} modal={modal} />
+      </AppStateProvider>);
+      await waitFor(() => terminal.screenRows().some((row) => row.includes("delegate-capable")));
+      for (const columns of [160, 200, 160]) {
+        await terminal.resize(columns);
+        const rows = terminal.screenRows();
+        const markers = ["name · Role", "default", "runner", "reviewer", "Plan", "scanner", "when-to-use", "tools", "model", "budget"];
+        const tableStart = rows.findIndex((row) => row.includes("name · Role"));
+        const positions = markers.map((marker) => rows.findIndex((row, index) => index >= tableStart && new RegExp(`\\b${marker}\\b`, "u").test(row)));
+        expect(positions.every((position) => position >= 0), rows.join("\n")).toBe(true);
+        expect(new Set(positions).size, rows.join("\n")).toBe(markers.length);
+        expect(rows.some((row) => row.includes("Review code and report findings."))).toBe(true);
+        expect(rows.some((row) => row.includes("2 tools · skills"))).toBe(true);
+      }
+    } finally {
+      await terminal.close();
+    }
+  });
+
+  test("removes maximum dimensions while preserving explicit zero and percentage limits", async () => {
+    const terminal = await createTerminal(80, 30);
+    let target: DOMElement | null = null;
+    const render = (maxWidth: number | `${number}%` | undefined, maxHeight: number | `${number}%` | undefined) => terminal.root.render(
+      <Box width={60} height={20}>
+        <Box ref={(node) => { target = node; }} width={40} height={10} maxWidth={maxWidth} maxHeight={maxHeight} flexShrink={0}>
+          <Text>dimension-marker</Text>
+        </Box>
+      </Box>,
+    );
+    try {
+      for (const [maximumWidth, maximumHeight, width, height] of [
+        [undefined, undefined, 40, 10],
+        [0, 0, 0, 0],
+        [undefined, undefined, 40, 10],
+        [12, 3, 12, 3],
+        ["50%", "25%", 30, 5],
+        [undefined, undefined, 40, 10],
+      ] as const) {
+        render(maximumWidth, maximumHeight);
+        await waitFor(() => target?.yogaNode?.getComputedWidth() === width && target.yogaNode.getComputedHeight() === height);
+        expect(target?.yogaNode?.getComputedWidth()).toBe(width);
+        expect(target?.yogaNode?.getComputedHeight()).toBe(height);
+      }
+    } finally {
+      await terminal.close();
+    }
+  });
+});

--- a/runtime/tests/unified-exec/scrub-env.test.ts
+++ b/runtime/tests/unified-exec/scrub-env.test.ts
@@ -72,6 +72,8 @@ describe("scrubEnvForChildProcess (SEC-01)", () => {
         TMP: "C:\\ambient\\tmp",
         Temp: "mixed-case-must-not-survive",
         tmpdir: "lowercase-must-not-survive",
+        TMPPREFIX: "/ambient/zsh",
+        TmPpReFiX: "/mixed/zsh",
         PATH: "/usr/bin",
       },
       "/captured/session-temp",
@@ -82,15 +84,23 @@ describe("scrubEnvForChildProcess (SEC-01)", () => {
       TMPDIR: "/captured/session-temp",
       TEMP: "/captured/session-temp",
       TMP: "/captured/session-temp",
+      TMPPREFIX: "/captured/session-temp/zsh",
       PATH: "/usr/bin",
     });
     expect(env).not.toHaveProperty("Temp");
     expect(env).not.toHaveProperty("tmpdir");
+    expect(env).not.toHaveProperty("TmPpReFiX");
   });
 
   it("rejects a relative child temp authority", () => {
     expect(() => withChildTempAuthority({}, "relative/temp")).toThrow(
       "child process temp root must be a non-empty absolute path",
     );
+  });
+
+  it("keeps spaces and Unicode in the captured shell temp prefix", () => {
+    const env = withChildTempAuthority({ TMPPREFIX: "/untrusted" }, "/captured/temporary files/é/");
+    expect(env.TMPPREFIX).toBe("/captured/temporary files/é/zsh");
+    expect(withChildTempAuthority({}, "/").TMPPREFIX).toBe("/zsh");
   });
 });

--- a/runtime/tests/unified-exec/subprocess-env-node-import.test.ts
+++ b/runtime/tests/unified-exec/subprocess-env-node-import.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+const runtimeRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+it("loads subprocess temp authority in plain Node without bundled feature shims", () => {
+  const result = spawnSync(process.execPath, [
+    "--input-type=module", "--eval",
+    `import { register } from 'tsx/esm/api';
+     register({ tsconfig: false });
+     const { registerBenchmarkModuleCompatibility } = await import('./benchmarks/fnd/module-compatibility.mjs');
+     registerBenchmarkModuleCompatibility();
+     const { withChildTempAuthority } = await import('./src/utils/subprocessEnv.ts');
+     process.stdout.write(JSON.stringify(withChildTempAuthority({}, process.cwd())));`,
+  ], {
+    cwd: runtimeRoot,
+    encoding: "utf8",
+    timeout: 15_000,
+    env: { ...process.env, NODE_OPTIONS: "" },
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  const environment = JSON.parse(result.stdout) as Record<string, string>;
+  expect(environment.AGENC_TMPDIR).toBe(runtimeRoot);
+  expect(environment.TMPPREFIX).toMatch(/\/zsh$/u);
+});

--- a/runtime/tests/utils/windows-path-conversion.test.ts
+++ b/runtime/tests/utils/windows-path-conversion.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+import { convertWindowsPathToPosix } from "../../src/utils/windows-path-conversion.js";
+import { windowsPathToPosixPath } from "../../src/utils/windowsPaths.js";
+
+it.each([
+  [String.raw`C:\Users\temporary files\é`, "/c/Users/temporary files/é"],
+  ["D:/temporary/files", "/d/temporary/files"],
+  [String.raw`\\server\share\temporary files`, "//server/share/temporary files"],
+  [String.raw`\\?\C:\temporary`, "//?/C:/temporary"],
+  ["//server/share", "//server/share"],
+  [String.raw`relative\folder`, "relative/folder"],
+  ["/tmp/é", "/tmp/é"],
+  ["C:", "C:"],
+  ["", ""],
+])("preserves Windows shell path conversion for %s", (input, expected) => {
+  expect(convertWindowsPathToPosix(input)).toBe(expected);
+  expect(windowsPathToPosixPath(input)).toBe(expected);
+});
+
+it("preserves the memoized path API", () => {
+  windowsPathToPosixPath.cache.clear();
+  expect(windowsPathToPosixPath(String.raw`C:\temp`)).toBe("/c/temp");
+  expect(windowsPathToPosixPath(String.raw`C:\temp`)).toBe("/c/temp");
+  expect(windowsPathToPosixPath.cache.size()).toBe(1);
+  windowsPathToPosixPath.cache.clear();
+});

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
 
 import {
   resolveWorkflowPermissionMode,
@@ -502,7 +503,10 @@ interface Harness {
 const RUN_ID = "run-wf-1";
 
 function makeHarness(
-  options: { readonly defaultReviewerModel?: () => string | undefined } = {},
+  options: {
+    readonly defaultReviewerModel?: () => string | undefined;
+    readonly admission?: () => ExecutionAdmissionClient;
+  } = {},
 ): Harness {
   const home = mkdtempSync(join(tmpdir(), "agenc-m5-controller-home-"));
   const cwd = mkdtempSync(join(tmpdir(), "agenc-m5-controller-cwd-"));
@@ -529,6 +533,7 @@ function makeHarness(
       },
     },
     admission: ({ runId }) => {
+      if (options.admission !== undefined) return options.admission();
       admission.scope.runId = runId;
       return admission;
     },
@@ -745,7 +750,7 @@ describe("VerifiedChangeWorkflowController — happy path", () => {
     });
     expect(terminal!.finalMessage).toContain(HEAD_COMMIT);
     expect(terminal!.finalMessage).toContain("Consider renaming");
-    expect(terminal!.usage).not.toBeNull();
+    expect(terminal!.usage).toBeNull();
 
     // Admission gated EVERY step, exactly once each.
     expect(harness.admission.acquired).toEqual([
@@ -1335,7 +1340,7 @@ describe("VerifiedChangeWorkflowController — reviewer that never answered", ()
 });
 
 describe("VerifiedChangeWorkflowController — child usage rollup", () => {
-  it("the terminal usage reflects the children's reconciled sums exactly; holds are noted, never spent", async () => {
+  it("retains child evidence without presenting partial sums as canonical usage", async () => {
     harness.spawner.queue("plan", {
       status: "completed",
       finalMessage: "PLAN: make the edit",
@@ -1370,13 +1375,7 @@ describe("VerifiedChangeWorkflowController — child usage rollup", () => {
     await runToTerminal(harness);
     const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
     expect(terminal.status).toBe("completed");
-    // Exact reconciled sums: 10+100+7 / 5+50+3 / 0.25+0.5+0.125.
-    expect(terminal.usage).toEqual({
-      inputTokens: 117,
-      outputTokens: 58,
-      totalTokens: 175,
-      costUsd: 0.875,
-    });
+    expect(terminal.usage).toBeNull();
     // The durable child evidence carries the usage and NOTES the holds
     // (held_unknown spend is never summed into any total).
     const implement = harness.repo.getEffect(RUN_ID, "workflow.implement")!;
@@ -1392,7 +1391,7 @@ describe("VerifiedChangeWorkflowController — child usage rollup", () => {
     expect(child.usageHeldUnknown).toBe(2);
   });
 
-  it("adoption and replay carry durably recorded child usage into the post-restart terminal rollup", async () => {
+  it("adopts child evidence without fabricating usage when the canonical reader is absent", async () => {
     harness.spawner.queue("plan", {
       status: "completed",
       finalMessage: "PLAN: make the edit",
@@ -1445,14 +1444,105 @@ describe("VerifiedChangeWorkflowController — child usage rollup", () => {
 
     const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
     expect(terminal.status).toBe("completed");
-    // Replayed plan (10/5/0.25) + adopted implement (40/2/0.5) + fresh
-    // verify agent (7/3/0.125): the post-restart rollup keeps every child.
-    expect(terminal.usage).toEqual({
-      inputTokens: 57,
-      outputTokens: 10,
-      totalTokens: 67,
-      costUsd: 0.875,
+    expect(terminal.usage).toBeNull();
+  });
+});
+
+describe("VerifiedChangeWorkflowController — canonical capped accounting", () => {
+  it("admits all children under one cap and counts the reviewer once", async () => {
+    harness.cleanup();
+    let client: ExecutionAdmissionClient;
+    harness = makeHarness({ admission: () => client });
+    const kernel = new ExecutionAdmissionKernel({
+      agencHome: harness.home,
+      ownerId: "workflow-cap-test",
+      ownerPid: process.pid,
     });
+    try {
+      client = kernel.bindClient({
+        cwd: harness.cwd,
+        scope: { runId: RUN_ID, sessionId: RUN_ID, autonomous: true },
+        budget: { runMaxCostUsd: 1, runMaxTokens: 1000 },
+      });
+      const charges: string[] = [];
+      const chargeChild = async (childRunId: string): Promise<void> => {
+        const child = client.forSession({ runId: childRunId, sessionId: childRunId });
+        const lease = await child.acquire({
+          stepId: "model:1",
+          kind: "model_turn",
+          model: "test-model",
+          provider: "test-provider",
+          maxInputTokens: 10,
+          maxOutputTokens: 10,
+          maxCostUsd: 0.2,
+        });
+        child.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+        child.reconcile(lease.reservation.reservationId, { inputTokens: 8, outputTokens: 2, costUsd: 0.1 });
+        expect(child.reconcile(lease.reservation.reservationId, { inputTokens: 8, outputTokens: 2, costUsd: 0.1 }).applied).toBe(false);
+        child.acknowledgeCompletion(lease.reservation.reservationId);
+        charges.push(childRunId);
+      };
+      const spawn = harness.spawner.spawn.bind(harness.spawner);
+      vi.spyOn(harness.spawner, "spawn").mockImplementation(async (input) => {
+        await chargeChild(input.childRunId);
+        return spawn(input);
+      });
+      const review = harness.reviewer.invoke.bind(harness.reviewer);
+      vi.spyOn(harness.reviewer, "invoke").mockImplementation(async (input) => {
+        await chargeChild(`${RUN_ID}:actual-review`);
+        return review(input);
+      });
+      await runToTerminal(harness, { budget: { maxCostUsd: 1, maxTokens: 1000 } });
+      expect(charges).toHaveLength(4);
+      const usage = { inputTokens: 32, outputTokens: 8, totalTokens: 40, costUsd: 0.4 };
+      expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({ status: "completed", usage });
+      expect(harness.ledgers.get(RUN_ID)?.records[0]?.usage).toEqual(usage);
+      expect(client.getUsageSummary?.()).toMatchObject({ ...usage, heldCostUsd: 0, hasUnknownCost: false });
+      const rows = harness.driver.state.prepare("SELECT reserved_tokens, reserved_cost_nanos, actual_cost_nanos FROM execution_admission_reservations WHERE run_id = ?").all(RUN_ID);
+      expect(rows.length).toBeGreaterThan(3);
+      for (const row of rows) expect(row).toEqual({ reserved_tokens: 0, reserved_cost_nanos: 0, actual_cost_nanos: 0 });
+    } finally {
+      kernel.close();
+    }
+  });
+
+  it("does not publish partial child rollups when canonical accounting fails", async () => {
+    Object.assign(harness.admission, { getUsageSummary: () => { throw new Error("canonical accounting unavailable"); } });
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({ status: "failed", usage: null });
+    expect(harness.ledgers.get(RUN_ID)?.records).toHaveLength(0);
+    expect(harness.warnings.some((warning) => warning.includes("canonical usage is unavailable"))).toBe(true);
+  });
+
+  it("keeps unknown child holds after wrapper failure and persists them on close", async () => {
+    harness.cleanup();
+    let client: ExecutionAdmissionClient;
+    harness = makeHarness({ admission: () => client });
+    const kernel = new ExecutionAdmissionKernel({ agencHome: harness.home, ownerId: "workflow-unknown-test", ownerPid: process.pid });
+    try {
+      const bind = () => kernel.bindClient({ cwd: harness.cwd, scope: { runId: RUN_ID, sessionId: RUN_ID, autonomous: true }, budget: { runMaxCostUsd: 1 } });
+      client = bind();
+      vi.spyOn(harness.spawner, "spawn").mockImplementation(async (input) => {
+        const child = client.forSession({ runId: input.childRunId, sessionId: input.childRunId });
+        const lease = await child.acquire({ stepId: "model:unknown", kind: "model_turn", maxInputTokens: 10, maxOutputTokens: 10, maxCostUsd: 0.3 });
+        child.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+        child.holdUnknown(lease.reservation.reservationId, "provider_disconnected");
+        child.acknowledgeCompletion(lease.reservation.reservationId);
+        return { status: "unknown_outcome", finalMessage: null, usage: null };
+      });
+      await runToTerminal(harness, { budget: { maxCostUsd: 1 } });
+      expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({ status: "unknown_outcome", usage: null });
+      expect(client.getUsageSummary?.()).toMatchObject({ costUsd: 0, heldCostUsd: 0.3, hasUnknownCost: true });
+      await expect(client.acquire({ stepId: "after-unknown", kind: "model_turn", maxInputTokens: 1, maxOutputTokens: 1, maxCostUsd: 0.8 })).rejects.toMatchObject({ reason: "budget_exceeded" });
+    } finally {
+      kernel.close();
+    }
+    const reopened = openStateDatabases({ cwd: harness.cwd, agencHome: harness.home });
+    try {
+      expect(reopened.state.prepare("SELECT status, reserved_cost_nanos FROM execution_admission_reservations WHERE run_id = ?").all(`${RUN_ID}:plan#1`)).toEqual([{ status: "held_unknown", reserved_cost_nanos: 300000000 }]);
+    } finally {
+      reopened.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the 13 issues from the September 10 isolated Grok workflow audit.

1. Allow only the owning session's exact plan file through plan mode, with signed execution authority and unchanged explicit ask/deny and native mutation checks.
2. Settle plan approval once so fast numeric input followed by Enter cannot change the chosen permission mode.
3. Prove failed worktree prerequisites had no effect before releasing admission; retain uncertainty after possible mutation or failed cleanup.
4. Bind live effect resolution to the correct session and home.
5. Remove duplicate model-budget reservations from workflow orchestration while retaining provider, child and reviewer accounting.
6. Resolve split child journals and admission databases by verified ownership; report separate source coordinates, including descendant admission events.
7. Preserve ordinary sandbox enforcement for status commands, report actionable failures and settle pre-spawn refusals without unknown holds.
8. Correct content-box sizing and measurement/layout cache reuse so the transcript does not lose terminal cells.
9. Restore unconstrained maximum dimensions correctly during agents-dialog resizing.
10. Price local Skill and Cron built-ins explicitly at zero without granting unknown tools free execution.
11. Reject unsupported startup options before starting a model call; keep the explicit literal-prompt boundary.
12. Bind zsh TMPPREFIX to the captured temporary directory and keep low-level path conversion usable by Node workers.
13. Generate memory instructions from the owning session's workspace, home and captured settings.

Session identity and exact plan-write authority are separate. EnterWorktree and
ExitWorktree require signed identity without requiring an active plan. Parent,
streaming and child dispatch paths have regression coverage.

## Verification

- Independent reviews cover permission boundaries, native mutation guards, budget accounting, ownership, recovery, layout and subprocess changes.
- New regressions were also run against the original production code. Existing worktree and plain-Node worker failures caught during integration are fixed, not suppressed.
- Runtime and SDK builds and type checks pass.
- 116 terminal scenarios pass, including ordinary-policy status commands and real terminal-cell resize checks.
- Final clean commit `5f4772ebc63c0377058f1af91d2bf817af629c9d`: 24,982 tests pass and six fail across 2,366 files, with zero skips. All six failure names and assertion details match the unchanged baseline exactly. No introduced failures remain.
- Final runtime rebuild and PTY startup pass. Daemon protocol checks pass 14/14, deterministic pipeline checks 7/7, pinned PowerShell 51/51 and pinned Neovim 18/18.
- The full terminal set passes twice, including after the rebuilt main fix commit. The final follow-up only preserves absent home identity for calls without a bound session; its 94 independently checked cases and the complete clean suite pass apart from the six baseline failures.

## Merge decision

The owner authorized merging this PR using local verification and independent
review. Native macOS and Windows coverage remains unavailable and is reported
below. Hosted test CI remains disabled as requested. The workflow diff only updates the
mandatory kernel-test count from 15 to 17; triggers are unchanged.

The baseline full suite has six existing failures in discovery, CLI fixtures,
source inventories and benchmark provenance. Bun also has an existing
`node:sqlite` failure. The cross-repository SDK contract has an existing
interface-parser failure. The parity command stops at the existing agent-CLI
fixture failure. None is bypassed or presented as a passing check.

The Linux kernel lane has one existing host AppArmor-label mismatch. The host
transitions bwrap children to `bwrap//&unpriv_bwrap (enforce)`, while the test
expects `agenc-native-userns (unconfined)`. Both new native controls pass; the
entire lane is still failed.

The temporary Grok login expired without authentication. No paid model session,
goal, loop or schedule started in this verification run. Live Grok verification
remains pending; deterministic tests are not a substitute for that check.

The verification counts above were recorded during implementation. The original
local logs were temporary and are no longer available; the PR and execution
transcript retain the reported results. The merge check confirmed that the
reviewed head and base commits are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication-adjacent permission boundaries, admission/budget accounting, multi-database run ownership, and sandbox/status-line execution paths where incorrect behavior could mis-report costs or allow wrong writes.
> 
> **Overview**
> Addresses a broad September workflow audit by tightening **session plan writes**, **run inspection**, **admission/budget accounting**, **CLI routing**, and **TUI layout**.
> 
> **Plan mode and filesystem authority** narrows out-of-workspace plan writes to the owning session’s **exact** plan file via HMAC-signed `SessionPlanFileAuthority`, wired through permissions, sandbox preflight, and child tool injection. Plan-mode denials no longer block those mutations; plan approval handlers settle once to avoid double-submit changing the mode.
> 
> **Worktree delegation** validates the base commit before `git worktree add`, surfaces `WorktreePreconditionError` with **confirmed_no_effect** when setup fails before mutation, cleans up partially created worktrees on spawn failure, and propagates authoritative `effectDisposition` through `delegate` / `spawn_agent` rejections.
> 
> **Daemon run inspection** resolves runs when canonical journals and admission accounting live in different project databases: `RunStateSource` / evidence gain `admissionProjectDir` and `admissionLastSequence`, completeness becomes **partial** when split, and `#locate` verifies journal-declared admission owners instead of treating duplicate run IDs as always ambiguous.
> 
> **Workflow and admission** drops inflated spawn reservations (`ZERO_ESTIMATE`), records terminal usage from canonical admission summaries, stamps `admissionOwner` on child rollout `session_meta`, and gives Skill/Cron tools explicit zero admission estimates so hard caps still block unpriced tools.
> 
> **Operational fixes** include rejecting unknown CLI flags before model startup (exit 2), deferring status-line admission until `beforeSpawn`, mapping sandbox failures to blocked status-line reasons, binding effect review DB opens to the manager’s `agencHome` under the live session scope, session-scoped memory prompt paths, `TMPPREFIX` for zsh, Yoga layout cache/content-box fixes for workbench resize, and docs/protocol updates for split sources and SDK `PATH` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4772ebc63c0377058f1af91d2bf817af629c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->