### PR TITLE
fix(plugins): keep skill IDs while exposing display names

### DIFF
--- a/runtime/src/plugins/cli/pluginOperations.ts
+++ b/runtime/src/plugins/cli/pluginOperations.ts
@@ -45,6 +45,7 @@ import {
   type ResolvedPluginSource,
 } from "../resolution.js";
 import { parsePluginIdentifier } from "../identifier.js";
+import { skillDisplayNameFromMarkdown } from "../skill-display-metadata.js";
 
 export type PluginScope = "user" | "project" | "local";
 
@@ -66,6 +67,7 @@ export interface PluginOperationOptions {
 
 export interface PluginComponentRow {
   readonly name: string;
+  readonly displayName?: string;
   readonly description?: string;
 }
 
@@ -751,9 +753,9 @@ function summarizeLoadedPlugin(plugin: LoadedPlugin): InstalledPluginSummary {
 /** Bounded frontmatter read: a skill listing must never slurp documents. */
 const SKILL_FRONTMATTER_MAX_BYTES = 8 * 1024;
 
-async function skillDescriptionAt(
+async function skillMetadataAt(
   skillDir: string,
-): Promise<string | undefined> {
+): Promise<Omit<PluginComponentRow, "name"> | undefined> {
   try {
     const handle = await open(join(skillDir, "SKILL.md"), "r");
     try {
@@ -761,7 +763,12 @@ async function skillDescriptionAt(
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
       const head = buffer.subarray(0, bytesRead).toString("utf8");
       const match = /^description:\s*(.+)$/mu.exec(head);
-      return match?.[1]?.trim().slice(0, 280);
+      const description = match?.[1]?.trim().slice(0, 280);
+      const displayName = skillDisplayNameFromMarkdown(head);
+      return {
+        ...(description !== undefined ? { description } : {}),
+        ...(displayName !== undefined ? { displayName } : {}),
+      };
     } finally {
       await handle.close();
     }
@@ -777,13 +784,13 @@ async function describeSkills(
   // conventional `skills/` root whose child dirs are the skills.
   const rows: PluginComponentRow[] = [];
   const seen = new Set<string>();
-  const push = (name: string, description: string | undefined): void => {
+  const push = (name: string, metadata: Omit<PluginComponentRow, "name"> | undefined): void => {
     if (name.length === 0 || seen.has(name)) return;
     seen.add(name);
-    rows.push({ name, ...(description !== undefined ? { description } : {}) });
+    rows.push({ name, ...metadata });
   };
   for (const skillPath of skillsPaths) {
-    const direct = await skillDescriptionAt(skillPath);
+    const direct = await skillMetadataAt(skillPath);
     let directExists = direct !== undefined;
     if (!directExists) {
       try {
@@ -809,7 +816,7 @@ async function describeSkills(
       } catch {
         continue;
       }
-      push(child, await skillDescriptionAt(childDir));
+      push(child, await skillMetadataAt(childDir));
     }
   }
   return rows;

--- a/runtime/src/plugins/marketplace/catalog-cli.ts
+++ b/runtime/src/plugins/marketplace/catalog-cli.ts
@@ -19,6 +19,7 @@
 import { createHash } from "node:crypto";
 import { isAbsolute, join, resolve, sep } from "node:path";
 import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { normalizeSkillDisplayName, skillDisplayNameFromMarkdown } from "../skill-display-metadata.js";
 
 import {
   findInstallableMarketplacePlugin,
@@ -249,6 +250,7 @@ async function fetchBounded(
  */
 interface MarketplaceComponentRow {
   readonly name: string;
+  readonly displayName?: string;
   readonly description?: string;
 }
 
@@ -271,6 +273,8 @@ const CARD_LIST_MAX = 12;
 const CARD_PROMPT_MAX = 4;
 const CARD_SKILLS_MAX = 8;
 const SKILL_PREFETCH_MAX_BYTES = 32 * 1024;
+// Older sidecars did not retain skill display labels, even for the same source SHA.
+const CARD_METADATA_VERSION = 1;
 
 function cardString(value: unknown, maxLength: number): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -329,8 +333,13 @@ function cardComponentRows(value: unknown): readonly MarketplaceComponentRow[] |
     const raw = entry as Record<string, unknown>;
     const name = cardString(raw.name, CARD_DISPLAY_NAME_MAX);
     if (name === undefined) return [];
+    const displayName = normalizeSkillDisplayName(raw.displayName);
     const description = cardString(raw.description, CARD_DESCRIPTION_MAX);
-    return [{ name, ...(description !== undefined ? { description } : {}) }];
+    return [{
+      name,
+      ...(displayName !== undefined ? { displayName } : {}),
+      ...(description !== undefined ? { description } : {}),
+    }];
   }).slice(0, CARD_LIST_MAX);
   return rows.length > 0 ? rows : undefined;
 }
@@ -339,29 +348,38 @@ async function prefetchSkillRows(
   fetcher: Fetcher,
   source: MarketplacePlugin["source"],
   declaredSkills: unknown,
-): Promise<readonly MarketplaceComponentRow[] | undefined> {
+): Promise<{ readonly rows: readonly MarketplaceComponentRow[]; readonly complete: boolean } | undefined> {
   if (!Array.isArray(declaredSkills)) return undefined;
   const rows: MarketplaceComponentRow[] = [];
+  let complete = true;
   for (const declared of declaredSkills.slice(0, CARD_SKILLS_MAX)) {
     if (typeof declared !== "string" || declared.length === 0) continue;
     const clean = declared.replace(/^\.\//u, "").replace(/\/+$/u, "");
     const name = clean.split("/").pop();
     if (name === undefined || name.length === 0) continue;
     let description: string | undefined;
+    let displayName: string | undefined;
     const skillUrl = pinnedRawUrl(source, `${clean}/SKILL.md`);
     if (skillUrl !== undefined) {
       const bytes = await fetchBounded(fetcher, skillUrl, SKILL_PREFETCH_MAX_BYTES);
       if (bytes !== undefined) {
         const head = Buffer.from(bytes).toString("utf8");
+        displayName = skillDisplayNameFromMarkdown(head);
         const match = /^description:\s*(.+)$/mu.exec(head);
         if (match?.[1] !== undefined) {
           description = match[1].trim().slice(0, CARD_DESCRIPTION_MAX);
         }
+      } else {
+        complete = false;
       }
     }
-    rows.push({ name, ...(description !== undefined ? { description } : {}) });
+    rows.push({
+      name,
+      ...(displayName !== undefined ? { displayName } : {}),
+      ...(description !== undefined ? { description } : {}),
+    });
   }
-  return rows.length > 0 ? rows : undefined;
+  return rows.length > 0 ? { rows, complete } : undefined;
 }
 
 function metaFromSidecar(value: unknown, logoPath: string | undefined): PrefetchedCardMeta {
@@ -397,6 +415,7 @@ async function prefetchPinnedCardMeta(
   if (manifestUrl === undefined) return undefined;
   const cacheRoot = logoCacheRoot(options);
   const key = createHash("sha256").update(manifestUrl).digest("hex").slice(0, 24);
+  let staleCached: PrefetchedCardMeta | undefined;
   try {
     const cachedRaw: unknown = JSON.parse(
       await readFile(join(cacheRoot, `${key}.meta.json`), "utf8"),
@@ -416,7 +435,9 @@ async function prefetchPinnedCardMeta(
           // Meta survives a pruned logo file.
         }
       }
-      return metaFromSidecar(cached, logoPath);
+      const metadata = metaFromSidecar(cached, logoPath);
+      if (cached.cardMetadataVersion === CARD_METADATA_VERSION) return metadata;
+      staleCached = metadata;
     }
   } catch {
     // Not cached yet.
@@ -426,16 +447,16 @@ async function prefetchPinnedCardMeta(
     manifestUrl,
     MANIFEST_PREFETCH_MAX_BYTES,
   );
-  if (manifestBytes === undefined) return undefined;
+  if (manifestBytes === undefined) return staleCached;
   let manifest: Record<string, unknown>;
   try {
     const parsed: unknown = JSON.parse(
       Buffer.from(manifestBytes).toString("utf8"),
     );
-    if (typeof parsed !== "object" || parsed === null) return undefined;
+    if (typeof parsed !== "object" || parsed === null) return staleCached;
     manifest = parsed as Record<string, unknown>;
   } catch {
-    return undefined;
+    return staleCached;
   }
   const surface = cardInterface(manifest.interface);
   const description = cardString(manifest.description, CARD_DESCRIPTION_MAX);
@@ -454,7 +475,8 @@ async function prefetchPinnedCardMeta(
           ),
         )
       : undefined;
-  const skills = await prefetchSkillRows(fetcher, plugin.source, manifest.skills);
+  const skillMetadata = await prefetchSkillRows(fetcher, plugin.source, manifest.skills);
+  const skills = skillMetadata?.rows;
   const declaredLogo =
     typeof manifest.interface === "object" && manifest.interface !== null
       ? ((manifest.interface as { logo?: unknown }).logo)
@@ -486,6 +508,9 @@ async function prefetchPinnedCardMeta(
     }
   }
   const sidecar = {
+    // Retry incomplete skill reads on the next catalog request; do not freeze a
+    // transient fetch failure into a current-version, permanently unlabeled card.
+    ...(skillMetadata?.complete !== false ? { cardMetadataVersion: CARD_METADATA_VERSION } : {}),
     ...(surface?.displayName !== undefined
       ? { displayName: surface.displayName }
       : {}),
@@ -720,4 +745,3 @@ export async function resolveMarketplaceInstallTarget(
 export function installRequiresSignature(record: MarketplaceRecord): boolean {
   return record.sourceType !== "local";
 }
-

--- a/runtime/src/plugins/skill-display-metadata.ts
+++ b/runtime/src/plugins/skill-display-metadata.ts
@@ -1,0 +1,22 @@
+import { parseYaml } from "../utils/yaml.js";
+
+/** Display-only copy. The skill directory remains its identity and path. */
+export function normalizeSkillDisplayName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const name = value.trim();
+  if (name.length === 0 || /[\u0000-\u001f\u007f]/u.test(name)) return undefined;
+  return name.slice(0, 80);
+}
+
+export function skillDisplayNameFromMarkdown(markdown: string): string | undefined {
+  const header = /^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(markdown);
+  if (header === null) return undefined;
+  try {
+    const fields = parseYaml(header[1] ?? "");
+    return fields !== null && typeof fields === "object" && !Array.isArray(fields)
+      ? normalizeSkillDisplayName((fields as Record<string, unknown>).name)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/runtime/src/skills/loadSkillsDir.ts
+++ b/runtime/src/skills/loadSkillsDir.ts
@@ -160,7 +160,7 @@ export function parseSkillFrontmatterFields(
 
   return {
     displayName:
-      frontmatter.name != null ? String(frontmatter.name) : undefined,
+      typeof frontmatter.name === 'string' ? frontmatter.name : undefined,
     description,
     hasUserSpecifiedDescription: validatedDescription !== null,
     allowedTools: parseSlashCommandToolsFromFrontmatter(

--- a/runtime/src/skills/skills-cli.ts
+++ b/runtime/src/skills/skills-cli.ts
@@ -14,6 +14,7 @@
 
 import { loadCanonicalConfig } from "../config/repository.js";
 import type { AgenCConfig } from "../config/schema.js";
+import { normalizeSkillDisplayName } from "../plugins/skill-display-metadata.js";
 import {
   loadLocalSkillsSnapshot,
   type LocalSkillMetadata,
@@ -43,6 +44,7 @@ export type SkillInventoryOrigin =
 
 export interface SkillInventoryRow {
   readonly name: string;
+  readonly displayName?: string;
   readonly description?: string;
   /** When the model should reach for this skill, straight from the source. */
   readonly whenToUse?: string;
@@ -179,8 +181,10 @@ function rowOf(
   skill: LocalSkillMetadata,
   conditional: boolean,
 ): SkillInventoryRow {
+  const displayName = normalizeSkillDisplayName(skill.displayName);
   return {
     name: skill.name,
+    ...(displayName !== undefined ? { displayName } : {}),
     ...(skill.description.length > 0
       ? { description: skill.description }
       : {}),

--- a/runtime/tests/plugins/skill-display-metadata.test.ts
+++ b/runtime/tests/plugins/skill-display-metadata.test.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { normalizeSkillDisplayName, skillDisplayNameFromMarkdown } from "../../src/plugins/skill-display-metadata.js";
+import { buildMarketplaceCatalog } from "../../src/plugins/marketplace/catalog-cli.js";
+import { addMarketplaceOp } from "../../src/plugins/marketplace/marketplace.js";
+import { installPluginOp, listInstalledPlugins } from "../../src/plugins/cli/pluginOperations.js";
+
+async function runtime() {
+  const root = await mkdtemp(join(tmpdir(), "agenc-skill-labels-"));
+  const agencHome = join(root, "home");
+  const workspaceRoot = join(root, "workspace");
+  const pluginStorageRoot = join(agencHome, "plugins");
+  await Promise.all([agencHome, workspaceRoot, pluginStorageRoot].map(path => mkdir(path, { recursive: true })));
+  return { root, agencHome, workspaceRoot, pluginStorageRoot,
+    sessionTempRoot: join(root, "sessions"), env: {} };
+}
+
+const SHA = "a".repeat(40);
+const MANIFEST_URL = `https://raw.githubusercontent.com/example/plugins/${SHA}/plugins/forja/.agenc-plugin/plugin.json`;
+const SKILL_URL = `https://raw.githubusercontent.com/example/plugins/${SHA}/plugins/forja/skills/calidad/SKILL.md`;
+const LABEL = '---\nname: "Code Quality"\ndescription: Review source code.\n---\n# Code Quality\n';
+
+async function catalogFixture() {
+  const options = await runtime();
+  const manifest = JSON.stringify({ name: "forja", version: "1.0.0", skills: ["./skills/calidad"] });
+  const catalog = JSON.stringify({ name: "labels", plugins: [{ name: "forja",
+    source: { source: "git-subdir", url: "https://github.com/example/plugins.git", path: "plugins/forja", sha: SHA },
+    policy: { installation: "AVAILABLE", authentication: "ON_USE" } }] });
+  const fetcher = vi.fn(async (url: string) => new Response(url === MANIFEST_URL ? manifest : LABEL));
+  await addMarketplaceOp({ ...options, source: "https://example.test/catalog.json",
+    fetcher: async () => new Response(catalog) });
+  const cacheDir = join(options.pluginStorageRoot, "marketplaces", ".logo-cache");
+  const key = createHash("sha256").update(MANIFEST_URL).digest("hex").slice(0, 24);
+  const cache = join(cacheDir, `${key}.meta.json`);
+  const get = async () => (await buildMarketplaceCatalog({ ...options, fetcher }, "desktop")).marketplaces[0]!.plugins[0]!;
+  return { ...options, fetcher, get, cache, cacheDir };
+}
+
+describe("skill display metadata", () => {
+  it("parses English labels without treating body text or non-string values as labels", () => {
+    expect(skillDisplayNameFromMarkdown(LABEL)).toBe("Code Quality");
+    expect(skillDisplayNameFromMarkdown(LABEL.replaceAll("\n", "\r\n"))).toBe("Code Quality");
+    for (const body of ["# Skill\nname: Body text", "---\ndescription: Skill\n---\nname: Body text",
+      "---\nname: [invalid\n---\n", "---\nname: [list, value]\n---\n", "---\nname: 12\n---\n",
+      '---\nname: ""\n---\n']) expect(skillDisplayNameFromMarkdown(body)).toBeUndefined();
+    expect(normalizeSkillDisplayName(`  ${"A".repeat(100)}  `)).toBe("A".repeat(80));
+    expect(normalizeSkillDisplayName("bad\u0000label")).toBeUndefined();
+  });
+
+  it("carries labels from uninstalled pinned skills into reusable metadata without renaming the skill", async () => {
+    const fixture = await catalogFixture();
+    const first = await fixture.get();
+    expect(first.skills).toEqual([{ name: "calidad", displayName: "Code Quality", description: "Review source code." }]);
+    expect(first.source).toMatchObject({ sha: SHA, path: "plugins/forja" });
+    expect(fixture.fetcher.mock.calls.map(([url]) => url)).toEqual([MANIFEST_URL, SKILL_URL]);
+    const sidecar = JSON.parse(await readFile(fixture.cache, "utf8"));
+    expect(sidecar.cardMetadataVersion).toBe(1);
+    fixture.fetcher.mockClear();
+    expect((await fixture.get()).skills).toEqual(first.skills);
+    expect(fixture.fetcher).not.toHaveBeenCalled();
+  });
+
+  it("refreshes old sidecars at the same SHA, preserving old copy offline until a retry succeeds", async () => {
+    const fixture = await catalogFixture();
+    await mkdir(fixture.cacheDir, { recursive: true });
+    const old = { description: "Cached plugin", skills: [{ name: "calidad", description: "Old copy" }] };
+    await writeFile(fixture.cache, JSON.stringify(old));
+    fixture.fetcher.mockRejectedValueOnce(new Error("offline"));
+    expect((await fixture.get()).skills).toEqual(old.skills);
+    expect(JSON.parse(await readFile(fixture.cache, "utf8"))).toEqual(old);
+    expect((await fixture.get()).skills).toEqual([{ name: "calidad", displayName: "Code Quality", description: "Review source code." }]);
+    expect(JSON.parse(await readFile(fixture.cache, "utf8")).cardMetadataVersion).toBe(1);
+  });
+
+  it("does not permanently cache a failed skill fetch as current metadata", async () => {
+    const fixture = await catalogFixture();
+    fixture.fetcher.mockImplementationOnce(async () => new Response(JSON.stringify({ name: "forja", skills: ["./skills/calidad"] })));
+    fixture.fetcher.mockRejectedValueOnce(new Error("skill unavailable"));
+    expect((await fixture.get()).skills).toEqual([{ name: "calidad" }]);
+    expect(JSON.parse(await readFile(fixture.cache, "utf8")).cardMetadataVersion).toBeUndefined();
+    expect((await fixture.get()).skills?.[0]?.displayName).toBe("Code Quality");
+  });
+
+  it("keeps missing or invalid label fallbacks and bounds cached display values", async () => {
+    const fixture = await catalogFixture();
+    await mkdir(fixture.cacheDir, { recursive: true });
+    await writeFile(fixture.cache, JSON.stringify({ cardMetadataVersion: 1, skills: [
+      { name: "calidad", displayName: { forged: true } }, { name: "legacy" },
+      { name: "bounded", displayName: "X".repeat(200) },
+    ] }));
+    expect((await fixture.get()).skills).toEqual([
+      { name: "calidad" }, { name: "legacy" }, { name: "bounded", displayName: "X".repeat(80) },
+    ]);
+    expect(fixture.fetcher).not.toHaveBeenCalled();
+  });
+
+  it.each([{ skills: "./skills" }, { skills: ["./skills/calidad", "./skills/legacy"] }])("adds installed labels with declaration $skills while preserving identities and paths", async ({ skills }) => {
+    const options = await runtime();
+    const source = join(options.root, "source");
+    await mkdir(join(source, ".agenc-plugin"), { recursive: true });
+    await writeFile(join(source, ".agenc-plugin", "plugin.json"), JSON.stringify({ name: "forja", version: "1.0.0", skills }));
+    for (const [name, text] of [["calidad", LABEL], ["legacy", "---\ndescription: Legacy skill.\n---\n# Legacy\n"]]) {
+      await mkdir(join(source, "skills", name!), { recursive: true });
+      await writeFile(join(source, "skills", name!, "SKILL.md"), text!);
+    }
+    const installed = await installPluginOp({ ...options, source, name: "forja@labels", scope: "user" });
+    const result = await listInstalledPlugins(options);
+    expect(result.errors).toEqual([]);
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0]).toMatchObject({ id: "forja@labels", name: "forja", root: installed.destination,
+      skills: [{ name: "calidad", displayName: "Code Quality", description: "Review source code." },
+        { name: "legacy", description: "Legacy skill." }] });
+  });
+});

--- a/runtime/tests/skills/skills-cli.test.ts
+++ b/runtime/tests/skills/skills-cli.test.ts
@@ -102,6 +102,40 @@ describe("agenc skills CLI", () => {
     );
   });
 
+  it("exposes English display labels separately from stable skill names, roots, and plugin identity", async () => {
+    const agencHome = await mkdtemp(join(tmpdir(), "agenc-skills-label-home-"));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "agenc-skills-label-ws-"));
+    const pluginRoot = join(agencHome, "plugins", "forja");
+    await mkdir(join(pluginRoot, ".agenc-plugin"), { recursive: true });
+    await writeFile(join(pluginRoot, ".agenc-plugin", "plugin.json"), JSON.stringify({ name: "forja", skills: "./skills" }));
+    const roots = [
+      { root: join(pluginRoot, "skills"), name: "calidad", label: '"Code Quality"', origin: "plugin" },
+      { root: join(agencHome, "skills"), name: "notas", label: '"Notes"', origin: "personal" },
+      { root: join(agencHome, "skills"), name: "legacy", label: null, origin: "personal" },
+      { root: join(workspaceRoot, ".agenc", "skills"), name: "invalid", label: "123", origin: "project" },
+      { root: join(workspaceRoot, ".agenc", "skills"), name: "invalid-object", label: "{ label: invalid }", origin: "project" },
+    ];
+    for (const { root, name, label } of roots) {
+      await mkdir(join(root, name), { recursive: true });
+      await writeFile(join(root, name, "SKILL.md"), `---\n${label === null ? "" : `name: ${label}\n`}description: English description.\n---\n# English heading\n`);
+    }
+    await writeFile(join(agencHome, "config.toml"), "config_version = 2\n\n[plugins]\nenabled = true\n");
+    const inventory = await buildSkillsInventory({ agencHome, workspaceRoot,
+      pluginStorageRoot: join(agencHome, "plugins"), env: { AGENC_HOME: agencHome } });
+    const find = (origin: string, name: string) => inventory.skills.find(row => row.origin === origin && row.name === name);
+    expect(find("plugin", "calidad")).toMatchObject({ name: "calidad", displayName: "Code Quality", pluginRoot });
+    expect(find("personal", "notas")).toMatchObject({ name: "notas", displayName: "Notes" });
+    for (const { origin, name, root } of roots) {
+      const row = find(origin, name);
+      expect(row).toBeDefined();
+      expect(row?.root).toBe(root);
+      expect(row?.description).toBe("English description.");
+    }
+    expect(find("personal", "legacy")).not.toHaveProperty("displayName");
+    expect(find("project", "invalid")).not.toHaveProperty("displayName");
+    expect(find("project", "invalid-object")).not.toHaveProperty("displayName");
+  });
+
   it("reports roots holding more skills than the per-root cap", async () => {
     const agencHome = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cap-"));
     const workspaceRoot = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cap-ws-"));


### PR DESCRIPTION
## Summary

- Carry optional skill `displayName` separately from canonical names, IDs and paths through pinned catalog metadata, installed plugin summaries and the skills inventory.
- Read the existing SKILL.md frontmatter `name` as bounded display copy. Keep technical directory names unchanged; omit malformed/non-string labels.
- Refresh pre-label cached projections even at the same source SHA. Preserve offline fallback and retry incomplete skill fetches instead of permanently caching missing labels.

## Local validation

Private hosted CI is unavailable, so validation ran locally with Node 26.8.1:

- 19 focused catalog, installed metadata, inventory and fallback tests passed.
- 85 adjacent plugin registration, local skill loader and config migration tests passed.
- Runtime and test-support TypeScript checks passed.
- Production runtime build, package-entrypoint checks and generated SDK type checks passed.
- The compiled CLI installed the actual Forge, Quill and Olympus 0.2.4 payloads into a disposable home. Both `plugin list --json` and `skills list --json` returned Code Quality, Writing and Olympiad Practice while retaining calidad, escritura and olimpiada names and paths.
- Independent review found no remaining actionable issue.

No protocol version changes, runtime identity migrations, permission changes, application restarts or production-profile writes.
