### PR TITLE
Honor native DeepSeek reasoning across managed runs

### DIFF
--- a/packages/agenc-sdk/src/protocol-wire.generated.ts
+++ b/packages/agenc-sdk/src/protocol-wire.generated.ts
@@ -917,6 +917,7 @@ export const RUN_RUNTIME_REASONING_EFFORTS = [
     "medium",
     "high",
     "xhigh",
+    "max",
     "none",
 ] as const;
 

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -3381,7 +3381,7 @@ export function validateProfilesConfig(
     validateEnumValue(
       profile.reasoning_effort,
       `${name}.reasoning_effort`,
-      ["minimal", "low", "medium", "high", "xhigh", "none"],
+      ["minimal", "low", "medium", "high", "xhigh", "max", "none"],
       makeError,
     );
     validateEnumValue(

--- a/runtime/src/config/strict-schema.ts
+++ b/runtime/src/config/strict-schema.ts
@@ -554,7 +554,7 @@ const ROOT_FIELD_VALIDATORS = {
   sandbox_mode: enumValidator("sandbox_mode", ["read-only", "workspace-write", "danger-full-access"]),
   sandbox: delegatedObjectValidator("sandbox"),
   shell_environment_policy: validateShellEnvironmentPolicy,
-  reasoning_effort: enumValidator("reasoning_effort", ["minimal", "low", "medium", "high", "xhigh", "none"]),
+  reasoning_effort: enumValidator("reasoning_effort", ["minimal", "low", "medium", "high", "xhigh", "max", "none"]),
   reasoning_summary: enumValidator("reasoning_summary", ["auto", "concise", "detailed", "none"]),
   approvals_reviewer: enumValidator("approvals_reviewer", ["user", "auto_review"]),
   model_verbosity: enumValidator("model_verbosity", ["low", "medium", "high"]),

--- a/runtime/src/contracts/run-contracts.ts
+++ b/runtime/src/contracts/run-contracts.ts
@@ -121,6 +121,7 @@ export const RUN_RUNTIME_REASONING_EFFORTS = [
   "medium",
   "high",
   "xhigh",
+  "max",
   "none",
 ] as const;
 export type RunRuntimeReasoningEffort =

--- a/runtime/src/llm/registry/agenc-deepseek.ts
+++ b/runtime/src/llm/registry/agenc-deepseek.ts
@@ -1,6 +1,6 @@
 /** Exact model in the reviewed AgenC promotion, not a public entitlement. */
 export const AGENC_DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash-0731";
 
-// AgenC's endpoint review permits one explicit reasoning level. Other
-// OpenRouter routes for this model can have different capabilities.
-export const AGENC_DEEPSEEK_REASONING_LEVELS = ["medium"] as const;
+// Native levels published for this exact model. Medium is a legacy alias
+// for High, not a distinct reasoning level to offer in the selector.
+export const AGENC_DEEPSEEK_REASONING_LEVELS = ["low", "high", "max"] as const;

--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -531,7 +531,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       supportsReasoningSummaries: false,
       defaultReasoningSummary: "none",
       supportedReasoningLevels: AGENC_DEEPSEEK_REASONING_LEVELS,
-      defaultReasoningLevel: "medium",
+      defaultReasoningLevel: "high",
       additionalSpeedTiers: NO_ADDITIONAL_SPEED_TIERS,
       priority: 0,
       visibility: "none",

--- a/runtime/src/state/migrations/033_runtime_settings_max_effort.ts
+++ b/runtime/src/state/migrations/033_runtime_settings_max_effort.ts
@@ -1,0 +1,105 @@
+import type { SqlMigration } from "./types.js";
+
+export const RUNTIME_SETTINGS_MAX_EFFORT_SCHEMA_VERSION = 33;
+
+/** Preserve native `max` reasoning in durable settings and run resumption. */
+export const runtimeSettingsMaxEffortMigration: SqlMigration = {
+  version: RUNTIME_SETTINGS_MAX_EFFORT_SCHEMA_VERSION,
+  name: "runtime_settings_max_effort",
+  apply(db) {
+    const table = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name = 'run_runtime_settings'`,
+      )
+      .get();
+    if (table === undefined) return;
+
+    db.exec(`
+      ALTER TABLE run_runtime_settings
+      RENAME TO run_runtime_settings_without_max_effort;
+
+      CREATE TABLE run_runtime_settings (
+        run_id TEXT NOT NULL,
+        epoch INTEGER NOT NULL,
+        settings_event_id TEXT NOT NULL,
+        settings_sequence INTEGER NOT NULL,
+        previous_settings_event_id TEXT,
+        rollback_of_settings_event_id TEXT,
+        reason TEXT NOT NULL,
+        changed_at TEXT NOT NULL,
+        permission_mode TEXT NOT NULL,
+        pre_plan_mode TEXT,
+        auto_mode_active INTEGER NOT NULL,
+        auto_mode_available INTEGER NOT NULL,
+        bypass_permissions_mode_available INTEGER NOT NULL,
+        bypass_permissions_workspace TEXT,
+        bypass_permissions_consent_workspace TEXT,
+        model TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        profile TEXT,
+        reasoning_effort TEXT,
+        model_verbosity TEXT,
+        service_tier TEXT,
+        hooks_disabled INTEGER NOT NULL,
+        PRIMARY KEY (run_id, settings_event_id),
+        FOREIGN KEY (run_id, epoch)
+          REFERENCES run_lifecycle_epochs(run_id, epoch) ON DELETE RESTRICT,
+        CHECK (length(run_id) > 0),
+        CHECK (epoch > 0),
+        CHECK (length(settings_event_id) > 0),
+        CHECK (settings_sequence > 0),
+        CHECK (previous_settings_event_id IS NULL OR length(previous_settings_event_id) > 0),
+        CHECK (rollback_of_settings_event_id IS NULL OR length(rollback_of_settings_event_id) > 0),
+        CHECK (reason IN ('initial', 'permission_mode_changed', 'model_provider_changed', 'config_applied', 'hooks_changed', 'compensating_rollback')),
+        CHECK (length(changed_at) > 0),
+        CHECK (permission_mode IN ('default', 'plan', 'acceptEdits', 'bypassPermissions', 'dontAsk', 'auto', 'unattended')),
+        CHECK (pre_plan_mode IS NULL OR pre_plan_mode IN ('default', 'acceptEdits', 'bypassPermissions', 'dontAsk', 'auto', 'unattended')),
+        CHECK ((permission_mode = 'plan' AND pre_plan_mode IS NOT NULL) OR (permission_mode <> 'plan' AND pre_plan_mode IS NULL)),
+        CHECK (auto_mode_active IN (0, 1)),
+        CHECK (auto_mode_available IN (0, 1)),
+        CHECK (auto_mode_active = 0 OR auto_mode_available = 1),
+        CHECK ((permission_mode = 'auto' AND auto_mode_active = 1) OR permission_mode = 'plan' OR (permission_mode NOT IN ('auto', 'plan') AND auto_mode_active = 0)),
+        CHECK (bypass_permissions_mode_available IN (0, 1)),
+        CHECK (bypass_permissions_consent_workspace IS NULL OR (bypass_permissions_mode_available = 1 AND length(bypass_permissions_consent_workspace) > 0)),
+        CHECK (((permission_mode = 'bypassPermissions' OR pre_plan_mode = 'bypassPermissions') AND bypass_permissions_mode_available = 1 AND bypass_permissions_workspace IS NOT NULL AND bypass_permissions_workspace = bypass_permissions_consent_workspace AND length(bypass_permissions_workspace) > 0) OR ((permission_mode <> 'bypassPermissions' AND (pre_plan_mode IS NULL OR pre_plan_mode <> 'bypassPermissions')) AND bypass_permissions_workspace IS NULL)),
+        CHECK (length(trim(model)) > 0 AND length(model) <= 1024),
+        CHECK (length(trim(provider)) > 0 AND length(provider) <= 256),
+        CHECK (profile IS NULL OR (length(trim(profile)) > 0 AND length(profile) <= 256)),
+        CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'none')),
+        CHECK (model_verbosity IS NULL OR model_verbosity IN ('low', 'medium', 'high')),
+        CHECK (service_tier IS NULL OR service_tier IN ('priority', 'flex')),
+        CHECK (hooks_disabled IN (0, 1)),
+        CHECK ((reason = 'initial' AND previous_settings_event_id IS NULL AND rollback_of_settings_event_id IS NULL) OR reason <> 'initial'),
+        CHECK ((reason = 'compensating_rollback' AND rollback_of_settings_event_id IS NOT NULL) OR (reason <> 'compensating_rollback' AND rollback_of_settings_event_id IS NULL))
+      );
+
+      INSERT INTO run_runtime_settings (
+        run_id, epoch, settings_event_id, settings_sequence,
+        previous_settings_event_id, rollback_of_settings_event_id, reason,
+        changed_at, permission_mode, pre_plan_mode, auto_mode_active,
+        auto_mode_available, bypass_permissions_mode_available,
+        bypass_permissions_workspace, bypass_permissions_consent_workspace,
+        model, provider, profile, reasoning_effort, model_verbosity,
+        service_tier, hooks_disabled
+      )
+      SELECT
+        run_id, epoch, settings_event_id, settings_sequence,
+        previous_settings_event_id, rollback_of_settings_event_id, reason,
+        changed_at, permission_mode, pre_plan_mode, auto_mode_active,
+        auto_mode_available, bypass_permissions_mode_available,
+        bypass_permissions_workspace, bypass_permissions_consent_workspace,
+        model, provider, profile, reasoning_effort, model_verbosity,
+        service_tier, hooks_disabled
+      FROM run_runtime_settings_without_max_effort;
+
+      DROP TABLE run_runtime_settings_without_max_effort;
+
+      CREATE UNIQUE INDEX idx_run_runtime_settings_sequence
+        ON run_runtime_settings(run_id, settings_sequence);
+
+      CREATE INDEX idx_run_runtime_settings_current
+        ON run_runtime_settings(run_id, epoch DESC, settings_sequence DESC);
+    `);
+  },
+};

--- a/runtime/src/state/migrations/index.ts
+++ b/runtime/src/state/migrations/index.ts
@@ -31,6 +31,7 @@ import { terminalAgentRunReconciliationMigration } from "./029_terminal_agent_ru
 import { runtimeSettingsPermissionCapabilitiesMigration } from "./030_runtime_settings_permission_capabilities.js";
 import { runtimeSettingsMinimalEffortMigration } from "./031_runtime_settings_minimal_effort.js";
 import { dropThreadsLastItemIndexMigration } from "./032_drop_threads_last_item_index.js";
+import { runtimeSettingsMaxEffortMigration } from "./033_runtime_settings_max_effort.js";
 import type { SqlMigration } from "./types.js";
 
 /**
@@ -69,6 +70,7 @@ export const STATE_DB_MIGRATIONS: readonly SqlMigration[] = [
   runtimeSettingsPermissionCapabilitiesMigration,
   runtimeSettingsMinimalEffortMigration,
   dropThreadsLastItemIndexMigration,
+  runtimeSettingsMaxEffortMigration,
 ];
 
 export const LOGS_DB_MIGRATIONS: readonly SqlMigration[] = [

--- a/runtime/tests/app-server-client/index.test.ts
+++ b/runtime/tests/app-server-client/index.test.ts
@@ -549,7 +549,7 @@ describe("app-server-client daemon helpers", () => {
     }
   });
 
-  it("hydrates config-default bypass authority from the live attach snapshot", async () => {
+  it.each(["low", "high", "max"] as const)("hydrates bypass authority and native %s effort from the live attach snapshot", async (reasoningEffort) => {
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-live-bypass-home-"));
     const workspace = mkdtempSync(join(tmpdir(), "agenc-live-bypass-workspace-"));
     writeFileSync(
@@ -593,7 +593,7 @@ describe("app-server-client daemon helpers", () => {
           provider: "grok",
           model: "grok-live-model",
           profile: "live",
-          reasoningEffort: "high",
+          reasoningEffort,
           modelVerbosity: "low",
           serviceTier: "flex",
           hooksDisabled: false,
@@ -613,7 +613,7 @@ describe("app-server-client daemon helpers", () => {
         provider: { slug: "grok" },
         collaborationMode: {
           model: "grok-live-model",
-          reasoningEffort: "high",
+          reasoningEffort,
         },
         modelVerbosity: "low",
         serviceTier: "flex",

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -2802,13 +2802,23 @@ describe("AgenC delegate background-agent runner", () => {
       expectedMode: "plan" as const,
       expectedSettingsEvents: 2,
     },
+    {
+      label: "with native Max reasoning",
+      permissionMode: undefined,
+      expectedMode: "default" as const,
+      expectedSettingsEvents: 1,
+      reasoningEffort: "max" as const,
+    },
   ])(
     "keeps a fresh default run cold-resumable $label",
-    async ({ permissionMode, expectedMode, expectedSettingsEvents }) => {
+    async ({ permissionMode, expectedMode, expectedSettingsEvents, reasoningEffort }) => {
       const runId = `session-default-cold-${expectedMode}`;
       const harness = makeTopLevelRunner({
         conversationId: runId,
         canonicalRuntimeSettings: true,
+      });
+      Object.assign(harness.sessionState.sessionConfiguration.collaborationMode, {
+        reasoningEffort,
       });
       const baseline: RunRuntimeSettingsSnapshot = {
         permissionMode: "default",
@@ -2821,7 +2831,7 @@ describe("AgenC delegate background-agent runner", () => {
         model: "base-model",
         provider: "grok",
         profile: null,
-        reasoningEffort: null,
+        reasoningEffort: reasoningEffort ?? null,
         modelVerbosity: null,
         serviceTier: null,
         hooksDisabled: false,
@@ -5908,6 +5918,18 @@ describe("AgenC delegate background-agent runner", () => {
     expect(recordedRuntimeSettingsEvents(rolloutItems)).toHaveLength(
       beforeEvents,
     );
+  });
+
+  it.each(["low", "high", "max"] as const)("persists native %s reasoning when creating a run", async (reasoningEffort) => {
+    const agentId = `native-effort-${reasoningEffort}`;
+    const { runner, sessionState, rolloutItems } = makeTopLevelRunner({
+      conversationId: agentId,
+      canonicalRuntimeSettings: true,
+    });
+    Object.assign(sessionState.sessionConfiguration.collaborationMode, { reasoningEffort });
+    await runner.startAgent({ objective: "work", cwd: process.cwd() });
+    expect((await runner.getAgentSnapshot(agentId))?.runtimeSettings).toMatchObject({ reasoningEffort });
+    expect(recordedRuntimeSettingsEvents(rolloutItems).at(-1)?.msg?.payload).toMatchObject({ reasoningEffort });
   });
 
   it.each([undefined, null])("normalizes absent optional runtime settings from %s", async (absent) => {

--- a/runtime/tests/auth/account-access.test.ts
+++ b/runtime/tests/auth/account-access.test.ts
@@ -115,8 +115,18 @@ describe("AgenC account model access", () => {
       if (provider) writeFileSync(join(home, "config.toml"), `config_version = 2\nmodel_provider = "${provider}"\nmodel = "previous-model"\nreasoning_effort = "xhigh"\n`);
       saveAccountDefaultModel(home, { authenticated: true, managedModelsEnabled: true, models: [{ id: AGENC_DEEPSEEK_MODEL, name: "DeepSeek" }] });
       const config = parseToml(readFileSync(join(home, "config.toml"), "utf8"));
-      expect(config.reasoning_effort).toBe(provider === "openai" ? "xhigh" : "medium");
+      expect(config.reasoning_effort).toBe(provider === "openai" ? "xhigh" : "high");
       expect(config.model_provider).toBe(provider === "openai" ? "openai" : "agenc");
+    } finally { rmSync(home, { recursive: true, force: true }); }
+  });
+
+  it.each(["medium", "low", "high", "max"])("migrates the old managed alias while preserving native effort %s", effort => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-account-native-effort-"));
+    try {
+      writeFileSync(join(home, "config.toml"), `config_version = 2\nmodel_provider = "agenc"\nmodel = "${AGENC_DEEPSEEK_MODEL}"\nreasoning_effort = "${effort}"\n`);
+      saveAccountDefaultModel(home, { authenticated: true, managedModelsEnabled: true, models: [{ id: AGENC_DEEPSEEK_MODEL, name: "DeepSeek" }] });
+      const config = parseToml(readFileSync(join(home, "config.toml"), "utf8"));
+      expect(config.reasoning_effort).toBe(effort === "medium" ? "high" : effort);
     } finally { rmSync(home, { recursive: true, force: true }); }
   });
 

--- a/runtime/tests/config/strict-schema-validation.test.ts
+++ b/runtime/tests/config/strict-schema-validation.test.ts
@@ -40,7 +40,7 @@ describe("strict schema-v2 validation coverage", () => {
     ["model", { model: 42 }, /Invalid model/u],
     ["approval policy", { approval_policy: "sometimes" }, /approval_policy/u],
     ["sandbox mode", { sandbox_mode: "container" }, /sandbox_mode/u],
-    ["reasoning effort", { reasoning_effort: "max" }, /reasoning_effort/u],
+    ["reasoning effort", { reasoning_effort: "unlimited" }, /reasoning_effort/u],
     ["agent threads", { agent_max_threads: 0 }, /agent_max_threads/u],
     ["agent depth", { agent_max_depth: -1 }, /agent_max_depth/u],
     ["project markers", { project_root_markers: [".git", 4] }, /project_root_markers/u],
@@ -56,12 +56,12 @@ describe("strict schema-v2 validation coverage", () => {
     expect(() => validateAgenCConfigBlocks(malformed(config))).toThrow(error);
   });
 
-  test("accepts the Meta-compatible minimal reasoning effort", () => {
+  test.each(["minimal", "max"])("accepts native %s reasoning in root and profile settings", effort => {
     expect(() =>
       validateAgenCConfigBlocks(
         malformed({
-          reasoning_effort: "minimal",
-          profiles: { meta: { reasoning_effort: "minimal" } },
+          reasoning_effort: effort,
+          profiles: { native: { reasoning_effort: effort } },
         }),
       ),
     ).not.toThrow();

--- a/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
+++ b/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
@@ -6,7 +6,7 @@ import { deriveFlatCatalog, resolveRegisteredModelCatalogEntry } from "../../../
 import { chatCompletionsCapabilityHintsForProvider } from "../../../../src/llm/wire/capability-gating.js";
 
 describe("AgenC DeepSeek promotion wire", () => {
-  it.each([false, true])("completes a tool round trip within the reviewed gateway contract (stream=%s)", async stream => {
+  it.each([false, true].flatMap(stream => (["low", "high", "max"] as const).map(effort => ({ stream, effort }))))("preserves $effort through a tool round trip (stream=$stream)", async ({ stream, effort }) => {
     const bodies: Record<string, any>[] = [];
     const allowed = new Set(["model", "messages", "stream", "stream_options", "max_tokens", "temperature",
       "top_p", "stop", "frequency_penalty", "presence_penalty", "top_k", "seed", "response_format",
@@ -17,7 +17,7 @@ describe("AgenC DeepSeek promotion wire", () => {
       const body = JSON.parse(String(init?.body));
       bodies.push(body);
       expect(Object.keys(body).filter(key => !allowed.has(key))).toEqual([]);
-      if (body.reasoning_effort !== undefined) expect(body.reasoning_effort).toBe("medium");
+      expect(body.reasoning_effort).toBe(effort);
       const first = bodies.length === 1;
       const message = first
         ? { role: "assistant", content: null, reasoning: "Read the synthetic marker.", tool_calls: [
@@ -50,7 +50,7 @@ describe("AgenC DeepSeek promotion wire", () => {
       const run: typeof provider.chat = (messages, options) => stream
         ? provider.chatStream(messages, () => {}, options) : provider.chat(messages, options);
       const first = await run([{ role: "user", content: "Read marker" }], {
-        reasoningEffort: "medium", parallelToolCalls: true, toolChoice: "required", maxOutputTokens: 256,
+        reasoningEffort: effort, parallelToolCalls: true, toolChoice: "required", maxOutputTokens: 256,
       });
       expect(first.toolCalls).toEqual([{ id: "call_marker", name: "read_marker", arguments: "{}" }]);
       const final = await run([
@@ -59,10 +59,10 @@ describe("AgenC DeepSeek promotion wire", () => {
           providerReasoningContent: first.providerReasoningContent,
           providerReasoningProvenance: first.providerReasoningProvenance },
         { role: "tool", content: "marker", toolCallId: "call_marker", toolName: "read_marker" },
-      ], { reasoningEffort: "xhigh", parallelToolCalls: true, maxOutputTokens: 256 });
+      ], { reasoningEffort: effort, parallelToolCalls: true, maxOutputTokens: 256 });
       expect(final.content).toBe("marker");
-      expect(bodies[0]).toMatchObject({ model, max_tokens: 256, reasoning_effort: "medium" });
-      expect(bodies[1].reasoning_effort).toBeUndefined();
+      expect(bodies[0]).toMatchObject({ model, max_tokens: 256, reasoning_effort: effort });
+      expect(bodies[1].reasoning_effort).toBe(effort);
       expect(bodies[1].messages.find((row: any) => row.role === "assistant").reasoning).toBe("Read the synthetic marker.");
       expect(bodies[1].messages.find((row: any) => row.role === "tool").tool_call_id).toBe("call_marker");
       expect(bodies).toHaveLength(2);
@@ -72,7 +72,7 @@ describe("AgenC DeepSeek promotion wire", () => {
   it("keeps route metadata hidden and does not change direct OpenRouter capabilities", () => {
     expect(resolveRegisteredModelCatalogEntry({ provider: "agenc", model })).toMatchObject({
       contextWindow: 1_048_576, maxOutputTokens: 8_192, maxOutputTokensUpperLimit: 384_000,
-      supportedReasoningLevels: ["medium"], defaultReasoningLevel: "medium", visibility: "none",
+      supportedReasoningLevels: ["low", "high", "max"], defaultReasoningLevel: "high", visibility: "none",
     });
     expect(deriveFlatCatalog().agenc ?? []).not.toContain(model);
     expect(chatCompletionsCapabilityHintsForProvider("openrouter", model).acceptsParallelToolCalls).toBeUndefined();

--- a/runtime/tests/state/migrations.test.ts
+++ b/runtime/tests/state/migrations.test.ts
@@ -58,7 +58,7 @@ describe("state migration registry", () => {
   it("loads state migrations from numbered migration files in order", () => {
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.version)).toEqual([
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-      22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+      22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
     ]);
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.name)).toEqual([
       "initial_state_schema",
@@ -93,6 +93,7 @@ describe("state migration registry", () => {
       "runtime_settings_permission_capabilities",
       "runtime_settings_minimal_effort",
       "drop_threads_last_item_index",
+      "runtime_settings_max_effort",
     ]);
     expectMigrationVersionsAreUnique(STATE_DB_MIGRATIONS);
   });
@@ -143,6 +144,7 @@ describe("state migration registry", () => {
       "030_runtime_settings_permission_capabilities.ts",
       "031_runtime_settings_minimal_effort.ts",
       "032_drop_threads_last_item_index.ts",
+      "033_runtime_settings_max_effort.ts",
     ]);
   });
 
@@ -287,6 +289,34 @@ describe("state migration registry", () => {
     } finally {
       db.close();
     }
+  });
+
+  it("preserves settings history while adding durable Max reasoning", () => {
+    const db = new Database(":memory:");
+    try {
+      db.pragma("foreign_keys = ON");
+      applyMigrations(db, STATE_DB_MIGRATIONS.filter(migration => migration.version <= 32));
+      db.exec(`
+        INSERT INTO run_lifecycle_epochs (run_id, epoch, opened_at)
+        VALUES ('max-run', 1, '2026-09-10T00:00:00.000Z');
+        INSERT INTO run_runtime_settings (
+          run_id, epoch, settings_event_id, settings_sequence, reason, changed_at,
+          permission_mode, auto_mode_active, auto_mode_available,
+          bypass_permissions_mode_available, model, provider, reasoning_effort, hooks_disabled
+        ) VALUES ('max-run', 1, 'settings-1', 1, 'initial', '2026-09-10T00:00:00.000Z',
+          'default', 0, 0, 0, 'deepseek/deepseek-v4-flash-0731', 'agenc', 'high', 0);
+      `);
+      const before = db.prepare("SELECT * FROM run_runtime_settings").all();
+      const indexes = db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='run_runtime_settings' ORDER BY name").all();
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+      expect(db.prepare("SELECT * FROM run_runtime_settings").all()).toEqual(before);
+      expect(db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='run_runtime_settings' ORDER BY name").all()).toEqual(indexes);
+      expect(() => db.exec("UPDATE run_runtime_settings SET reasoning_effort='max'")).not.toThrow();
+      expect(db.prepare("SELECT reasoning_effort FROM run_runtime_settings").get()).toEqual({ reasoning_effort: "max" });
+      expect(() => db.exec("UPDATE run_runtime_settings SET reasoning_effort='unlimited'")).toThrow();
+      expect(() => db.exec("DELETE FROM run_lifecycle_epochs WHERE run_id='max-run'")).toThrow();
+      expect(db.pragma("foreign_key_check")).toEqual([]);
+    } finally { db.close(); }
   });
 
   it("adds durable CSV writer anchor state without backfilling legacy intents", () => {


### PR DESCRIPTION
AgenC’s DeepSeek V4 Flash 0731 integration exposed only Medium, and selecting the native Max level failed when creating or restoring a durable session. Expose Low, High and Max with High as the default, migrate the legacy managed default, and carry Max through config validation, durable run contracts, migration 33 and the generated SDK. Streaming and non-streaming function continuations retain the selected native effort.

Validation: local `npm run test:fast` passed (345 focused tests plus 19,290 related tests). Creation, attachment and cold-resume regressions passed. The final generated SDK Max enum synchronization passed runtime build, SDK parity and a final typecheck. A real native Desktop Max turn read a synthetic file and returned its contents. The paired Desktop source pin will reference this branch; retain it after merge. The managed backend policy supports the same three native levels and explicitly normalizes the legacy Medium alias before dispatch. This does not activate other models or paid subscriptions.
