### PR TITLE
fix(admission): let a small context window admit a turn

### DIFF
--- a/runtime/src/budget/admitted-model-call.ts
+++ b/runtime/src/budget/admitted-model-call.ts
@@ -343,6 +343,15 @@ function isSameModelIdentity(reported: string, requested: string): boolean {
   return normalize(reported) === normalize(requested);
 }
 
+/**
+ * Smallest answer worth admitting a turn for.
+ *
+ * Below this the window is genuinely spent: the reply would be truncated into
+ * uselessness and the turn is better refused with a reason than answered with
+ * a fragment. Compaction is the path back from here, not a smaller ceiling.
+ */
+const MIN_ADMISSIBLE_OUTPUT_TOKENS = 1_024;
+
 export async function runAdmittedModelCall(
   params: AdmittedModelCallOptions,
 ): Promise<LLMResponse> {
@@ -495,6 +504,10 @@ export async function runAdmittedModelCall(
   });
   let accountingResult: TokenAccountingResult | undefined;
   let accountingFailureReason: string | undefined;
+  // Reduced below when the prompt leaves less room than the reservation asks
+  // for. Everything downstream — cost ceiling, lease, provider request — reads
+  // the admitted value, so the reservation and the wire request cannot drift.
+  let admittedMaxOutputTokens = maxOutputTokens;
   try {
     accountingResult = await tokenAccountingService.count(accountingRequest, {
       ...(params.provider.tokenCountCapability !== undefined
@@ -505,7 +518,21 @@ export async function runAdmittedModelCall(
     if (!accountingResult.admissible) {
       accountingFailureReason = "token_accounting_uncertain";
     } else if (accountingResult.totalTokens > contextWindowTokens) {
-      accountingFailureReason = "context_window_exceeded";
+      // The prompt and the reservation share one window, and only the prompt
+      // is fixed. Denying here throws away a turn the model could still have
+      // answered, just more briefly, so spend what the prompt left instead.
+      //
+      // The reservation is a ceiling on the answer, not a promise of one, and
+      // it only ever shrinks on this path: a caller cannot widen its budget by
+      // sending a longer prompt. Deny remains for the case that is genuinely
+      // unanswerable, where the prompt alone leaves less room than a usable
+      // reply needs.
+      const roomLeftByPrompt = contextWindowTokens - accountingResult.inputTokens;
+      if (roomLeftByPrompt >= MIN_ADMISSIBLE_OUTPUT_TOKENS) {
+        admittedMaxOutputTokens = Math.min(maxOutputTokens, roomLeftByPrompt);
+      } else {
+        accountingFailureReason = "context_window_exceeded";
+      }
     }
   } catch (error) {
     if (params.signal?.aborted === true) {
@@ -540,7 +567,7 @@ export async function runAdmittedModelCall(
     effectiveModel,
     effectiveProvider,
     maxInputTokens,
-    maxOutputTokens,
+    admittedMaxOutputTokens,
     accountingOptions,
   );
   const denialReason =
@@ -604,7 +631,7 @@ export async function runAdmittedModelCall(
         model: effectiveModel,
         provider: effectiveProvider,
         maxInputTokens,
-        maxOutputTokens,
+        maxOutputTokens: admittedMaxOutputTokens,
         maxCostUsd: maximumCost,
         ...(denialReason !== undefined ? { denialReason } : {}),
       },
@@ -648,7 +675,7 @@ export async function runAdmittedModelCall(
               routedFromProvider: params.providerName,
             }
           : {}),
-        maxOutputTokens,
+        maxOutputTokens: admittedMaxOutputTokens,
         tokenAccountingSource: accountingResult?.source,
         tokenAccountingConfidence: accountingResult?.confidence,
         tokenAccountingCoverageComplete: accountingResult?.coverage.complete,
@@ -670,7 +697,7 @@ export async function runAdmittedModelCall(
       // The admitted maximum is the provider-facing maximum. A caller cannot
       // raise it after reservation by mutating/rebuilding options.
       maxOutputTokens: Math.min(
-        maxOutputTokens,
+        admittedMaxOutputTokens,
         lease.request.estimate.maxOutputTokens,
       ),
       // The lease signal also carries parent cancellation, deadline expiry,

--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -954,6 +954,48 @@ function normalizePositiveInteger(value: unknown): number | undefined {
   return undefined;
 }
 
+/**
+ * Largest share of a context window an output reservation may claim.
+ *
+ * The reservation and the prompt come out of the same window, so a default
+ * that claims most of it leaves no room to be prompted at all.
+ */
+export const MAX_OUTPUT_TOKENS_WINDOW_FRACTION = 0.5;
+
+/**
+ * Hold an output reservation inside the window it has to share with a prompt.
+ *
+ * `getModelMaxOutputTokens` picks the reservation from the model name and
+ * never sees the context window, so an uncatalogued model takes the 32,000
+ * default whatever its window is. On a local runtime that window is routinely
+ * 32k, and admission compares prompt + reservation against it: 32,000 reserved
+ * against a measured 31,129-token window is refused before a single byte of
+ * prompt exists, so every turn is denied `context_window_exceeded` and no
+ * local model can answer at all.
+ *
+ * Half is the split, so the prompt always has as much of the window as the
+ * answer. Nothing catalogued moves: this only binds when the reservation is
+ * more than half the window, which for the 32,000 default means windows under
+ * 64k, and every catalogued hosted model is 128k or larger. It is the models
+ * with no catalogue entry, which is every local one, that this rescues.
+ */
+export function fitOutputTokensToContextWindow(
+  maxOutputTokens: number,
+  contextWindow: number | undefined,
+): number {
+  if (
+    contextWindow === undefined ||
+    !Number.isFinite(contextWindow) ||
+    contextWindow <= 0
+  ) {
+    return maxOutputTokens;
+  }
+  const cap = Math.floor(contextWindow * MAX_OUTPUT_TOKENS_WINDOW_FRACTION);
+  // A window too small to halve is already unusable; never return 0, which
+  // reads downstream as "no reservation configured" rather than a small one.
+  return Math.max(1, Math.min(maxOutputTokens, cap));
+}
+
 interface EffectiveOutputTokens {
   readonly maxOutputTokens: number;
   readonly maxOutputTokensUpperLimit: number;
@@ -973,15 +1015,16 @@ function resolveEffectiveOutputTokens(params: {
     metadata.maxOutputTokensUpperLimit ??
     metadata.maxOutputTokens ??
     DEFAULT_MAX_OUTPUT_TOKENS_UPPER_LIMIT;
+  const fit = (tokens: number): number =>
+    fitOutputTokensToContextWindow(tokens, metadata.contextWindow);
 
   if (
     metadata.maxOutputTokens !== undefined &&
     metadata.maxOutputTokensExplicit === true
   ) {
     return {
-      maxOutputTokens: boundedOutputTokens(
-        metadata.maxOutputTokens,
-        metadataUpper,
+      maxOutputTokens: fit(
+        boundedOutputTokens(metadata.maxOutputTokens, metadataUpper),
       ),
       maxOutputTokensUpperLimit: metadataUpper,
       maxOutputTokensExplicit: true,
@@ -994,7 +1037,9 @@ function resolveEffectiveOutputTokens(params: {
   const explicitOverride = envOverride ?? configOverride;
   if (explicitOverride !== undefined) {
     return {
-      maxOutputTokens: boundedOutputTokens(explicitOverride, metadataUpper),
+      maxOutputTokens: fit(
+        boundedOutputTokens(explicitOverride, metadataUpper),
+      ),
       maxOutputTokensUpperLimit: metadataUpper,
       maxOutputTokensExplicit: true,
       maxOutputTokensCappedDefault: false,
@@ -1006,11 +1051,13 @@ function resolveEffectiveOutputTokens(params: {
     params.config.capped_default_max_output_tokens === true
   ) {
     return {
-      maxOutputTokens: boundedOutputTokens(
-        metadata.maxOutputTokensCappedDefault === true
-          ? metadataDefault
-          : CAPPED_DEFAULT_MAX_OUTPUT_TOKENS,
-        metadataUpper,
+      maxOutputTokens: fit(
+        boundedOutputTokens(
+          metadata.maxOutputTokensCappedDefault === true
+            ? metadataDefault
+            : CAPPED_DEFAULT_MAX_OUTPUT_TOKENS,
+          metadataUpper,
+        ),
       ),
       maxOutputTokensUpperLimit: metadataUpper,
       maxOutputTokensExplicit: false,
@@ -1019,7 +1066,7 @@ function resolveEffectiveOutputTokens(params: {
   }
 
   return {
-    maxOutputTokens: boundedOutputTokens(metadataDefault, metadataUpper),
+    maxOutputTokens: fit(boundedOutputTokens(metadataDefault, metadataUpper)),
     maxOutputTokensUpperLimit: metadataUpper,
     maxOutputTokensExplicit: false,
     maxOutputTokensCappedDefault: false,

--- a/runtime/src/llm/token-accounting.ts
+++ b/runtime/src/llm/token-accounting.ts
@@ -10,6 +10,7 @@ import { createHash } from "node:crypto";
 import { performance } from "node:perf_hooks";
 
 import { LLMContextWindowExceededError } from "./errors.js";
+import { getTokenizerConfigForProvider } from "./token-estimation.js";
 import type { LLMChatOptions, LLMMessage, LLMTool } from "./types.js";
 import { chatCompletionsCapabilityHintsForProvider } from "./wire/capability-gating.js";
 import {
@@ -79,8 +80,43 @@ const TOKEN_ACCOUNTING_UTF8_WORST_CASE_BYTES_PER_TOKEN = 1;
  * 2 keeps a conservative floor — still below every catalogued ratio, so the
  * estimate stays an upper bound — without gating admission on a bound no
  * tokenizer can reach.
+ *
+ * It is only a floor. Where a tokenizer IS catalogued, that ratio is the
+ * better bound and `conservativeBytesPerToken` prefers it: 2 is what we use
+ * when nothing is known about the endpoint, not a ceiling on what we may know.
+ * Keeping the floor everywhere costs nothing on a large window and is fatal on
+ * a small one. Measured against a real 32k-window local model, the serialized
+ * prompt was 75,075 bytes; at 2 that reserves 42,214 tokens against a 31,129
+ * window and admission denies before the model is ever called, while the
+ * model's own tokenizer counts 15,055 — 4.99 bytes per token. A window under
+ * ~64k cannot absorb a 2.8x over-estimate, so on local runtimes the floor does
+ * not degrade admission, it removes it.
  */
 const TOKEN_ACCOUNTING_CONSERVATIVE_BYTES_PER_TOKEN = 2;
+
+/**
+ * The bytes-per-token bound to estimate this request with.
+ *
+ * Prefers the catalogued tokenizer for the endpoint and falls back to the
+ * floor when the endpoint matches nothing. The catalogue is deliberately set
+ * below measured ratios (ollama is listed at 3.8 against 4.99 measured), so
+ * preferring it keeps the estimate an upper bound rather than abandoning one.
+ */
+export function conservativeBytesPerToken(
+  provider: string | undefined,
+  model: string | undefined,
+): number {
+  const config = getTokenizerConfigForProvider({
+    ...(provider !== undefined ? { provider } : {}),
+    ...(model !== undefined ? { model } : {}),
+  });
+  // An unmatched endpoint tells us nothing, and DEFAULT_BYTES_PER_TOKEN is a
+  // guess, not a bound. Hold the floor for those.
+  if (config.modelFamily === "unknown") {
+    return TOKEN_ACCOUNTING_CONSERVATIVE_BYTES_PER_TOKEN;
+  }
+  return Math.max(TOKEN_ACCOUNTING_CONSERVATIVE_BYTES_PER_TOKEN, config.bytesPerToken);
+}
 const TOKEN_ACCOUNTING_MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
 const TOKEN_ACCOUNTING_METRICS_OVERFLOW_MODEL = "other";
 const TOKEN_ACCOUNTING_METRICS_OVERFLOW_PROVIDER = "other";
@@ -1022,7 +1058,7 @@ function conservativeFallbackResult(
   );
   const promptTokens = estimateUtf8TokenUnits(
     stableStringify(promptIdentity),
-    TOKEN_ACCOUNTING_CONSERVATIVE_BYTES_PER_TOKEN,
+    conservativeBytesPerToken(request.provider, request.model),
   );
   const frameTokens =
     TOKEN_ACCOUNTING_REQUEST_FRAME_TOKENS +

--- a/runtime/tests/llm/small-context-window-admission.test.ts
+++ b/runtime/tests/llm/small-context-window-admission.test.ts
@@ -1,0 +1,116 @@
+/**
+ * A model whose whole context window is smaller than the default output
+ * reservation.
+ *
+ * Every hosted model core catalogues has a window of 128k or more, so the two
+ * numbers that decide admission — the output reservation and the conservative
+ * token estimate — were only ever exercised where a wide margin hid them. A
+ * local runtime has neither. Measured against a real ollama 32k model, the
+ * reservation alone was 32,000 against a 31,129-token window and the estimate
+ * was 42,214 tokens for a prompt the model's own tokenizer counted at 15,055.
+ * Either number alone denies `context_window_exceeded` before the model is
+ * called, so no local model could answer at all.
+ *
+ * These pin both numbers, and pin that nothing catalogued moved.
+ */
+import { describe, expect, test } from "vitest";
+
+import {
+  MAX_OUTPUT_TOKENS_WINDOW_FRACTION,
+  fitOutputTokensToContextWindow,
+} from "../../src/llm/model-metadata.js";
+import { conservativeBytesPerToken } from "../../src/llm/token-accounting.js";
+
+/** The window a real `ollama` 32k model presented to admission. */
+const LOCAL_WINDOW = 31_129;
+/** The default an uncatalogued model takes from `getModelMaxOutputTokens`. */
+const DEFAULT_OUTPUT = 32_000;
+
+describe("an output reservation shares the window with the prompt", () => {
+  test("never claims a window it would leave no room in", () => {
+    const fitted = fitOutputTokensToContextWindow(DEFAULT_OUTPUT, LOCAL_WINDOW);
+    expect(fitted).toBeLessThan(LOCAL_WINDOW);
+    expect(fitted).toBe(Math.floor(LOCAL_WINDOW * MAX_OUTPUT_TOKENS_WINDOW_FRACTION));
+  });
+
+  test("leaves at least as much room for the prompt as for the answer", () => {
+    // The measured prompt was 15,055 tokens. It has to fit beside the
+    // reservation or the turn is denied before the model is called.
+    const fitted = fitOutputTokensToContextWindow(DEFAULT_OUTPUT, LOCAL_WINDOW);
+    expect(LOCAL_WINDOW - fitted).toBeGreaterThanOrEqual(15_055);
+  });
+
+  test("leaves every catalogued hosted window untouched", () => {
+    // The clamp binds only when the reservation is more than half the window,
+    // which for the 32,000 default means windows under 64k. Nothing hosted is
+    // anywhere near that, so this must be a no-op for all of them.
+    for (const window of [128_000, 200_000, 400_000, 500_000, 1_000_000]) {
+      expect(fitOutputTokensToContextWindow(DEFAULT_OUTPUT, window)).toBe(DEFAULT_OUTPUT);
+      expect(fitOutputTokensToContextWindow(64_000, window)).toBe(64_000);
+    }
+  });
+
+  test("holds a reservation that already fits", () => {
+    // Exactly half is not too much; only more than half is.
+    expect(fitOutputTokensToContextWindow(4_096, 8_192)).toBe(4_096);
+  });
+
+  test("passes through when the window is unknown", () => {
+    // No window is not a small window. Inventing a clamp from nothing would
+    // silently shrink every answer on an endpoint that reports no limit.
+    expect(fitOutputTokensToContextWindow(DEFAULT_OUTPUT, undefined)).toBe(DEFAULT_OUTPUT);
+    expect(fitOutputTokensToContextWindow(DEFAULT_OUTPUT, 0)).toBe(DEFAULT_OUTPUT);
+    expect(fitOutputTokensToContextWindow(DEFAULT_OUTPUT, Number.NaN)).toBe(DEFAULT_OUTPUT);
+  });
+
+  test("never returns zero, which downstream reads as unset", () => {
+    expect(fitOutputTokensToContextWindow(DEFAULT_OUTPUT, 1)).toBe(1);
+  });
+});
+
+describe("the conservative token estimate", () => {
+  test("prefers the tokenizer core already catalogues for the endpoint", () => {
+    // 3.8 is core's own figure for ollama in token-estimation.ts. The
+    // accounting path used to ignore it and hardcode 2, which is the whole
+    // 2.8x over-estimate: measured, the endpoint runs at 4.99 bytes/token,
+    // so 3.8 is still an upper bound and 2 was never a reachable one.
+    expect(conservativeBytesPerToken("ollama", "qwen2.5-coder:7b")).toBe(3.8);
+    // The model's own family wins over the runtime serving it, which is what
+    // we want: `deepseek-r1:7b` on ollama is tokenized as deepseek, not as
+    // whatever ollama happens to serve most often.
+    expect(conservativeBytesPerToken("ollama", "deepseek-r1:7b")).toBe(3.5);
+    // And the runtime answers for a model it has no entry for at all.
+    expect(conservativeBytesPerToken("ollama", "some-local-build:7b")).toBe(3.8);
+  });
+
+  test("stays an upper bound on what the endpoint really does", () => {
+    // The measured prompt: 75,075 bytes, 15,055 real tokens. The estimate has
+    // to be at or above the truth, or admission lets through a turn the
+    // provider will refuse.
+    const estimate = 75_075 / conservativeBytesPerToken("ollama", "qwen2.5-coder:7b");
+    expect(estimate).toBeGreaterThanOrEqual(15_055);
+  });
+
+  test("brings a 32k window back within reach", () => {
+    // The point of the change. At 2 bytes/token the prompt alone was 37,537
+    // tokens against a 31,129 window, so no reservation policy could have
+    // rescued it.
+    const atFloor = 75_075 / 2;
+    const catalogued = 75_075 / conservativeBytesPerToken("ollama", "qwen2.5-coder:7b");
+    expect(atFloor).toBeGreaterThan(LOCAL_WINDOW);
+    expect(catalogued).toBeLessThan(LOCAL_WINDOW);
+  });
+
+  test("holds the floor for an endpoint it knows nothing about", () => {
+    // An unmatched endpoint tells us nothing, and the catalogue's own default
+    // is a guess rather than a bound. 2 stays for those.
+    expect(conservativeBytesPerToken("some-unknown-vendor", "mystery-model")).toBe(2);
+    expect(conservativeBytesPerToken(undefined, undefined)).toBe(2);
+  });
+
+  test("never drops below the floor", () => {
+    for (const provider of ["ollama", "grok", "anthropic", "google", "lmstudio", "groq"]) {
+      expect(conservativeBytesPerToken(provider, "")).toBeGreaterThanOrEqual(2);
+    }
+  });
+});


### PR DESCRIPTION
## Why

A local model has a context window around 32k. Two numbers that decide admission were only ever exercised against hosted models of 128k and more, and on a small window each of them denies every turn on its own, before the model is ever called. On ollama every turn died with:

```
execution admission deny: context_window_exceeded
```

Instrumented admission, first turn, trivial prompt, `providers.ollama.context_window_tokens = 32768`:

```
contextWindowTokens 31129
maxOutputTokens     32000     <- the reservation alone exceeds the window
inputTokens         42214     <- the estimate
totalTokens         74214
source              conservative_fallback
```

The same prompt measured against ollama's own tokenizer:

```
prompt bytes            75075   (system 24311 + messages 4340 + 38 tools 46424)
real tokens, with tools 15055
real bytes per token      4.99
```

So the estimate was 2.8x the truth and the output reservation was larger than the entire window.

**Two independent guaranteed denies.**

1. The output reservation ignores the context window. `getModelMaxOutputTokens` picks it from the model name and never sees the window, so a model with no catalogue entry takes the 32,000 default whatever its window is. 32,000 reserved against a 31,129-token window is refused before a single byte of prompt exists.
2. The conservative estimate is 2 bytes per token for every endpoint. Core already catalogues ollama at 3.8 in `token-estimation.ts`; the accounting path ignored it and hardcoded 2. On a 200k window a 2.8x over-estimate is invisible. On a 32k window it alone exceeds the window.

Either one alone denies every turn, so both had to be fixed. And neither is sufficient: at 2 bytes/token the prompt alone (37,537) exceeds the window, and with an accurate estimate a fixed half-window reservation still overflows it (22,778 + 15,564 = 38,342 > 31,129). So admission also had to stop treating a full window as a refusal when the prompt still leaves usable room.

## What, per file

- **`runtime/src/llm/token-accounting.ts`** — new `conservativeBytesPerToken(provider, model)` prefers the tokenizer core already catalogues for the endpoint and keeps 2 as the floor when the endpoint matches nothing, so an unknown endpoint is estimated exactly as before. The conservative fallback estimates with it instead of the bare constant. 3.8 is still an upper bound on the 4.99 measured.
- **`runtime/src/llm/model-metadata.ts`** — new `fitOutputTokensToContextWindow`, and every `resolveEffectiveOutputTokens` return path passes through it. Holds the reservation to half the window so the prompt always has as much room as the answer. This binds only when the reservation is more than half the window, which for the 32,000 default means windows under 64k.
- **`runtime/src/budget/admitted-model-call.ts`** — on an over-window total, shrink the reservation to the room the prompt actually left rather than denying the turn; deny only below `MIN_ADMISSIBLE_OUTPUT_TOKENS` (1,024), which is a window that is genuinely spent. The reservation only ever shrinks on this path, so a caller cannot widen its budget by sending a longer prompt. The cost ceiling, the lease and the provider request all read the admitted value so the reservation and the wire request cannot drift.
- **`runtime/tests/llm/small-context-window-admission.test.ts`** — 11 new tests pinning both numbers, including that hosted windows do not move.

## Evidence

A real turn through the desktop app on `qwen2.5-coder:7b` via ollama answers `4` to "What is 2+2?". Before this change the same app denied every turn with `context_window_exceeded`.

## Tests

`tests/budget` + `tests/llm`: **120 files, 2,226 tests, all passing.**

Note for anyone reproducing locally: `TMPDIR` must not sit under `/var`. macOS resolves `/var` to `/private/var` and the config repository's symlink-ancestor check rejects it, which fails 9 unrelated tests in these directories. `TMPDIR=/private/tmp/tt/vt` runs clean.

## Not changed

- Compaction thresholds.
- `DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS = 4096` in `context-window.ts`.
- Any provider adapter or wire-format code.
- Nothing catalogued moves: every hosted model is 128k or larger, so the reservation clamp is a no-op for all of them, and an endpoint with no catalogue entry keeps the 2-byte floor.

Small models writing tool calls as chat text is **not** this bug and is not fixed here. Probed directly against ollama with no core in the path and a single tool defined, `qwen2.5-coder:7b` returns `tool_calls: null` and puts the call in `content`. That is the model, not core.

## Counterpart PRs

- agenc-desktop: `fix/first-run-view-and-model-switch-20260910` carries the desktop half, where choosing a local model wrote the model without its provider and every later session was created on the previous provider.
