### PR TITLE
fix(runtime): repair planning authority and interactive cancellation

### DIFF
--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -51,7 +51,8 @@ and searches remain available within the worker's read permissions.
 
 Constrained workers reject `git status` and `git diff`, which can invoke
 repository-configured conversion filters. Object-only Git inspection is
-available when no read-path denial applies; Git objects can otherwise reveal
+available only when the original filesystem authority permits unrestricted
+reads and no read-path denial applies. Git objects can otherwise reveal
 denied file contents. PDF reads that require an external converter are also
 unavailable to these workers. These restrictions do not change ordinary
 coding or verification workers.

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -33,6 +33,34 @@ in `runtime/src/bin/model-facing-tools.ts`, not inside `v2/index.ts`.
 | `show_csv_job_review` | Read one bounded review record |
 | `resolve_csv_job_review` | Approval-gated operator resolution with canonical evidence |
 
+### Read-only planning workers
+
+Plan mode can spawn workers with `isolation: "none"`. AgenC assigns those
+workers a permanent read-only constraint, regardless of the requested role.
+The built-in `Plan` and `scanner` roles have that constraint in every mode.
+Their descendants inherit it, including after reconnect or restoration.
+
+Constrained workers can read and search files, run supported literal
+inspection commands, and coordinate their own constrained descendants. They
+cannot edit files, create worktrees, schedule work, request wider permissions,
+or direct writable workers. Shell inspection uses direct arguments, a
+sanitized environment, and required read-only process isolation with network
+access disabled. If that isolation is unavailable, the command is refused.
+Constrained shell inspection is unavailable on Windows; native file reads
+and searches remain available within the worker's read permissions.
+
+Constrained workers reject `git status` and `git diff`, which can invoke
+repository-configured conversion filters. Object-only Git inspection is
+available when no read-path denial applies; Git objects can otherwise reveal
+denied file contents. PDF reads that require an external converter are also
+unavailable to these workers. These restrictions do not change ordinary
+coding or verification workers.
+
+Changing the parent to YOLO does not make existing planning workers writable.
+Spawn a new coding or verification worker after leaving plan mode when the
+task requires edits, builds, or tests. Ordinary workers keep the parent's
+authorized permission behavior.
+
 ### CSV job contract
 
 CSV fan-out keeps three identities separate. A configured `source_id` is exact
@@ -203,11 +231,13 @@ prompt; consumed or indeterminate outcomes are not duplicated. Per model
 turn, agent projection is capped at 32 records / 128 KiB. Oversized first
 records are visibly truncated for forward progress; only deferred triggers
 schedule autonomous follow-up turns, while passive context waits for the next
-human/root turn. A user Stop holds even the deferred triggers: until the user
+human/root turn. A user Stop or explicit approval denial holds deferred
+triggers: until the user
 speaks again, a child receipt stays in the mailbox instead of starting a parent
 turn, so stopping a turn does not let its verifiers resume it. Only a message
 the daemon admits counts as speaking again; a prompt refused while the stop is
-still unwinding leaves the hold in place.
+still unwinding leaves the hold in place. The hold survives session recovery;
+queued child receipts cannot clear it or restart the denied turn.
 
 `wait_agent` drains all currently delivered updates, not one named worker. It
 is therefore mutating and intentionally has no target filter. Use

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -767,6 +767,10 @@ approval and denial commands. A pending request is not a grant.
 `--scope once` approves only that request. Broader scopes require an explicit
 operator choice. Use the listed owner run ID for `--session` when approving or
 revoking a child request; the child's session ID is shown for identification.
+Conversation owner IDs (`conv-*`) resolve consistently for list, approve, and
+revoke. Workflow owner IDs (`wf-*`) remain scoped to their workflow.
+`--reason` carries denial feedback to the requesting turn. It does not change
+the denial classification or grant permission to retry.
 
 ```bash
 agenc permissions list

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -395,6 +395,15 @@ current session and workspace; it does not write durable consent. The
 `--dangerously-bypass-approvals-and-sandbox` flag is the separate combined
 escape hatch for bypassed prompts and `danger-full-access`.
 
+Neither bypass setting removes a planning worker's permanent read-only
+constraint. See [read-only planning workers](agents.md#read-only-planning-workers).
+Normal coding and verification workers retain the configured bypass behavior.
+
+Shell tools reject deterministically invalid commands before asking for
+approval and recheck the command before execution. Approval cannot override
+protected-path or shell-write-policy refusals. Operations that need ordinary
+workspace deletion approval still use the configured permission mode.
+
 **Internal-only** (valid runtime state, not CLI defaults):
 
 | Mode | Intent |
@@ -403,8 +412,9 @@ escape hatch for bypassed prompts and `danger-full-access`.
 | `bubble` | Nested/child contexts that bubble denials to the parent |
 
 The daemon permission overlay classifies low / medium / destructive requests.
-Destructive requests require typed confirmation; low/medium use engine
-allow/reject callbacks and `confirm:yes` keybinding shortcuts.
+Destructive requests require typed confirmation. For low/medium requests,
+Enter applies the selected row, including deny or session approval. The
+explicit yes/no shortcuts remain available.
 
 ### Interactive tool prompts
 

--- a/runtime/scripts/check-tui-e2e/scenarios/137-escape-blocking-shell.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/137-escape-blocking-shell.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+export const meta = {
+  description: "Escape stops a foreground command and its descendant before yielding, then the same session accepts another turn.",
+  timeoutMs: 75_000,
+  slimCwd: true,
+  sandboxMode: "danger-full-access",
+  args: ["--provider", "grok", "--model", "grok-4.6", "--dangerously-bypass-approvals-and-sandbox"],
+  skip: process.platform === "linux" ? undefined : "Linux process identity verification requires /proc.",
+};
+
+function shellQuote(value) {
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+async function ownedProcessAlive(processId, marker) {
+  if (!Number.isInteger(processId) || processId < 2) return false;
+  try {
+    const [command, stat] = await Promise.all([
+      readFile(`/proc/${processId}/cmdline`, "utf8"),
+      readFile(`/proc/${processId}/stat`, "utf8"),
+    ]);
+    return command.includes(marker) && stat.slice(stat.lastIndexOf(")") + 2, stat.lastIndexOf(")") + 3) !== "Z";
+  } catch (error) {
+    if (error.code === "ENOENT" || error.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function waitForCheck(session, check, timeout, label) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    session.throwIfAborted();
+    if (await check()) return;
+    await delay(50);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+export default async function (session) {
+  const probePath = path.join(session.cwd, "agenc-blocking-shell-probe.cjs");
+  const readyPath = path.join(session.cwd, "agenc-blocking-shell-ready.json");
+  const childSource = `process.send('ready'); setInterval(() => {}, 1000); setTimeout(() => process.exit(0), 60000); void ${JSON.stringify(probePath)};`;
+  await writeFile(probePath, [
+    `const { spawn } = require('node:child_process');`,
+    `const { writeFileSync } = require('node:fs');`,
+    `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childSource)}], { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });`,
+    `child.once('message', () => writeFileSync(${JSON.stringify(readyPath)}, JSON.stringify({ parent: process.pid, descendant: child.pid })));`,
+    `setInterval(() => {}, 1000);`,
+    `setTimeout(() => { child.kill(); process.exit(0); }, 60000);`,
+  ].join("\n"), "utf8");
+  let dispatched = false;
+  let processIds;
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404).end();
+        return;
+      }
+      const chunks = [];
+      for await (const chunk of request) chunks.push(chunk);
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      const firstToolCall = body.stream === true && !dispatched;
+      const output = firstToolCall
+        ? [{
+            type: "function_call", id: "fc_blocking_shell", call_id: "call_blocking_shell",
+            name: "exec_command", status: "completed",
+            arguments: JSON.stringify({ cmd: `${shellQuote(process.execPath)} ${shellQuote(probePath)}`, yield_time_ms: 30000, timeoutMs: 60000, max_output_tokens: 1000 }),
+          }]
+        : [{
+            type: "message", id: "msg_shell_recovery", role: "assistant", status: "completed",
+            content: [{ type: "output_text", text: body.stream === true ? "SCRIPTED_SHELL_ESCAPE_RECOVERY_OK" : "OK", annotations: [] }],
+          }];
+      const result = {
+        id: firstToolCall ? "resp_blocking_shell" : "resp_shell_recovery", object: "response",
+        created_at: Math.floor(Date.now() / 1000), status: "completed", model: body.model, output,
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      };
+      if (body.stream !== true) {
+        response.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify(result));
+        return;
+      }
+      const events = [];
+      if (firstToolCall) {
+        dispatched = true;
+        events.push({ type: "response.output_item.added", output_index: 0, item: output[0] });
+        events.push({ type: "response.output_item.done", output_index: 0, item: output[0] });
+      }
+      events.push({ type: "response.completed", response: result });
+      response.writeHead(200, { "Content-Type": "text/event-stream" });
+      response.end(events.map(event => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n");
+    } catch (error) {
+      response.destroy(error);
+    }
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    Object.assign(session.envOverrides, {
+      AGENC_PROVIDER: "grok", AGENC_MODEL: "grok-4.6", AGENC_MAX_OUTPUT_TOKENS: "4096",
+      GROK_AUTH_MODE: "api-key", XAI_API_KEY: "local-inert-shell-key",
+      XAI_BASE_URL: `http://127.0.0.1:${address.port}/v1`, AGENC_AUTH_MANAGED_KEYS_ENABLED: "0",
+    });
+    await session.start();
+    await session.waitForPrompt({ timeout: 15_000 });
+    await session.submit("Run the blocking shell fixture and wait for completion.");
+    await waitForCheck(session, async () => {
+      try {
+        processIds = JSON.parse(await readFile(readyPath, "utf8"));
+        return await ownedProcessAlive(processIds.parent, probePath) && await ownedProcessAlive(processIds.descendant, probePath);
+      } catch (error) {
+        if (error.code === "ENOENT") return false;
+        throw error;
+      }
+    }, 15_000, "foreground command and descendant readiness");
+    const before = (await session.readRolloutItems()).filter(item => item.type === "event_msg").map(item => item.payload.msg);
+    assert.equal(before.filter(event => event.type === "turn_complete").length, 0, "The shell already yielded or completed before Escape");
+    const cancelledAt = Date.now();
+    session.sendEscape();
+    await waitForCheck(session, async () => !(await ownedProcessAlive(processIds.parent, probePath)) && !(await ownedProcessAlive(processIds.descendant, probePath)), 7_000, "cancelled command process tree");
+    assert.ok(Date.now() - cancelledAt < 7_000);
+    await waitForCheck(session, async () => (await session.readRolloutItems()).some(item => item.type === "event_msg" && item.payload.msg.type === "turn_aborted"), 5_000, "durable turn cancellation");
+    await session.waitForIdle({ idleWindow: 1_000, timeout: 5_000 });
+    await session.submit("Reply after the cancelled shell command.");
+    await session.waitFor(/SCRIPTED_SHELL_ESCAPE_RECOVERY_OK/u, { timeout: 15_000 });
+    await session.waitForIdle({ idleWindow: 1_000, timeout: 5_000 });
+    const events = (await session.readRolloutItems()).filter(item => item.type === "event_msg").map(item => item.payload.msg);
+    assert.equal(events.filter(event => event.type === "turn_started").length, 2);
+    assert.equal(events.filter(event => event.type === "turn_aborted").length, 1);
+    assert.equal(events.find(event => event.type === "turn_aborted").payload.reason, "interrupted");
+    assert.equal(events.filter(event => event.type === "turn_complete").length, 1);
+  } finally {
+    for (const processId of [processIds?.descendant, processIds?.parent]) {
+      if (await ownedProcessAlive(processId, probePath)) process.kill(processId, "SIGKILL");
+    }
+    server.closeAllConnections();
+    await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  }
+}

--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -33,6 +33,7 @@
  */
 
 import { emitError, emitWarning } from "../session/event-log.js";
+import { childReadOnlyDelegation, normalizeReadOnlyDelegationConstraint } from "./readonly-delegation.js";
 import type { LLMMessage, LLMUsage } from "../llm/types.js";
 import { assertAgentInvocationChannelMessage } from "../contracts/agent-invocation-envelope.js";
 import type { ThreadSpawnEdgeStatus } from "../session/rollout-store.js";
@@ -418,7 +419,7 @@ export class AgentControl {
   assertAgentMetadataRoleWorkspace(
     metadata: Pick<
       AgentMetadata,
-      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint" | "executionConstraint"
     >,
   ): string {
     const normalized = normalizeAgentRoleMetadata(metadata);
@@ -463,7 +464,7 @@ export class AgentControl {
     /** Fail-closed role identity for restart/rehydration spawns. */
     readonly expectedRoleProvenance?: Pick<
       AgentMetadata,
-      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint" | "executionConstraint"
     >;
   }): Promise<LiveAgent> {
     if (this.threadManager) {
@@ -484,7 +485,7 @@ export class AgentControl {
     readonly capacityOwnerId?: string;
     readonly expectedRoleProvenance?: Pick<
       AgentMetadata,
-      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+      "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint" | "executionConstraint"
     >;
   }): Promise<LiveAgent> {
     const parentDepth = depthOfAgentPath(opts.parentPath);
@@ -516,6 +517,17 @@ export class AgentControl {
     const baseChildConfig = getChildBaseConfig(this.session) ?? {};
     void applyRoleToConfig(role, baseChildConfig);
     const roleFingerprint = this.roleCatalog.fingerprint(role);
+    const parentMetadata = this.registry.agentMetadataForThread(
+      this.registry.agentIdForPath(opts.parentPath) ?? this.session.conversationId,
+    );
+    const restoredConstraint = normalizeReadOnlyDelegationConstraint(
+      opts.expectedRoleProvenance?.executionConstraint,
+    );
+    const executionConstraint = childReadOnlyDelegation(
+      this.session,
+      role,
+      restoredConstraint ?? parentMetadata?.executionConstraint,
+    );
     if (
       expectedRoleProvenance !== undefined &&
       roleFingerprint !== expectedRoleProvenance.agentRoleFingerprint
@@ -657,6 +669,7 @@ export class AgentControl {
         role,
         roleWorkspaceId: this.roleWorkspace.id,
         roleFingerprint,
+        ...(executionConstraint !== undefined ? { executionConstraint } : {}),
         nickname,
         depth: childDepth,
         ...(opts.agentName !== undefined ? { agentName: opts.agentName } : {}),
@@ -976,7 +989,7 @@ export class AgentControl {
         spawnOpts as {
           expectedRoleProvenance?: Pick<
             AgentMetadata,
-            "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint"
+            "agentRole" | "agentRoleWorkspaceId" | "agentRoleFingerprint" | "executionConstraint"
           >;
         }
       ).expectedRoleProvenance = options.metadata;
@@ -2378,6 +2391,8 @@ function assertSameAgentIdentity(
       normalizedActual.agentRoleWorkspaceId ||
     normalizedExpected.agentRoleFingerprint !==
       normalizedActual.agentRoleFingerprint ||
+    JSON.stringify(normalizedExpected.executionConstraint) !==
+      JSON.stringify(normalizedActual.executionConstraint) ||
     normalizedExpected.depth !== normalizedActual.depth
   ) {
     throw new InvalidAgentMetadataError(

--- a/runtime/src/agents/delegate.ts
+++ b/runtime/src/agents/delegate.ts
@@ -17,6 +17,7 @@
  */
 
 import type { Session } from "../session/session.js";
+import { childReadOnlyDelegation } from "./readonly-delegation.js";
 import type { ToolEffectDispositionEvidence } from "../contracts/run-contracts.js";
 import type { LLMMessage } from "../llm/types.js";
 import type { LLMContentPart } from "../llm/types.js";
@@ -185,6 +186,20 @@ export async function delegate(opts: DelegateOpts): Promise<DelegateOutcome> {
       "INVALID_DELEGATE_REQUEST",
       "invalid_request",
       "worktree isolation requires a non-empty worktreeSlug",
+    );
+  }
+
+  const parentThreadId = opts.registry.agentIdForPath?.(opts.parentPath);
+  const readOnlyConstraint = childReadOnlyDelegation(
+    opts.parent,
+    opts.control.roleCatalog?.require(opts.role),
+    parentThreadId === undefined ? undefined : opts.registry.agentMetadataForThread?.(parentThreadId)?.executionConstraint,
+  );
+  if (readOnlyConstraint !== undefined && isolation === "worktree") {
+    return reject(
+      "INVALID_DELEGATE_REQUEST",
+      "invalid_request",
+      "Read-only delegation cannot create a worktree. Use isolation none.",
     );
   }
 

--- a/runtime/src/agents/readonly-delegation.ts
+++ b/runtime/src/agents/readonly-delegation.ts
@@ -6,7 +6,8 @@ import { expandTilde, isPathAllowed, matchPathRuleContent } from "../permissions
 import { hasTrustedBuiltinImplementation } from "../tools/builtin-provenance.js";
 import { resolve } from "node:path";
 import { getDenyRuleForTool, getRuleByContentsForTool, findMatchingContentRule } from "../permissions/rules.js";
-import { canReadPathWithCwd } from "../sandbox/engine/index.js";
+import { canReadPathWithCwd, hasFullDiskReadAccess } from "../sandbox/engine/index.js";
+import { permissionProfileForSandboxMode } from "../tools/runtimes/sandboxing.js";
 import { isDirectExecEligible, lexShellCommand } from "../utils/shell/command-line.js";
 
 const COORDINATION_TOOLS = new Set(["spawn_agent", "list_agents", "wait_agent", "close_agent", "send_message", "assign_task"]);
@@ -52,6 +53,14 @@ export function readOnlyDelegationDeniedReadPatterns(session: Session): readonly
   ))];
 }
 
+function readOnlyGitObjectsHaveReadAuthority(session: Session): boolean {
+  const broker = session.services.sandboxExecutionBroker;
+  const authority = broker?.executionAuthority?.();
+  if (broker === undefined || authority === undefined) return false;
+  const profile = authority.permissionProfile ?? permissionProfileForSandboxMode(authority.mode, { cwd: broker.cwd });
+  return profile.fileSystem.kind !== "external_sandbox" && hasFullDiskReadAccess(profile.fileSystem);
+}
+
 export function readOnlyDelegationToolRefusal(
   session: Session,
   tool: ReadOnlyDelegationTool,
@@ -78,7 +87,7 @@ export function readOnlyDelegationToolRefusal(
   if (tool.name === "exec_command" || tool.name === "system.bash") {
     const result = inspectReadOnlyCommand(tool.name, input, session.sessionConfiguration.cwd);
     if (!result.allowed) return result.reason;
-    if (result.invocation.command === "git" && readOnlyDelegationDeniedReadPatterns(session).length > 0) return "Read-only Git inspection cannot enforce file-path denials over repository objects. Use authorized native file reads and searches.";
+    if (result.invocation.command === "git" && (readOnlyDelegationDeniedReadPatterns(session).length > 0 || !readOnlyGitObjectsHaveReadAuthority(session))) return "Read-only Git inspection cannot enforce filesystem read restrictions over repository objects. Use authorized native file reads and searches.";
     const command = tool.name === "exec_command" ? args.cmd : args.command;
     const commandRules = getRuleByContentsForTool(inheritedContext, tool.name, "deny");
     const literalCommand = [result.invocation.command, ...result.invocation.args].join(" ");

--- a/runtime/src/agents/readonly-delegation.ts
+++ b/runtime/src/agents/readonly-delegation.ts
@@ -1,0 +1,169 @@
+import type { Session } from "../session/session.js";
+import type { AgentRole } from "./role.js";
+import type { AgentMetadata } from "./registry.js";
+import { inspectReadOnlyCommand } from "../permissions/readonly-inspection.js";
+import { expandTilde, isPathAllowed, matchPathRuleContent } from "../permissions/path-validation.js";
+import { hasTrustedBuiltinImplementation } from "../tools/builtin-provenance.js";
+import { resolve } from "node:path";
+import { getDenyRuleForTool, getRuleByContentsForTool, findMatchingContentRule } from "../permissions/rules.js";
+import { canReadPathWithCwd } from "../sandbox/engine/index.js";
+import { isDirectExecEligible, lexShellCommand } from "../utils/shell/command-line.js";
+
+const COORDINATION_TOOLS = new Set(["spawn_agent", "list_agents", "wait_agent", "close_agent", "send_message", "assign_task"]);
+const NATIVE_INSPECTION_TOOLS = new Set(["FileRead", "Glob", "Grep", "system.searchTools"]);
+
+export interface ReadOnlyDelegationTool {
+  readonly name: string;
+  readonly execute?: unknown;
+  readonly metadata?: { readonly source?: string; readonly mutating?: boolean };
+}
+
+export function isReadOnlyCoordinationTool(tool: ReadOnlyDelegationTool): boolean {
+  return hasTrustedBuiltinImplementation(tool) && COORDINATION_TOOLS.has(tool.name);
+}
+
+export function isReadOnlyCoordinationName(name: string): boolean {
+  return COORDINATION_TOOLS.has(name);
+}
+
+export function readOnlyDelegationToolAvailable(tool: ReadOnlyDelegationTool): boolean {
+  return hasTrustedBuiltinImplementation(tool) && (
+    COORDINATION_TOOLS.has(tool.name) || NATIVE_INSPECTION_TOOLS.has(tool.name) ||
+    ["exec_command", "system.bash", "write_stdin", "kill_process"].includes(tool.name)
+  );
+}
+
+export function readOnlyDelegationPathAllowed(session: Session, target: string): boolean {
+  const resolved = resolve(session.sessionConfiguration.cwd, target);
+  const currentContext = session.permissionModeRegistry.current();
+  const inheritedContext = { ...currentContext, alwaysDenyRules: { session: session.services.readOnlyDelegation?.deniedRules ?? [] } };
+  const broker = session.services.sandboxExecutionBroker;
+  const profile = broker?.executionAuthority?.().permissionProfile;
+  if (profile?.fileSystem.entries.some((entry) => entry.access === "none" && entry.path.kind === "glob" && matchPathRuleContent(resolve(broker!.cwd, entry.path.pattern), resolved))) return false;
+  return (profile === undefined || canReadPathWithCwd(profile.fileSystem, resolved, broker!.cwd, broker!.sessionTempRoot)) &&
+    [currentContext, inheritedContext].every((context) => isPathAllowed(resolved, context, "read", session.sessionConfiguration.cwd).allowed);
+}
+
+export function readOnlyDelegationDeniedReadPatterns(session: Session): readonly string[] {
+  const currentContext = session.permissionModeRegistry.current();
+  const inheritedContext = { ...currentContext, alwaysDenyRules: { session: session.services.readOnlyDelegation?.deniedRules ?? [] } };
+  return [...new Set([currentContext, inheritedContext].flatMap((context) =>
+    ["FileRead", "Read"].flatMap((name) => [...getRuleByContentsForTool(context, name, "deny").keys()].map((pattern) => resolve(session.sessionConfiguration.cwd, expandTilde(pattern)))),
+  ))];
+}
+
+export function readOnlyDelegationToolRefusal(
+  session: Session,
+  tool: ReadOnlyDelegationTool,
+  input: unknown,
+): string | undefined {
+  if (sessionReadOnlyDelegation(session) === undefined) return undefined;
+  if (!readOnlyDelegationToolAvailable(tool)) return `Read-only delegation cannot use ${tool.name}. Report findings without changing the project or external state.`;
+  const args = input !== null && typeof input === "object" && !Array.isArray(input) ? input as Record<string, unknown> : {};
+  const currentContext = session.permissionModeRegistry.current();
+  const inheritedContext = {
+    ...currentContext,
+    alwaysDenyRules: { session: session.services.readOnlyDelegation?.deniedRules ?? [] },
+  };
+  if (getDenyRuleForTool(inheritedContext, tool.name) !== null) return "Read-only delegation retains the parent's original tool denial.";
+  if (args.sandbox_permissions === "require_escalated" || args.additional_permissions !== undefined) return "Read-only delegation cannot request wider execution permissions.";
+  if (tool.name === "spawn_agent" && args.isolation !== undefined && args.isolation !== "none") return "Read-only delegation cannot create a worktree. Use isolation none.";
+  if (tool.name === "write_stdin" && args.chars !== undefined && args.chars !== "") return "Read-only delegation may poll its command, but cannot send interactive input.";
+  if (NATIVE_INSPECTION_TOOLS.has(tool.name)) {
+    const pathInput = tool.name === "FileRead" ? args.file_path : args.path ?? args.cwd;
+    if (typeof pathInput === "string" && !readOnlyDelegationPathAllowed(session, pathInput)) {
+      return "Read-only delegation cannot read the requested path.";
+    }
+  }
+  if (tool.name === "exec_command" || tool.name === "system.bash") {
+    const result = inspectReadOnlyCommand(tool.name, input, session.sessionConfiguration.cwd);
+    if (!result.allowed) return result.reason;
+    if (result.invocation.command === "git" && readOnlyDelegationDeniedReadPatterns(session).length > 0) return "Read-only Git inspection cannot enforce file-path denials over repository objects. Use authorized native file reads and searches.";
+    const command = tool.name === "exec_command" ? args.cmd : args.command;
+    const commandRules = getRuleByContentsForTool(inheritedContext, tool.name, "deny");
+    const literalCommand = [result.invocation.command, ...result.invocation.args].join(" ");
+    const literalRuleMatches = [...commandRules.keys()].some((content) => {
+      const parsed = lexShellCommand(content);
+      return isDirectExecEligible(parsed) && parsed.tokens.map((token) => token.value).join(" ") === literalCommand;
+    });
+    if (literalRuleMatches || [command, literalCommand].some((candidate) => typeof candidate === "string" && findMatchingContentRule(commandRules, candidate) !== null)) return "Read-only delegation retains the parent's original command denial.";
+    for (const target of result.invocation.readPaths) {
+      if (!readOnlyDelegationPathAllowed(session, target)) return `Read-only inspection cannot read ${target}.`;
+    }
+  }
+  return undefined;
+}
+
+export interface ReadOnlyDelegationConstraint {
+  readonly kind: "read-only";
+  readonly ownerThreadId: string;
+  readonly deniedRules?: readonly string[];
+}
+
+export function normalizeReadOnlyDelegationConstraint(
+  input: unknown,
+): ReadOnlyDelegationConstraint | undefined {
+  if (input === undefined) return undefined;
+  if (
+    input === null || typeof input !== "object" || Array.isArray(input) ||
+    Object.keys(input).some((key) => key !== "kind" && key !== "ownerThreadId" && key !== "deniedRules")
+  ) {
+    throw new TypeError("invalid agent execution constraint");
+  }
+  const value = input as Record<string, unknown>;
+  if (
+    value.kind !== "read-only" || typeof value.ownerThreadId !== "string" ||
+    value.ownerThreadId.trim().length === 0 || value.ownerThreadId.length > 512 ||
+    /[\u0000-\u001f\u007f]/u.test(value.ownerThreadId)
+  ) {
+    throw new TypeError("invalid agent execution constraint");
+  }
+  if (value.deniedRules !== undefined && (!Array.isArray(value.deniedRules) || value.deniedRules.length > 4096 || value.deniedRules.some((rule) => typeof rule !== "string" || rule.length > 32_768))) {
+    throw new TypeError("invalid agent execution constraint denied rules");
+  }
+  return Object.freeze({ kind: "read-only", ownerThreadId: value.ownerThreadId, ...(value.deniedRules !== undefined ? { deniedRules: Object.freeze([...(value.deniedRules as string[])]) } : {}) });
+}
+
+export function sessionReadOnlyDelegation(
+  session: Session | null | undefined,
+): ReadOnlyDelegationConstraint | undefined {
+  return session?.services?.readOnlyDelegation;
+}
+
+export function sessionIsPlanning(session: Session | null | undefined): boolean {
+  return session?.permissionModeRegistry?.current?.().mode === "plan";
+}
+
+export function childReadOnlyDelegation(
+  session: Session,
+  role: AgentRole | undefined,
+  inherited?: ReadOnlyDelegationConstraint,
+): ReadOnlyDelegationConstraint | undefined {
+  const existing = inherited ?? sessionReadOnlyDelegation(session);
+  if (existing !== undefined) return normalizeReadOnlyDelegationConstraint(existing);
+  if (!sessionIsPlanning(session) && role?.config.executionConstraint !== "read-only") {
+    return undefined;
+  }
+  return Object.freeze({ kind: "read-only", ownerThreadId: session.conversationId, deniedRules: Object.freeze(Object.values(session.permissionModeRegistry?.current?.().alwaysDenyRules ?? {}).flat()) });
+}
+
+export function readOnlyCoordinationRefusal(
+  session: Session,
+  senderPath: string,
+  target: AgentMetadata | undefined,
+  senderConstraint?: ReadOnlyDelegationConstraint,
+): string | undefined {
+  const constraint = senderConstraint ?? sessionReadOnlyDelegation(session);
+  if (constraint === undefined && !sessionIsPlanning(session)) return undefined;
+  const ownerThreadId = constraint?.ownerThreadId ?? session.conversationId;
+  if (
+    target?.executionConstraint?.ownerThreadId !== ownerThreadId ||
+    !target.agentPath?.startsWith(`${senderPath}/`)
+  ) {
+    return "Read-only delegation can control only its own constrained descendants. It cannot direct writable workers or another agent subtree.";
+  }
+  return undefined;
+}
+
+export const READ_ONLY_DELEGATION_PROMPT =
+  "This worker has permanent read-only execution authority. Read and inspect the assigned project and report findings in your final answer. Do not edit files, create worktrees, run builds or tests that write output, schedule work, request wider permissions, or leave plan mode. A later parent mode change does not remove this restriction. Use native read/search tools or one literal supported inspection command per shell call. Shell profiles, expansion, redirection, pipelines, scripts, and interactive input are unavailable.";

--- a/runtime/src/agents/registry.ts
+++ b/runtime/src/agents/registry.ts
@@ -20,6 +20,10 @@
 
 import { AsyncLock } from "./_deps/async-lock.js";
 import {
+  normalizeReadOnlyDelegationConstraint,
+  type ReadOnlyDelegationConstraint,
+} from "./readonly-delegation.js";
+import {
   defaultAgentNicknameCandidates,
   formatNicknameWithSuffix,
   type AgentRole,
@@ -36,6 +40,7 @@ export const ROOT_AGENT_PATH = "/root" as AgentPath;
 export const MEMORY_AGENT_PATH = "/morpheus" as AgentPath;
 
 export interface AgentMetadata {
+  readonly executionConstraint?: ReadOnlyDelegationConstraint;
   readonly agentId?: ThreadId;
   readonly agentPath?: AgentPath;
   readonly agentNickname?: string;
@@ -111,6 +116,7 @@ export function normalizeAgentMetadata(metadata: unknown): AgentMetadata {
     throw new InvalidAgentMetadataError("invalid agent metadata depth");
   }
   const roleMetadata = normalizeAgentRoleMetadata(record);
+  const executionConstraint = normalizeReadOnlyDelegationConstraint(record.executionConstraint);
   const agentId = optionalMetadataString(record.agentId, "agentId", true);
   const agentPath = optionalMetadataString(record.agentPath, "agentPath", true);
   const agentNickname = optionalMetadataString(
@@ -125,6 +131,7 @@ export function normalizeAgentMetadata(metadata: unknown): AgentMetadata {
   );
   return {
     depth: record.depth,
+    ...(executionConstraint !== undefined ? { executionConstraint } : {}),
     ...(agentId !== undefined ? { agentId } : {}),
     ...(agentPath !== undefined ? { agentPath } : {}),
     ...(agentNickname !== undefined ? { agentNickname } : {}),
@@ -824,6 +831,7 @@ export function buildChildMetadata(opts: {
   readonly roleFingerprint: string;
   readonly nickname: string;
   readonly depth: number;
+  readonly executionConstraint?: ReadOnlyDelegationConstraint;
   readonly agentName?: string;
   readonly agentPath?: AgentPath;
 }): AgentMetadata {
@@ -841,6 +849,9 @@ export function buildChildMetadata(opts: {
     agentRole: opts.role.name,
     agentRoleWorkspaceId: opts.roleWorkspaceId,
     agentRoleFingerprint: opts.roleFingerprint,
+    ...(opts.executionConstraint !== undefined
+      ? { executionConstraint: normalizeReadOnlyDelegationConstraint(opts.executionConstraint) }
+      : {}),
     depth: opts.depth,
   };
 }

--- a/runtime/src/agents/role.ts
+++ b/runtime/src/agents/role.ts
@@ -71,6 +71,7 @@ export type AgentReasoningEffort =
   | "xhigh";
 
 export interface AgentRoleConfig {
+  readonly executionConstraint?: "read-only";
   readonly description?: string;
   /** AgenC-shaped role layer file. Built-ins resolve against embedded
    *  TOML content; user-defined roles read the path from disk. */
@@ -315,6 +316,7 @@ const SCANNER_ROLE: AgentRole = freezeRole({
   source: "built-in",
   config: {
     description: SCANNER_DESCRIPTION,
+    executionConstraint: "read-only",
     configFile: "scanner.toml",
     systemPrompt: SCANNER_SYSTEM_PROMPT,
     disallowlist: BUILTIN_READONLY_DISALLOWLIST,
@@ -335,6 +337,7 @@ const PLAN_ROLE: AgentRole = freezeRole({
   source: "built-in",
   config: {
     description: PLAN_WHEN_TO_USE,
+    executionConstraint: "read-only",
     systemPrompt: PLAN_SYSTEM_PROMPT,
     disallowlist: BUILTIN_READONLY_DISALLOWLIST,
   },

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -3800,9 +3800,12 @@ export async function* runAgent(
           : {}),
         ...(live.role.config.systemPrompt || live.metadata.executionConstraint !== undefined
           ? {
-              systemPrompt: live.metadata.executionConstraint !== undefined
-                ? READ_ONLY_DELEGATION_PROMPT
-                : live.role.config.systemPrompt,
+              systemPrompt: [
+                live.role.config.systemPrompt,
+                live.metadata.executionConstraint !== undefined
+                  ? READ_ONLY_DELEGATION_PROMPT
+                  : undefined,
+              ].filter(Boolean).join("\n\n"),
               systemPromptTrust: "workspace_role" as const,
             }
           : {}),

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -18,6 +18,8 @@
  */
 
 import { normalize } from "node:path";
+import { inheritBuiltinToolProvenance } from "../tools/builtin-provenance.js";
+import { attachReadOnlyDelegationReadGuard } from "../permissions/readonly-read-guard.js";
 import { LRUCache } from "lru-cache";
 import { registerChildApprovalSession, revokeChildApprovalSession } from "./child-approval-context.js";
 import { createInertMcpManager } from "../mcp-client/inert-manager.js";
@@ -43,6 +45,20 @@ import {
   readProviderIdentity,
 } from "../llm/provider.js";
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
+import {
+  isReadOnlyCoordinationTool,
+  readOnlyDelegationToolAvailable,
+  readOnlyDelegationToolRefusal,
+  readOnlyDelegationPathAllowed,
+  readOnlyDelegationDeniedReadPatterns,
+  READ_ONLY_DELEGATION_PROMPT,
+  type ReadOnlyDelegationConstraint,
+} from "./readonly-delegation.js";
+import {
+  attachReadOnlyInspectionInvocation,
+  inspectReadOnlyCommand,
+  prepareReadOnlyInspectionInvocation,
+} from "../permissions/readonly-inspection.js";
 import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
 import {
   toRuntimeTools,
@@ -129,6 +145,8 @@ import { disposeSandboxExecutionBroker } from "../sandbox/execution-lifecycle.js
 import { runAdmittedToolCall } from "../budget/admitted-tool-call.js";
 import { AdmissionDeniedError } from "../budget/admission-client.js";
 import type { AssistantOutputStreamSink } from "../contracts/assistant-output-stream.js";
+
+const inspectionBrokers = new WeakMap<Session, Map<string, SandboxExecutionBrokerLike>>();
 
 // ─────────────────────────────────────────────────────────────────────
 // Types
@@ -1565,6 +1583,7 @@ interface ParentFollowupState {
   transientFailureCount: number;
   transientFailureWarningReported: boolean;
   lastAuthor: string;
+  readonly generation: number;
 }
 
 const followupTurnStateByParent = new WeakMap<Session, ParentFollowupState>();
@@ -1593,7 +1612,10 @@ function requestParentFollowupTurn(params: {
   // parent context. Defer the submit by a short window so clustered
   // completions drain together in a single turn.
   const existing = followupTurnStateByParent.get(parent);
-  if (existing !== undefined) {
+  if (existing !== undefined && existing.generation !== parent.userStopGeneration) {
+    if (existing.timer !== null) clearTimeout(existing.timer);
+    followupTurnStateByParent.delete(parent);
+  } else if (existing !== undefined) {
     existing.lastAuthor = params.live.agentPath;
     // Requests that arrive inside the coalescing window are already covered by
     // the pending submit, which drains the entire burst. Only a receipt that
@@ -1611,20 +1633,24 @@ function requestParentFollowupTurn(params: {
     transientFailureCount: 0,
     transientFailureWarningReported: false,
     lastAuthor: params.live.agentPath,
+    generation: parent.userStopGeneration,
   };
   const schedule = (delayMs = PARENT_FOLLOWUP_COALESCE_MS): void => {
     state.timer = setTimeout(() => {
       state.timer = null;
+      if (followupTurnStateByParent.get(parent) !== state) return;
       // A stop that landed inside the coalescing window holds the burst too.
-      if (parent.stoppedByUserSinceLastPrompt === true) {
+      if (parent.stoppedByUserSinceLastPrompt === true || state.generation !== parent.userStopGeneration) {
         followupTurnStateByParent.delete(parent);
         return;
       }
       state.submitInFlight = true;
       let transientSubmitFailure = false;
+      let suppressed = false;
       void parent
-        .submit("", { displayUserMessage: null })
-        .then(() => {
+        .submitChildFollowup(state.generation)
+        .then((admitted) => {
+          suppressed = !admitted;
           state.transientFailureCount = 0;
           state.transientFailureWarningReported = false;
         })
@@ -1650,7 +1676,8 @@ function requestParentFollowupTurn(params: {
         })
         .finally(() => {
           state.submitInFlight = false;
-          if (parent.abortController.signal.aborted) {
+          if (followupTurnStateByParent.get(parent) !== state) return;
+          if (parent.abortController.signal.aborted || suppressed || parent.stoppedByUserSinceLastPrompt || state.generation !== parent.userStopGeneration) {
             followupTurnStateByParent.delete(parent);
             return;
           }
@@ -2168,6 +2195,7 @@ export function buildFilteredRegistry(
   opts: {
     readonly allowlist?: ReadonlyArray<string>;
     readonly childConversationId: string;
+    readonly executionConstraint?: ReadOnlyDelegationConstraint;
     readonly worktree?: WorktreeHandle;
     readonly disabledTools?: ReadonlySet<string>;
     readonly childToolPolicy?: ChildToolPolicy;
@@ -2183,7 +2211,11 @@ export function buildFilteredRegistry(
   const mcpOriginToolNames = new Set(
     base.tools.filter(isMcpOriginTool).map((tool) => tool.name),
   );
+  const constrainedTools = opts.executionConstraint === undefined ? undefined : new Set(
+    base.tools.filter(readOnlyDelegationToolAvailable).map((tool) => tool.name),
+  );
   const isEligible = (name: string): boolean =>
+    (constrainedTools === undefined || constrainedTools.has(name)) &&
     !disabled.has(name) &&
     !mcpOriginToolNames.has(name) &&
     !isMcpWireToolName(name) &&
@@ -2649,7 +2681,7 @@ function wrapToolForChild(
     readonly getSession?: () => Session | null | undefined;
   },
 ): Tool {
-  return {
+  return inheritBuiltinToolProvenance(tool, {
     ...tool,
     async execute(args) {
       const prepared = await prepareChildToolCall(tool, args, opts);
@@ -2657,7 +2689,7 @@ function wrapToolForChild(
         ? prepared.result
         : tool.execute(prepared.args);
     },
-  };
+  });
 }
 
 async function prepareChildToolCall(
@@ -2677,15 +2709,52 @@ async function prepareChildToolCall(
   // SECURITY: strip model-supplied `__agenc*` keys before the child
   // policy/injection runs (idempotent if the caller already stripped).
   const sanitizedArgs = stripModelSuppliedChildArgs(args);
+  const childSession = opts.getSession?.();
+  if (childSession !== undefined && childSession !== null) {
+    const refusal = readOnlyDelegationToolRefusal(childSession, tool, sanitizedArgs);
+    if (refusal !== undefined) {
+      return { result: { content: safeStringify({ error: refusal }), isError: true, metadata: { childPolicyDenied: true } } };
+    }
+  }
   const policyResult = await applyChildToolPolicy(tool, sanitizedArgs, opts);
   if ("result" in policyResult) return policyResult;
+  if (childSession !== undefined && childSession !== null) {
+    const refusal = readOnlyDelegationToolRefusal(childSession, tool, policyResult.args);
+    if (refusal !== undefined) {
+      return { result: { content: safeStringify({ error: refusal }), isError: true, metadata: { childPolicyDenied: true } } };
+    }
+  }
   const childArgs = injectChildToolArgs(policyResult.args, tool.name, opts);
+  if (childSession?.services.readOnlyDelegation !== undefined) {
+    attachReadOnlyDelegationReadGuard(childArgs, (target) => readOnlyDelegationPathAllowed(childSession, target));
+  }
   if (opts.sandboxExecutionBroker !== undefined) {
     attachSandboxExecutionBroker(
       childArgs,
       opts.sandboxExecutionBroker,
       "child_agent",
     );
+  }
+  if (childSession?.services.readOnlyDelegation !== undefined && !isReadOnlyCoordinationTool(tool)) {
+    let brokers = inspectionBrokers.get(childSession);
+    const deniedReadPatterns = readOnlyDelegationDeniedReadPatterns(childSession);
+    const authorityKey = JSON.stringify([deniedReadPatterns, opts.sandboxExecutionBroker?.executionAuthority?.()]);
+    let broker = brokers?.get(authorityKey);
+    if (broker === undefined && opts.sandboxExecutionBroker !== undefined) {
+      broker = opts.sandboxExecutionBroker.forkForReadOnlyInspection?.(childSession.sessionConfiguration.cwd, deniedReadPatterns);
+      if (broker === undefined) throw new Error("Read-only inspection requires a sandbox broker that can narrow execution authority");
+      brokers ??= new Map();
+      brokers.set(authorityKey, broker);
+      inspectionBrokers.set(childSession, brokers);
+    }
+    if (broker !== undefined) attachSandboxExecutionBroker(childArgs, broker, "child_agent");
+    if (tool.name !== "exec_command" && tool.name !== "system.bash") return { args: childArgs };
+    const inspected = inspectReadOnlyCommand(tool.name, childArgs, childSession.sessionConfiguration.cwd);
+    if (!inspected.allowed) return { result: { content: safeStringify({ error: inspected.reason }), isError: true, metadata: { childPolicyDenied: true } } };
+    if (broker === undefined) throw new Error("Read-only inspection requires a sandbox broker that can narrow execution authority");
+    const runtimeSandbox = broker.runtimeSandbox("child_agent");
+    if (runtimeSandbox === undefined) throw new Error("Read-only inspection requires platform isolation");
+    attachReadOnlyInspectionInvocation(childArgs, prepareReadOnlyInspectionInvocation(inspected.invocation, runtimeSandbox));
   }
   return { args: childArgs };
 }
@@ -2948,6 +3017,7 @@ function buildChildSession(
   }
   let childSession: ChildSession | undefined;
   const registry = buildFilteredRegistry(params.parent.services.registry, {
+    ...(params.live.metadata.executionConstraint !== undefined ? { executionConstraint: params.live.metadata.executionConstraint } : {}),
     allowlist:
       params.toolAllowlist ?? params.live.role.config.allowlist ?? undefined,
     childConversationId: params.live.agentId,
@@ -2995,6 +3065,7 @@ function buildChildSession(
     mcpManagerOwnership: "borrowed",
     services: {
       ...params.parent.services,
+      readOnlyDelegation: params.live.metadata.executionConstraint,
       provider,
       // A provider service is session-owned. Do not let the parent's service
       // survive the spread above and silently override the forked provider in
@@ -3727,9 +3798,11 @@ export async function* runAgent(
         ...(firstTurn && userMessageRuntimeOnly !== undefined
           ? { seedUserMessageRuntimeOnly: userMessageRuntimeOnly }
           : {}),
-        ...(live.role.config.systemPrompt
+        ...(live.role.config.systemPrompt || live.metadata.executionConstraint !== undefined
           ? {
-              systemPrompt: live.role.config.systemPrompt,
+              systemPrompt: live.metadata.executionConstraint !== undefined
+                ? READ_ONLY_DELEGATION_PROMPT
+                : live.role.config.systemPrompt,
               systemPromptTrust: "workspace_role" as const,
             }
           : {}),
@@ -4366,6 +4439,17 @@ export async function* runAgent(
         await disposeSandboxExecutionBroker(childSandboxExecutionBroker);
       } catch (error) {
         cleanupErrors.push(error);
+      }
+    }
+    const childInspectionBrokers = childSession === null ? undefined : inspectionBrokers.get(childSession);
+    if (childInspectionBrokers !== undefined) {
+      inspectionBrokers.delete(childSession!);
+      for (const inspectionBroker of childInspectionBrokers.values()) {
+        try {
+          await disposeSandboxExecutionBroker(inspectionBroker);
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
       }
     }
     if (ownedChildProvider !== null) {

--- a/runtime/src/agents/thread-manager.ts
+++ b/runtime/src/agents/thread-manager.ts
@@ -585,7 +585,7 @@ async function submitToSession(
         throw new MailboxCapacityError(session.conversationId);
       }
       if (op.communication.triggerTurn) {
-        await session.submit("", { displayUserMessage: null });
+        await session.submitChildFollowup();
       }
       return session.conversationId;
     }

--- a/runtime/src/agents/v2/close-agent.ts
+++ b/runtime/src/agents/v2/close-agent.ts
@@ -1,4 +1,5 @@
 import type { Tool, ToolResult } from "../../tools/types.js";
+import { readOnlyCoordinationRefusal } from "../readonly-delegation.js";
 import type { AgentStatus } from "../status.js";
 import {
   agentValidationError,
@@ -50,6 +51,8 @@ export function createCloseAgentTool(opts: MultiAgentV2Options): Tool {
     if (agentId === sessionOrError.conversationId) {
       return agentValidationError("root is not a spawned agent");
     }
+    const coordinationRefusal = readOnlyCoordinationRefusal(sessionOrError, current.agentPath, control.getAgentMetadata(agentId) ?? control.getLive(agentId)?.metadata, control.getAgentMetadata(current.threadId)?.executionConstraint);
+    if (coordinationRefusal !== undefined) return agentValidationError(coordinationRefusal);
     const callId = callIdFromArgs(args, "close");
     const receiverMetadata = receiverMetadataFor(sessionOrError, agentId, opts);
     emit(sessionOrError, {

--- a/runtime/src/agents/v2/index.ts
+++ b/runtime/src/agents/v2/index.ts
@@ -1,4 +1,5 @@
 import type { Tool } from "../../tools/types.js";
+import { registerBuiltinTool } from "../../tools/builtin-provenance.js";
 import type { MultiAgentV2Options } from "./common.js";
 import { createAssignTaskTool } from "./assign-task.js";
 import { createCloseAgentTool } from "./close-agent.js";
@@ -17,5 +18,5 @@ export function createMultiAgentV2Tools(
     createAssignTaskTool(opts),
     createSendMessageTool(opts),
     createListAgentsTool(opts),
-  ];
+  ].map(registerBuiltinTool);
 }

--- a/runtime/src/agents/v2/message-tool.ts
+++ b/runtime/src/agents/v2/message-tool.ts
@@ -1,4 +1,5 @@
 import type { ToolResult } from "../../tools/types.js";
+import { readOnlyCoordinationRefusal } from "../readonly-delegation.js";
 import {
   AgentAssignmentRejectedError,
   type AgentAssignmentRejectionCode,
@@ -90,6 +91,8 @@ export async function handleMessageStringTool(
   const callId = callIdFromArgs(args, "message");
   const live = control.getLive(agentId);
   const metadata = control.getAgentMetadata(agentId);
+  const coordinationRefusal = readOnlyCoordinationRefusal(sessionOrError, current.agentPath, metadata ?? live?.metadata, control.getAgentMetadata(current.threadId)?.executionConstraint);
+  if (coordinationRefusal !== undefined) return agentValidationError(coordinationRefusal);
   const receiverAgentPath = metadata?.agentPath ?? live?.agentPath;
   if (!receiverAgentPath) {
     return agentValidationError("target agent is missing an agent_path");

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -7,6 +7,7 @@ import { validationErrorToolResult } from "../../tools/results.js";
 import type { Session } from "../../session/session.js";
 import type { ModelInfo, ReasoningEffort } from "../../session/turn-context.js";
 import { delegate } from "../delegate.js";
+import { READ_ONLY_DELEGATION_PROMPT, sessionIsPlanning, sessionReadOnlyDelegation } from "../readonly-delegation.js";
 import type { ForkMode } from "../fork-context.js";
 import type { AgentThread } from "../thread.js";
 import {
@@ -100,6 +101,9 @@ ${SPAWN_AGENT_INHERITED_MODEL_GUIDANCE}
 It will be able to send you and other running agents messages, and its final answer will be provided to you when it finishes.
 The new agent's canonical task name will be provided to it along with the message.`;
   const cfg = session?.config?.multiAgentV2;
+  if (sessionIsPlanning(session) || sessionReadOnlyDelegation(session) !== undefined) {
+    return `${base}\n\n${READ_ONLY_DELEGATION_PROMPT}\nDelegate bounded independent inspection tasks in parallel. Use isolation none, list_agents, wait_agent, and close_agent for your constrained workers.`;
+  }
   let result = `${base}${SPAWN_AGENT_DELEGATION_DISCIPLINE}`;
   if (cfg?.usageHintEnabled && cfg.usageHintText) {
     result = `${result}\n${cfg.usageHintText}`;

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -2440,9 +2440,7 @@ export class AgenCDaemonAgentManager {
     if (this.#approvalBroker?.isWorkflowOwner(params.sessionId)) {
       return this.#approveWorkflowTool(params);
     }
-    const agentId = await this.#resolveActiveAgentIdForSession(
-      params.sessionId,
-    );
+    const { agentId, sessionId } = await this.#resolvePermissionOwner(params.sessionId);
     const responseKey = this.#approvalBroker?.pending(agentId, params.requestId)?.responseKey ?? params.requestId;
     const allowAllToolsForSession = params.allowAllToolsForSession === true;
     if (allowAllToolsForSession && params.scope !== "session") {
@@ -2490,7 +2488,7 @@ export class AgenCDaemonAgentManager {
     // Plain scope=session intentionally retains its historic per-rule cache.
     const modeChange = allowAllToolsForSession
       ? await this.#runner!.setAgentPermissionMode!(agentId, {
-          sessionId: params.sessionId,
+          sessionId,
           mode: "bypassPermissions",
           bypassAuthority: "operator_tool_approval",
         })
@@ -2507,7 +2505,7 @@ export class AgenCDaemonAgentManager {
     } catch (error) {
       await this.#rollbackAllToolsPermissionMode(
         agentId,
-        params.sessionId,
+        sessionId,
         modeChange,
       );
       throw error;
@@ -2515,7 +2513,7 @@ export class AgenCDaemonAgentManager {
     if (!resolved) {
       await this.#rollbackAllToolsPermissionMode(
         agentId,
-        params.sessionId,
+        sessionId,
         modeChange,
       );
       // The request is no longer pending, so the deferred ExitPlanMode tool will
@@ -2615,8 +2613,10 @@ export class AgenCDaemonAgentManager {
   }
 
   async denyTool(params: ToolDenyParams): Promise<ToolDecisionResult> {
+    const reason = normalizeNonEmpty(params.reason);
+    const decision = reason === undefined ? DENIED : { kind: "denied" as const, reason };
     if (this.#approvalBroker?.isWorkflowOwner(params.sessionId)) {
-      if (!this.#approvalBroker.resolve(params.sessionId, params.requestId, DENIED)) {
+      if (!this.#approvalBroker.resolve(params.sessionId, params.requestId, decision)) {
         throw new AgenCDaemonAgentLifecycleError("INVALID_ARGUMENT", `AgenC daemon tool request is not pending: ${params.requestId}`);
       }
       await this.#recordToolDecisionAudit({
@@ -2625,12 +2625,10 @@ export class AgenCDaemonAgentManager {
       });
       return { requestId: params.requestId, decision: "denied" };
     }
-    const agentId = await this.#resolveActiveAgentIdForSession(
-      params.sessionId,
-    );
+    const { agentId } = await this.#resolvePermissionOwner(params.sessionId);
     const resolved = await this.#runner!.resolveToolDecision!(agentId, {
       requestId: params.requestId,
-      decision: DENIED,
+      decision,
     });
     if (!resolved) {
       throw new AgenCDaemonAgentLifecycleError(
@@ -4094,15 +4092,7 @@ export class AgenCDaemonAgentManager {
       );
     }
     if (sessionId !== undefined) {
-      const daemonSessionId = await this.#state.with((state) => {
-        const canonicalAgent = state.agents.get(sessionId);
-        return canonicalAgent === undefined
-          ? sessionId
-          : latestSessionIdForAgentRun(canonicalAgent) ?? sessionId;
-      });
-      return this.#resolveActiveAgentIdForSession(daemonSessionId, {
-        allowListPermissions: true,
-      });
+      return (await this.#resolvePermissionOwner(sessionId, true)).agentId;
     }
     if (agentId === undefined) {
       throw new AgenCDaemonAgentLifecycleError(
@@ -4127,6 +4117,27 @@ export class AgenCDaemonAgentManager {
       }
     });
     return agentId;
+  }
+
+  async #resolvePermissionOwner(
+    ownerId: string,
+    allowListPermissions = false,
+  ): Promise<{ readonly agentId: string; readonly sessionId: string }> {
+    const resolvedOwner = await this.#state.with((state) => {
+      const canonicalAgent = state.agents.get(ownerId);
+      if (canonicalAgent === undefined) return { sessionId: ownerId };
+      const latestSessionId = latestSessionIdForAgentRun(canonicalAgent);
+      if (latestSessionId === undefined) {
+        throw new AgenCDaemonAgentLifecycleError("AGENT_NOT_FOUND", `AgenC daemon session not found or closed: ${ownerId}`);
+      }
+      return { sessionId: latestSessionId, expectedAgentId: canonicalAgent.agentId };
+    });
+    const { sessionId } = resolvedOwner;
+    const agentId = await this.#resolveActiveAgentIdForSession(sessionId, { allowListPermissions });
+    if (resolvedOwner.expectedAgentId !== undefined && resolvedOwner.expectedAgentId !== agentId) {
+      throw new AgenCDaemonAgentLifecycleError("INVALID_ARGUMENT", `Permission owner changed while resolving session: ${ownerId}`);
+    }
+    return { agentId, sessionId };
   }
 
   async #refreshAgentFromRunner(

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -388,6 +388,11 @@ export {
   planApprovalPayloadFields,
 } from "./background-agent-runner/tool-recovery.js";
 
+const DAEMON_USER_STOP_GENERATION: unique symbol = Symbol("agenc.daemon-user-stop-generation");
+type DaemonHumanSessionSubmitOptions = DaemonSessionSubmitOptions & {
+  readonly [DAEMON_USER_STOP_GENERATION]?: number;
+};
+
 /**
  * A routine invocation, which is the one agent kind that runs with nobody
  * attached to answer an approval. Both keys are required: the routine service
@@ -2064,6 +2069,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       );
     }
 
+    const userStopGenerationToRelease = active.bootstrap.session.userStopGeneration;
     let resolveSubmission!: (result: AgenCBackgroundAgentMessageResult) => void;
     let rejectSubmission!: (error: unknown) => void;
     const promise = new Promise<AgenCBackgroundAgentMessageResult>(
@@ -2096,6 +2102,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
             agentId,
             params,
             submission,
+            userStopGenerationToRelease,
           );
         } finally {
           if (active.messageSubmission === submission) {
@@ -2449,6 +2456,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     agentId: string,
     params: AgenCBackgroundAgentMessageParams,
     submission: ActiveMessageSubmission,
+    userStopGenerationToRelease: number,
   ): Promise<AgenCBackgroundAgentMessageResult> {
     let input = messageContentToAgentInput(params.content);
     if (params.editorInteraction === undefined) {
@@ -2508,7 +2516,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         },
       });
     }
-    const submitOptions: DaemonSessionSubmitOptions = {
+    const submitOptions: DaemonHumanSessionSubmitOptions = {
+      [DAEMON_USER_STOP_GENERATION]: userStopGenerationToRelease,
       [DAEMON_LOCAL_MCP_ACCESS]: params.localMcpAccess === true,
       ...(params.editorInteraction === undefined
         ? { [DAEMON_USER_PROMPT_PREPARED]: true as const }
@@ -2521,7 +2530,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ? { editorInteraction: params.editorInteraction }
         : {}),
     };
-    active.bootstrap.session.clearUserStop?.();
     if (typeof input === "string") {
       await active.control.sendInput(agentId, input, submitOptions);
     } else {
@@ -5398,7 +5406,7 @@ function installDaemonTurnDriverHooks(
       installTurnDriverHooks?: (hooks: {
         readonly submit: (
           message: string | readonly LLMContentPart[],
-          opts?: DaemonSessionSubmitOptions,
+          opts?: DaemonHumanSessionSubmitOptions,
         ) => Promise<void>;
         readonly flushEventLog?: () => Promise<void> | void;
       }) => void;
@@ -5467,6 +5475,9 @@ function installDaemonTurnDriverHooks(
           // excluded by rootHumanTurnText below.
           querySource: "sdk",
           displayUserMessage: null,
+          ...(opts?.[DAEMON_USER_STOP_GENERATION] !== undefined
+            ? { userStopGenerationToRelease: opts[DAEMON_USER_STOP_GENERATION] }
+            : {}),
           ...(rootHumanTurnText !== undefined ? { rootHumanTurnText } : {}),
           ...(opts?.editorInteraction !== undefined
             ? {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -2081,11 +2081,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       promise,
       settled: false,
     };
-    // The user speaks again: child receipts held since a stop may now start
-    // follow-up turns (#2236). Only an admitted message counts — a refused one
-    // never reaches the session, so releasing the latch there let a receipt
-    // restart the very work the user stopped (#2201).
-    active.bootstrap.session.clearUserStop?.();
     active.messageSubmissionsById.set(params.messageId, submission);
     active.pendingMessageSubmissionCount += 1;
 
@@ -2526,6 +2521,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ? { editorInteraction: params.editorInteraction }
         : {}),
     };
+    active.bootstrap.session.clearUserStop?.();
     if (typeof input === "string") {
       await active.control.sendInput(agentId, input, submitOptions);
     } else {
@@ -4278,21 +4274,24 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     if (active === undefined || !isInterruptibleActiveAgent(active))
       return false;
     // A client asked for the stop; hold child receipts until the next prompt.
-    active.bootstrap.session.markStoppedByUser?.();
     try {
-      await active.bootstrap.session.abortAllTasks("interrupted");
-    } catch {
-      /* interrupt delivery still falls through the managed thread path */
+      active.bootstrap.session.markStoppedByUser?.();
+    } finally {
+      try {
+        await active.bootstrap.session.abortAllTasks("interrupted");
+      } catch {
+        /* interrupt delivery still falls through the managed thread path */
+      }
+      void active.thread.submit({ type: "interrupt", reason }).catch(() => {
+        /* interrupt delivery surfaces via session events */
+      });
+      for (const [childThreadId] of active.control.openThreadSpawnChildren(
+        active.thread.threadId,
+      )) {
+        active.control.interrupt(childThreadId, reason);
+      }
+      active.lastActiveAt = this.#now();
     }
-    void active.thread.submit({ type: "interrupt", reason }).catch(() => {
-      /* interrupt delivery surfaces via session events */
-    });
-    for (const [childThreadId] of active.control.openThreadSpawnChildren(
-      active.thread.threadId,
-    )) {
-      active.control.interrupt(childThreadId, reason);
-    }
-    active.lastActiveAt = this.#now();
     return true;
   }
 
@@ -4334,13 +4333,16 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ...(turnAfterAttempt !== expectedTurnId ? { stale: true } : {}),
       };
     }
-    active.bootstrap.session.markStoppedByUser?.();
-    for (const [childThreadId] of active.control.openThreadSpawnChildren(
-      active.thread.threadId,
-    )) {
-      active.control.interrupt(childThreadId, reason);
+    try {
+      active.bootstrap.session.markStoppedByUser?.();
+    } finally {
+      for (const [childThreadId] of active.control.openThreadSpawnChildren(
+        active.thread.threadId,
+      )) {
+        active.control.interrupt(childThreadId, reason);
+      }
+      active.lastActiveAt = this.#now();
     }
-    active.lastActiveAt = this.#now();
     return { cancelled: true, activeTurnId: expectedTurnId };
   }
 

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -1794,10 +1794,12 @@ async function stopAgenCDaemon(
               }
             }
           } catch (error) {
-            io.stderr.write(
-              `agenc: refusing Linux numeric shutdown for pid ${boundPid} because its authenticated instance could not be rebound: ${formatCleanupError(error)}\n`,
-            );
-            return 1;
+            if (!(await waitForBoundPidExit(host, bound.process, 0))) {
+              io.stderr.write(
+                `agenc: refusing Linux numeric shutdown for pid ${boundPid} because its authenticated instance could not be rebound: ${formatCleanupError(error)}\n`,
+              );
+              return 1;
+            }
           }
         }
         await lifecycle.acquire();

--- a/runtime/src/app-server/live-approval-broker.ts
+++ b/runtime/src/app-server/live-approval-broker.ts
@@ -182,6 +182,10 @@ export class LiveApprovalBroker {
   resolve(ownerRunId: string, requestId: string, decision: ReviewDecision): boolean {
     const pending = this.pending(ownerRunId, requestId);
     if (pending === undefined || pending.ctx.signal?.aborted) return false;
+    const owner = this.#owners.get(ownerRunId)!;
+    if (!owner.workflow && decision.kind === "denied") {
+      owner.session.markStoppedByUser?.();
+    }
     pending.settle(decision);
     return true;
   }

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -304,6 +304,7 @@ import { installGlobalErrorNet } from "../utils/gracefulShutdown.js";
 import { registerProcessOutputErrorHandlers } from "../utils/process.js";
 import { isRecord } from "../utils/record.js";
 import type { AgenCTuiBridgeSession } from "../tui/daemon-session.js";
+import { createWorkflowApprovalControls, type WorkflowApprovalControls } from "../tui/workflow-approval-controls.js";
 
 type AgenCDaemonCliDeps = {
   readonly startPromptAgent: typeof startAgenCDaemonPromptAgent;
@@ -970,6 +971,7 @@ export interface RunSingleTurnOpts {
    * `null` suppresses the visible user-message event for internal meta turns.
    */
   readonly displayInput?: string | null;
+  readonly userStopGenerationToRelease?: number;
   /** T10: config snapshot + latch so `maybeReloadConfigBetweenTurns` can drain SIGUSR1. */
   readonly configStore: ConfigStore;
   readonly configReloadLatch: ConfigReloadLatch;
@@ -1077,6 +1079,7 @@ export async function* runSingleTurn(
       .join("\n\n"),
     systemPromptReplacesBase: true,
     displayUserMessage: opts.displayInput,
+    userStopGenerationToRelease: opts.userStopGenerationToRelease,
   });
   while (true) {
     const step = await iter.next();
@@ -1230,6 +1233,9 @@ function installTuiSessionContract(params: {
       submitOpts?: SessionSubmitOptions,
     ) => {
       const isAutonomousTick = submitOpts?.source === AUTONOMOUS_SUBMIT_SOURCE;
+      const userStopGenerationToRelease = submitOpts?.source === "user"
+        ? params.session.userStopGeneration
+        : undefined;
       if (!isAutonomousTick) autonomousKeepalive.cancel();
       if (
         isAutonomousTick &&
@@ -1290,6 +1296,7 @@ function installTuiSessionContract(params: {
           session: params.session,
           ctx,
           input: preparedPrompt.input,
+          userStopGenerationToRelease,
           displayInput:
             opts.displayInput !== undefined
               ? opts.displayInput
@@ -2550,6 +2557,7 @@ type DeferredWorkspaceEditorSessionSurface = Pick<
 >;
 
 type TuiSessionShape = DeferredWorkspaceEditorSessionSurface & {
+  readonly workflowApprovalControls?: WorkflowApprovalControls;
   executeShellCommand?: AgenCTuiBridgeSession["executeShellCommand"];
   executeDaemonStatusLine?: AgenCTuiBridgeSession["executeDaemonStatusLine"];
   readonly services?: {
@@ -2734,6 +2742,7 @@ async function createDeferredDaemonPromptTuiSession(params: {
     request<Method extends AgenCDaemonKnownMethod>(
       method: Method,
       params?: JsonObject,
+      options?: { readonly signal?: AbortSignal },
     ): Promise<AgenCDaemonKnownResultByMethod[Method]>;
   };
   let workspaceEditorControlClient: WorkspaceEditorControlClient | null = null;
@@ -3568,6 +3577,15 @@ async function createDeferredDaemonPromptTuiSession(params: {
   };
   const session: TuiSessionShape & Record<string, unknown> = {
     ...daemonSessionBase,
+    workflowApprovalControls: createWorkflowApprovalControls({
+      async request(method, requestParams, options) {
+        options.signal.throwIfAborted();
+        const client = await ensureWorkspaceEditorControlClient();
+        options.signal.throwIfAborted();
+        if (deferredSessionClosed) throw new Error("Deferred TUI session is already closed.");
+        return client.request(method, requestParams, options);
+      },
+    }),
     // The deferred TUI never owns an MCP runtime. This stable facade forwards
     // to the daemon-backed session after attach and exposes only empty passive
     // state before then; it intentionally replaces any bootstrap manager.

--- a/runtime/src/conversation/thread-manager.ts
+++ b/runtime/src/conversation/thread-manager.ts
@@ -361,6 +361,7 @@ export class ConversationThreadManager extends ThreadManager {
     rolloutItems: ReadonlyArray<RolloutItem>,
     opts: ConversationReplayOptions = {},
   ): Promise<ConversationReplayResult> {
+    session.restoreUserStopFromRollout(rolloutItems);
     const checkpointProjection = checkpointProjectionFor(
       session,
       "root-reconstruction",

--- a/runtime/src/llm/shell-write-policy.ts
+++ b/runtime/src/llm/shell-write-policy.ts
@@ -112,6 +112,7 @@ export interface ShellWorkspaceWritePolicyInput {
   readonly toolName: string;
   readonly args: Record<string, unknown>;
   readonly workspaceRoot?: string;
+  readonly validationPhase?: "preflight" | "execution";
   /**
    * Whether this call may remove or move files that already exist in the
    * workspace: true when the session's permission mode allows edits without
@@ -790,6 +791,9 @@ export function classifyShellWorkspaceWritePolicy(
     if (verdict.kind === "allowed") {
       if (verdict.inWorkspace) deletionTargets.push(target);
     } else {
+      if (params.validationPhase === "preflight" && verdict.reason === "needs_approval") {
+        continue;
+      }
       blockedDeletions.push(target);
       deletionReasons.add(verdict.reason);
     }

--- a/runtime/src/permissions/approval-failure.ts
+++ b/runtime/src/permissions/approval-failure.ts
@@ -1,6 +1,7 @@
 export interface ApprovalFailureMetadata {
   readonly decision: string;
   readonly source: string;
+  readonly reason?: string;
 }
 
 const workflowApprovalSessions = new WeakSet<object>();
@@ -19,7 +20,7 @@ export class WorkflowApprovalFailure extends Error {
 
   constructor(readonly approvalFailure: ApprovalFailureMetadata) {
     super(
-      `Workflow tool approval ${approvalFailure.decision} (${approvalFailure.source}).`,
+      `Workflow tool approval ${approvalFailure.decision} (${approvalFailure.source}).${approvalFailure.reason?.trim() ? ` ${approvalFailure.reason}` : ""}`,
     );
     this.name = "WorkflowApprovalFailure";
     this.stopReason =
@@ -44,6 +45,7 @@ export function workflowApprovalFailureFromMetadata(
   return new WorkflowApprovalFailure({
     decision: metadata.decision,
     source: metadata.source,
+    ...(typeof metadata.reason === "string" ? { reason: metadata.reason } : {}),
   });
 }
 

--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -42,6 +42,7 @@
  */
 
 import { resolve } from "node:path";
+import { isReadOnlyCoordinationName, isReadOnlyCoordinationTool, readOnlyDelegationToolRefusal, sessionReadOnlyDelegation } from "../agents/readonly-delegation.js";
 import {
   freshDenialTracking,
   handleDenialLimitExceeded,
@@ -163,7 +164,7 @@ export interface ToolLike {
   readonly name: string;
   readonly isReadOnly?: boolean;
   readonly requiresApproval?: boolean;
-  readonly metadata?: { readonly mutating?: boolean };
+  readonly metadata?: { readonly mutating?: boolean; readonly source?: string };
   checkPermissions?(
     input: unknown,
     context: ToolEvaluatorContext,
@@ -274,6 +275,17 @@ export async function checkRuleBasedPermissions(
 
   const appState = context.getAppState();
 
+  const delegatedRefusal = readOnlyDelegationToolRefusal(context.session, tool, input);
+  if (delegatedRefusal !== undefined) {
+    return Object.freeze({ behavior: "deny" as const, message: delegatedRefusal, decisionReason: { type: "other" as const, reason: delegatedRefusal } });
+  }
+  if (appState.toolPermissionContext.mode === "plan" && isReadOnlyCoordinationName(tool.name) && !isReadOnlyCoordinationTool(tool)) {
+    return Object.freeze({ behavior: "deny" as const, message: "Plan delegation requires the canonical runtime coordinator implementation.", decisionReason: { type: "other" as const, reason: "untrusted coordinator implementation" } });
+  }
+  const readOnlyCoordination = isReadOnlyCoordinationTool(tool) && (
+    appState.toolPermissionContext.mode === "plan" || sessionReadOnlyDelegation(context.session) !== undefined
+  );
+
   // 1a. Whole-tool deny rule.
   const denyRule = getDenyRuleForTool(
     appState.toolPermissionContext,
@@ -299,6 +311,7 @@ export async function checkRuleBasedPermissions(
     appState.autoModeActive !== true &&
     !toolDoesNotRequireApproval(tool) &&
     !SAFE_YOLO_ALLOWLISTED_TOOLS.has(tool.name) &&
+    !readOnlyCoordination &&
     !planModeReadOnlyShellCommand(tool, input) &&
     !isSessionPlanMutation(tool, input, context.session)
   ) {
@@ -394,6 +407,9 @@ export async function checkRuleBasedPermissions(
   // return here — they must continue into step 2/3.
   if (toolResult.behavior === "allow") {
     return toolResult as PermissionAllowDecision;
+  }
+  if (readOnlyCoordination && toolResult.behavior !== "ask") {
+    return { behavior: "allow", updatedInput: input !== null && typeof input === "object" && !Array.isArray(input) ? input as Record<string, unknown> : {}, decisionReason: { type: "other", reason: "Read-only agent coordination" } };
   }
   return null;
 }

--- a/runtime/src/permissions/guardian/arbiter.ts
+++ b/runtime/src/permissions/guardian/arbiter.ts
@@ -618,7 +618,13 @@ async function resolveApproval(
       if (!activeApprovalTurnStillMatches(opts.ctx, opts.getActiveTurnId)) {
         throw new ModalApprovalError("stale_modal_decision");
       }
-      return { decision, source: "resolver" };
+      return {
+        decision,
+        source: "resolver",
+        ...(decision.kind === "denied" && decision.reason !== undefined
+          ? { reason: decision.reason }
+          : {}),
+      };
     };
     const fetchDecision = async (): Promise<ReviewDecision> => {
       fetchedResult = await fetchApprovalResult();

--- a/runtime/src/permissions/path-validation.ts
+++ b/runtime/src/permissions/path-validation.ts
@@ -262,7 +262,7 @@ function wildcardPatternToRegExp(pattern: string): RegExp {
   return new RegExp(`^${body}$`);
 }
 
-function matchPathRuleContent(ruleContent: string, filePath: string): boolean {
+export function matchPathRuleContent(ruleContent: string, filePath: string): boolean {
   const expandedRule = normalizeSlashes(expandTilde(ruleContent));
   const expandedPath = normalizeSlashes(filePath);
   if (expandedRule === expandedPath) return true;

--- a/runtime/src/permissions/readonly-inspection.ts
+++ b/runtime/src/permissions/readonly-inspection.ts
@@ -1,0 +1,198 @@
+import { closeSync, openSync, readSync, realpathSync, statSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { lexShellCommand, isDirectExecEligible } from "../utils/shell/command-line.js";
+import { validateFlags, type ExternalCommandConfig, type FlagArgType } from "../utils/shell/readOnlyCommandValidation.js";
+import type { UnifiedExecRuntimeSandbox } from "../unified-exec/types.js";
+import { networkPolicyEnabled } from "../sandbox/engine/index.js";
+
+export interface ReadOnlyInspectionCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly readPaths: readonly string[];
+}
+
+export interface ReadOnlyInspectionInvocation {
+  readonly program: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly runtimeSandbox: UnifiedExecRuntimeSandbox;
+}
+
+export type ReadOnlyInspectionResult =
+  | { readonly allowed: true; readonly invocation: ReadOnlyInspectionCommand }
+  | { readonly allowed: false; readonly reason: string };
+
+const FLAGS = (none: string[], values: Record<string, FlagArgType> = {}): ExternalCommandConfig => ({
+  safeFlags: Object.fromEntries([...none.map((name) => [name, "none"]), ...Object.entries(values)]),
+});
+
+const INSPECTION_COMMANDS: Readonly<Record<string, ExternalCommandConfig>> = Object.freeze({
+  pwd: FLAGS(["-L", "-P"]),
+  ls: FLAGS(["-a", "-A", "-l", "-h", "-n", "-d", "-R", "-t", "-r", "-S", "-1", "--all", "--almost-all", "--directory", "--recursive", "--human-readable"]),
+  cat: FLAGS(["-n", "-b", "-s", "-v", "-E", "-T", "-A", "--number", "--show-all"]),
+  head: FLAGS(["-q", "-v", "--quiet", "--verbose"], { "-n": "number", "--lines": "number", "-c": "number", "--bytes": "number" }),
+  tail: FLAGS(["-q", "-v", "--quiet", "--verbose"], { "-n": "number", "--lines": "number", "-c": "number", "--bytes": "number" }),
+  wc: FLAGS(["-l", "-w", "-c", "-m", "-L", "--lines", "--words", "--bytes", "--chars", "--max-line-length"]),
+  grep: FLAGS(["-r", "-R", "-n", "-i", "-v", "-l", "-L", "-c", "-w", "-x", "-F", "-E", "-H", "-h", "-o", "-s", "--recursive", "--line-number", "--ignore-case", "--fixed-strings", "--files-with-matches"], { "-e": "string", "--regexp": "string", "-A": "number", "-B": "number", "-C": "number", "-m": "number", "--include": "string", "--exclude": "string", "--exclude-dir": "string" }),
+  rg: FLAGS(["-n", "-i", "-S", "-v", "-l", "-c", "-w", "-x", "-F", "-H", "-o", "-u", "--files", "--hidden", "--no-ignore", "--no-ignore-vcs", "--line-number", "--ignore-case", "--fixed-strings", "--files-with-matches", "--files-without-match", "--count", "--json", "--no-heading", "--heading", "--column", "--no-config"], { "-e": "string", "--regexp": "string", "-g": "string", "--glob": "string", "-t": "string", "--type": "string", "-T": "string", "-A": "number", "-B": "number", "-C": "number", "-m": "number", "--max-count": "number", "--max-depth": "number" }),
+  "git status": FLAGS(["--short", "-s", "--branch", "-b", "--porcelain", "--long", "--untracked-files", "--ignored"]),
+  "git diff": FLAGS(["--stat", "--numstat", "--shortstat", "--name-only", "--name-status", "--cached", "--staged", "--check", "--no-color", "--no-ext-diff", "--no-textconv", "--binary", "--exit-code", "--quiet", "-p", "-u", "-w", "--ignore-all-space"]),
+  "git log": FLAGS(["--oneline", "--graph", "--all", "--decorate", "--no-decorate", "--stat", "--name-only", "--name-status", "--no-color", "--no-ext-diff", "--no-textconv", "--reverse", "--first-parent", "-p"], { "-n": "number", "--max-count": "number", "--since": "string", "--until": "string", "--author": "string", "--grep": "string" }),
+  "git show": FLAGS(["--stat", "--name-only", "--name-status", "--oneline", "--no-color", "--no-ext-diff", "--no-textconv", "-p", "-s"]),
+  "git ls-files": FLAGS(["--cached", "--deleted", "--modified", "--others", "--ignored", "--exclude-standard", "--stage", "-s", "-z"]),
+  "git branch": FLAGS(["--list", "-l", "--all", "-a", "--remotes", "-r", "--show-current", "-v", "-vv", "--no-color"]),
+  "git merge-base": FLAGS(["--all", "--is-ancestor", "--octopus", "--independent", "--fork-point"]),
+  "git rev-parse": FLAGS(["--show-toplevel", "--show-prefix", "--git-dir", "--absolute-git-dir", "--is-inside-work-tree", "--verify", "--short", "--abbrev-ref", "--symbolic-full-name"]),
+});
+
+const invocationByArgs = new WeakMap<object, ReadOnlyInspectionInvocation>();
+const identityByInvocation = new WeakMap<object, string>();
+
+function refusal(reason: string): ReadOnlyInspectionResult {
+  return { allowed: false, reason: `Read-only inspection: ${reason}` };
+}
+
+function inside(target: string, root: string): boolean {
+  const suffix = relative(root, target);
+  return suffix === "" || (!suffix.startsWith("..") && !isAbsolute(suffix));
+}
+
+function positionalArguments(args: readonly string[], config: ExternalCommandConfig): string[] {
+  const positional: string[] = [];
+  let operandsOnly = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]!;
+    if (operandsOnly) { positional.push(argument); continue; }
+    if (argument === "--") { operandsOnly = true; continue; }
+    if (!argument.startsWith("-") || argument === "-") { positional.push(argument); continue; }
+    const flag = argument.split("=", 1)[0]!;
+    const kind = config.safeFlags[flag];
+    if (kind !== undefined && kind !== "none" && !argument.includes("=")) index += 1;
+  }
+  return positional;
+}
+
+export function inspectReadOnlyCommand(toolName: string, input: unknown, cwd: string, options: { readonly enforceWorkspaceBoundary?: boolean; readonly allowWorktreeGitInspection?: boolean } = {}): ReadOnlyInspectionResult {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) return refusal("arguments must be an object");
+  const record = input as Record<string, unknown>;
+  if (record.shell !== undefined || record.login === true || record.tty === true || record.run_in_background === true || record.sandbox_permissions === "require_escalated" || record.additional_permissions !== undefined) {
+    return refusal("shell profiles, interactive execution, background flags, and wider permissions are unavailable");
+  }
+  const raw = toolName === "exec_command" ? record.cmd : record.command;
+  if (typeof raw !== "string" || raw.length > 32_768) return refusal("a bounded literal command is required");
+  const parsed = lexShellCommand(raw);
+  if (!isDirectExecEligible(parsed)) return refusal("use one literal command without expansion, pipes, redirects, or chaining");
+  const words = parsed.tokens.map((token) => token.value);
+  if (toolName === "system.bash" && record.args !== undefined) {
+    if (!Array.isArray(record.args) || record.args.some((argument) => typeof argument !== "string" || argument.includes("\0"))) return refusal("direct arguments must be literal strings");
+    words.push(...record.args as string[]);
+  }
+  const command = words.shift();
+  if (!command || !/^[a-z][a-z-]*$/u.test(command)) return refusal("use a supported installed command name, not a path or wrapper");
+  const configKey = command === "git" ? `git ${words[0] ?? ""}` : command;
+  const config = INSPECTION_COMMANDS[configKey];
+  if (config === undefined) return refusal(`${configKey} is not a supported inspection command`);
+  if (options.allowWorktreeGitInspection !== true && ["git status", "git diff"].includes(configKey)) return refusal("worktree Git inspection can invoke repository-defined filters; use native file inspection or object-only Git log/show");
+  const operands = command === "git" ? words.slice(1) : words;
+  if (!validateFlags([...operands], 0, config, { commandName: command })) return refusal("an option is unsupported or can change state");
+  const positional = positionalArguments(operands, config);
+  const commandOptions = operands.slice(0, operands.includes("--") ? operands.indexOf("--") : operands.length);
+  if (configKey === "git branch" && positional.length > 0 && !commandOptions.includes("--list")) return refusal("branch names require explicit --list; creating branches is forbidden");
+  if (configKey === "git status" && positional.length > 0 && !operands.includes("--")) return refusal("status paths require --");
+  if (command === "pwd" && positional.length > 0) return refusal("pwd accepts no path operands");
+  const requestedCwd = toolName === "exec_command" ? record.workdir : record.cwd;
+  if (requestedCwd !== undefined && typeof requestedCwd !== "string") return refusal("working directory must be a string");
+  const workdir = resolve(cwd, requestedCwd as string | undefined ?? ".");
+  if (options.enforceWorkspaceBoundary !== false && !inside(workdir, resolve(cwd))) return refusal("the working directory must remain inside the assigned project");
+  let paths = positional;
+  if (command === "git") {
+    const separator = operands.indexOf("--");
+    paths = separator >= 0 ? operands.slice(separator + 1) : configKey === "git ls-files" ? positional : [];
+  } else if (command === "grep" || command === "rg") {
+    const explicitPattern = operands.some((argument) => argument === "-e" || argument === "--regexp" || argument.startsWith("--regexp="));
+    if (!explicitPattern && !operands.includes("--files")) paths = positional.slice(1);
+  }
+  const readPaths = [workdir, ...paths.filter((operand) => operand !== "-").map((operand) => resolve(workdir, operand))];
+  if (options.enforceWorkspaceBoundary !== false && readPaths.some((target) => !inside(target, resolve(cwd)))) return refusal("path operands must remain inside the assigned project");
+  return { allowed: true, invocation: Object.freeze({ command, args: Object.freeze(words), cwd: workdir, readPaths: Object.freeze(readPaths) }) };
+}
+
+function executableIdentity(program: string): string {
+  const stat = statSync(program, { bigint: true });
+  if (!stat.isFile()) throw new Error("Read-only inspection executable is not a regular file");
+  if (process.platform !== "win32" && (stat.uid !== 0n || (stat.mode & 0o022n) !== 0n || (stat.mode & 0o111n) === 0n)) {
+    throw new Error("Read-only inspection requires a system-owned executable that users cannot replace");
+  }
+  if (process.platform !== "win32") {
+    let directory = dirname(program);
+    for (;;) {
+      const parentStat = statSync(directory, { bigint: true });
+      if (parentStat.uid !== 0n || (parentStat.mode & 0o022n) !== 0n) throw new Error("Read-only inspection executable directory is writable by an untrusted user");
+      if (dirname(directory) === directory) break;
+      directory = dirname(directory);
+    }
+  }
+  const descriptor = openSync(program, "r");
+  try {
+    const header = Buffer.alloc(4);
+    if (readSync(descriptor, header, 0, 4, 0) !== 4 || !["7f454c46", "feedface", "feedfacf", "cefaedfe", "cffaedfe", "cafebabe", "bebafeca"].includes(header.toString("hex")) && header.subarray(0, 2).toString() !== "MZ") {
+      throw new Error("Read-only inspection requires a native executable, not a script shim");
+    }
+  } finally { closeSync(descriptor); }
+  return [stat.dev, stat.ino, stat.mode, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+}
+
+function trustedInspectionExecutable(command: string, cwd: string): string {
+  if (process.platform === "win32") throw new Error("Read-only shell inspection requires verified executable ownership; use native read tools on Windows");
+  const directories = ["/usr/bin", "/bin", "/usr/local/bin"];
+  for (const directory of directories) {
+    try {
+      const program = realpathSync(resolve(directory, command));
+      if (inside(program, realpathSync(cwd))) continue;
+      executableIdentity(program);
+      return program;
+    } catch { continue; }
+  }
+  throw new Error(`Read-only inspection requires a trusted installed ${command} executable`);
+}
+
+export function prepareReadOnlyInspectionInvocation(
+  inspection: ReadOnlyInspectionCommand,
+  runtimeSandbox: UnifiedExecRuntimeSandbox,
+): ReadOnlyInspectionInvocation {
+  if (runtimeSandbox.preference !== "require" || runtimeSandbox.permissionProfile.fileSystem.kind !== "restricted" || runtimeSandbox.permissionProfile.fileSystem.entries.some((entry) => entry.access === "write") || networkPolicyEnabled(runtimeSandbox.permissionProfile.network)) {
+    throw new Error("Read-only inspection requires mandatory no-write, no-network platform isolation");
+  }
+  const program = trustedInspectionExecutable(inspection.command, inspection.cwd);
+  const env: Record<string, string> = { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" };
+  if (process.platform === "win32" && process.env.SystemRoot !== undefined) env.SystemRoot = process.env.SystemRoot;
+  let args = [...inspection.args];
+  if (inspection.command === "rg") args = ["--no-config", ...args];
+  if (inspection.command === "git") {
+    const subcommand = args.shift()!;
+    Object.assign(env, { GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null", GIT_ATTR_NOSYSTEM: "1", GIT_TERMINAL_PROMPT: "0", GIT_OPTIONAL_LOCKS: "0", GIT_PAGER: "", GIT_ASKPASS: "", GIT_NO_LAZY_FETCH: "1" });
+    args = ["--no-pager", "-c", "core.fsmonitor=false", "-c", `core.hooksPath=${process.platform === "win32" ? "NUL" : "/dev/null"}`, "-c", "credential.helper=", "-c", "protocol.allow=never", "-c", "diff.external=", "-c", "gc.auto=0", "-c", "maintenance.auto=false", "-c", "log.showSignature=false", "-c", "format.pretty=medium", "-c", "submodule.recurse=false", subcommand,
+      ...(["diff", "log", "show"].includes(subcommand) ? ["--no-ext-diff", "--no-textconv"] : []), ...args];
+  }
+  const invocation = Object.freeze({ program, args: Object.freeze(args), cwd: inspection.cwd, env: Object.freeze(env), runtimeSandbox });
+  identityByInvocation.set(invocation, executableIdentity(program));
+  return invocation;
+}
+
+export function attachReadOnlyInspectionInvocation(args: object, invocation: ReadOnlyInspectionInvocation): void {
+  invocationByArgs.set(args, invocation);
+}
+
+export function readReadOnlyInspectionInvocation(args: object): ReadOnlyInspectionInvocation | undefined {
+  const invocation = invocationByArgs.get(args);
+  if (invocation !== undefined) assertReadOnlyInspectionInvocation(invocation);
+  return invocation;
+}
+
+export function assertReadOnlyInspectionInvocation(invocation: ReadOnlyInspectionInvocation): void {
+  if (identityByInvocation.get(invocation) !== executableIdentity(invocation.program)) {
+    throw new Error("Read-only inspection executable changed before launch or invocation authority is missing");
+  }
+}

--- a/runtime/src/permissions/readonly-read-guard.ts
+++ b/runtime/src/permissions/readonly-read-guard.ts
@@ -1,0 +1,22 @@
+const guards = new WeakMap<object, { readonly check: (absolutePath: string) => boolean; readonly paths: Set<string> }>();
+
+export function attachReadOnlyDelegationReadGuard(args: object, guard: (absolutePath: string) => boolean): void {
+  guards.set(args, { check: guard, paths: new Set() });
+}
+
+export function readOnlyDelegationReadPathAllowed(args: object, absolutePath: string): boolean {
+  const authority = guards.get(args);
+  if (authority === undefined) return true;
+  if (!authority.check(absolutePath)) return false;
+  authority.paths.add(absolutePath);
+  return true;
+}
+
+export function hasReadOnlyDelegationReadGuard(args: object): boolean {
+  return guards.has(args);
+}
+
+export function readOnlyDelegationReadAuthorityCurrent(args: object): boolean {
+  const authority = guards.get(args);
+  return authority === undefined || [...authority.paths].every((path) => authority.check(path));
+}

--- a/runtime/src/permissions/review-decision.ts
+++ b/runtime/src/permissions/review-decision.ts
@@ -66,7 +66,7 @@ export type ReviewDecision =
       readonly kind: "network_policy_amendment";
       readonly amendment: NetworkPolicyAmendment;
     }
-  | { readonly kind: "denied" }
+  | { readonly kind: "denied"; readonly reason?: string }
   | { readonly kind: "timed_out" }
   | { readonly kind: "abort" };
 

--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -462,7 +462,13 @@ function approvalRejectedResult(err: ApprovalRejectedError, session?: object): T
     }),
     isError: true,
     metadata: {
-      approvalFailure: { decision: err.decision.kind, source: err.source ?? "policy" },
+      approvalFailure: {
+        decision: err.decision.kind,
+        source: err.source ?? "policy",
+        ...(err.decision.kind === "denied" && err.decision.reason !== undefined
+          ? { reason: err.decision.reason }
+          : {}),
+      },
       ...(approvalDenialEndsTurn(err) ? { approvalDenied: true } : {}),
     },
     ...(approvalDenialEndsTurn(err) || isWorkflowApprovalSession(session)

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -19,6 +19,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   canWritePathWithCwd,
+  restrictedFileSystemPolicy,
+  resolvePermissionPath,
   SandboxManager,
   type AdditionalPermissionProfile,
   type PermissionProfile,
@@ -165,6 +167,7 @@ export interface SandboxExecutionBrokerLike {
   isClosedAfterLifecycleAuthorityFailure?(): boolean;
   /** Fork an independent boundary for a child session or worktree. */
   forkForCwd(cwd: string): SandboxExecutionBrokerLike;
+  forkForReadOnlyInspection?(cwd: string, deniedReadPatterns?: readonly string[]): SandboxExecutionBrokerLike;
   status(): SandboxExecutionStatus;
   assertReady(surface: SandboxExecutionSurface): SandboxExecutionStatus;
   runtimeSandbox(
@@ -921,6 +924,56 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
             ),
           }
         : {}),
+      platform: this.#platform,
+      sandboxManager: this.#sandboxManager,
+      probe: this.#probe,
+      planLandlockPolicy: this.#planLandlockPolicy,
+      forkDepth: this.forkDepth + 1,
+      lifecycleLeaseDrainTimeoutMs: this.#lifecycleLeaseDrainTimeoutMs,
+    });
+  }
+
+  forkForReadOnlyInspection(cwd: string, deniedReadPatterns: readonly string[] = []): SandboxExecutionBroker {
+    this.#assertLifecycleAuthorityOpen("child_agent");
+    const base = this.#permissionProfile ?? permissionProfileForSandboxMode(this.mode, { cwd: this.#cwd });
+    if (base.fileSystem.kind === "external_sandbox") {
+      throw new Error("Read-only inspection requires an enforceable managed sandbox, not an external sandbox declaration");
+    }
+    const fileSystem = base.fileSystem;
+    const permissionProfile: PermissionProfile = {
+      fileSystem: fileSystem.kind === "restricted"
+        ? restrictedFileSystemPolicy(fileSystem.entries.map((entry) => {
+            const resolved = resolvePermissionPath(entry.path, this.#cwd, this.#sessionTempRoot);
+            return {
+              path: entry.path.kind === "glob"
+                ? { kind: "glob" as const, pattern: path.resolve(this.#cwd, entry.path.pattern) }
+                : resolved === null ? entry.path : { kind: "path" as const, path: resolved },
+              access: entry.access === "write" ? "read" as const : entry.access,
+            };
+          }), {
+            ...(fileSystem.globScanMaxDepth !== undefined ? { globScanMaxDepth: fileSystem.globScanMaxDepth } : {}),
+            ...(fileSystem.includePlatformDefaults !== undefined ? { includePlatformDefaults: fileSystem.includePlatformDefaults } : {}),
+            ...(fileSystem.reservedReadOnlyPaths !== undefined ? { reservedReadOnlyPaths: fileSystem.reservedReadOnlyPaths } : {}),
+          })
+        : restrictedFileSystemPolicy([{ path: { kind: "special", value: { kind: "root" } }, access: "read" }], { includePlatformDefaults: true }),
+      network: "disabled",
+      ...(base.enforcement !== undefined ? { enforcement: base.enforcement } : {}),
+    };
+    const deniedEntries = deniedReadPatterns.map((pattern) => {
+      if (/[\[\]{}]/u.test(pattern) || /(?:[^/]\*\*|\*\*[^/])/u.test(pattern)) throw new Error("Read-only inspection cannot safely lower this read-denial pattern to platform isolation");
+      const target = pattern.endsWith("/**") ? pattern.slice(0, -3) : pattern;
+      return { path: /[*?]/u.test(target) ? { kind: "glob" as const, pattern: target } : { kind: "path" as const, path: target }, access: "none" as const };
+    });
+    return new SandboxExecutionBroker({
+      mode: "read_only",
+      cwd,
+      env: this.#env,
+      sessionTempRoot: this.#sessionTempRoot,
+      ...(this.#explicitLinuxHelper !== undefined ? { agencLinuxSandboxExe: this.#explicitLinuxHelper } : {}),
+      windowsSandboxLevel: this.#windowsSandboxLevel,
+      windowsSandboxPrivateDesktop: this.#windowsSandboxPrivateDesktop,
+      allowGpu: false,
+      permissionProfile: { ...permissionProfile, fileSystem: { ...permissionProfile.fileSystem, entries: [...permissionProfile.fileSystem.entries, ...deniedEntries] } },
       platform: this.#platform,
       sandboxManager: this.#sandboxManager,
       probe: this.#probe,

--- a/runtime/src/session/rollout-item.ts
+++ b/runtime/src/session/rollout-item.ts
@@ -68,9 +68,25 @@ export interface SessionMemoryExtractionState {
 export interface SessionStateUpdate {
   readonly agentTask?: SessionAgentTask;
   readonly memoryExtraction?: SessionMemoryExtractionState;
+  readonly userStop?: {
+    readonly stopped: boolean;
+    readonly generation: number;
+  };
 }
 
 export type SessionStateSlot = keyof SessionStateUpdate;
+
+export function readPersistedUserStopState(item: RolloutItem): NonNullable<SessionStateUpdate["userStop"]> | undefined {
+  if (item.type !== "session_state" || !Object.hasOwn(item.payload, "userStop")) return undefined;
+  const state = item.payload.userStop;
+  if (
+    state === undefined || state === null || typeof state !== "object" ||
+    typeof state.stopped !== "boolean" || !Number.isSafeInteger(state.generation) ||
+    state.generation < 0 ||
+    Object.keys(state).some((key) => key !== "stopped" && key !== "generation")
+  ) throw new Error("Invalid persisted user-stop state");
+  return state;
+}
 
 /**
  * Whether a persisted `session_state` payload addresses `slot`.

--- a/runtime/src/session/rollout-reconstruction.ts
+++ b/runtime/src/session/rollout-reconstruction.ts
@@ -40,6 +40,7 @@ import type {
   RolloutItem,
   TurnContextItem,
 } from "./rollout-item.js";
+import { readPersistedUserStopState } from "./rollout-item.js";
 import { isAgentInvocationTurnBoundary } from "../contracts/agent-invocation-envelope.js";
 import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 import {
@@ -792,6 +793,9 @@ export function reconstructFromRollout(
   // validating every superseded checkpoint would repeatedly rescan growing
   // prefixes. Only an orphan's highest checkpoint can authorize execution.
   const turnBuildIds = new Map<string, string | undefined>();
+  const turnStartedIndexes = new Map<string, number>();
+  let latestUserStopIndex = -1;
+  const resolverDeniedTurns = new Set<string>();
   const highestCheckpointByTurn = new Map<
     string,
     { readonly checkpoint: TurnCheckpointEvent; readonly rolloutIndex: number }
@@ -802,13 +806,20 @@ export function reconstructFromRollout(
     rolloutIndex += 1
   ) {
     const item = rolloutItems[rolloutIndex];
+    if (item !== undefined && readPersistedUserStopState(item)?.stopped === true) latestUserStopIndex = rolloutIndex;
     if (item?.type !== "event_msg") continue;
+    if (
+      item.payload.msg.type === "permission_decision" &&
+      item.payload.msg.payload.decision === "denied" &&
+      item.payload.msg.payload.source === "resolver"
+    ) resolverDeniedTurns.add(item.payload.msg.payload.turnId);
     const inner = item.payload.msg as { type?: string; payload?: unknown };
     if (inner.type === "turn_started") {
       const payload = inner.payload as { turnId?: string; buildId?: string };
       if (typeof payload?.turnId === "string") {
         seenStarted.add(payload.turnId);
         turnBuildIds.set(payload.turnId, payload.buildId);
+        if (!turnStartedIndexes.has(payload.turnId)) turnStartedIndexes.set(payload.turnId, rolloutIndex);
       }
       continue;
     }
@@ -969,7 +980,10 @@ export function reconstructFromRollout(
       // gate) is byte-identical to today; only the resume CONSUMER acts on
       // a descriptor whose gates pass.
       const checkpointRecord = highestCheckpointByTurn.get(turnId);
-      if (checkpointRecord !== undefined) {
+      if (
+        checkpointRecord !== undefined && !resolverDeniedTurns.has(turnId) &&
+        (turnStartedIndexes.get(turnId) ?? -1) > latestUserStopIndex
+      ) {
         const { checkpoint, rolloutIndex } = checkpointRecord;
         const buildId = turnBuildIds.get(turnId);
         const buildMatches = buildId === expectedBuildId;

--- a/runtime/src/session/rollout-reconstruction.ts
+++ b/runtime/src/session/rollout-reconstruction.ts
@@ -795,10 +795,13 @@ export function reconstructFromRollout(
   const turnBuildIds = new Map<string, string | undefined>();
   const turnStartedIndexes = new Map<string, number>();
   let latestUserStopIndex = -1;
+  let userStopHeld = false;
+  let hasExplicitUserStop = false;
+  const reconstructionRunId = reconstructionSessionId ?? opts.checkpointProjection?.expectedRunId;
   const resolverDeniedTurns = new Set<string>();
   const highestCheckpointByTurn = new Map<
     string,
-    { readonly checkpoint: TurnCheckpointEvent; readonly rolloutIndex: number }
+    { readonly checkpoint: TurnCheckpointEvent; readonly rolloutIndex: number; readonly userStopHeld: boolean }
   >();
   for (
     let rolloutIndex = 0;
@@ -806,13 +809,34 @@ export function reconstructFromRollout(
     rolloutIndex += 1
   ) {
     const item = rolloutItems[rolloutIndex];
-    if (item !== undefined && readPersistedUserStopState(item)?.stopped === true) latestUserStopIndex = rolloutIndex;
+    const persistedUserStop = item === undefined ? undefined : readPersistedUserStopState(item);
+    if (persistedUserStop !== undefined) {
+      hasExplicitUserStop = true;
+      userStopHeld = persistedUserStop.stopped;
+      if (userStopHeld) latestUserStopIndex = rolloutIndex;
+    }
     if (item?.type !== "event_msg") continue;
+    const event = item.payload.msg;
     if (
-      item.payload.msg.type === "permission_decision" &&
-      item.payload.msg.payload.decision === "denied" &&
-      item.payload.msg.payload.source === "resolver"
-    ) resolverDeniedTurns.add(item.payload.msg.payload.turnId);
+      event.type === "permission_decision" &&
+      event.payload.decision === "denied" &&
+      event.payload.source === "resolver"
+    ) {
+      resolverDeniedTurns.add(event.payload.turnId);
+      if (reconstructionRunId === undefined || event.payload.runId === reconstructionRunId) {
+        userStopHeld = true;
+        latestUserStopIndex = rolloutIndex;
+      }
+    } else if (event.type === "turn_aborted" && event.payload.reason === "interrupted") {
+      userStopHeld = true;
+      latestUserStopIndex = rolloutIndex;
+    } else if (
+      !hasExplicitUserStop &&
+      (event.type === "user_message" || event.type === "message_submission") &&
+      typeof event.payload.messageId === "string" &&
+      typeof event.payload.acceptedAt === "string" &&
+      event.payload.streamId !== "session.shell.execute"
+    ) userStopHeld = false;
     const inner = item.payload.msg as { type?: string; payload?: unknown };
     if (inner.type === "turn_started") {
       const payload = inner.payload as { turnId?: string; buildId?: string };
@@ -843,6 +867,7 @@ export function reconstructFromRollout(
       highestCheckpointByTurn.set(checkpoint.turnId, {
         checkpoint,
         rolloutIndex,
+        userStopHeld,
       });
     }
   }
@@ -981,7 +1006,8 @@ export function reconstructFromRollout(
       // a descriptor whose gates pass.
       const checkpointRecord = highestCheckpointByTurn.get(turnId);
       if (
-        checkpointRecord !== undefined && !resolverDeniedTurns.has(turnId) &&
+        checkpointRecord !== undefined && !userStopHeld && !checkpointRecord.userStopHeld &&
+        !resolverDeniedTurns.has(turnId) &&
         (turnStartedIndexes.get(turnId) ?? -1) > latestUserStopIndex
       ) {
         const { checkpoint, rolloutIndex } = checkpointRecord;

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -294,6 +294,7 @@ export interface RunTurnOptions {
    * Never model-supplied; daemon turn drivers derive it from Session.submit.
    */
   readonly rootHumanTurnText?: string;
+  readonly userStopGenerationToRelease?: number;
   /**
    * GOAL #4b Stage 1 — durable-turn resume. When set, the kernel re-enters
    * the drain loop CONTINUING an interrupted turn from the last completed
@@ -2273,6 +2274,18 @@ async function* runTurnKernelInner(
     });
   }
   persistNewResponseItems();
+  if (
+    opts.resume === undefined &&
+    opts.userStopGenerationToRelease !== undefined &&
+    opts.userStopGenerationToRelease === session.userStopGeneration &&
+    session.stoppedByUserSinceLastPrompt
+  ) {
+    if (rolloutPersistenceSuspended() || session.rolloutStore === null) {
+      throw new Error("Releasing a user stop requires a durable human instruction");
+    }
+    session.rolloutStore.flushDurable();
+    session.clearUserStop();
+  }
   if (opts.initialHistoryPersistence === "persist_before_turn") {
     if (rolloutPersistenceSuspended() || session.rolloutStore === null) {
       throw new Error(
@@ -3162,8 +3175,15 @@ async function* runTurnKernelInner(
         (result) => result.isError === true && result.metadata?.approvalDenied === true,
       );
       if (approvalDeniedTools.length > 0) {
+        session.markStoppedByUser();
         const toolNames = [...new Set(approvalDeniedTools.map((result) => result.toolName))];
         lastContent = `Approval was denied for ${toolNames.join(", ")}. The turn stopped without running the denied action.`;
+        const reasons = [...new Set(approvalDeniedTools.flatMap((result) => {
+          const failure = result.metadata?.approvalFailure;
+          if (typeof failure !== "object" || failure === null || !("reason" in failure)) return [];
+          return typeof failure.reason === "string" && failure.reason.trim().length > 0 ? [failure.reason] : [];
+        }))];
+        if (reasons.length > 0) lastContent += ` ${reasons.join("\n")}`;
         const error = new Error(lastContent);
         state.messages.push({ role: "assistant", content: lastContent });
         await syncSessionState();
@@ -3336,6 +3356,7 @@ export function runTurn(
         skipCacheWrite?: boolean;
         displayUserMessage?: string | null;
         rootHumanTurnText?: string;
+        userStopGenerationToRelease?: number;
         instructionPolicy?: LiveInstructionPolicy;
         systemPromptTrust?: "trusted_internal" | "workspace_role";
         systemPromptReplacesBase?: boolean;
@@ -3356,6 +3377,7 @@ export function runTurn(
       skipCacheWrite: opts.skipCacheWrite,
       displayUserMessage: opts.displayUserMessage,
       rootHumanTurnText: opts.rootHumanTurnText,
+      userStopGenerationToRelease: opts.userStopGenerationToRelease,
       instructionPolicy: opts.instructionPolicy,
       systemPromptTrust: opts.systemPromptTrust,
       systemPromptReplacesBase: opts.systemPromptReplacesBase,

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -34,6 +34,9 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { readPersistedUserStopState, type RolloutItem } from "./rollout-item.js";
+import type { ReadOnlyDelegationConstraint } from "../agents/readonly-delegation.js";
 import { isDeepStrictEqual } from "node:util";
 import {
   AsyncLock,
@@ -1355,6 +1358,7 @@ export interface StateDbContext {
 
 /** agenc runtime `SessionServices` — DI container of all session-scoped services. */
 export interface SessionServices {
+  readonly readOnlyDelegation?: ReadOnlyDelegationConstraint;
   /** Immutable operator policy captured for this session at creation time. */
   readonly runtimeOptions: AgentRuntimeOptions;
   readonly mcpConnectionManager: McpConnectionManager;
@@ -2612,6 +2616,10 @@ export class Session {
 
   /** Serialize submit calls so the session keeps a single active turn. */
   private submitQueue: Promise<void> = Promise.resolve();
+  private readonly childFollowupAdmission = new AsyncLocalStorage<{
+    readonly generation: number;
+    suppressed: boolean;
+  }>();
   private hasDeferredAgentMailboxProjection = false;
   private readonly idleInputAdmissions = new Map<string, ReadonlySet<number>>();
 
@@ -3417,6 +3425,7 @@ export class Session {
     userMessage: string | readonly LLMContentPart[],
     opts: SessionRunTurnOptions = {},
   ): AsyncGenerator<PhaseEvent, Terminal> {
+    if (!this.canAdmitCurrentChildFollowup()) return { reason: "cancelled" };
     this.assertProviderSwitchTransactionHealthy();
     this.rolloutStore?.assertCompactionProjectionReady();
     if (
@@ -3466,6 +3475,7 @@ export class Session {
     const { runTurnKernel } = await withTurnAuthority(
       () => import("./run-turn.js"),
     );
+    if (!this.canAdmitCurrentChildFollowup()) return { reason: "cancelled" };
     const history =
       runOpts.history ??
       normalizeHistoryMessages(this.state.unsafePeek().history);
@@ -3753,7 +3763,31 @@ export class Session {
     message: string | readonly LLMContentPart[],
     opts: SessionSubmitOptions = {},
   ): Promise<void> {
+    await this.enqueueSubmit(message, opts);
+  }
+
+  submitChildFollowup(generation = this.userStopGeneration): Promise<boolean> {
+    return this.enqueueSubmit("", { displayUserMessage: null }, generation);
+  }
+
+  private canAdmitCurrentChildFollowup(): boolean {
+    const admission = this.childFollowupAdmission.getStore();
+    if (admission === undefined) return true;
+    if (
+      this.lifecycleState !== "open" ||
+      this.stoppedByUserSinceLastPrompt ||
+      admission.generation !== this.userStopGeneration
+    ) admission.suppressed = true;
+    return !admission.suppressed;
+  }
+
+  private async enqueueSubmit(
+    message: string | readonly LLMContentPart[],
+    opts: SessionSubmitOptions,
+    generation?: number,
+  ): Promise<boolean> {
     if (this.lifecycleState !== "open") {
+      if (generation !== undefined) return false;
       throw new Error("session is shutting down");
     }
     const hooks = this.turnDriverHooks;
@@ -3762,8 +3796,12 @@ export class Session {
     }
     const run = this.submitQueue.then(async () => {
       if (this.lifecycleState !== "open") {
+        if (generation !== undefined) return false;
         throw new Error("session is shutting down");
       }
+      const permitted = (): boolean => generation === undefined ||
+        (!this.stoppedByUserSinceLastPrompt && generation === this.userStopGeneration);
+      if (!permitted()) return false;
       if (this.pendingCompactionCleanups.size > 0) {
         await this.repairPendingCompactionCleanups();
       }
@@ -3781,17 +3819,27 @@ export class Session {
         await this.flushDeferredOrdinarySubmitHooks();
       }
       if (this.lifecycleState !== "open") {
+        if (generation !== undefined) return false;
         throw new Error("session is shutting down");
       }
+      if (!permitted()) return false;
       if (opts.onAccepted !== undefined) {
         await opts.onAccepted();
         if (this.lifecycleState !== "open") {
+          if (generation !== undefined) return false;
           throw new Error("session is shutting down");
         }
       }
-      await hooks.submit(message, opts);
+      if (!permitted()) return false;
+      if (generation === undefined) {
+        await this.childFollowupAdmission.exit(() => hooks.submit(message, opts));
+        return true;
+      }
+      const admission = { generation, suppressed: false };
+      await this.childFollowupAdmission.run(admission, () => hooks.submit(message, opts));
+      return !admission.suppressed;
     });
-    this.submitQueue = run.catch(() => {
+    this.submitQueue = run.then(() => {}, () => {
       /* keep the queue alive for the next submit */
     });
     return run;
@@ -5218,6 +5266,7 @@ export class Session {
   }
 
   private stoppedByUserSinceLastPromptFlag = false;
+  private userStopGenerationValue = 0;
 
   /**
    * A user Stop holds the session quiet until the user speaks again: while
@@ -5228,14 +5277,74 @@ export class Session {
    */
   markStoppedByUser(): void {
     this.stoppedByUserSinceLastPromptFlag = true;
+    if (this.userStopGenerationValue >= Number.MAX_SAFE_INTEGER) {
+      throw new Error("User-stop generation is exhausted");
+    }
+    this.userStopGenerationValue += 1;
+    this.rolloutStore?.appendRollout({
+      type: "session_state",
+      payload: { userStop: { stopped: true, generation: this.userStopGenerationValue } },
+    }, { durable: true });
   }
 
   clearUserStop(): void {
+    if (!this.stoppedByUserSinceLastPromptFlag) return;
+    this.rolloutStore?.appendRollout({
+      type: "session_state",
+      payload: { userStop: { stopped: false, generation: this.userStopGenerationValue } },
+    }, { durable: true });
     this.stoppedByUserSinceLastPromptFlag = false;
   }
 
   get stoppedByUserSinceLastPrompt(): boolean {
     return this.stoppedByUserSinceLastPromptFlag;
+  }
+
+  get userStopGeneration(): number {
+    return this.userStopGenerationValue;
+  }
+
+  restoreUserStopFromRollout(items: readonly RolloutItem[]): void {
+    let stopped = false;
+    let generation = 0;
+    for (const item of items) {
+      let state;
+      try {
+        state = readPersistedUserStopState(item);
+        if (state !== undefined && state.generation < generation) throw new Error("Invalid persisted user-stop generation order");
+      } catch (error) {
+        this.stoppedByUserSinceLastPromptFlag = true;
+        throw error;
+      }
+      if (state !== undefined) {
+        stopped = state.stopped;
+        generation = state.generation;
+        continue;
+      }
+      if (item.type !== "event_msg") continue;
+      const event = item.payload.msg;
+      if (
+        event.type === "permission_decision" &&
+        event.payload.runId === this.conversationId &&
+        event.payload.decision === "denied" &&
+        event.payload.source === "resolver"
+      ) {
+        if (!stopped) generation += 1;
+        stopped = true;
+      } else if (event.type === "turn_aborted" && event.payload.reason === "interrupted") {
+        if (!stopped) generation += 1;
+        stopped = true;
+      }
+      else if (
+        (event.type === "user_message" || event.type === "message_submission") &&
+        typeof event.payload.messageId === "string" &&
+        typeof event.payload.acceptedAt === "string" &&
+        event.payload.streamId !== "session.shell.execute"
+      ) stopped = false;
+    }
+    if (generation < this.userStopGenerationValue) return;
+    this.stoppedByUserSinceLastPromptFlag = stopped;
+    this.userStopGenerationValue = generation;
   }
 
   hasDeferredAgentMailboxMessages(): boolean {

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -5307,6 +5307,7 @@ export class Session {
   restoreUserStopFromRollout(items: readonly RolloutItem[]): void {
     let stopped = false;
     let generation = 0;
+    let hasExplicitUserStopState = false;
     for (const item of items) {
       let state;
       try {
@@ -5317,6 +5318,7 @@ export class Session {
         throw error;
       }
       if (state !== undefined) {
+        hasExplicitUserStopState = true;
         stopped = state.stopped;
         generation = state.generation;
         continue;
@@ -5336,6 +5338,7 @@ export class Session {
         stopped = true;
       }
       else if (
+        !hasExplicitUserStopState &&
         (event.type === "user_message" || event.type === "message_submission") &&
         typeof event.payload.messageId === "string" &&
         typeof event.payload.acceptedAt === "string" &&

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -1487,6 +1487,7 @@ const ROLLOUT_PAYLOAD_VALIDATORS = defineRolloutPayloadValidators({
     {
       agentTask: isSessionAgentTask,
       memoryExtraction: isSessionMemoryExtractionState,
+      userStop: objectShape({ stopped: isBoolean, generation: isNonNegativeInteger }),
     },
   ),
   response_item: isResponseItem,

--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -40,6 +40,7 @@ import {
 } from "./tools/system/coding.js";
 import { SYSTEM_SEARCH_TOOLS_NAME } from "./tools/system/tool-search-name.js";
 import { createBashTool } from "./tools/system/bash.js";
+import { registerBuiltinTool } from "./tools/builtin-provenance.js";
 import { createExecCommandTool } from "./tools/system/exec-command.js";
 import { createWriteStdinTool } from "./tools/system/write-stdin.js";
 import { createKillProcessTool } from "./tools/system/kill-process.js";
@@ -930,6 +931,9 @@ export function buildToolRegistry(
       stringArgumentFields: modelFacingStringArgumentFields,
     },
   ];
+  for (const group of baseBuiltinSurfaceGroups) {
+    if (group.id !== "model-facing") group.tools.forEach(registerBuiltinTool);
+  }
   const baseBuiltinSurface = buildBuiltinToolSurface(baseBuiltinSurfaceGroups);
   const rawDefaultBuiltinTools = baseBuiltinSurface.tools;
   const configuredRawDefaultBuiltinTools = configuredTools(

--- a/runtime/src/tools/builtin-provenance.ts
+++ b/runtime/src/tools/builtin-provenance.ts
@@ -1,0 +1,16 @@
+import type { Tool } from "./types.js";
+
+const builtinImplementations = new WeakMap<object, string>();
+
+export function registerBuiltinTool<ToolType extends Tool>(tool: ToolType): ToolType {
+  builtinImplementations.set(tool.execute, tool.name);
+  return tool;
+}
+
+export function hasTrustedBuiltinImplementation(tool: { readonly name: string; readonly execute?: unknown }): boolean {
+  return typeof tool.execute === "function" && builtinImplementations.get(tool.execute) === tool.name;
+}
+
+export function inheritBuiltinToolProvenance(original: Tool, wrapped: Tool): Tool {
+  return hasTrustedBuiltinImplementation(original) ? registerBuiltinTool(wrapped) : wrapped;
+}

--- a/runtime/src/tools/orchestrator.ts
+++ b/runtime/src/tools/orchestrator.ts
@@ -515,6 +515,9 @@ function approvalRejectionMessage(
   result: RequestApprovalResult,
   toolName: string,
 ): string {
+  if (result.source === "resolver" && result.decision.kind === "denied" && result.reason?.trim()) {
+    return `Permission denied: ${toolName}. ${result.reason}`;
+  }
   if (result.reason !== undefined && result.reason.trim().length > 0) {
     return result.reason;
   }

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -1964,7 +1964,13 @@ function toolDispatchErrorResult(err: unknown, session?: Session): ToolDispatchR
         : {}),
       metadata: {
         ...(approvalDenialEndsTurn(err) ? { approvalDenied: true } : {}),
-        approvalFailure: { decision: err.decision.kind, source: err.source ?? "policy" },
+        approvalFailure: {
+          decision: err.decision.kind,
+          source: err.source ?? "policy",
+          ...(err.decision.kind === "denied" && err.decision.reason !== undefined
+            ? { reason: err.decision.reason }
+            : {}),
+        },
       },
     };
   }

--- a/runtime/src/tools/runtimes/shell.ts
+++ b/runtime/src/tools/runtimes/shell.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+import { inspectReadOnlyCommand } from "../../permissions/readonly-inspection.js";
 import {
   isShellCommandSeparator,
   lexShellCommand,
@@ -22,34 +22,6 @@ export interface ShellRuntimeAccessAnalysis {
   readonly knownSafeWhenTargetless: boolean;
 }
 
-const READ_ONLY_SHELL_COMMANDS = new Set([
-  "basename",
-  "cat",
-  "cut",
-  "dirname",
-  "grep",
-  "head",
-  "ls",
-  "pwd",
-  "rg",
-  "sort",
-  "stat",
-  "tail",
-  "test",
-  "true",
-  "uniq",
-  "wc",
-]);
-
-const READ_ONLY_GIT_SUBCOMMANDS = new Set([
-  "branch",
-  "diff",
-  "log",
-  "merge-base",
-  "rev-parse",
-  "show",
-  "status",
-]);
 const DYNAMIC_SHELL_READ_TARGET_RE = /(?:[$*?\[\]{}~]|`|\$\(|<\()/u;
 
 export function analyzeShellRuntimeAccess(
@@ -71,10 +43,15 @@ export function analyzeShellRuntimeAccess(
     };
   }
 
-  const knownReadOnly = isShellCommandKnownReadOnly(command);
-  const reads = shellCommandReadTargets(command, runtimeCommand.cwd);
+  const inspection = inspectReadOnlyCommand(tool.name, { ...args, ...(tool.name === "exec_command" ? { cmd: command } : { command }) }, cwd, { enforceWorkspaceBoundary: false, allowWorktreeGitInspection: true });
+  const literalStdin = isLiteralCatHereDocument(command);
+  const knownReadOnly = inspection.allowed || literalStdin;
+  const reads = inspection.allowed
+    ? { targets: inspection.invocation.readPaths, indeterminate: false }
+    : literalStdin ? { targets: [], indeterminate: false }
+    : shellCommandReadTargets(command, runtimeCommand.cwd);
   for (const target of reads.targets) {
-    readTargets.add(target);
+    if (!isSafePseudoDevicePath(target)) readTargets.add(target);
   }
   const decision = classifyShellWorkspaceWritePolicy({
     toolName: "exec_command",
@@ -95,11 +72,14 @@ export function analyzeShellRuntimeAccess(
   };
 }
 
-function isShellCommandKnownReadOnly(command: string): boolean {
+function isLiteralCatHereDocument(command: string): boolean {
   const parsed = lexShellCommand(command);
-  if (parsed.malformed || parsed.hasCommandSubstitution) return false;
-  const segments = tokenizeShellLike(command);
-  return segments.length > 0 && segments.every(isShellSegmentKnownReadOnly);
+  const [program, redirect, delimiter, ...tail] = parsed.tokens;
+  return !parsed.malformed && !parsed.hasCommandSubstitution && !parsed.hasComment &&
+    program?.kind === "word" && program.value === "cat" && !program.requiresExpansion &&
+    redirect?.kind === "operator" && ["<<", "<<-"].includes(redirect.value) &&
+    delimiter?.kind === "word" && !delimiter.requiresExpansion &&
+    tail.every((token) => token.kind === "operator" && token.value === ";");
 }
 
 function shellCommandReadTargets(
@@ -148,17 +128,6 @@ function collectShellSegmentReadTargets(
   return { indeterminate };
 }
 
-function isShellSegmentKnownReadOnly(segment: readonly string[]): boolean {
-  const command = shellSegmentCommand(segment);
-  if (command === undefined) return true;
-  const basename = path.basename(command);
-  if (basename === "git") {
-    const subcommand = gitSubcommand(segment);
-    return subcommand !== undefined && READ_ONLY_GIT_SUBCOMMANDS.has(subcommand);
-  }
-  return READ_ONLY_SHELL_COMMANDS.has(basename);
-}
-
 function tokenizeShellLike(command: string): string[][] {
   const segments: string[][] = [];
   let current: string[] = [];
@@ -189,16 +158,6 @@ function shellSegmentCommand(segment: readonly string[]): string | undefined {
     index += 1;
   }
   return segment[index];
-}
-
-function gitSubcommand(segment: readonly string[]): string | undefined {
-  const gitIndex = segment.findIndex((token) => path.basename(token) === "git");
-  if (gitIndex < 0) return undefined;
-  for (const token of segment.slice(gitIndex + 1)) {
-    if (token.startsWith("-")) continue;
-    return token;
-  }
-  return undefined;
 }
 
 function isShellPathOperand(token: string): boolean {

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -11,7 +11,7 @@
 import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { randomBytes } from "node:crypto";
-import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
+import type { Tool, ToolExecutionInjectedArgs, ToolPreflightFailure, ToolResult } from "../types.js";
 import type { BashToolConfig, BashToolInput } from "./types.js";
 import {
   SHELL_COMMAND_SEPARATORS,
@@ -34,6 +34,7 @@ import { silentLogger } from "../../utils/logger.js";
 import type { Logger } from "../../utils/logger.js";
 import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
 import { shellWorkspaceMutationPermission } from "./shell-mutation-permission.js";
+import { preflightShellWorkspaceWritePolicy } from "./shell-preflight.js";
 import { bashToolHasPermission } from "../../permissions/bash.js";
 import type { PermissionResult } from "../../permissions/types.js";
 import { buildRecoverableToolFailureMetadata } from "../result-metadata.js";
@@ -45,7 +46,8 @@ import {
   applyRuntimeSandboxToSpawn,
   type SandboxSpawnCommand,
 } from "./apply-runtime-sandbox.js";
-import type { SandboxPreparedSpawn } from "../../sandbox/execution-broker.js";
+import { readSandboxExecutionBroker, type SandboxPreparedSpawn } from "../../sandbox/execution-broker.js";
+import { assertReadOnlyInspectionInvocation, readReadOnlyInspectionInvocation, type ReadOnlyInspectionInvocation } from "../../permissions/readonly-inspection.js";
 import {
   runSupervisedProcess,
   type SupervisedProcessStopReason,
@@ -384,9 +386,13 @@ function runSpawnedCommand(params: {
   readonly cleanupDirectory?: string;
   readonly signal?: AbortSignal;
   readonly onProgress?: ToolExecutionInjectedArgs["__onProgress"];
+  readonly inspection?: ReadOnlyInspectionInvocation;
 }): Promise<ToolResult> {
   return (async () => {
     try {
+      if (params.inspection !== undefined) {
+        assertReadOnlyInspectionInvocation(params.inspection);
+      }
       const result = await runSupervisedProcess(params.spawnCommand, {
         maxOutputBytes: params.maxOutputBytes * 4,
         ...(params.timeout !== undefined ? { timeoutMs: params.timeout } : {}),
@@ -898,6 +904,66 @@ export function createBashTool(config?: BashToolConfig): Tool {
   const shellModeEnabled = config?.shellMode !== false;
   const execObserver = config?.execObserver;
 
+  function prepareInput(input: Readonly<Record<string, unknown>>): ToolPreflightFailure | {
+    command: string;
+    shellCommand: string;
+    cwd: string;
+    useShellMode: boolean;
+    directArgs: string[];
+  } {
+    const failure = (message: string): ToolPreflightFailure => ({ code: "invalid_input", message });
+    if (Object.prototype.hasOwnProperty.call(input, "timeout")) return failure("unknown field `timeout`");
+    if (typeof input.command !== "string" || input.command.trim().length === 0) {
+      return failure("command must be a non-empty string");
+    }
+    if (input.args !== undefined && !Array.isArray(input.args)) return failure("args must be an array of strings");
+    if (Array.isArray(input.args) && input.args.some((argument) => typeof argument !== "string")) {
+      return failure("Each argument must be a string");
+    }
+    const normalized = normalizeDirectInvocation({
+      command: input.command.trim(),
+      args: input.args as string[] | undefined,
+    });
+    const command = normalized.command;
+    const builtinFallback = normalizeBuiltinShellFallback({ command, args: normalized.args, shellModeEnabled });
+    const shellCommand = builtinFallback ?? command;
+    if (input.cwd !== undefined && lockCwd) return failure("Per-call cwd override is disabled (lockCwd is enabled)");
+    if (input.cwd !== undefined && typeof input.cwd !== "string") return failure("cwd must be a string");
+    const cwd = input.cwd ?? defaultCwd;
+    const useShellMode = shellModeEnabled && (builtinFallback !== undefined || isShellModeCommand(command, normalized.args));
+    const directArgs = normalized.args ?? [];
+    if (useShellMode) {
+      const shellCheck = validateShellCommand(shellCommand);
+      if (!shellCheck.allowed) return failure(shellCheck.reason);
+      if (!unrestricted) {
+        const shellExecutables = extractShellExecutables(shellCommand);
+        if (shellExecutables.dynamicExecutableReason) return failure(shellExecutables.dynamicExecutableReason);
+        for (const executable of shellExecutables.executables) {
+          const check = isCommandAllowed(executable, denySet, allowSet, denyExclusionSet);
+          if (!check.allowed) return failure(check.reason);
+        }
+      }
+    } else {
+      if (normalized.args === undefined && shellModeEnabled && !SINGLE_EXECUTABLE_RE.test(command)) {
+        return failure("Shell mode is disabled. Use `command` + `args` for direct execution.");
+      }
+      const shapeError = validateCommandShape(command) ?? validateShellBuiltin(command);
+      if (shapeError) return failure(shapeError);
+      if (!unrestricted) {
+        const check = isCommandAllowed(command, denySet, allowSet, denyExclusionSet);
+        if (!check.allowed) return failure(check.reason);
+      }
+      const argsError = validateDirectArgs(command, directArgs);
+      if (argsError) return failure(argsError);
+      const wrapperScript = extractShellWrapperInlineScript(command, directArgs);
+      if (wrapperScript) {
+        const shellCheck = validateShellCommand(wrapperScript);
+        if (!shellCheck.allowed) return failure(shellCheck.reason);
+      }
+    }
+    return { command, shellCommand, cwd, useShellMode, directArgs };
+  }
+
   return {
     name: "system.bash",
     // Marked deferred: exec_command is the canonical shell tool (donor runtime
@@ -957,6 +1023,21 @@ export function createBashTool(config?: BashToolConfig): Tool {
       );
     },
 
+    preflight(input) {
+      const prepared = prepareInput(input);
+      if ("code" in prepared) return prepared;
+      const directoryError = validateWorkingDirectory(prepared.cwd);
+      if (directoryError !== null) return { code: "workdir-validation", message: directoryError };
+      return preflightShellWorkspaceWritePolicy({
+        toolName: "system.bash",
+        args: prepared.useShellMode
+          ? { command: prepared.shellCommand, cwd: prepared.cwd }
+          : { command: prepared.command, args: prepared.directArgs, cwd: prepared.cwd },
+        workspaceRoot: prepared.cwd,
+        ...shellWorkspaceMutationPermission(input),
+      });
+    },
+
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
       const input = rawArgs as unknown as BashToolInput &
         ToolExecutionInjectedArgs;
@@ -965,11 +1046,17 @@ export function createBashTool(config?: BashToolConfig): Tool {
       }
       const abortSignal = input.__abortSignal;
       const onProgress = input.__onProgress;
+      let inspection: ReadOnlyInspectionInvocation | undefined;
+      try {
+        inspection = readReadOnlyInspectionInvocation(rawArgs);
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
 
       let commandAuthority:
         | ReturnType<NonNullable<BashToolConfig["commandExecutionAuthority"]>>
         | undefined;
-      if (config?.commandExecutionAuthority !== undefined) {
+      if (inspection === undefined && config?.commandExecutionAuthority !== undefined) {
         try {
           commandAuthority = config.commandExecutionAuthority();
           if (commandAuthority === undefined) {
@@ -983,165 +1070,24 @@ export function createBashTool(config?: BashToolConfig): Tool {
           );
         }
       }
-      const env = buildEnv(
+      const env = inspection?.env ?? buildEnv(
         commandAuthority?.childEnvironment ?? standaloneEnv,
       );
       const shellPath = commandAuthority?.path ?? "/bin/bash";
       const commandWrapperArgv = commandAuthority?.commandWrapperArgv ?? [];
 
-      // Validate command
-      if (
-        typeof input.command !== "string" ||
-        input.command.trim().length === 0
-      ) {
-        return errorResult("command must be a non-empty string");
+      const prepared = prepareInput(rawArgs);
+      if ("code" in prepared) {
+        logger.warn(`Bash tool denied: ${prepared.message}`);
+        return errorResult(prepared.message);
       }
-      if (input.args !== undefined && !Array.isArray(input.args)) {
-        return errorResult("args must be an array of strings");
-      }
-
-      const directArgs = Array.isArray(input.args) ? input.args : undefined;
-      const normalizedDirectInvocation = normalizeDirectInvocation({
-        command: input.command.trim(),
-        args: directArgs,
-      });
-      const command = normalizedDirectInvocation.command;
-      const normalizedArgs = normalizedDirectInvocation.args;
-      const builtinShellFallback = normalizeBuiltinShellFallback({
-        command,
-        args: normalizedArgs,
-        shellModeEnabled,
-      });
-      const shellCommand = builtinShellFallback ?? command;
-
-      // Apply cwd — reject per-call override if lockCwd is enabled.
-      let cwd = defaultCwd;
-      if (input.cwd !== undefined) {
-        if (lockCwd) {
-          return errorResult(
-            "Per-call cwd override is disabled (lockCwd is enabled)",
-          );
-        }
-        cwd = input.cwd;
-      }
-
-      // Determine execution mode: shell vs direct
-      const useShellMode =
-        shellModeEnabled &&
-        (builtinShellFallback !== undefined ||
-          isShellModeCommand(command, normalizedArgs));
-
-      let execCommand: string;
-      let execArgs: string[];
-
-      if (useShellMode) {
-        // Shell mode: validate against dangerous patterns, then run via bash -c
-        const shellCheck = validateShellCommand(shellCommand);
-        if (!shellCheck.allowed) {
-          logger.warn(`Bash tool shell-mode denied: ${shellCheck.reason}`);
-          return errorResult(shellCheck.reason);
-        }
-
-        // Enforce deny/allow policy for each executable discovered in shell mode.
-        if (!unrestricted) {
-          const { executables: shellExecutables, dynamicExecutableReason } =
-            extractShellExecutables(shellCommand);
-          if (dynamicExecutableReason) {
-            logger.warn(
-              `Bash tool shell-mode denied: ${dynamicExecutableReason}`,
-            );
-            return errorResult(dynamicExecutableReason);
-          }
-          for (const shellExecutable of shellExecutables) {
-            const check = isCommandAllowed(
-              shellExecutable,
-              denySet,
-              allowSet,
-              denyExclusionSet,
-            );
-            if (!check.allowed) {
-              logger.warn(`Bash tool shell-mode denied: ${check.reason}`);
-              return errorResult(check.reason);
-            }
-          }
-        }
-
-        execCommand = shellPath;
-        execArgs = [
-          "-c",
-          wrapCommandForShell(shellPath, commandWrapperArgv, shellCommand),
-        ];
-      } else {
-        // Direct mode: validate command shape, builtins, and deny/allow lists
-        if (
-          normalizedArgs === undefined &&
-          shellModeEnabled &&
-          !SINGLE_EXECUTABLE_RE.test(command)
-        ) {
-          // Command has shell operators but shell mode is enabled — this was caught
-          // by isShellModeCommand above, so this branch shouldn't be reached.
-          // Safety fallback for edge cases.
-          return errorResult(
-            "Shell mode is disabled. Use `command` + `args` for direct execution.",
-          );
-        }
-
-        const commandShapeError = validateCommandShape(command);
-        if (commandShapeError) {
-          return errorResult(commandShapeError);
-        }
-        const shellBuiltinError = validateShellBuiltin(command);
-        if (shellBuiltinError) {
-          return errorResult(shellBuiltinError);
-        }
-
-        // Check deny/allow lists (skipped in unrestricted mode)
-        if (!unrestricted) {
-          const check = isCommandAllowed(
-            command,
-            denySet,
-            allowSet,
-            denyExclusionSet,
-          );
-          if (!check.allowed) {
-            logger.warn(`Bash tool denied: ${check.reason}`);
-            return errorResult(check.reason);
-          }
-        }
-
-        // Validate args
-        const args: string[] = [];
-        if (normalizedArgs !== undefined) {
-          if (!Array.isArray(normalizedArgs)) {
-            return errorResult("args must be an array of strings");
-          }
-          for (const arg of normalizedArgs) {
-            if (typeof arg !== "string") {
-              return errorResult("Each argument must be a string");
-            }
-            args.push(arg);
-          }
-          const directArgsError = validateDirectArgs(command, args);
-          if (directArgsError) {
-            return errorResult(directArgsError);
-          }
-        }
-
-        const shellWrapperScript = extractShellWrapperInlineScript(
-          command,
-          args,
-        );
-        if (shellWrapperScript) {
-          const shellCheck = validateShellCommand(shellWrapperScript);
-          if (!shellCheck.allowed) {
-            logger.warn(`Bash tool shell-wrapper denied: ${shellCheck.reason}`);
-            return errorResult(shellCheck.reason);
-          }
-        }
-
-        execCommand = command;
-        execArgs = args;
-      }
+      const { command, shellCommand } = prepared;
+      const cwd = inspection?.cwd ?? prepared.cwd;
+      const useShellMode = inspection === undefined && prepared.useShellMode;
+      const execCommand = inspection?.program ?? (useShellMode ? shellPath : command);
+      const execArgs = inspection !== undefined ? [...inspection.args] : useShellMode
+        ? ["-c", wrapCommandForShell(shellPath, commandWrapperArgv, shellCommand)]
+        : prepared.directArgs;
 
       const workspaceWriteDecision = classifyShellWorkspaceWritePolicy({
         toolName: "system.bash",
@@ -1214,6 +1160,19 @@ export function createBashTool(config?: BashToolConfig): Tool {
           }
         | { readonly ok: false; readonly error: ToolResult } => {
         try {
+          if (inspection !== undefined) {
+            const broker = readSandboxExecutionBroker(rawArgs);
+            if (broker === undefined || broker.mode !== "read_only" || !broker.required) {
+              throw new Error("Read-only inspection requires its authenticated read-only execution broker");
+            }
+            return {
+              ok: true,
+              spawnCommand: broker.prepareSpawn("tool", {
+                program, args, cwd, env: { ...env }, argv0: basename(program),
+                permissionProfileOverride: inspection.runtimeSandbox.permissionProfile,
+              }),
+            };
+          }
           const sandboxed = applyRuntimeSandboxToSpawn({
             toolArgs: rawArgs as Record<string, unknown>,
             fallbackCwd: defaultCwd,
@@ -1399,6 +1358,7 @@ export function createBashTool(config?: BashToolConfig): Tool {
       return observeEnd(
         runSpawnedCommand({
           spawnCommand: sandboxedDirect.spawnCommand,
+          ...(inspection !== undefined ? { inspection } : {}),
           cwd,
           timeout,
           maxOutputBytes,

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -1,9 +1,11 @@
+import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 
-import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
+import type { Tool, ToolExecutionInjectedArgs, ToolPreflightFailure, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
 import { shellWorkspaceMutationPermission } from "./shell-mutation-permission.js";
+import { preflightShellWorkspaceWritePolicy } from "./shell-preflight.js";
 import type { BashToolConfig } from "./types.js";
 import { UnifiedExecError } from "../../unified-exec/types.js";
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
@@ -38,6 +40,7 @@ import {
   sandboxEscalationAvailable,
 } from "./exec-sandbox-denial.js";
 import { parseSandboxPermissionsArgs } from "../../sandbox/escalation/sandboxing.js";
+import { readReadOnlyInspectionInvocation } from "../../permissions/readonly-inspection.js";
 import {
   permissionProfileForRuntimeContext,
   runtimePlatformSandboxStatus,
@@ -369,6 +372,47 @@ const REMOVED_ALIAS_HINTS = {
   cwd: "the working directory goes in `workdir`",
 } as const;
 
+function validateExecCommandInput(
+  args: Readonly<Record<string, unknown>>,
+  config: ExecCommandToolConfig | undefined,
+): ToolPreflightFailure | null {
+  for (const removedAlias of ["command", "cwd"] as const) {
+    if (Object.prototype.hasOwnProperty.call(args, removedAlias)) {
+      return { code: "invalid-input", message: `unknown field \`${removedAlias}\`; ${REMOVED_ALIAS_HINTS[removedAlias]}` };
+    }
+  }
+  const permissions = parseSandboxPermissionsArgs(args);
+  if (permissions.kind === "invalid") return { code: "invalid-input", message: permissions.reason };
+  const cmd = asString(args.cmd);
+  if (cmd === undefined) return { code: "invalid-input", message: "cmd must be a non-empty string" };
+  const workdir = asString(args.workdir);
+  if (workdir !== undefined && workdir.trim().length > 0) {
+    const canonicalPath = (candidate: string): string => {
+      try {
+        return existsSync(candidate) ? realpathSync(candidate) : candidate;
+      } catch {
+        return candidate;
+      }
+    };
+    const resolvedWorkdir = canonicalPath(resolve(config?.cwd ?? process.cwd(), workdir));
+    const roots = (config?.allowedPaths ?? (config?.cwd !== undefined ? [config.cwd] : [])).map(canonicalPath);
+    if (roots.length > 0 && !roots.some((root) =>
+      resolvedWorkdir === root ||
+      resolvedWorkdir.startsWith(root.endsWith("/") || root.endsWith("\\") ? root : `${root}/`) ||
+      resolvedWorkdir.startsWith(root.endsWith("/") || root.endsWith("\\") ? root : `${root}\\`),
+    )) {
+      return { code: "workdir-validation", message: `workdir is outside allowed workspace paths: ${workdir}` };
+    }
+  }
+  if (isMcpShellPlaceholderCommand(cmd)) {
+    return {
+      code: "mcp-routing",
+      message: "MCP tools are not shell commands. Load the tool with system.searchTools if needed, then call the mcp.<server>.<tool> tool directly with JSON arguments. Do not simulate MCP results with exec_command.",
+    };
+  }
+  return null;
+}
+
 export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
   const manager =
     config?.unifiedExecManager ??
@@ -409,6 +453,19 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
     supportsParallelToolCalls: false,
     isConcurrencySafe: () => false,
     interruptBehavior: () => "cancel",
+    preflight(args) {
+      const failure = validateExecCommandInput(args, config);
+      if (failure !== null) return failure;
+      const cmd = asString(args.cmd)!;
+      if (args.tty === true && isPlainInteractiveShellCommand(cmd)) return null;
+      const workdir = asString(args.workdir);
+      return preflightShellWorkspaceWritePolicy({
+        toolName: "exec_command",
+        args: { command: cmd, ...(workdir !== undefined ? { cwd: workdir } : {}) },
+        workspaceRoot: config?.cwd ?? config?.allowedPaths?.[0],
+        ...shellWorkspaceMutationPermission(args),
+      });
+    },
     inputSchema: {
       type: "object",
       properties: {
@@ -463,120 +520,22 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
     },
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
       const args = rawArgs as Record<string, unknown> & ToolExecutionInjectedArgs;
-      for (const removedAlias of ["command", "cwd"] as const) {
-        if (Object.prototype.hasOwnProperty.call(args, removedAlias)) {
-          // Name the field that replaced the alias: a bare "unknown field"
-          // gave the model nothing to correct, and a goal run's implement
-          // child repeated the same `cwd` call 44 times until the backstop
-          // ended the turn.
-          const message =
-            `unknown field \`${removedAlias}\`; ${REMOVED_ALIAS_HINTS[removedAlias]}`;
-          return {
-            content: safeStringify({ error: message }),
-            isError: true,
-            effectDisposition: confirmedNoEffectDisposition(
-              "tool:system.exec-command:invalid-input",
-              message,
-            ),
-          };
-        }
-      }
-      // An escalation request the runtime cannot parse must be refused, not
-      // dropped: the schema invites an object here, and silently treating an
-      // unknown one as "no escalation requested" left the live incident's
-      // model re-sending the same request twelve times with no sign it had
-      // never been read.
-      const permissionsParse = parseSandboxPermissionsArgs(args);
-      if (permissionsParse.kind === "invalid") {
+      const failure = validateExecCommandInput(args, config);
+      if (failure !== null) {
         return {
-          content: safeStringify({ error: permissionsParse.reason }),
+          content: safeStringify({ error: failure.message }),
           isError: true,
+          ...(failure.code === "mcp-routing" ? { metadata: buildRecoverableToolFailureMetadata("mcp_tool_not_shell_command") } : {}),
           effectDisposition: confirmedNoEffectDisposition(
-            "tool:system.exec-command:invalid-input",
-            permissionsParse.reason,
+            `tool:system.exec-command:${failure.code}`,
+            failure.message,
           ),
         };
       }
-      const cmd = asString(args.cmd);
-      if (!cmd) {
-        const message = "cmd must be a non-empty string";
-        return {
-          content: safeStringify({ error: message }),
-          isError: true,
-          effectDisposition: confirmedNoEffectDisposition(
-            "tool:system.exec-command:invalid-input",
-            message,
-          ),
-        };
-      }
+      const cmd = asString(args.cmd)!;
       const workdir = asString(args.workdir);
       const timeoutMs = asNumber(args.timeoutMs);
       const tty = asBoolean(args.tty);
-
-      // Constrain workdir to allowedPaths / workspace root (todo-132).
-      if (workdir !== undefined && workdir.trim().length > 0) {
-        const { resolve: pathResolve, isAbsolute } = await import("node:path");
-        const { realpathSync, existsSync } = await import("node:fs");
-        let resolvedWorkdir = isAbsolute(workdir)
-          ? workdir
-          : pathResolve(config?.cwd ?? process.cwd(), workdir);
-        try {
-          if (existsSync(resolvedWorkdir)) {
-            resolvedWorkdir = realpathSync(resolvedWorkdir);
-          }
-        } catch {
-          /* keep resolvedWorkdir */
-        }
-        const roots = (
-          config?.allowedPaths ??
-          (config?.cwd !== undefined ? [config.cwd] : [])
-        ).map((r) => {
-          try {
-            return existsSync(r) ? realpathSync(r) : r;
-          } catch {
-            return r;
-          }
-        });
-        if (roots.length > 0) {
-          const allowed = roots.some(
-            (root) =>
-              resolvedWorkdir === root ||
-              resolvedWorkdir.startsWith(
-                root.endsWith("/") || root.endsWith("\\") ? root : `${root}/`,
-              ) ||
-              resolvedWorkdir.startsWith(
-                root.endsWith("/") || root.endsWith("\\") ? root : `${root}\\`,
-              ),
-          );
-          if (!allowed) {
-            const message = `workdir is outside allowed workspace paths: ${workdir}`;
-            return {
-              content: safeStringify({ error: message }),
-              isError: true,
-              effectDisposition: confirmedNoEffectDisposition(
-                "tool:system.exec-command:workdir-validation",
-                message,
-              ),
-            };
-          }
-        }
-      }
-
-      if (isMcpShellPlaceholderCommand(cmd)) {
-        const message =
-          "MCP tools are not shell commands. Load the tool with system.searchTools if needed, then call the mcp.<server>.<tool> tool directly with JSON arguments. Do not simulate MCP results with exec_command.";
-        return {
-          content: safeStringify({ error: message }),
-          isError: true,
-          metadata: buildRecoverableToolFailureMetadata(
-            "mcp_tool_not_shell_command",
-          ),
-          effectDisposition: confirmedNoEffectDisposition(
-            "tool:system.exec-command:mcp-routing",
-            message,
-          ),
-        };
-      }
 
       if (!(tty === true && isPlainInteractiveShellCommand(cmd))) {
         const workspaceWriteDecision = classifyShellWorkspaceWritePolicy({
@@ -607,7 +566,8 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
       }
 
       try {
-        const runtimeSandbox = runtimeSandboxForExec(
+        const inspection = readReadOnlyInspectionInvocation(args);
+        const runtimeSandbox = inspection?.runtimeSandbox ?? runtimeSandboxForExec(
           args,
           config?.cwd ?? process.cwd(),
         );
@@ -617,10 +577,14 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
         const output = await manager.execCommand({
           cmd,
           callId: asString(args.__callId),
-          ...(workdir !== undefined ? { workdir } : {}),
-          ...(asString(args.shell) !== undefined ? { shell: asString(args.shell) } : {}),
-          ...(asBoolean(args.login) !== undefined ? { login: asBoolean(args.login) } : {}),
-          ...(tty !== undefined ? { tty } : {}),
+          ...(inspection !== undefined
+            ? { directInvocation: inspection, workdir: inspection.cwd }
+            : {
+                ...(workdir !== undefined ? { workdir } : {}),
+                ...(asString(args.shell) !== undefined ? { shell: asString(args.shell) } : {}),
+                ...(asBoolean(args.login) !== undefined ? { login: asBoolean(args.login) } : {}),
+                ...(tty !== undefined ? { tty } : {}),
+              }),
           ...(asNumber(args.yield_time_ms) !== undefined
             ? { yield_time_ms: asNumber(args.yield_time_ms) }
             : {}),

--- a/runtime/src/tools/system/file-read.ts
+++ b/runtime/src/tools/system/file-read.ts
@@ -43,6 +43,10 @@ import { createReadStream } from "node:fs";
 import { open, readFile, stat } from "node:fs/promises";
 import { dirname, extname, isAbsolute, resolve } from "node:path";
 import { createInterface } from "node:readline";
+import {
+  hasReadOnlyDelegationReadGuard,
+  readOnlyDelegationReadPathAllowed,
+} from "../../permissions/readonly-read-guard.js";
 
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
 import { plainTextErrorToolResult as errorResult } from "../results.js";
@@ -620,6 +624,7 @@ async function resolveAndCheck(
 // ─────────────────────────────────────────────────────────────────────
 
 interface TextReadOpts {
+  readonly readGuard?: () => void;
   readonly maxTextBytes: number;
   readonly maxTokens: number;
   readonly offset: number;
@@ -693,6 +698,7 @@ async function readTextFile(
         boundFile?.stats.size ??
         fileStats?.size ??
         0);
+  opts.readGuard?.();
   if (!explicitWindow && authoritativeBytes > opts.maxTextBytes) {
     return errorResult(
       `File size ${formatBytes(authoritativeBytes)} exceeds the text-read limit of ${formatBytes(
@@ -755,6 +761,7 @@ async function readTextFile(
   // still satisfy the read-before-write gate. AgenC only blocks
   // auto-injected processed partial views; AgenC does not populate that
   // path here.
+  opts.readGuard?.();
   recordSessionRead(sessionId, resolvedPath.canonical, {
     content: sliced.content,
     timestamp:
@@ -1050,6 +1057,7 @@ async function readNotebookFile(
     }
   }
   const fileStats = boundFile?.stats ?? rawFileStats;
+  opts.readGuard?.();
   const rawText =
     editorRead?.content ??
     boundFile?.content.toString("utf8") ??
@@ -1087,6 +1095,7 @@ async function readNotebookFile(
     );
   }
 
+  opts.readGuard?.();
   recordSessionRead(sessionId, resolvedPath.canonical, {
     content: sliced.content,
     timestamp:
@@ -1153,6 +1162,7 @@ async function readNotebookFile(
 }
 
 interface ImageReadOpts {
+  readonly readGuard?: () => void;
   readonly displayPath: string;
   readonly ext: string;
   readonly maxImageBytes: number;
@@ -1367,6 +1377,7 @@ async function readImageFile(
     return errorResult("Path is not a regular file");
   }
   const fileStats = boundFile?.stats ?? rawFileStats!;
+  opts.readGuard?.();
   if (fileStats.size === 0) {
     return errorResult(`Image file is empty: ${opts.displayPath}`);
   }
@@ -1403,6 +1414,7 @@ async function readImageFile(
   // of the same image to dedup if the session needs the gate. The
   // changed-files producer uses `rawContent` (base64 here) as the diff
   // anchor for image edits.
+  opts.readGuard?.();
   recordSessionRead(sessionId, resolvedPath.canonical, {
     content: null,
     timestamp:
@@ -1581,16 +1593,39 @@ export function createFileReadTool(config: FileReadToolConfig): Tool {
       const resolveResult = await resolveAndCheck(filePath, config, rawArgs);
       if ("err" in resolveResult) return resolveResult.err;
       const resolved = resolveResult.ok;
+      const guardedRead = hasReadOnlyDelegationReadGuard(rawArgs);
+      const readGuard = (): void => {
+        if (
+          !readOnlyDelegationReadPathAllowed(rawArgs, resolved.absolute) ||
+          !readOnlyDelegationReadPathAllowed(rawArgs, resolved.canonical)
+        ) {
+          throw new Error("Access denied: file is outside delegated read authority");
+        }
+      };
+      const finalizeRead = async (
+        pending: Promise<ToolResult>,
+      ): Promise<ToolResult> => {
+        const result = await pending;
+        readGuard();
+        return result;
+      };
 
       const sessionId = resolveSessionId(rawArgs);
       let boundRead: WorkspaceBoundFileReadCapability | undefined;
 
       try {
+        readGuard();
+        if (guardedRead && isPdf) {
+          return errorResult(
+            "PDF extraction is unavailable under delegated read authority because the external PDF helper cannot use a held file descriptor portably.",
+          );
+        }
         const trustedEditorInteraction =
           readToolRuntimeContext(rawArgs)?.invocation.turn.editorInteraction !==
           undefined;
         const editorRead = workspaceAuthoritativeRead(resolved.canonical);
         const protectedByEditor =
+          guardedRead ||
           trustedEditorInteraction ||
           workspaceHasProtectedEditorPaths(resolved.canonical);
         const needsDiskCapability = isImage || isPdf || editorRead === null;
@@ -1598,13 +1633,16 @@ export function createFileReadTool(config: FileReadToolConfig): Tool {
           boundRead = await bindWorkspaceFileReadCapability(resolved.canonical);
         }
         await config.__testAfterFinalPathCheck?.();
+        readGuard();
 
         if (isImage) {
-          return await readImageFile(
-            resolved,
-            { displayPath: filePath, ext, maxImageBytes },
-            sessionId,
-            boundRead,
+          return await finalizeRead(
+            readImageFile(
+              resolved,
+              { displayPath: filePath, ext, maxImageBytes, readGuard },
+              sessionId,
+              boundRead,
+            ),
           );
         }
         if (isPdf) {
@@ -1628,7 +1666,27 @@ export function createFileReadTool(config: FileReadToolConfig): Tool {
           );
         }
         if (isNotebook) {
-          return await readNotebookFile(
+          return await finalizeRead(
+            readNotebookFile(
+              resolved,
+              {
+                maxTextBytes,
+                maxTokens,
+                offset,
+                limit,
+                displayPath: filePath,
+                maxImageBytes,
+                maxNotebookBytes,
+                readGuard,
+              },
+              sessionId,
+              editorRead,
+              boundRead,
+            ),
+          );
+        }
+        return await finalizeRead(
+          readTextFile(
             resolved,
             {
               maxTextBytes,
@@ -1636,27 +1694,13 @@ export function createFileReadTool(config: FileReadToolConfig): Tool {
               offset,
               limit,
               displayPath: filePath,
-              maxImageBytes,
-              maxNotebookBytes,
+              readGuard,
             },
             sessionId,
             editorRead,
             boundRead,
-          );
-        }
-        return await readTextFile(
-          resolved,
-          {
-            maxTextBytes,
-            maxTokens,
-            offset,
-            limit,
-            displayPath: filePath,
-          },
-          sessionId,
-          editorRead,
-          boundRead,
-          !trustedEditorInteraction,
+            !trustedEditorInteraction,
+          ),
         );
       } catch (err) {
         const code = (err as NodeJS.ErrnoException)?.code;

--- a/runtime/src/tools/system/glob.ts
+++ b/runtime/src/tools/system/glob.ts
@@ -20,6 +20,13 @@
 
 import { promises as fs } from "node:fs";
 import {
+  hasReadOnlyDelegationReadGuard,
+  readOnlyDelegationReadAuthorityCurrent,
+  readOnlyDelegationReadPathAllowed,
+} from "../../permissions/readonly-read-guard.js";
+import { collectGuardedSearchCandidates } from "./guarded-search-candidates.js";
+import { createSearchIgnoreMatcher, pinnedSnapshotPathEligibility } from "./grep.js";
+import {
   basename,
   dirname,
   isAbsolute,
@@ -799,11 +806,13 @@ const MATCH_VALIDATION_CONCURRENCY = 16;
 async function validateMatch(params: {
   readonly match: Buffer;
   readonly target: ResolvedGlobTarget;
+  readonly toolArgs?: object;
   readonly readCapability?: WorkspaceBoundReadCapability;
 }): Promise<string | undefined> {
   const normalizedBytes = normalizeRelativeRipgrepPathBytes(params.match);
   if (!isSafeRelativeRipgrepPathBytes(normalizedBytes)) return undefined;
   const decoded = decodeRipgrepPathBytes(normalizedBytes);
+  if (params.toolArgs !== undefined && (decoded === undefined || !readOnlyDelegationReadPathAllowed(params.toolArgs, resolve(params.target.displayRoot, decoded)))) return undefined;
   if (params.readCapability !== undefined) {
     if (decoded === undefined) return undefined;
     const absolute = resolve(params.target.displayRoot, decoded);
@@ -821,6 +830,7 @@ async function validateMatch(params: {
     } catch {
       return undefined;
     }
+    if (params.toolArgs !== undefined && !readOnlyDelegationReadPathAllowed(params.toolArgs, absolute)) return undefined;
     return renderRipgrepPathBytes(normalizedBytes);
   }
   if (decoded === undefined) {
@@ -837,6 +847,7 @@ async function validateMatch(params: {
 async function normalizeAndFilterMatches(params: {
   readonly matches: readonly Buffer[];
   readonly target: ResolvedGlobTarget;
+  readonly toolArgs?: object;
   readonly readCapability?: WorkspaceBoundReadCapability;
 }): Promise<readonly string[]> {
   const safeMatches: string[] = [];
@@ -854,6 +865,7 @@ async function normalizeAndFilterMatches(params: {
         validateMatch({
           match,
           target: params.target,
+          toolArgs: params.toolArgs,
           ...(params.readCapability !== undefined
             ? { readCapability: params.readCapability }
             : {}),
@@ -1004,6 +1016,7 @@ export function createGlobTool(
       if ("error" in target) {
         return errorResult(target.error);
       }
+      if (!readOnlyDelegationReadPathAllowed(rawArgs, target.searchRoot)) return errorResult("Access denied: search path is outside delegated read authority");
       let readCapability: WorkspaceBoundReadCapability | undefined;
       let enumerationCapability: WorkspaceBoundReadCapability | undefined;
       let toolOperation: WorkspaceToolOperationToken | undefined;
@@ -1047,6 +1060,40 @@ export function createGlobTool(
         const effectiveLimit = limit + 1;
         const signal = args.__abortSignal;
         const includeIgnored = asBoolean(args.includeIgnored) ?? false;
+        if (hasReadOnlyDelegationReadGuard(rawArgs)) {
+          const ignored = includeIgnored ? async () => false : await createSearchIgnoreMatcher(target.displayRoot, {
+            toolArgs: rawArgs,
+            readCapability: enumerationCapability,
+          });
+          const excludedDirectories = new Set(DEFAULT_GLOB_EXCLUDE_GLOBS.filter(pattern => pattern.endsWith("/**")).map(pattern => pattern.split("/")[1]));
+          const candidates = await collectGuardedSearchCandidates({
+            root: target.searchRoot,
+            toolArgs: rawArgs,
+            signal,
+            acceptPath: async (path, directory) => (includeIgnored || !relative(target.displayRoot, path).split(sep).some(segment => excludedDirectories.has(segment))) && !(await ignored(directory ? join(path, ".agenc-search-candidate") : path)),
+          });
+          const selected = await pinnedSnapshotPathEligibility({
+            relativePaths: candidates.map(candidate => relative(target.searchRoot, candidate.path)),
+            globs: [target.pattern, ...(includeIgnored ? [] : DEFAULT_GLOB_EXCLUDE_GLOBS.map(pattern => `!${pattern}`))],
+            signal,
+          });
+          if ("error" in selected) return errorResult(selected.error);
+          const matches = candidates.filter(candidate => selected.has(relative(target.searchRoot, candidate.path).split(sep).join("/"))).sort((left, right) => right.modifiedMs - left.modifiedMs || left.path.localeCompare(right.path));
+          const normalized = await normalizeAndFilterMatches({
+            matches: matches.map(candidate => Buffer.from(relative(target.displayRoot, candidate.path))),
+            target,
+            toolArgs: rawArgs,
+            readCapability,
+          });
+          const kept = normalized.slice(0, limit);
+          const truncated = normalized.length > limit;
+          if (!readOnlyDelegationReadAuthorityCurrent(rawArgs)) {
+            return errorResult("Access denied: delegated read authority changed during search");
+          }
+          return textResult(kept.length === 0 ? "No files found" : [...kept, ...(truncated ? [TRUNCATION_NOTE] : [])].join("\n"), {
+            pattern, searchRoot: target.searchRoot, numFiles: kept.length, durationMs: Date.now() - startedAt, truncated,
+          });
+        }
         const rootIgnoreFiles = includeIgnored
           ? []
           : await discoverRipgrepRootIgnoreFiles({

--- a/runtime/src/tools/system/grep.ts
+++ b/runtime/src/tools/system/grep.ts
@@ -19,6 +19,7 @@ import {
   dirname,
   isAbsolute,
   join,
+  parse,
   relative,
   resolve,
   sep,
@@ -27,6 +28,12 @@ import {
 import { performance } from "node:perf_hooks";
 
 import ignore from "ignore";
+import {
+  hasReadOnlyDelegationReadGuard,
+  readOnlyDelegationReadAuthorityCurrent,
+  readOnlyDelegationReadPathAllowed,
+} from "../../permissions/readonly-read-guard.js";
+import { collectGuardedSearchCandidates } from "./guarded-search-candidates.js";
 
 import { resolveSessionTempRoot } from "../../session/runtime-options.js";
 import { scrubEnvForChildProcess } from "../../unified-exec/scrub-env.js";
@@ -823,6 +830,10 @@ async function resolveSearchPath(params: {
     const candidateSafe = await safePath(rawCandidate, allowedPaths);
     if (!candidateSafe.safe) {
       lastDenied = candidateSafe.reason;
+      continue;
+    }
+    if (!readOnlyDelegationReadPathAllowed(params.args, candidateSafe.resolved)) {
+      lastDenied = "search path is outside delegated read authority";
       continue;
     }
     const candidateStat = await stat(candidateSafe.resolved, {
@@ -2346,7 +2357,7 @@ export function searchPathUsesDefaultExcludedDirectory(
   );
 }
 
-async function pinnedSnapshotPathEligibility(params: {
+export async function pinnedSnapshotPathEligibility(params: {
   readonly relativePaths: readonly string[];
   readonly globs: readonly string[];
   readonly type?: string;
@@ -2550,7 +2561,8 @@ async function eligibleAuthoritativeSnapshots(params: {
 }): Promise<
   readonly WorkspaceAuthoritativeDirtySnapshot[] | { readonly error: string }
 > {
-  const relativePaths = params.snapshots.map((snapshot) =>
+  const permittedSnapshots = params.snapshots.filter(snapshot => readOnlyDelegationReadPathAllowed(params.toolArgs, snapshot.path));
+  const relativePaths = permittedSnapshots.map((snapshot) =>
     toRelativeIfInside(snapshot.path, params.target.searchRoot),
   );
   const selectedPaths =
@@ -2569,6 +2581,7 @@ async function eligibleAuthoritativeSnapshots(params: {
   const isIgnored = params.opts.includeIgnored
     ? async (): Promise<boolean> => false
     : await createSearchIgnoreMatcher(params.target.displayRoot, {
+        toolArgs: params.toolArgs,
         ...(params.ignoreReadCapability !== undefined
           ? { readCapability: params.ignoreReadCapability }
           : {}),
@@ -2577,7 +2590,7 @@ async function eligibleAuthoritativeSnapshots(params: {
       });
 
   const eligible: WorkspaceAuthoritativeDirtySnapshot[] = [];
-  for (const snapshot of params.snapshots) {
+  for (const snapshot of permittedSnapshots) {
     if (
       params.deadline !== undefined &&
       remainingGrepOperationMs(params.deadline) < 1
@@ -2643,13 +2656,15 @@ async function collectAuthoritativeSnapshotRecords(params: {
   const eligible = await eligibleAuthoritativeSnapshots(params);
   if ("error" in eligible) return eligible;
   const maximumLines = params.maximumLines;
+  const guardedRead = hasReadOnlyDelegationReadGuard(params.toolArgs);
   const searchSnapshot = (
     snapshot: WorkspaceAuthoritativeDirtySnapshot,
     skipLines: number,
     retainedLineLimit: number | undefined,
     readCapability?: WorkspaceBoundReadCapability,
-  ): Promise<LimitedRipgrepResult> =>
-    runRipgrepCollectRecords({
+  ): Promise<LimitedRipgrepResult> => {
+    if (!readOnlyDelegationReadPathAllowed(params.toolArgs, snapshot.path)) return Promise.resolve(emptyLimitedRipgrepResult());
+    return runRipgrepCollectRecords({
       outputMode: params.opts.outputMode,
       args: buildRipgrepArgs({
         ...params.opts,
@@ -2657,7 +2672,7 @@ async function collectAuthoritativeSnapshotRecords(params: {
         type: undefined,
         globs: [],
       }),
-      cwd: ripgrepCwdForTarget(params.target),
+      cwd: guardedRead ? parse(params.target.absolute).root : ripgrepCwdForTarget(params.target),
       toolArgs: params.toolArgs,
       ...(retainedLineLimit !== undefined
         ? { maximumLines: retainedLineLimit }
@@ -2665,10 +2680,11 @@ async function collectAuthoritativeSnapshotRecords(params: {
       ...(skipLines > 0 ? { skipLines } : {}),
       stdin: snapshot.content,
       signal: params.signal,
-      ...(readCapability !== undefined ? { readCapability } : {}),
+      ...(readCapability !== undefined && !guardedRead ? { readCapability } : {}),
       ...(params.deadline !== undefined ? { deadline: params.deadline } : {}),
       operationBudget: params.operationBudget,
     });
+  };
   const records: RipgrepOutputRecord[] = [];
   let collectedLines = 0;
   let processedLines = 0;
@@ -2724,6 +2740,7 @@ async function collectAuthoritativeSnapshotRecords(params: {
     }
     processedLines += result.processedLines;
     remainingSkip = Math.max(0, remainingSkip - result.processedLines);
+    if (!readOnlyDelegationReadPathAllowed(params.toolArgs, snapshot.path)) continue;
     for (const record of result.records) {
       const attributed = attributeStdinResultRecord(record, snapshot.path);
       if (attributed !== null) {
@@ -3464,7 +3481,8 @@ async function collectDescriptorBoundDiskRecords(params: {
 }): Promise<LimitedRipgrepResult> {
   if (!params.target.existsOnDisk) return emptyLimitedRipgrepResult();
 
-  if (params.target.isDirectory && params.opts.outputMode === "content") {
+  const guardedRead = hasReadOnlyDelegationReadGuard(params.toolArgs);
+  if (!guardedRead && params.target.isDirectory && params.opts.outputMode === "content") {
     return collectDescriptorBoundContentFromSpool(params);
   }
 
@@ -3479,7 +3497,31 @@ async function collectDescriptorBoundDiskRecords(params: {
   let candidatePaths: string[];
   let discoveryTruncated = false;
   let discoveryProcessedLines = 0;
-  if (params.target.isDirectory) {
+  let remainingInputBytes = MAX_GREP_DECODED_BYTES;
+  if (params.target.isDirectory && guardedRead) {
+    const ignored = params.opts.includeIgnored ? async () => false : await createSearchIgnoreMatcher(params.target.displayRoot, {
+      toolArgs: params.toolArgs,
+      readCapability: discoveryReadCapability,
+      deadline: params.deadline,
+      respectVcsIgnores: params.target.respectVcsIgnores,
+    });
+    const candidates = await collectGuardedSearchCandidates({
+      root: params.target.absolute,
+      toolArgs: params.toolArgs,
+      signal: params.signal,
+      acceptPath: async (path, directory) => !searchPathUsesDefaultExcludedDirectory(relative(params.target.displayRoot, path), params.opts.includeIgnored) && !(await ignored(directory ? join(path, ".agenc-search-candidate") : path)),
+    });
+    const selected = await pinnedSnapshotPathEligibility({
+      relativePaths: candidates.map(candidate => relative(params.target.searchRoot, candidate.path)),
+      globs: params.opts.globs,
+      type: params.opts.type,
+      signal: params.signal,
+      deadline: params.deadline,
+    });
+    if ("error" in selected) return { ...emptyLimitedRipgrepResult(), exitCode: 127, spawnError: new Error(selected.error) };
+    candidatePaths = candidates.map(candidate => candidate.path).filter(path => !dirtyDiskPaths.has(path) && selected.has(normalizedRelativeResultPath(relative(params.target.searchRoot, path)))).sort();
+    params.operationBudget.consumeWork(candidatePaths.length);
+  } else if (params.target.isDirectory) {
     const discoveryOutputMode: OutputMode =
       params.opts.outputMode === "count" ? "count" : "files_with_matches";
     const excludedPaths = params.authoritativeSnapshots
@@ -3585,6 +3627,7 @@ async function collectDescriptorBoundDiskRecords(params: {
     skipLines: number,
     retainedLineLimit: number | undefined,
   ): Promise<LimitedRipgrepResult> => {
+    if (!readOnlyDelegationReadPathAllowed(params.toolArgs, candidatePath)) return emptyLimitedRipgrepResult();
     const relativeInputFile = descriptorRelativePath(
       candidatePath,
       capability.rootPath,
@@ -3598,6 +3641,23 @@ async function collectDescriptorBoundDiskRecords(params: {
         ),
       };
     }
+    let stdin: Buffer | undefined;
+    if (guardedRead) {
+      if (params.signal?.aborted) return { ...emptyLimitedRipgrepResult(), aborted: true };
+      try {
+        const admitted = await capability.readRelativeFile(relativeInputFile, remainingInputBytes);
+        remainingInputBytes -= admitted.content.byteLength;
+        stdin = admitted.content;
+      } catch (error) {
+        return {
+          ...emptyLimitedRipgrepResult(),
+          exitCode: 127,
+          spawnError: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+      if (!readOnlyDelegationReadPathAllowed(params.toolArgs, candidatePath)) return emptyLimitedRipgrepResult();
+      if (params.signal?.aborted) return { ...emptyLimitedRipgrepResult(), aborted: true };
+    }
     return runRipgrepCollectRecords({
       outputMode: params.opts.outputMode,
       args: buildRipgrepArgs({
@@ -3606,15 +3666,14 @@ async function collectDescriptorBoundDiskRecords(params: {
         type: undefined,
         globs: [],
       }),
-      cwd: capability.rootPath,
+      cwd: guardedRead ? parse(capability.rootPath).root : capability.rootPath,
       toolArgs: params.toolArgs,
       ...(retainedLineLimit !== undefined
         ? { maximumLines: retainedLineLimit }
         : {}),
       ...(skipLines > 0 ? { skipLines } : {}),
-      relativeInputFile,
+      ...(stdin !== undefined ? { stdin } : { relativeInputFile, readCapability: capability }),
       signal: params.signal,
-      readCapability: capability,
       ...(params.deadline !== undefined ? { deadline: params.deadline } : {}),
       operationBudget: params.operationBudget,
     });
@@ -3627,7 +3686,7 @@ async function collectDescriptorBoundDiskRecords(params: {
   let killedAfterLimit = discoveryTruncated;
   let remainingSkip = params.skipLines ?? 0;
   const verifiedResults =
-    params.opts.outputMode === "content"
+    guardedRead || params.opts.outputMode === "content"
       ? undefined
       : await mapProtectedRipgrepTasks({
           items: candidatePaths,
@@ -3686,6 +3745,7 @@ async function collectDescriptorBoundDiskRecords(params: {
     decodedBytes += verified.decodedBytes;
     processedLines += verified.processedLines;
     remainingSkip = Math.max(0, remainingSkip - verified.processedLines);
+    if (!readOnlyDelegationReadPathAllowed(params.toolArgs, candidatePath)) continue;
     for (const record of verified.records) {
       const attributed = attributeStdinResultRecord(record, candidatePath);
       if (attributed !== null) {
@@ -3710,7 +3770,7 @@ async function collectDescriptorBoundDiskRecords(params: {
     killedAfterLimit,
     aborted: false,
     processedLines:
-      params.opts.outputMode === "content"
+      guardedRead || params.opts.outputMode === "content"
         ? processedLines
         : discoveryProcessedLines,
   };
@@ -3755,6 +3815,7 @@ async function discoverSearchRootIgnoreFiles(params: {
 export async function createSearchIgnoreMatcher(
   displayRoot: string,
   options: {
+    readonly toolArgs?: object;
     readonly readCapability?: WorkspaceBoundReadCapability;
     readonly deadline?: GrepOperationDeadline;
     readonly respectVcsIgnores?: boolean;
@@ -3796,6 +3857,7 @@ export async function createSearchIgnoreMatcher(
   }
 
   async function readIgnoreFile(path: string): Promise<string | undefined> {
+    if (options.toolArgs !== undefined && !readOnlyDelegationReadPathAllowed(options.toolArgs, path)) return undefined;
     if (
       options.deadline !== undefined &&
       remainingGrepOperationMs(options.deadline) < 1
@@ -4078,6 +4140,7 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
       if ("error" in target) {
         return errorResult(target.error);
       }
+      if (!readOnlyDelegationReadPathAllowed(rawArgs, target.absolute)) return errorResult("Access denied: search path is outside delegated read authority");
       let readCapability: WorkspaceBoundReadCapability | undefined;
       let toolOperation: WorkspaceToolOperationToken | undefined;
       let requiresStrictCandidateReads = false;
@@ -4087,7 +4150,7 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
           GREP_TOOL_NAME,
         );
         toolOperation = operation.token;
-        requiresStrictCandidateReads = operation.requiresStrictCandidateReads;
+        requiresStrictCandidateReads = operation.requiresStrictCandidateReads || hasReadOnlyDelegationReadGuard(rawArgs);
         readCapability = requiresStrictCandidateReads
           ? await bindTargetReadCapability(target)
           : await bindWorkspaceDirectoryReadCapability(target.displayRoot, {
@@ -4124,18 +4187,24 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
         try {
           authoritativeCapture = captureWorkspaceAuthoritativeDirtySnapshots(
             target.absolute,
-            { includeDescendants: target.isDirectory },
+            {
+              includeDescendants: target.isDirectory,
+              ...(hasReadOnlyDelegationReadGuard(rawArgs) ? { pathAllowed: (path: string) => readOnlyDelegationReadPathAllowed(rawArgs, path) } : {}),
+            },
           );
         } catch (error) {
           return editorCoherenceError(error);
         }
-        const authoritativeSnapshots = authoritativeCapture.snapshots;
+        const authoritativeSnapshots = authoritativeCapture.snapshots.filter(snapshot => readOnlyDelegationReadPathAllowed(rawArgs, snapshot.path));
         await afterFinalPathCheck?.();
         const finalizeAuthoritativeResult = async (
           result: ToolResult,
         ): Promise<ToolResult> => {
           await beforeAuthoritativeSnapshotValidation?.();
           try {
+            if (!readOnlyDelegationReadAuthorityCurrent(rawArgs)) {
+              return errorResult("Access denied: delegated read authority changed during search");
+            }
             return authoritativeCapture.isCurrent()
               ? result
               : editorCoherenceError();
@@ -4148,7 +4217,7 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
         const deadline = createGrepOperationDeadline();
         let rootIgnoreSnapshots: readonly RipgrepIgnoreFileSnapshot[];
         try {
-          rootIgnoreSnapshots = normalized.includeIgnored
+          rootIgnoreSnapshots = normalized.includeIgnored || hasReadOnlyDelegationReadGuard(rawArgs)
             ? []
             : await discoverSearchRootIgnoreFiles({
                 target,
@@ -4185,12 +4254,14 @@ export function createGrepTool(config?: GrepToolConfig): Tool {
           );
         }
 
-        const cwdForProbe = ripgrepCwdForTarget(target) || process.cwd();
+        const cwdForProbe = hasReadOnlyDelegationReadGuard(rawArgs)
+          ? parse(target.absolute).root
+          : ripgrepCwdForTarget(target) || process.cwd();
         const ripgrepReady = await isRipgrepAvailable(
           cwdForProbe,
           rawArgs,
           signal,
-          readCapability,
+          hasReadOnlyDelegationReadGuard(rawArgs) ? undefined : readCapability,
           deadline,
         );
 

--- a/runtime/src/tools/system/guarded-search-candidates.ts
+++ b/runtime/src/tools/system/guarded-search-candidates.ts
@@ -1,0 +1,47 @@
+import { lstat, opendir } from "node:fs/promises";
+import { join } from "node:path";
+import { readOnlyDelegationReadPathAllowed } from "../../permissions/readonly-read-guard.js";
+import { MAX_GREP_DECODED_BYTES, MAX_GREP_RESULTS, MAX_GREP_WALL_MS } from "./ripgrep-protocol.js";
+
+export async function collectGuardedSearchCandidates(params: {
+  readonly root: string;
+  readonly toolArgs: object;
+  readonly signal?: AbortSignal;
+  readonly acceptPath: (path: string, directory: boolean) => boolean | Promise<boolean>;
+}): Promise<Array<{ readonly path: string; readonly modifiedMs: number }>> {
+  const candidates: Array<{ readonly path: string; readonly modifiedMs: number }> = [];
+  const pending = [{ path: params.root, depth: 0 }];
+  const startedAt = Date.now();
+  let visited = 0;
+  let pathBytes = 0;
+  while (pending.length > 0) {
+    const directory = pending.pop()!;
+    if (directory.depth > 256) throw new Error("Search exceeds the directory depth limit");
+    if (!readOnlyDelegationReadPathAllowed(params.toolArgs, directory.path)) continue;
+    if (!(await params.acceptPath(directory.path, true))) continue;
+    if (!readOnlyDelegationReadPathAllowed(params.toolArgs, directory.path)) continue;
+    const handle = await opendir(directory.path);
+    for await (const entry of handle) {
+      if (params.signal?.aborted) throw new Error("Search aborted");
+      if (Date.now() - startedAt > MAX_GREP_WALL_MS) throw new Error("Search timed out");
+      if (++visited > MAX_GREP_RESULTS) throw new Error("Search exceeds the candidate safety limit");
+      const path = join(directory.path, entry.name);
+      pathBytes += Buffer.byteLength(path, "utf8");
+      if (pathBytes > MAX_GREP_DECODED_BYTES) throw new Error("Search exceeds the candidate path byte limit");
+      if (!readOnlyDelegationReadPathAllowed(params.toolArgs, path)) continue;
+      if (entry.isSymbolicLink()) continue;
+      const identity = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return undefined;
+        throw error;
+      });
+      if (identity === undefined || identity.isSymbolicLink()) continue;
+      if (identity.isDirectory()) {
+        pending.push({ path, depth: directory.depth + 1 });
+      } else if (identity.isFile() && await params.acceptPath(path, false)) {
+        if (!readOnlyDelegationReadPathAllowed(params.toolArgs, path)) continue;
+        candidates.push({ path, modifiedMs: identity.mtimeMs });
+      }
+    }
+  }
+  return candidates;
+}

--- a/runtime/src/tools/system/shell-preflight.ts
+++ b/runtime/src/tools/system/shell-preflight.ts
@@ -1,0 +1,18 @@
+import {
+  classifyShellWorkspaceWritePolicy,
+  type ShellWorkspaceWritePolicyInput,
+} from "../../llm/shell-write-policy.js";
+import type { ToolPreflightFailure } from "../types.js";
+
+export function preflightShellWorkspaceWritePolicy(
+  input: Omit<ShellWorkspaceWritePolicyInput, "validationPhase">,
+): ToolPreflightFailure | null {
+  const decision = classifyShellWorkspaceWritePolicy({
+    ...input,
+    validationPhase: "preflight",
+  });
+  return decision.blocked ? {
+    code: "shell_workspace_write_policy",
+    message: decision.message ?? "Shell workspace write policy blocked the command.",
+  } : null;
+}

--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -2,6 +2,7 @@ import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
 import { shellWorkspaceMutationPermission } from "./shell-mutation-permission.js";
+import { preflightShellWorkspaceWritePolicy } from "./shell-preflight.js";
 import { UnifiedExecError } from "../../unified-exec/types.js";
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
 import type { UnifiedExecProcessManagerLike } from "../../unified-exec/types.js";
@@ -115,6 +116,16 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
     supportsParallelToolCalls: false,
     isConcurrencySafe: () => false,
     interruptBehavior: () => "cancel",
+    preflight(args) {
+      const chars = asString(args.chars) ?? "";
+      if (chars.trim().length === 0) return null;
+      return preflightShellWorkspaceWritePolicy({
+        toolName: "write_stdin",
+        args: { command: chars, cwd: config?.cwd },
+        workspaceRoot: config?.cwd ?? config?.allowedPaths?.[0],
+        ...shellWorkspaceMutationPermission(args),
+      });
+    },
     inputSchema: {
       type: "object",
       properties: {

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -331,6 +331,7 @@ export type McpFieldParseResult =
     };
 
 type LiveSubmitOptions = {
+  readonly automatic?: boolean;
   readonly fromQueue?: boolean;
   readonly workspaceViewOverride?: WorkspaceView;
   readonly pastedContentsOverride?: Record<number, any>;
@@ -5717,6 +5718,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         acknowledge: acknowledgeWorkbenchAttachments,
         value,
         options: {
+          ...(options?.automatic === true ? {} : { source: "user" as const }),
           clientMessageId,
           displayUserMessage: options?.displayUserMessage ?? value,
           ...(editorInteraction === undefined ? {} : { editorInteraction }),
@@ -5797,7 +5799,11 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
               { content: loaded.blocks },
             ];
             submission.value = "";
-            submission.options = { clientMessageId, displayUserMessage: displayText };
+            submission.options = {
+              ...(options?.automatic === true ? {} : { source: "user" as const }),
+              clientMessageId,
+              displayUserMessage: displayText,
+            };
             const admissionToken = admitPendingInputs(submission.inputs);
             admissionLease = {
               commit: () => {
@@ -6294,6 +6300,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     onboardingWasActiveRef.current = false;
     void submit(
       "Introduce yourself in a sentence, then take a quick look at the current directory and suggest one useful thing you could help with here.",
+      { automatic: true },
     ).catch(logError);
   }, [
     onboarding.active,

--- a/runtime/src/tui/components/MessageSelector.tsx
+++ b/runtime/src/tui/components/MessageSelector.tsx
@@ -4,7 +4,7 @@ import figures from 'figures';
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAppState } from '../state/AppState.js';
-import { type DiffStats, type FileHistoryState, fileHistoryCanRestore, fileHistoryGetDiffStats } from '../../utils/fileHistory.js';
+import { type DiffStats, type FileHistoryState, fileHistoryGetDiffStats } from '../../utils/fileHistory.js';
 import { logError } from '../../utils/log.js';
 import { useExitOnCtrlCDWithKeybindings } from 'src/tui/hooks/useExitOnCtrlCDWithKeybindings.js';
 import { useSettings } from '../hooks/useSettings.js';
@@ -57,7 +57,7 @@ export function buildMessageSelectorFileHistoryMetadata({
   currentUUID,
   fileHistory,
   isFileHistoryEnabled,
-  canRestoreMessage = fileHistoryCanRestore
+  canRestoreMessage = (state, messageId) => state.snapshots.some(snapshot => snapshot.messageId === messageId)
 }: BuildFileHistoryMetadataOptions): FileHistoryMetadataByMessageId {
   if (!isFileHistoryEnabled) {
     return {};
@@ -117,8 +117,7 @@ export function MessageSelector({
   const fileRestoreAvailable = onPreviewRewind !== undefined || isFileHistoryEnabled;
   const resolveRestoreDiffStats = useCallback(async (message: UserMessage): Promise<DiffStats> => {
     if (onPreviewRewind !== undefined) {
-      const daemonStats = await onPreviewRewind(message);
-      if (daemonStats !== undefined) return daemonStats;
+      return await onPreviewRewind(message);
     }
     if (isFileHistoryEnabled) {
       return await fileHistoryGetDiffStats(fileHistory, message.uuid);
@@ -345,6 +344,25 @@ export function MessageSelector({
   });
   const [fileHistoryMetadata, setFileHistoryMetadata] = useState<FileHistoryMetadataByMessageId>({});
   useEffect(() => {
+    if (onPreviewRewind !== undefined) {
+      let cancelled = false;
+      setFileHistoryMetadata({});
+      if (preselectedMessage === undefined && isFileHistoryEnabled) {
+        const visibleMessages = messageOptions.slice(firstVisibleIndex, firstVisibleIndex + MAX_VISIBLE_MESSAGES)
+          .filter(message => message.uuid !== currentUUID);
+        void Promise.all(visibleMessages.map(async message => {
+          try {
+            return [message.uuid, await onPreviewRewind(message)] as const;
+          } catch (previewError) {
+            logError(previewError as Error);
+            return [message.uuid, undefined] as const;
+          }
+        })).then(entries => {
+          if (!cancelled) setFileHistoryMetadata(Object.fromEntries(entries));
+        });
+      }
+      return () => { cancelled = true; };
+    }
     setFileHistoryMetadata(buildMessageSelectorFileHistoryMetadata({
       messageOptions,
       messages,
@@ -352,7 +370,8 @@ export function MessageSelector({
       fileHistory,
       isFileHistoryEnabled
     }));
-  }, [messageOptions, messages, currentUUID, fileHistory, isFileHistoryEnabled]);
+    return undefined;
+  }, [messageOptions, messages, currentUUID, fileHistory, isFileHistoryEnabled, onPreviewRewind, firstVisibleIndex, preselectedMessage]);
   const canRestoreCode_0 = fileRestoreAvailable && diffStatsForRestore?.filesChanged && diffStatsForRestore.filesChanged.length > 0;
   const showPickList = !error && !messageToRestore && !preselectedMessage && hasMessagesToSelect;
   return <Popup title="rewind" footer={MESSAGE_SELECTOR_FOOTER} status={hasMessagesToSelect ? `${Math.max(0, messageOptions.length - 1)} messages` : 'empty'}>

--- a/runtime/src/tui/components/markdown/Markdown.tsx
+++ b/runtime/src/tui/components/markdown/Markdown.tsx
@@ -173,7 +173,7 @@ function MarkdownBody(t0: Props & { highlight: CliHighlight | null }): React.Rea
   const elements_0 = elements;
   let t1;
   if ($[5] !== elements_0) {
-    t1 = <Box flexDirection="column" gap={1}>{elements_0}</Box>;
+    t1 = <Box flexDirection="column" flexShrink={0} gap={1}>{elements_0}</Box>;
     $[5] = elements_0;
     $[6] = t1;
   } else {
@@ -240,7 +240,7 @@ export function StreamingMarkdown({
 
   // stablePrefix is memoized inside <Markdown> via useMemo([children, ...])
   // so it never re-parses as the unstable suffix grows
-  return <Box flexDirection="column" gap={1}>
+  return <Box flexDirection="column" flexShrink={0} gap={1}>
       {stablePrefix && <Markdown>{stablePrefix}</Markdown>}
       {unstableSuffix && <Markdown>{unstableSuffix}</Markdown>}
     </Box>;

--- a/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
+++ b/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
@@ -249,7 +249,9 @@ export function AssistantToolUseMessage({
         ? baseReason
           ? `×${retriedFailureCount} (last: ${baseReason})`
           : `×${retriedFailureCount} attempts failed`
-        : `succeeded after ${retriedFailureCount} attempts`
+        : toolState === "done"
+          ? `succeeded after ${retriedFailureCount} attempts`
+          : `attempt ${retriedFailureCount} · ${toolState}`
       : baseReason;
   // Cross-turn "fixed re-run" linkage: when THIS command row passes (`●`) and
   // the identical command most-recently FAILED (`✕`) earlier in the session,

--- a/runtime/src/tui/message-renderers/fixedRerunLink.ts
+++ b/runtime/src/tui/message-renderers/fixedRerunLink.ts
@@ -1,4 +1,5 @@
 import type { MessageLookups } from '../../utils/messages.js'
+import { shellOperationIdentity } from '../shell-operation-identity.js'
 
 /**
  * "Fixed re-run" linkage detection for command-bearing tool rows (Run/Bash).
@@ -27,11 +28,6 @@ import type { MessageLookups } from '../../utils/messages.js'
  *     prior tool-use's resolution/error state.
  *
  * Matching rules (kept minimal + robust):
- *   - Only command-bearing tool-uses participate: the input must carry a string
- *     `command` field. Write/Edit (file_path/content) never match, so there are
- *     no false positives from non-command tools.
- *   - Identity is `(tool name, trimmed command string)`. Two runs link only when
- *     both the tool name and the normalized command are identical.
  *   - "First success after a failure" scoping: we inspect the MOST RECENT prior
  *     RESOLVED occurrence of the same command. If that most recent resolved
  *     occurrence ERRORED, this passing row is the fix → annotate. If it
@@ -45,14 +41,6 @@ type CommandToolUse = {
   readonly command: string
 }
 
-/** Normalize a command string for cross-run identity (trim only — preserve
- * internal whitespace so genuinely different commands stay distinct). */
-function normalizeCommand(command: string): string {
-  return command.trim()
-}
-
-/** Extract the command-bearing identity of a tool-use, or null if it carries no
- * string `command` (e.g. Write/Edit/Read), so non-command tools never match. */
 function asCommandToolUse(
   param: { id?: unknown; name?: unknown; input?: unknown } | undefined | null,
 ): CommandToolUse | null {
@@ -61,12 +49,9 @@ function asCommandToolUse(
   const name = (param as { name?: unknown }).name
   const input = (param as { input?: unknown }).input
   if (typeof id !== 'string' || typeof name !== 'string') return null
-  if (!input || typeof input !== 'object') return null
-  const command = (input as { command?: unknown }).command
-  if (typeof command !== 'string') return null
-  const normalized = normalizeCommand(command)
-  if (normalized.length === 0) return null
-  return { id, name, command: normalized }
+  const command = shellOperationIdentity(name, input)
+  if (command === null) return null
+  return { id, name, command }
 }
 
 /**

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -21,9 +21,10 @@ import type { AgenCBridgeSession } from "./session-types.js";
 import { createSessionAppStateBridge } from "./session-app-state.js";
 import type { AppState } from "./state/AppState.js";
 import { approvalInputText } from "./approval-input-text.js";
-import { Box, useInput } from "./ink.js";
+import { Box, useInput, type Key } from "./ink.js";
+import type { InputEvent } from "./ink/events/input-event.js";
 import { useRegisterKeybindingContext } from "./keybindings/KeybindingContext.js";
-import { useKeybindings } from "./keybindings/useKeybinding.js";
+import { useInputCapture, useKeybindings } from "./keybindings/useKeybinding.js";
 import { useRegisterOverlay } from "./context/overlayContext.js";
 import { ApprovalCard, type ApprovalDiffPreview } from "./components/v2/primitives.js";
 import { buildEditDiffPreview } from "./edit-diff-preview.js";
@@ -574,22 +575,32 @@ function AgenCApprovalOverlay({
     toolInput: toolUseConfirm.input,
   });
   const [typed, setTyped] = useState("");
+  const typedRef = useRef("");
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const selectedIndexRef = useRef(0);
+  const settled = useRef(false);
   useRegisterKeybindingContext("Confirmation");
+  const settle = useCallback((decision: () => void) => {
+    if (settled.current || request.ctx.signal?.aborted === true) return;
+    settled.current = true;
+    decision();
+  }, [request]);
   const approve = useCallback(() => {
-    toolUseConfirm.onAllow(toolUseConfirm.input, []);
-  }, [toolUseConfirm]);
+    settle(() => toolUseConfirm.onAllow(toolUseConfirm.input, []));
+  }, [settle, toolUseConfirm]);
   const approveForSession = useCallback(() => {
     if (destructive) return;
-    toolUseConfirm.onAllowForSession(toolUseConfirm.input);
-  }, [destructive, toolUseConfirm]);
+    settle(() => toolUseConfirm.onAllowForSession(toolUseConfirm.input));
+  }, [destructive, settle, toolUseConfirm]);
   const reject = useCallback(() => {
-    toolUseConfirm.onReject();
-  }, [toolUseConfirm]);
+    settle(() => toolUseConfirm.onReject());
+  }, [settle, toolUseConfirm]);
   const abort = useCallback(() => {
-    if (onDismiss !== undefined) onDismiss();
-    else toolUseConfirm.onAbort();
-  }, [onDismiss, toolUseConfirm]);
+    settle(() => {
+      if (onDismiss !== undefined) onDismiss();
+      else toolUseConfirm.onAbort();
+    });
+  }, [onDismiss, settle, toolUseConfirm]);
 
   const confirmSelection = useCallback(
     (index: number) => {
@@ -605,6 +616,53 @@ function AgenCApprovalOverlay({
     },
     [approve, approveForSession, reject],
   );
+
+  const handleSelectionInput = useCallback(
+    (input: string, key: Key, event: InputEvent): boolean => {
+      if (input === "1") {
+        event.stopImmediatePropagation();
+        selectedIndexRef.current = 0;
+        setSelectedIndex(0);
+        approve();
+        return true;
+      }
+      if (input === "2") {
+        event.stopImmediatePropagation();
+        selectedIndexRef.current = 1;
+        setSelectedIndex(1);
+        approveForSession();
+        return true;
+      }
+      if (input === "3") {
+        event.stopImmediatePropagation();
+        selectedIndexRef.current = 2;
+        setSelectedIndex(2);
+        reject();
+        return true;
+      }
+      if (key.upArrow) {
+        event.stopImmediatePropagation();
+        selectedIndexRef.current = (selectedIndexRef.current + 2) % 3;
+        setSelectedIndex(selectedIndexRef.current);
+        return true;
+      }
+      if (key.downArrow) {
+        event.stopImmediatePropagation();
+        selectedIndexRef.current = (selectedIndexRef.current + 1) % 3;
+        setSelectedIndex(selectedIndexRef.current);
+        return true;
+      }
+      if (key.return) {
+        event.stopImmediatePropagation();
+        confirmSelection(selectedIndexRef.current);
+        return true;
+      }
+      return false;
+    },
+    [approve, approveForSession, confirmSelection, reject],
+  );
+  useInputCapture(handleSelectionInput, { context: "Modal", isActive: !destructive });
+  useInput(handleSelectionInput, { isActive: !destructive });
 
   useKeybindings(
     {
@@ -625,61 +683,25 @@ function AgenCApprovalOverlay({
 
   useInput(
     (input, key, event) => {
-      if (input === "1") {
-        event.stopImmediatePropagation();
-        setSelectedIndex(0);
-        approve();
-        return;
-      }
-      if (input === "2") {
-        event.stopImmediatePropagation();
-        setSelectedIndex(1);
-        approveForSession();
-        return;
-      }
-      if (input === "3") {
-        event.stopImmediatePropagation();
-        setSelectedIndex(2);
-        reject();
-        return;
-      }
-      if (key.upArrow) {
-        event.stopImmediatePropagation();
-        setSelectedIndex((index) => (index + 2) % 3);
-        return;
-      }
-      if (key.downArrow) {
-        event.stopImmediatePropagation();
-        setSelectedIndex((index) => (index + 1) % 3);
-        return;
-      }
-      if (key.return) {
-        event.stopImmediatePropagation();
-        confirmSelection(selectedIndex);
-      }
-    },
-    { isActive: !destructive },
-  );
-
-  useInput(
-    (input, key, event) => {
       if (!destructive) return;
       event.stopImmediatePropagation();
       if (key.return) {
-        if (typed === requiredWord) approve();
+        if (typedRef.current === requiredWord) approve();
         return;
       }
       if (key.escape) {
-        if (onDismiss !== undefined) onDismiss();
+        if (onDismiss !== undefined) abort();
         else reject();
         return;
       }
       if (key.backspace || key.delete) {
-        setTyped((value) => value.slice(0, -1));
+        typedRef.current = typedRef.current.slice(0, -1);
+        setTyped(typedRef.current);
         return;
       }
       if (input.length > 0 && !key.ctrl && !key.meta && !/[\u0000-\u001f\u007f]/u.test(input)) {
-        setTyped((value) => (value + input).slice(0, requiredWord.length + 1));
+        typedRef.current = (typedRef.current + input).slice(0, requiredWord.length + 1);
+        setTyped(typedRef.current);
       }
     },
     { isActive: destructive },

--- a/runtime/src/tui/shell-operation-identity.ts
+++ b/runtime/src/tui/shell-operation-identity.ts
@@ -1,0 +1,44 @@
+const SHELL_TOOLS = new Set(["Bash", "system.bash", "exec_command", "Run", "shell", "shell_command", "local_shell"]);
+
+function stableValue(value: unknown, ancestors = new Set<object>()): string | null {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "number") return Number.isFinite(value) ? JSON.stringify(value) : null;
+  if (typeof value !== "object" || value === undefined) return null;
+  if (ancestors.has(value)) return null;
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const items = value.map(item => stableValue(item, ancestors));
+      return items.some(item => item === null) ? null : `[${items.join(",")}]`;
+    }
+    if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) return null;
+    const entries: string[] = [];
+    for (const key of Object.keys(value).sort()) {
+      const item = stableValue((value as Record<string, unknown>)[key], ancestors);
+      if (item === null) return null;
+      entries.push(`${JSON.stringify(key)}:${item}`);
+    }
+    return `{${entries.join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+export function shellOperationIdentity(toolName: string, input: unknown): string | null {
+  if (!SHELL_TOOLS.has(toolName) || input === null || typeof input !== "object" || Array.isArray(input)) return null;
+  const record = input as Record<string, unknown>;
+  const command = record.cmd ?? record.command ?? record.argv;
+  const validCommand = typeof command === "string"
+    ? command.trim().length > 0
+    : Array.isArray(command) && command.length > 0 && command.every(argument => typeof argument === "string");
+  if (!validCommand) return null;
+  const operation = Object.fromEntries(Object.entries(record).filter(([key, value]) =>
+    value !== undefined && !["description", "justification", "yield_time_ms", "max_output_tokens"].includes(key),
+  ));
+  if (typeof command === "string") {
+    const commandKey = record.cmd !== undefined ? "cmd" : record.command !== undefined ? "command" : "argv";
+    operation[commandKey] = command.trim();
+  }
+  const encoded = stableValue(operation);
+  return encoded === null ? null : `${toolName}\u0000${encoded}`;
+}

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { assertReadOnlyInspectionInvocation } from "../permissions/readonly-inspection.js";
 import { basename, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import treeKill from "tree-kill";
@@ -572,11 +573,15 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       request.cmd,
     );
     const args = commandShellArgs(shell, command, request.login === true);
+    const direct = request.directInvocation;
+    if (direct !== undefined && (request.tty === true || request.login === true || request.shell !== undefined || request.runtimeSandbox !== direct.runtimeSandbox)) {
+      throw new UnifiedExecError("create_process", "Read-only direct execution cannot use shell options or a different sandbox");
+    }
     const spawnCommand = this.buildSpawnCommand({
-      program: shell,
-      args,
-      cwd,
-      env: buildEnv(this.baseEnv, this.env),
+      program: direct?.program ?? shell,
+      args: direct?.args ?? args,
+      cwd: direct?.cwd ?? cwd,
+      env: direct?.env ?? buildEnv(this.baseEnv, this.env),
       ...(request.runtimeSandbox !== undefined
         ? { runtimeSandbox: request.runtimeSandbox }
         : {}),
@@ -587,6 +592,7 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       typeof request.ownerId === "string" && request.ownerId.trim().length > 0
         ? request.ownerId.trim()
         : undefined;
+    if (direct !== undefined) assertReadOnlyInspectionInvocation(direct);
     const entry = await this.spawnProcess({
       processId,
       callId,

--- a/runtime/src/unified-exec/types.ts
+++ b/runtime/src/unified-exec/types.ts
@@ -1,4 +1,5 @@
 import type { ToolExecutionInjectedArgs } from "../tools/types.js";
+import type { ReadOnlyInspectionInvocation } from "../permissions/readonly-inspection.js";
 import type {
   AdditionalPermissionProfile,
   NetworkProxyConfig,
@@ -79,6 +80,7 @@ export interface UnifiedExecManagerOptions {
 }
 
 export interface ExecCommandRequest extends ToolExecutionInjectedArgs {
+  readonly directInvocation?: ReadOnlyInspectionInvocation;
   readonly callId?: string;
   readonly cmd: string;
   readonly workdir?: string;

--- a/runtime/src/utils/collapseReadSearch.ts
+++ b/runtime/src/utils/collapseReadSearch.ts
@@ -1,4 +1,5 @@
 import { feature } from 'bun:bundle'
+import { shellOperationIdentity } from '../tui/shell-operation-identity.js'
 import type { UUID } from 'crypto'
 import { findToolByName, type Tools } from '../tools/Tool.js'
 import { extractBashCommentLabel } from '../tools/BashTool/commentLabel.js'
@@ -390,8 +391,6 @@ function isNonCollapsibleToolUse(
  * can be rolled up into a single row. Returns null when the message is not a
  * single non-collapsible tool use we can key (e.g. grouped/multi tool uses).
  *
- * The target is the file path (Edit/Write) or the command (Bash); when neither
- * is present we fall back to the tool name alone so unrelated calls don't merge.
  */
 function nonCollapsibleToolUseKey(msg: RenderableMessage): string | null {
   if (msg.type !== 'assistant') return null
@@ -400,11 +399,12 @@ function nonCollapsibleToolUseKey(msg: RenderableMessage): string | null {
   // Only single-tool-use assistant messages are keyable here; grouped tool uses
   // are handled by the existing collapse paths.
   if (msg.message.content.length !== 1) return null
-  const input = content.input as
-    | { file_path?: string; path?: string; command?: string }
-    | undefined
-  const target = input?.file_path ?? input?.path ?? input?.command ?? ''
-  return `${content.name}\u0000${target}`
+  const shellKey = shellOperationIdentity(content.name, content.input)
+  if (shellKey !== null) return shellKey
+  if (!['Edit', 'Write', 'FileEdit', 'FileWrite', 'MultiEdit', 'NotebookEdit'].includes(content.name)) return null
+  const input = content.input as { file_path?: unknown; path?: unknown; notebook_path?: unknown } | undefined
+  const target = input?.file_path ?? input?.path ?? input?.notebook_path
+  return typeof target === 'string' && target.length > 0 ? `${content.name}\u0000${target}` : null
 }
 
 /**

--- a/runtime/src/workspace/mutation-coordinator.ts
+++ b/runtime/src/workspace/mutation-coordinator.ts
@@ -1520,6 +1520,7 @@ export class WorkspaceMutationCoordinator {
 
   authoritativeDirtySnapshotsUnderIdentity(
     path: string,
+    pathAllowed?: (path: string) => boolean,
   ): readonly WorkspaceAuthoritativeDirtySnapshot[] {
     this.#expireLeaseIfNeeded();
     const target = normalizePathIdentity(path);
@@ -1539,6 +1540,7 @@ export class WorkspaceMutationCoordinator {
     const snapshots: WorkspaceAuthoritativeDirtySnapshot[] = [];
     for (const state of this.#buffers.values()) {
       if (!isSameOrDescendantPath(target, state.path)) continue;
+      if (pathAllowed !== undefined && !pathAllowed(state.path)) continue;
       if (state.authority === "stale_dirty") {
         throw new WorkspaceMutationCoordinatorError(
           "EDITOR_LEASE_EXPIRED",
@@ -6940,7 +6942,7 @@ export interface WorkspaceAuthoritativeDirtySnapshotCapture {
 
 export function captureWorkspaceAuthoritativeDirtySnapshots(
   path: string,
-  options: { readonly includeDescendants?: boolean } = {},
+  options: { readonly includeDescendants?: boolean; readonly pathAllowed?: (path: string) => boolean } = {},
 ): WorkspaceAuthoritativeDirtySnapshotCapture {
   // Preserve the once-admitted identity across later rename/symlink exchange.
   const target = normalizePathIdentity(path);
@@ -6953,7 +6955,7 @@ export function captureWorkspaceAuthoritativeDirtySnapshots(
       return {
         coordinator,
         scope,
-        snapshots: coordinator.authoritativeDirtySnapshotsUnderIdentity(scope),
+        snapshots: coordinator.authoritativeDirtySnapshotsUnderIdentity(scope, options.pathAllowed),
       };
     });
   const snapshots = captures
@@ -6975,6 +6977,7 @@ export function captureWorkspaceAuthoritativeDirtySnapshots(
           capture.snapshots,
           capture.coordinator.authoritativeDirtySnapshotsUnderIdentity(
             capture.scope,
+            options.pathAllowed,
           ),
         ),
       ),

--- a/runtime/tests/agents/control.test.ts
+++ b/runtime/tests/agents/control.test.ts
@@ -3,6 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { createMultiAgentV2Tools } from "../../src/agents/v2/index.js";
+import { injectChildToolArgs } from "../../src/agents/run-agent.js";
 import {
   AgentControl,
   AgentAssignmentRejectedError,
@@ -159,6 +162,52 @@ afterEach(() => {
 });
 
 describe("AgentControl", () => {
+  it("retains planning authority through a live nested spawn after YOLO, without restricting an ordinary verification sibling", async () => {
+    const session = stubSession();
+    let context = createEmptyToolPermissionContext({ mode: "plan" });
+    Object.assign(session, { permissionModeRegistry: { current: () => context } });
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry, maxDepth: 3 });
+    const inspector = await control.spawn({ parentPath: "/root", roleName: "default" });
+    expect(inspector.metadata.executionConstraint).toMatchObject({ kind: "read-only", ownerThreadId: session.conversationId });
+    context = createEmptyToolPermissionContext({ mode: "bypassPermissions" });
+    const descendant = await control.spawn({ parentPath: inspector.agentPath, roleName: "verification" });
+    const sibling = await control.spawn({ parentPath: "/root", roleName: "verification" });
+    expect(descendant.metadata.executionConstraint).toEqual(inspector.metadata.executionConstraint);
+    expect(sibling.metadata.executionConstraint).toBeUndefined();
+  });
+
+  it("restores a persisted planning constraint even under a writable current parent", async () => {
+    const session = stubSession();
+    let context = createEmptyToolPermissionContext({ mode: "plan" });
+    Object.assign(session, { permissionModeRegistry: { current: () => context } });
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry });
+    const inspector = await control.spawn({ parentPath: "/root", roleName: "default" });
+    context = createEmptyToolPermissionContext({ mode: "bypassPermissions" });
+    const recovered = await control.spawn({ parentPath: "/root", expectedRoleProvenance: JSON.parse(JSON.stringify(inspector.metadata)) });
+    expect(recovered.metadata.executionConstraint).toEqual(inspector.metadata.executionConstraint);
+  });
+
+  it("uses the signed child sender's readonly authority in root-owned coordinator closures", async () => {
+    const session = stubSession();
+    let context = createEmptyToolPermissionContext({ mode: "plan" });
+    Object.assign(session, { permissionModeRegistry: { current: () => context } });
+    const registry = new AgentRegistry();
+    const control = new AgentControl({ session, registry, maxDepth: 3 });
+    const inspector = await control.spawn({ parentPath: "/root", roleName: "default" });
+    context = createEmptyToolPermissionContext({ mode: "bypassPermissions" });
+    const writer = await control.spawn({ parentPath: "/root", roleName: "default" });
+    const tools = createMultiAgentV2Tools({ getSession: () => session, workspace: control.roleWorkspace, roleCatalog: control.roleCatalog, ensureAgentControl: () => ({ control, registry }) });
+    for (const name of ["send_message", "assign_task", "close_agent"]) {
+      const tool = tools.find((candidate) => candidate.name === name)!;
+      const args = injectChildToolArgs({ target: writer.agentPath, ...(name !== "close_agent" ? { message: "change something" } : {}) }, name, { childConversationId: inspector.agentId });
+      const result = await tool.execute(args);
+      expect(result.isError, result.content).toBe(true);
+      expect(result.content).toContain("own constrained descendants");
+    }
+  });
+
   it("spawn() produces a LiveAgent with allocated path + nickname", async () => {
     const session = stubSession();
     const registry = new AgentRegistry();

--- a/runtime/tests/agents/readonly-delegation.test.ts
+++ b/runtime/tests/agents/readonly-delegation.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { normalizeAgentMetadata } from "../../src/agents/registry.js";
+import { createAgentRoleWorkspace, requireAgentRole } from "../../src/agents/role.js";
+import { childReadOnlyDelegation, isReadOnlyCoordinationTool, readOnlyCoordinationRefusal, readOnlyDelegationToolAvailable, readOnlyDelegationToolRefusal } from "../../src/agents/readonly-delegation.js";
+import { buildToolRegistry, type ToolRegistry } from "../../src/tool-registry.js";
+import { buildFilteredRegistry } from "../../src/agents/run-agent.js";
+import { createMultiAgentV2Tools } from "../../src/agents/v2/index.js";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { checkRuleBasedPermissions, type ToolEvaluatorContext } from "../../src/permissions/evaluator.js";
+import type { Session } from "../../src/session/session.js";
+import type { Tool } from "../../src/tools/types.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { canReadPathWithCwd, canWritePathWithCwd } from "../../src/sandbox/engine/index.js";
+
+function authoritySession(mode: "plan" | "bypassPermissions" = "plan") {
+  let context = createEmptyToolPermissionContext({ mode });
+  const session = {
+    conversationId: "parent-owner",
+    sessionConfiguration: { cwd: process.cwd() },
+    services: {},
+    permissionModeRegistry: { current: () => context },
+  } as Session;
+  return { session, replaceContext: (next: typeof context) => { context = next; } };
+}
+
+function forgedTool(name: string): Tool {
+  return { name, description: "forged builtin", inputSchema: { type: "object" }, recoveryCategory: "idempotent", metadata: { source: "builtin", mutating: false }, execute: vi.fn(async () => ({ content: "unsafe" })) };
+}
+
+describe("read-only delegation authority", () => {
+  it("retains a validated constraint when recovering child metadata", () => {
+    const constraint = { kind: "read-only", ownerThreadId: "parent-owner" };
+    expect(normalizeAgentMetadata({ depth: 1, executionConstraint: constraint }))
+      .toMatchObject({ executionConstraint: constraint });
+  });
+
+  it.each([null, false, {}, { kind: "read-only" }, { kind: "write", ownerThreadId: "parent" }])(
+    "rejects malformed persisted execution constraints: %j",
+    (executionConstraint) => {
+      expect(() => normalizeAgentMetadata({ depth: 1, executionConstraint }))
+        .toThrow(/execution constraint/);
+    },
+  );
+
+  it("declares inspection roles separately from build verification", () => {
+    const workspace = createAgentRoleWorkspace(process.cwd());
+    for (const name of ["Plan", "scanner", "Explore"]) {
+      expect(requireAgentRole(workspace, name).config).toMatchObject({ executionConstraint: "read-only" });
+    }
+    expect(requireAgentRole(workspace, "verification").config)
+      .not.toHaveProperty("executionConstraint");
+  });
+
+  it("inherits planning authority through role changes and later YOLO mode", () => {
+    const { session, replaceContext } = authoritySession();
+    const workspace = createAgentRoleWorkspace(process.cwd());
+    const constraint = childReadOnlyDelegation(session, requireAgentRole(workspace, "verification"));
+    expect(constraint).toMatchObject({ kind: "read-only", ownerThreadId: session.conversationId });
+    replaceContext(createEmptyToolPermissionContext({ mode: "bypassPermissions" }));
+    Object.assign(session.services, { readOnlyDelegation: constraint });
+    expect(childReadOnlyDelegation(session, requireAgentRole(workspace, "default"))).toEqual(constraint);
+    expect(readOnlyDelegationToolRefusal(session, forgedTool("FileWrite"), {})).toMatch(/Read-only/);
+  });
+
+  it("does not constrain ordinary YOLO verification or coding", () => {
+    const { session } = authoritySession("bypassPermissions");
+    const workspace = createAgentRoleWorkspace(process.cwd());
+    for (const name of ["verification", "default"]) {
+      expect(childReadOnlyDelegation(session, requireAgentRole(workspace, name))).toBeUndefined();
+    }
+    expect(readOnlyDelegationToolRefusal(session, forgedTool("exec_command"), { cmd: "npm test && npm run build" })).toBeUndefined();
+  });
+
+  it.each(["FileRead", "exec_command", "spawn_agent", "assign_task"])("rejects forged builtin identity in direct child registries: %s", async (name) => {
+    const forged = forgedTool(name);
+    expect(readOnlyDelegationToolAvailable(forged)).toBe(false);
+    const base = { tools: [forged], toLLMTools: () => [], dispatch: vi.fn() } as ToolRegistry;
+    const registry = buildFilteredRegistry(base, { childConversationId: "worker", executionConstraint: { kind: "read-only", ownerThreadId: "owner" } });
+    expect(registry.tools).toEqual([]);
+    expect((await registry.dispatch({ name, arguments: "{}" })).isError).toBe(true);
+    expect(forged.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not authenticate model-facing extensions, but retains canonical coordinator identity", async () => {
+    const { session } = authoritySession();
+    const forged = forgedTool("spawn_agent");
+    const untrusted = buildToolRegistry({ workspaceRoot: process.cwd(), requireAdmission: false, modelFacingTools: [forged] });
+    expect(isReadOnlyCoordinationTool(untrusted.tools.find((tool) => tool.name === "spawn_agent")!)).toBe(false);
+    const canonical = createMultiAgentV2Tools({ getSession: () => null, workspace: createAgentRoleWorkspace(process.cwd()), ensureAgentControl: () => { throw new Error("not executed"); } });
+    const registry = buildToolRegistry({ workspaceRoot: process.cwd(), requireAdmission: false, modelFacingTools: canonical });
+    const tool = registry.tools.find((candidate) => candidate.name === "spawn_agent")!;
+    expect(isReadOnlyCoordinationTool(tool)).toBe(true);
+    const context = { session, getAppState: () => ({ toolPermissionContext: session.permissionModeRegistry.current(), autoModeActive: false }) } as ToolEvaluatorContext;
+    expect(await checkRuleBasedPermissions(tool, { message: "inspect", task_name: "inspect" }, context)).toMatchObject({ behavior: "allow" });
+    expect(await checkRuleBasedPermissions(forged, {}, context)).toMatchObject({ behavior: "deny" });
+  });
+
+  it("persists original read denials when live rules are cleared in YOLO", () => {
+    const { session, replaceContext } = authoritySession();
+    replaceContext({ ...session.permissionModeRegistry.current(), alwaysDenyRules: { session: ["FileRead(**/secret.txt)"] } });
+    const constraint = childReadOnlyDelegation(session, undefined)!;
+    Object.assign(session.services, { readOnlyDelegation: normalizeAgentMetadata({ depth: 1, executionConstraint: JSON.parse(JSON.stringify(constraint)) }).executionConstraint });
+    replaceContext(createEmptyToolPermissionContext({ mode: "bypassPermissions" }));
+    const registry = buildToolRegistry({ workspaceRoot: process.cwd(), requireAdmission: false });
+    const reader = registry.tools.find((tool) => tool.name === "FileRead")!;
+    expect(readOnlyDelegationToolRefusal(session, reader, { file_path: "secret.txt" })).toMatch(/cannot read/);
+    expect(readOnlyDelegationToolRefusal(session, reader, { file_path: "README.md" })).toBeUndefined();
+  });
+
+  it("retains content-qualified command denials across structured arguments and quoting", () => {
+    const { session, replaceContext } = authoritySession();
+    replaceContext({ ...session.permissionModeRegistry.current(), alwaysDenyRules: { session: ["system.bash(cat 'secret file.txt')"] } });
+    Object.assign(session.services, { readOnlyDelegation: childReadOnlyDelegation(session, undefined) });
+    replaceContext(createEmptyToolPermissionContext({ mode: "bypassPermissions" }));
+    const registry = buildToolRegistry({ workspaceRoot: process.cwd(), requireAdmission: false });
+    const shell = registry.tools.find((tool) => tool.name === "system.bash")!;
+    expect(readOnlyDelegationToolRefusal(session, shell, { command: "cat", args: ["secret file.txt"] })).toMatch(/original command denial/);
+  });
+
+  it("prevents cross-subtree and writable-worker control even after YOLO", () => {
+    const { session, replaceContext } = authoritySession();
+    const constraint = childReadOnlyDelegation(session, undefined)!;
+    Object.assign(session.services, { readOnlyDelegation: constraint });
+    replaceContext(createEmptyToolPermissionContext({ mode: "bypassPermissions" }));
+    expect(readOnlyCoordinationRefusal(session, "/root/inspection", { depth: 3, agentPath: "/root/inspection/child", executionConstraint: constraint })).toBeUndefined();
+    expect(readOnlyCoordinationRefusal(session, "/root/inspection", { depth: 2, agentPath: "/root/writer" })).toMatch(/own constrained descendants/);
+    expect(readOnlyCoordinationRefusal(session, "/root/inspection", { depth: 2, agentPath: "/root/other", executionConstraint: constraint })).toMatch(/own constrained descendants/);
+  });
+
+  it("narrows a YOLO broker and preserves denied absolute paths with a nested workdir", () => {
+    const cwd = process.cwd();
+    const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd, permissionProfile: { fileSystem: { kind: "restricted", entries: [{ path: { kind: "special", value: { kind: "root" } }, access: "write" }, { path: { kind: "path", path: `${cwd}/secret.txt` }, access: "none" }] }, network: "enabled" } });
+    const child = broker.forkForReadOnlyInspection(`${cwd}/src`);
+    const profile = child.executionAuthority().permissionProfile!;
+    expect(child.required).toBe(true);
+    expect(child.mode).toBe("read_only");
+    expect(profile.network).toBe("disabled");
+    expect(canReadPathWithCwd(profile.fileSystem, `${cwd}/secret.txt`, child.cwd, child.sessionTempRoot)).toBe(false);
+    expect(canReadPathWithCwd(profile.fileSystem, `${cwd}/README.md`, child.cwd, child.sessionTempRoot)).toBe(true);
+    expect(canWritePathWithCwd(profile.fileSystem, `${cwd}/README.md`, child.cwd, child.sessionTempRoot)).toBe(false);
+    expect(broker.mode).toBe("danger_full_access");
+  });
+
+});

--- a/runtime/tests/agents/readonly-delegation.test.ts
+++ b/runtime/tests/agents/readonly-delegation.test.ts
@@ -10,7 +10,7 @@ import { checkRuleBasedPermissions, type ToolEvaluatorContext } from "../../src/
 import type { Session } from "../../src/session/session.js";
 import type { Tool } from "../../src/tools/types.js";
 import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
-import { canReadPathWithCwd, canWritePathWithCwd } from "../../src/sandbox/engine/index.js";
+import { canReadPathWithCwd, canWritePathWithCwd, type FileSystemSandboxPolicy } from "../../src/sandbox/engine/index.js";
 
 function authoritySession(mode: "plan" | "bypassPermissions" = "plan") {
   let context = createEmptyToolPermissionContext({ mode });
@@ -139,6 +139,56 @@ describe("read-only delegation authority", () => {
     expect(canReadPathWithCwd(profile.fileSystem, `${cwd}/README.md`, child.cwd, child.sessionTempRoot)).toBe(true);
     expect(canWritePathWithCwd(profile.fileSystem, `${cwd}/README.md`, child.cwd, child.sessionTempRoot)).toBe(false);
     expect(broker.mode).toBe("danger_full_access");
+  });
+
+  it.each(["path", "glob", "implicit", "project-only", "external", "opaque"] as const)("refuses Git repository objects under %s filesystem read restrictions without tool rules", (restriction) => {
+    const { session } = authoritySession("bypassPermissions");
+    const cwd = process.cwd();
+    const fileSystem: FileSystemSandboxPolicy = restriction === "external"
+      ? { kind: "external_sandbox", entries: [] }
+      : {
+          kind: "restricted",
+          entries: restriction === "implicit"
+            ? [{ path: { kind: "path", path: cwd }, access: "read" }]
+            : restriction === "project-only"
+              ? [{ path: { kind: "special", value: { kind: "project_roots" } }, access: "read" }]
+              : [
+                  { path: { kind: "special", value: { kind: "root" } }, access: "read" },
+                  { path: restriction === "glob" ? { kind: "glob", pattern: "*.txt" } : { kind: "path", path: `${cwd}/secret.txt` }, access: "none" },
+                ],
+        };
+    const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd, permissionProfile: { fileSystem, network: "enabled" } });
+    Object.assign(session.services, {
+      readOnlyDelegation: { kind: "read-only", ownerThreadId: "owner" },
+      sandboxExecutionBroker: restriction === "opaque" ? { cwd, mode: "danger_full_access" } : broker,
+    });
+    const registry = buildToolRegistry({ workspaceRoot: cwd, requireAdmission: false });
+    const shell = registry.tools.find(tool => tool.name === "exec_command")!;
+    expect(readOnlyDelegationToolRefusal(session, shell, { cmd: "git show HEAD:secret.txt" })).toMatch(/repository objects/);
+    expect(readOnlyDelegationToolRefusal(session, shell, { cmd: "git log -p" })).toMatch(/repository objects/);
+    if (restriction === "path" || restriction === "glob") {
+      const reader = registry.tools.find(tool => tool.name === "FileRead")!;
+      expect(readOnlyDelegationToolRefusal(session, reader, { file_path: "secret.txt" })).toMatch(/cannot read/);
+      expect(readOnlyDelegationToolRefusal(session, reader, { file_path: "README.md" })).toBeUndefined();
+    }
+  });
+
+  it.each(["danger_full_access", "workspace_write", "read_only", "unrestricted-profile", "full-read-profile"] as const)("retains Git object inspection under %s authority with unrestricted reads", (authority) => {
+    const { session } = authoritySession("bypassPermissions");
+    const cwd = process.cwd();
+    const broker = authority === "unrestricted-profile" || authority === "full-read-profile"
+      ? new SandboxExecutionBroker({ mode: "workspace_write", cwd, permissionProfile: {
+          fileSystem: authority === "unrestricted-profile"
+            ? { kind: "unrestricted", entries: [] }
+            : { kind: "restricted", entries: [{ path: { kind: "special", value: { kind: "root" } }, access: "read" }, { path: { kind: "path", path: cwd }, access: "write" }] },
+          network: "enabled",
+        } })
+      : new SandboxExecutionBroker({ mode: authority, cwd });
+    Object.assign(session.services, { readOnlyDelegation: { kind: "read-only", ownerThreadId: "owner" }, sandboxExecutionBroker: broker });
+    const registry = buildToolRegistry({ workspaceRoot: cwd, requireAdmission: false });
+    const shell = registry.tools.find(tool => tool.name === "exec_command")!;
+    expect(readOnlyDelegationToolRefusal(session, shell, { cmd: "git show HEAD:README.md" })).toBeUndefined();
+    expect(readOnlyDelegationToolRefusal(session, shell, { cmd: "git log --oneline -5" })).toBeUndefined();
   });
 
 });

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -23,6 +23,8 @@ import { execFileSync } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AsyncQueue } from "../utils/async-queue.js";
 import { AgentControl } from "./control.js";
+import { buildToolRegistry as buildProductionToolRegistry } from "../../src/tool-registry.js";
+import { UnifiedExecProcessManager } from "../../src/unified-exec/process-manager.js";
 import { childApprovalRevocationSignal, isApprovalSessionOwnedBy, observeChildApprovalSessions } from "../../src/agents/child-approval-context.js";
 import { AgentRegistry } from "./registry.js";
 import {
@@ -585,7 +587,10 @@ function mkNamedTool(name: string): ToolRegistry["tools"][number] {
 }
 
 function mkNamedRegistry(names: readonly string[]): ToolRegistry {
-  const tools = names.map(mkNamedTool);
+  const tools = names.map((name) => ({
+    ...mkNamedTool(name),
+    metadata: { source: "builtin" as const },
+  }));
   return {
     tools,
     toLLMTools: () =>
@@ -2493,6 +2498,38 @@ describe("runAgent", () => {
     expect(session.mailbox.hasPending()).toBe(false);
   });
 
+  it("schedules a fresh receipt after a user stop supersedes an older coalescing window", async () => {
+    vi.useFakeTimers();
+    const session = makeStubSession({ services: { provider: makeProvider([{ content: "first receipt" }, { content: "second receipt" }]) } });
+    const submit = vi.fn(async () => { session.drainPendingInputMessages(); });
+    session.installTurnDriverHooks({ submit });
+    const first = await spawnLive(session);
+    await collectRun(runAgent({ live: first.live, parent: session, initialMessages: [{ role: "user", content: "first" }], taskPrompt: "first" }));
+    session.markStoppedByUser();
+    session.clearUserStop();
+    const second = await spawnLive(session);
+    await collectRun(runAgent({ live: second.live, parent: session, initialMessages: [{ role: "user", content: "second" }], taskPrompt: "second" }));
+    await vi.advanceTimersByTimeAsync(200);
+    expect(submit).toHaveBeenCalledOnce();
+    expect(session.mailbox.hasPending()).toBe(false);
+  });
+
+  it("does not retry closed-parent admission while a child receipt remains queued", async () => {
+    vi.useFakeTimers();
+    const session = makeStubSession({ services: { provider: makeProvider([{ content: "completed receipt" }]) } });
+    const submit = vi.fn(async () => {});
+    session.installTurnDriverHooks({ submit });
+    const submitChildFollowup = vi.spyOn(session, "submitChildFollowup");
+    const { live } = await spawnLive(session);
+    await collectRun(runAgent({ live, parent: session, initialMessages: [{ role: "user", content: "finish" }], taskPrompt: "finish" }));
+    expect(session.mailbox.hasPending()).toBe(true);
+    session.beginShutdown();
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(submitChildFollowup).toHaveBeenCalledOnce();
+    expect(submit).not.toHaveBeenCalled();
+    expect(session.mailbox.hasPending()).toBe(true);
+  });
+
   it("durably NACKs an accepted assignment that teardown prevents from starting", async () => {
     const provider = makeProvider([{ content: "initial result" }]);
     const session = makeStubSession({ services: { provider } });
@@ -3460,15 +3497,7 @@ describe("runAgent", () => {
         },
       ),
     } satisfies LLMProvider;
-    const parentRegistry = mkNamedRegistry([
-      "Edit",
-      "MultiEdit",
-      "Write",
-      "NotebookEdit",
-      "apply_patch",
-      "spawn_agent",
-      "Read",
-    ]);
+    const parentRegistry = buildProductionToolRegistry({ workspaceRoot: process.cwd(), requireAdmission: false });
     const session = makeStubSession({
       services: { provider, registry: parentRegistry },
     });
@@ -3502,7 +3531,44 @@ describe("runAgent", () => {
     ]) {
       expect(advertised).not.toContain(denied);
     }
-    expect(advertised).toContain("Read");
+    expect(advertised).toContain("FileRead");
+  });
+
+  it("executes a planned child's real FileRead and stamped exec tools through the provider loop after parent YOLO", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-planned-provider-"));
+    writeFileSync(join(cwd, "README.md"), "readonly provider fixture\n");
+    const manager = new UnifiedExecProcessManager({ cwd });
+    const exec = vi.spyOn(manager, "execCommand").mockImplementation(async (request) => {
+      expect(request.directInvocation?.program).toMatch(/\/cat$/);
+      expect(request.directInvocation?.args).toEqual(["README.md"]);
+      expect(request.runtimeSandbox).toBe(request.directInvocation?.runtimeSandbox);
+      expect(request.runtimeSandbox).toMatchObject({ preference: "require", permissionProfile: { network: "disabled" } });
+      expect(request.runtimeSandbox?.permissionProfile.fileSystem.entries.every((entry) => entry.access !== "write")).toBe(true);
+      return { output: "readonly shell fixture", stdout: "readonly shell fixture", stderr: "", exitCode: 0, exit_code: 0, durationMs: 1, wall_time_seconds: 0.001, timedOut: false, truncated: false, original_token_count: 3 };
+    });
+    const provider = makeProvider([
+      { toolCalls: [{ id: "read-plan", name: "FileRead", arguments: JSON.stringify({ file_path: join(cwd, "README.md") }) }], finishReason: "tool_calls" },
+      { toolCalls: [{ id: "inspect-plan", name: "exec_command", arguments: JSON.stringify({ cmd: "cat README.md" }) }], finishReason: "tool_calls" },
+      { content: "inspected without editing", finishReason: "stop" },
+    ]);
+    const permissionModeRegistry = new PermissionModeRegistry(createEmptyToolPermissionContext({ mode: "plan" }));
+    const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd, probe: (options) => ({ kind: "ready", mode: options.mode, platform: process.platform }) });
+    const session = makeStubSession({ sessionConfiguration: mkSessionConfiguration({ cwd, sandboxPolicy: { value: "danger_full_access" } }), services: { provider, permissionModeRegistry, sandboxExecutionBroker: broker, registry: buildProductionToolRegistry({ workspaceRoot: cwd, unifiedExecManager: manager, requireAdmission: false }) } });
+    const { live } = await spawnLive(session, "default");
+    expect(live.metadata.executionConstraint).toMatchObject({ kind: "read-only" });
+    await permissionModeRegistry.update({ ...permissionModeRegistry.current(), mode: "bypassPermissions", isBypassPermissionsModeAvailable: true, bypassPermissionsAcceptedIn: [cwd] });
+    try {
+      const { result } = await collectRun(runAgent({ live, parent: session, initialMessages: [{ role: "user", content: "Inspect README without changes" }], taskPrompt: "Inspect README without changes" }));
+      expect(result.outcome, String(result.error)).toBe("completed");
+      expect(exec).toHaveBeenCalledOnce();
+      const conversation = JSON.stringify(vi.mocked(provider.chatStream).mock.calls);
+      expect(conversation).toContain("readonly provider fixture");
+      expect(conversation).toContain("readonly shell fixture");
+    } finally {
+      exec.mockRestore();
+      await manager.closeAll();
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("strips model-supplied __agenc* keys before they reach a wrapped child tool", async () => {

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -3472,6 +3472,42 @@ describe("runAgent", () => {
     expect(allowed.isError).toBe(false);
   });
 
+  it.each(["Plan", "scanner", "verification", "custom-inspector"])(
+    "preserves constrained %s role instructions alongside read-only authority",
+    async (roleName) => {
+      registerAgentRole(ROLE_WORKSPACE, {
+        name: "custom-inspector",
+        config: { systemPrompt: "CUSTOM_INSPECTOR_SENTINEL: report timestamp edge cases." },
+      });
+      const provider = makeProvider([{ content: "inspection complete" }]);
+      const session = makeStubSession({
+        services: {
+          provider,
+          permissionModeRegistry: new PermissionModeRegistry(
+            createEmptyToolPermissionContext({ mode: "plan" }),
+          ),
+        },
+      });
+      const { live } = await spawnLive(session, roleName);
+      const rolePrompt = live.role.config.systemPrompt;
+      expect(rolePrompt).toBeTruthy();
+      expect(live.metadata.executionConstraint).toMatchObject({ kind: "read-only" });
+
+      const { result } = await collectRun(runAgent({
+        live,
+        parent: session,
+        initialMessages: [{ role: "user", content: "Inspect without changing files." }],
+        taskPrompt: "Inspect without changing files.",
+      }));
+
+      expect(result.outcome).toBe("completed");
+      const options = vi.mocked(provider.chatStream).mock.calls[0]?.[2];
+      expect(options?.systemPrompt).toContain(rolePrompt);
+      expect(options?.systemPrompt).toContain("permanent read-only execution authority");
+      expect(options?.systemPrompt).toContain('<workspace_agent_role trust="untrusted" authority="guidance_only">');
+    },
+  );
+
   it("a live read-only role spawn (Plan) strips mutating tools end-to-end", async () => {
     // Drives the real wiring: control.spawn -> role resolution (Plan carries the
     // read-only disallowlist) -> buildChildSession reads role.config.disallowlist

--- a/runtime/tests/agents/thread-manager.test.ts
+++ b/runtime/tests/agents/thread-manager.test.ts
@@ -16,6 +16,7 @@ function makeSession() {
     conversationId: "root-thread",
     agentStatus: { value: { status: "pending_init" } },
     submit: vi.fn(async () => {}),
+    submitChildFollowup: vi.fn(async () => true),
     shutdown: vi.fn(async () => {}),
     abortTerminal: vi.fn(),
     abortAllTasks: vi.fn(async () => {}),
@@ -170,9 +171,8 @@ describe("ThreadManager", () => {
       direction: "up",
       metadata: { kind: "inter_agent_communication" },
     });
-    expect(session.submit).toHaveBeenCalledWith("", {
-      displayUserMessage: null,
-    });
+    expect(session.submitChildFollowup).toHaveBeenCalledOnce();
+    expect(session.submit).not.toHaveBeenCalled();
   });
 
   it("owns agent spawning when bound to AgentControl", async () => {

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -7788,7 +7788,7 @@ describe("AgenC background agent lifecycle", () => {
         agentId: "agent_approve",
         params: {
           requestId: "call_2",
-          decision: { kind: "denied" },
+          decision: { kind: "denied", reason: "no" },
         },
       },
     ]);

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -8695,7 +8695,7 @@ describe("AgenC delegate background-agent runner", () => {
         ? { blockingError: { blockingError: "follow-up prompt denied" } }
         : {},
     );
-    const { runner, control, stub } = makeTopLevelRunner({
+    const { runner, control, stub, session } = makeTopLevelRunner({
       conversationId: "session-follow-up-prompt-survives-block",
       userPromptSubmitHooks: [blockHook],
     });
@@ -8705,6 +8705,8 @@ describe("AgenC delegate background-agent runner", () => {
       unattendedAllow: [],
       unattendedDeny: [],
     });
+    session.markStoppedByUser();
+    session.clearUserStop.mockClear();
 
     await expect(
       runner.submitAgentMessage("session-follow-up-prompt-survives-block", {
@@ -8718,6 +8720,8 @@ describe("AgenC delegate background-agent runner", () => {
     ).rejects.toMatchObject({
       code: "PROMPT_BLOCKED",
     });
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(session.clearUserStop).not.toHaveBeenCalled();
     const snapshot = await runner.getAgentSnapshot(
       "session-follow-up-prompt-survives-block",
     );
@@ -8734,7 +8738,20 @@ describe("AgenC delegate background-agent runner", () => {
       }),
     ).resolves.toMatchObject({ disposition: "started" });
     expect(control.sendInput).toHaveBeenCalledTimes(1);
+    expect(session.stoppedByUserSinceLastPrompt).toBe(false);
+    expect(session.clearUserStop).toHaveBeenCalledOnce();
     expect(stub.thread.submit).not.toHaveBeenCalled();
+    session.markStoppedByUser();
+    await expect(runner.submitAgentMessage("session-follow-up-prompt-survives-block", {
+      sessionId: "session_1",
+      content: "allowed follow-up prompt",
+      originalContent: "allowed follow-up prompt",
+      messageId: "allowed-follow-up-after-block",
+      streamId: "duplicate-stream",
+      acceptedAt: "2026-08-25T00:00:02.000Z",
+    })).resolves.toMatchObject({ disposition: "duplicate" });
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(session.clearUserStop).toHaveBeenCalledOnce();
   });
 
   it("[managed-thread] replays a legacy hook-block error as session-only after attach", async () => {
@@ -10896,6 +10913,32 @@ describe("AgenC delegate background-agent runner", () => {
       type: "interrupt",
       reason: "user_cancel",
     });
+  });
+
+  it.each([false, true])("cancels the whole active subtree when durable stop recording fails (scoped=%s)", async (scoped) => {
+    const { runner, session, stub, control, setActiveTurn, abortTurnIfActive } = makeTopLevelRunner({
+      conversationId: "session-stop-persistence-failure",
+      scopedTurnCancellation: scoped,
+    });
+    await runner.startAgent({ objective: "hi", unattendedAllow: [], unattendedDeny: [] });
+    setActiveTurn("turn-stop-persistence-failure");
+    control.openThreadSpawnChildren.mockReturnValue([
+      ["child-agent", { agentId: "child-agent", agentPath: "/root/worker", depth: 1 }],
+    ]);
+    stub.thread.submit.mockClear();
+    session.markStoppedByUser.mockImplementationOnce(() => { throw new Error("stop fsync failed"); });
+
+    const cancellation = scoped
+      ? runner.interruptAgentTurnIfMatches("session-stop-persistence-failure", "user_cancel", "turn-stop-persistence-failure")
+      : runner.interruptAgentTurn("session-stop-persistence-failure", "user_cancel");
+    await expect(cancellation).rejects.toThrow("stop fsync failed");
+    if (scoped) {
+      expect(abortTurnIfActive).toHaveBeenCalledWith("turn-stop-persistence-failure", "interrupted");
+    } else {
+      expect(session.abortAllTasks).toHaveBeenCalledWith("interrupted");
+      expect(stub.thread.submit).toHaveBeenCalledWith({ type: "interrupt", reason: "user_cancel" });
+    }
+    expect(control.interrupt).toHaveBeenCalledWith("child-agent", "user_cancel");
   });
 
   it("[managed-thread] interruptAgentTurn cascades cancellation to live child agents", async () => {

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -18,6 +18,7 @@ import {
   AgenCBackgroundAgentMessageError,
   AgenCBackgroundAgentSuspensionShutdownError,
   AgenCDelegateBackgroundAgentRunner,
+  __installDaemonTurnDriverHooksForTest,
   daemonEventFromUnboundSessionEvent,
   notificationFromDaemonEvent,
   resolvePermissionDecisionTimeoutMs,
@@ -768,6 +769,7 @@ function makeTopLevelRunner(opts: {
   // The real Session latches a client Stop until the next user message; the
   // stub carries the same state so tests can read it, not just the calls.
   let stoppedByUserSinceLastPrompt = false;
+  let userStopGeneration = 0;
   const session = {
     abortController: sessionAbortController,
     abortTerminal: vi.fn((reason: string) => {
@@ -840,12 +842,16 @@ function makeTopLevelRunner(opts: {
     abortAllTasks: vi.fn(async () => {}),
     markStoppedByUser: vi.fn(() => {
       stoppedByUserSinceLastPrompt = true;
+      userStopGeneration += 1;
     }),
     clearUserStop: vi.fn(() => {
       stoppedByUserSinceLastPrompt = false;
     }),
     get stoppedByUserSinceLastPrompt() {
       return stoppedByUserSinceLastPrompt;
+    },
+    get userStopGeneration() {
+      return userStopGeneration;
     },
     trackDurableOperation: <T>(operation: Promise<T>): Promise<T> => {
       durableOperations.add(operation);
@@ -8738,8 +8744,8 @@ describe("AgenC delegate background-agent runner", () => {
       }),
     ).resolves.toMatchObject({ disposition: "started" });
     expect(control.sendInput).toHaveBeenCalledTimes(1);
-    expect(session.stoppedByUserSinceLastPrompt).toBe(false);
-    expect(session.clearUserStop).toHaveBeenCalledOnce();
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(session.clearUserStop).not.toHaveBeenCalled();
     expect(stub.thread.submit).not.toHaveBeenCalled();
     session.markStoppedByUser();
     await expect(runner.submitAgentMessage("session-follow-up-prompt-survives-block", {
@@ -8751,7 +8757,63 @@ describe("AgenC delegate background-agent runner", () => {
       acceptedAt: "2026-08-25T00:00:02.000Z",
     })).resolves.toMatchObject({ disposition: "duplicate" });
     expect(session.stoppedByUserSinceLastPrompt).toBe(true);
-    expect(session.clearUserStop).toHaveBeenCalledOnce();
+    expect(session.clearUserStop).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])("[managed-thread] retains the stop during failed input admission (structured=%s)", async (structured) => {
+    const { runner, control, stub, session } = makeTopLevelRunner({
+      conversationId: "session-failed-stop-release",
+    });
+    await runner.startAgent({ objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+    session.markStoppedByUser();
+    const admission = structured ? stub.thread.submit : control.sendInput;
+    admission.mockImplementationOnce(async () => {
+      expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+      await Promise.resolve();
+      expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+      throw new Error("input admission failed");
+    });
+    const content = structured ? [{ type: "text" as const, text: "continue" }] : "continue";
+    await expect(runner.submitAgentMessage("session-failed-stop-release", {
+      sessionId: "session_1", content, originalContent: content,
+      messageId: "failed-stop-release", streamId: "stream_1", acceptedAt: "2026-09-10T00:00:00.000Z",
+    })).rejects.toThrow("input admission failed");
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(session.clearUserStop).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])("[managed-thread] passes the ingress stop generation to durable turn admission (newerStop=%s)", async (newerStop) => {
+    const harness = makeTopLevelRunner({
+      conversationId: "session-generation-stop-release",
+    });
+    const { runner, control, session, configStore } = harness;
+    await runner.startAgent({ objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+    session.markStoppedByUser();
+    const originalGeneration = session.userStopGeneration;
+    let submitDriver: (message: string, options?: unknown) => Promise<void> = async () => { throw new Error("driver missing"); };
+    const driverSession = {
+      ...session,
+      newDefaultTurn: () => ({}),
+      installTurnDriverHooks: (hooks: { submit: typeof submitDriver }) => { submitDriver = hooks.submit; },
+    };
+    const runTurnFn = vi.fn(async function* (_session: unknown, _turn: unknown, _input: unknown, options: { userStopGenerationToRelease?: number }) {
+      expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+      expect(options.userStopGenerationToRelease).toBe(originalGeneration);
+      if (options.userStopGenerationToRelease === session.userStopGeneration) session.clearUserStop();
+    });
+    __installDaemonTurnDriverHooksForTest(driverSession as never, configStore as never, runTurnFn as never);
+    control.sendInput.mockImplementationOnce(async (...invocation: unknown[]) => {
+      expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+      if (newerStop) session.markStoppedByUser();
+      await submitDriver(invocation[1] as string, invocation[2]);
+    });
+    await runner.submitAgentMessage("session-generation-stop-release", {
+      sessionId: "session_1", content: "continue", originalContent: "continue",
+      messageId: "generation-stop-release", streamId: "stream_1", acceptedAt: "2026-09-10T00:00:00.000Z",
+    });
+    expect(runTurnFn).toHaveBeenCalledOnce();
+    expect(session.stoppedByUserSinceLastPrompt).toBe(newerStop);
+    expect(session.clearUserStop).toHaveBeenCalledTimes(newerStop ? 0 : 1);
   });
 
   it("[managed-thread] replays a legacy hook-block error as session-only after attach", async () => {
@@ -9903,7 +9965,6 @@ describe("AgenC delegate background-agent runner", () => {
       ),
     });
 
-    // A prompt the daemon does admit still releases the latch.
     releaseInitialSubmission.resolve();
     await expect(
       runner.submitAgentMessage("session-stop-refusal", {
@@ -9915,7 +9976,8 @@ describe("AgenC delegate background-agent runner", () => {
         acceptedAt: "2026-09-07T00:00:01.000Z",
       }),
     ).resolves.toMatchObject({ disposition: "started" });
-    expect(session.stoppedByUserSinceLastPrompt).toBe(false);
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(session.clearUserStop).not.toHaveBeenCalled();
   });
 
   it("[managed-thread] accepts the first opt-in-admission message on a deferred spawn still in pending_init", async () => {

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -1990,6 +1990,46 @@ describe("AgenC daemon CLI", () => {
     }
   });
 
+  it.each(["exited", "replaced", "identity_missing"] as const)("handles Linux shutdown rebind race %s without signalling an unbound process", async (outcome) => {
+    const agencHome = await tempAgencHome();
+    const baseHost = createHost(agencHome);
+    const io = createIo();
+    const pid = 4321;
+    const pidPath = resolveAgenCDaemonPidPath(baseHost.env, baseHost.userHome);
+    const runtimeInfoPath = resolveAgenCDaemonRuntimeInfoPath(agencHome);
+    const identity = recordTestDaemon(agencHome, pid);
+    baseHost.runningPids.add(pid);
+    await writeAgenCDaemonPid(pidPath, pid);
+    let processStart = identity.processStart;
+    const host = { ...baseHost, platform: "linux" as const, readProcessIdentity: () => processStart };
+    try {
+      const result = await runAgenCDaemonCli({ kind: "command", action: "stop" }, {
+        host, io, stopTimeoutMs: 0,
+        requestDaemonInstanceIdentity: () => identity,
+        requestDaemonShutdown: () => {},
+        inspectLegacyDaemonProcess: async () => {
+          await rm(runtimeInfoPath, { force: true });
+          if (outcome === "exited") baseHost.runningPids.delete(pid);
+          if (outcome === "replaced") {
+            processStart = `${identity.processStart}:replacement`;
+            recordTestDaemon(agencHome, pid, { processStart, instanceId: "replacement-after-shutdown" });
+          }
+          return null;
+        },
+      });
+      expect(result).toBe(outcome === "identity_missing" ? 1 : 0);
+      expect(baseHost.terminatedSignals).toEqual([]);
+      if (outcome === "replaced") {
+        expect(readDaemonRuntimeInfo(runtimeInfoPath)?.instanceId).toBe("replacement-after-shutdown");
+        expect(await readAgenCDaemonPid(pidPath)).toBe(pid);
+      }
+      if (outcome === "identity_missing") expect(io.stderrText()).toContain("refusing Linux numeric shutdown");
+      else expect(io.stderrText()).toBe("");
+    } finally {
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
   it("refuses a reused pid whose process token does not match the sidecar", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);

--- a/runtime/tests/app-server/permission-owner-decisions.test.ts
+++ b/runtime/tests/app-server/permission-owner-decisions.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { LiveApprovalBroker } from "../../src/app-server/live-approval-broker.js";
+import { registerChildApprovalSession } from "../../src/agents/child-approval-context.js";
+import { requestApproval } from "../../src/permissions/guardian/arbiter.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { EventLog } from "../../src/session/event-log.js";
+import type { Session } from "../../src/session/session.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function fixture(workflow = false) {
+  const owner = approvalSession("conv-owner");
+  const child = approvalSession("conv-child");
+  const broker = new LiveApprovalBroker();
+  cleanups.push(() => owner.shutdown(), () => child.shutdown());
+  cleanups.push(broker.register(owner, { workflow, isActive: () => true }));
+  registerChildApprovalSession(child, owner);
+  const sessions = new AgenCDaemonSessionManager({ createSessionId: () => "daemon-permission-session" });
+  const setAgentPermissionMode = vi.fn(async () => ({ applied: true, previousMode: "default", rollback: vi.fn(async () => {}) }));
+  const manager = new AgenCDaemonAgentManager({
+    approvalBroker: broker,
+    sessionManager: sessions,
+    runner: {
+      startAgent: async () => ({ agentId: owner.conversationId, agentPath: "/root", startedAt: new Date().toISOString(), status: "running" }),
+      listPermissions: async (agentId) => ({ permissions: [], pendingRequests: broker.list(agentId) }),
+      resolveToolDecision: async (agentId, params) => broker.resolve(agentId, params.requestId, params.decision),
+      setAgentPermissionMode,
+    },
+  });
+  await manager.createAgent({ objective: "Review a child request", cwd: "/tmp", runtimeOptions: resolveAgentRuntimeOptions({}) });
+  await sessions.restoreSession({ sessionId: owner.conversationId, agentId: "agent_default", status: "waiting", metadata: { recovered: true } });
+  const waiting = requestApproval({
+    ctx: {
+      callId: "child-call", toolName: "exec_command", turnId: "child-turn",
+      invocation: { callId: "child-call", session: child, payload: { kind: "function", name: "exec_command", arguments: '{"cmd":"node --test"}' }, turn: { subId: "child-turn", cwd: "/tmp" } } as never,
+    },
+    resolver: owner.services.approvalResolver,
+    args: { cmd: "node --test" },
+  });
+  await vi.waitFor(() => expect(broker.list(owner.conversationId)).toHaveLength(1));
+  const requestId = broker.list(owner.conversationId)[0]!.requestId;
+  return { owner, child, manager, broker, sessions, waiting, requestId, setAgentPermissionMode };
+}
+
+function approvalSession(conversationId: string): Session {
+  const eventLog = new EventLog();
+  let sequence = 0;
+  let stopped = false;
+  return {
+    conversationId,
+    eventLog,
+    abortController: new AbortController(),
+    services: { admissionRequired: false },
+    rolloutStore: {},
+    permissionModeRegistry: new PermissionModeRegistry(createEmptyToolPermissionContext()),
+    onBeforeDurableClose: () => () => {},
+    emit: (event: Parameters<EventLog["emit"]>[0]) => {
+      const canonical = { ...event, eventId: `${conversationId}:${++sequence}`, seq: sequence };
+      eventLog.emit(canonical);
+      return canonical;
+    },
+    markStoppedByUser: () => { stopped = true; },
+    get stoppedByUserSinceLastPrompt() { return stopped; },
+    shutdown: async () => {},
+  } as unknown as Session;
+}
+
+describe("permission owner decisions", () => {
+  it.each(["canonical", "lifecycle"])("approves a child request using its %s owner ID", async (identifier) => {
+    const state = await fixture();
+    const sessionId = identifier === "canonical" ? state.owner.conversationId : "daemon-permission-session";
+    expect((await state.manager.listPermissions({ sessionId })).pendingRequests?.[0]?.requestId).toBe(state.requestId);
+    await state.manager.approveTool({ sessionId, requestId: state.requestId, scope: "session", allowAllToolsForSession: true });
+    expect((await state.waiting).decision.kind).toBe("approved_for_session");
+    expect(state.setAgentPermissionMode).toHaveBeenCalledWith(state.owner.conversationId, expect.objectContaining({ sessionId: "daemon-permission-session", mode: "bypassPermissions" }));
+    await expect(state.manager.approveTool({ sessionId, requestId: state.requestId })).rejects.toThrow("not pending");
+  });
+
+  it.each([false, true])("preserves denial feedback and fences only ordinary owners (workflow=%s)", async (workflow) => {
+    const state = await fixture(workflow);
+    const reason = "Do not commit.\nExplain the changes instead.";
+    await state.manager.denyTool({ sessionId: state.owner.conversationId, requestId: state.requestId, reason });
+    expect(await state.waiting).toMatchObject({ decision: { kind: "denied", reason }, source: "resolver", reason });
+    expect(state.owner.stoppedByUserSinceLastPrompt).toBe(!workflow);
+    expect(state.owner.abortController.signal.aborted).toBe(false);
+  });
+
+  it("rejects a closed canonical owner without using its recovered shadow", async () => {
+    const state = await fixture();
+    await state.sessions.terminateSession({ sessionId: "daemon-permission-session" });
+    await expect(state.manager.denyTool({ sessionId: state.owner.conversationId, requestId: state.requestId })).rejects.toThrow("not found or closed");
+    expect(state.broker.list(state.owner.conversationId)).toHaveLength(1);
+    expect(state.owner.stoppedByUserSinceLastPrompt).toBe(false);
+  });
+
+  it("rejects a request from another owner without latching a stop", async () => {
+    const state = await fixture();
+    await expect(state.manager.denyTool({ sessionId: "daemon-permission-session", requestId: "other-owner-request" })).rejects.toThrow("not pending");
+    expect(state.broker.list(state.owner.conversationId)).toHaveLength(1);
+    expect(state.owner.stoppedByUserSinceLastPrompt).toBe(false);
+  });
+
+  it.each(["default", "acceptEdits", "plan", "bypassPermissions"] as const)("rolls back stale session promotion from %s", async (previousMode) => {
+    const state = await fixture();
+    const rollback = vi.fn(async () => {});
+    state.setAgentPermissionMode.mockImplementation(async () => {
+      state.broker.abort(state.owner.conversationId);
+      return { applied: true, previousMode, rollback };
+    });
+    await expect(state.manager.approveTool({ sessionId: state.owner.conversationId, requestId: state.requestId, scope: "session", allowAllToolsForSession: true })).rejects.toThrow("not pending");
+    expect(rollback).toHaveBeenCalledOnce();
+    expect((await state.waiting).decision.kind).toBe("abort");
+    expect(state.owner.stoppedByUserSinceLastPrompt).toBe(false);
+  });
+
+  it.each([undefined, "", "  ", "Keep this unchanged.\nUse another approach."])("retains optional denial feedback %j", async (reason) => {
+    const state = await fixture();
+    await state.manager.denyTool({ sessionId: "daemon-permission-session", requestId: state.requestId, ...(reason === undefined ? {} : { reason }) });
+    const result = await state.waiting;
+    expect(result.decision).toEqual(reason?.trim() ? { kind: "denied", reason } : { kind: "denied" });
+    expect(result.reason).toBe(reason?.trim() || undefined);
+  });
+});

--- a/runtime/tests/bin/agenc.deferred-workflow.test.ts
+++ b/runtime/tests/bin/agenc.deferred-workflow.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { __createDeferredDaemonPromptTuiSessionForTest } from "../../src/bin/agenc-main.js";
+import { ConfigStore } from "../../src/config/store.js";
+import { DENIED } from "../../src/permissions/review-decision.js";
+import type { WorkflowApprovalControls } from "../../src/tui/workflow-approval-controls.js";
+
+describe("cold deferred workflow controls", () => {
+  it("cancels a connecting panel without dispatching and closes the shared connection", async () => {
+    const request = vi.fn();
+    const close = vi.fn(async () => {});
+    let connectReady!: (client: { request: typeof request; close: typeof close }) => void;
+    const connect = vi.fn(() => new Promise<{ request: typeof request; close: typeof close }>(resolve => { connectReady = resolve; }));
+    const deferred = await __createDeferredDaemonPromptTuiSessionForTest({
+      baseSession: { services: { configStore: new ConfigStore({ env: {} }) } },
+      deps: { createConnectedTuiClient: connect } as never,
+      agencHome: process.cwd(), env: {}, cwd: process.cwd(), clientId: "cancelled-workflow-controls-test",
+    });
+    const controller = new AbortController();
+    const session = deferred.session as { workflowApprovalControls: WorkflowApprovalControls };
+    const listing = session.workflowApprovalControls.list("wf-owner", controller.signal);
+    const failedListing = expect(listing).rejects.toThrow();
+    controller.abort();
+    connectReady({ request, close });
+    await failedListing;
+    expect(request).not.toHaveBeenCalled();
+    await deferred.close();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("retries failed connection establishment but never replays an ambiguous approval", async () => {
+    const pending = { ownerRunId: "wf-owner", requestId: "request-one", sessionId: "child-one", toolName: "Read", input: {} };
+    const request = vi.fn(async (method: string) => {
+      if (method === "permission.list") return { permissions: [], pendingRequests: [pending] };
+      throw new Error("connection lost after dispatch");
+    });
+    const connect = vi.fn().mockRejectedValueOnce(new Error("offline")).mockResolvedValue({ request, close: async () => {} });
+    const deferred = await __createDeferredDaemonPromptTuiSessionForTest({
+      baseSession: { services: { configStore: new ConfigStore({ env: {} }) } },
+      deps: { createConnectedTuiClient: connect } as never,
+      agencHome: process.cwd(), env: {}, cwd: process.cwd(), clientId: "retry-workflow-controls-test",
+    });
+    try {
+      const session = deferred.session as { workflowApprovalControls: WorkflowApprovalControls };
+      const signal = new AbortController().signal;
+      await expect(session.workflowApprovalControls.list("wf-owner", signal)).rejects.toThrow("offline");
+      expect(await session.workflowApprovalControls.list("wf-owner", signal)).toEqual([pending]);
+      await expect(session.workflowApprovalControls.respond(pending, DENIED, "response", signal)).rejects.toThrow("after dispatch");
+      expect(connect).toHaveBeenCalledTimes(2);
+      expect(request.mock.calls.filter(([method]) => method === "tool.deny")).toHaveLength(1);
+    } finally {
+      await deferred.close();
+    }
+  });
+
+  it("resolves workflow requests without starting an unrelated coding turn", async () => {
+    const pending = { ownerRunId: "wf-owner", requestId: "request-one", sessionId: "child-one", toolName: "Read", input: { file_path: "fixture" } };
+    const request = vi.fn(async (method: string) => method === "permission.list" ? { permissions: [], pendingRequests: [pending] } : { requestId: pending.requestId, decision: "denied" });
+    const close = vi.fn(async () => {});
+    const connect = vi.fn(async () => ({ request, close }));
+    const startPromptAgent = vi.fn();
+    const deferred = await __createDeferredDaemonPromptTuiSessionForTest({
+      baseSession: { services: { configStore: new ConfigStore({ env: {} }) } },
+      deps: { createConnectedTuiClient: connect, startPromptAgent } as never,
+      agencHome: process.cwd(), env: {}, cwd: process.cwd(), clientId: "workflow-controls-test",
+    });
+    try {
+      const session = deferred.session as { workflowApprovalControls: WorkflowApprovalControls };
+      expect(connect).not.toHaveBeenCalled();
+      const signal = new AbortController().signal;
+      expect(await session.workflowApprovalControls.list("wf-owner", signal)).toEqual([pending]);
+      expect(await session.workflowApprovalControls.respond(pending, DENIED, "response", signal)).toBe(true);
+      expect(request).toHaveBeenLastCalledWith("tool.deny", { sessionId: "wf-owner", requestId: pending.requestId, reason: "denied" }, { signal });
+      expect(connect).toHaveBeenCalledOnce();
+      expect(startPromptAgent).not.toHaveBeenCalled();
+      await deferred.close();
+      expect(close).toHaveBeenCalledOnce();
+      await expect(session.workflowApprovalControls.list("wf-owner", signal)).rejects.toThrow("closed");
+    } finally {
+      await deferred.close();
+    }
+  });
+});

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1521,6 +1521,7 @@ describe("runSingleTurn seam (R1 multi-turn future-proofing)", () => {
       session,
       ctx,
       input: "hi",
+      userStopGenerationToRelease: 7,
       configStore: store,
       configReloadLatch: latch,
       memoryPromptText: "",
@@ -1546,6 +1547,7 @@ describe("runSingleTurn seam (R1 multi-turn future-proofing)", () => {
     // runTurn must receive the assembled system prompt through opts.
     const rtCall = runTurnFn.mock.calls[0]!;
     expect(rtCall[3]!.systemPrompt.length).toBeGreaterThan(0);
+    expect(rtCall[3]!.userStopGenerationToRelease).toBe(7);
   });
 
   it("calls reload again when invoked a second time (multi-turn loop compat)", async () => {

--- a/runtime/tests/bin/agenc.user-prompt-submit.test.ts
+++ b/runtime/tests/bin/agenc.user-prompt-submit.test.ts
@@ -37,6 +37,8 @@ function fakeSession(cwd: string) {
   const events: unknown[] = [];
   const session = {
     abortController: new AbortController(),
+    clearUserStop: vi.fn(),
+    userStopGeneration: 7,
     activeTurn: { unsafePeek: () => null },
     conversationId: "conv-hooks",
     emit: (event: unknown) => {
@@ -221,6 +223,74 @@ function installOneShotDaemonSpies() {
 }
 
 describe("UserPromptSubmit prompt ingress", () => {
+  it("cannot authorize release of a newer stop raised during prompt preparation", async () => {
+    const { session } = fakeSession("/workspace");
+    session.services.hooks.userPromptSubmitHooks.push(() => {
+      session.userStopGeneration += 1;
+      return {};
+    });
+    const runSingleTurnFn = vi.fn(async function* () {
+      return { reason: "completed" };
+    });
+    const uninstall = __installTuiSessionContractForTest({
+      session: session as never,
+      configStore: { current: () => defaultConfig },
+      agencHome: "/tmp/agenc",
+      resolvedProvider: "stub",
+      autonomousModeEnabled: false,
+      loadTurnInputsFn: async () => EMPTY_TURN_INPUTS,
+      runSingleTurnFn: runSingleTurnFn as never,
+    });
+    try {
+      await session.submit("new prompt", { source: "user" });
+      expect(runSingleTurnFn).toHaveBeenCalledWith(expect.objectContaining({ userStopGenerationToRelease: 7 }));
+      expect(session.userStopGeneration).toBe(8);
+      expect(session.clearUserStop).not.toHaveBeenCalled();
+    } finally {
+      uninstall();
+    }
+  });
+
+  it.each([
+    { source: "user", blocked: false, releasesStop: true },
+    { source: "user", blocked: true, releasesStop: false },
+    { source: undefined, blocked: false, releasesStop: false },
+    { source: "autonomous_tick", blocked: false, releasesStop: false },
+  ] as const)("releases local stop only after trusted human admission ($source, $blocked)", async ({ source, blocked, releasesStop }) => {
+    const { session } = fakeSession("/workspace");
+    session.services.hooks.userPromptSubmitHooks.push(() => {
+      expect(session.clearUserStop).not.toHaveBeenCalled();
+      return blocked ? { blockingError: { blockingError: "policy denied" } } : {};
+    });
+    const runSingleTurnFn = vi.fn(async function* (options: { userStopGenerationToRelease?: number }) {
+      expect(session.clearUserStop).not.toHaveBeenCalled();
+      expect(options.userStopGenerationToRelease).toBe(releasesStop ? 7 : undefined);
+      yield {
+        type: "turn_complete",
+        content: "ok",
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        stopReason: "completed",
+      } satisfies PhaseEvent;
+      return { reason: "completed" };
+    });
+    const uninstall = __installTuiSessionContractForTest({
+      session: session as never,
+      configStore: { current: () => defaultConfig },
+      agencHome: "/tmp/agenc",
+      resolvedProvider: "stub",
+      autonomousModeEnabled: false,
+      loadTurnInputsFn: async () => EMPTY_TURN_INPUTS,
+      runSingleTurnFn: runSingleTurnFn as never,
+    });
+    try {
+      await session.submit("new prompt", { source });
+    } finally {
+      uninstall();
+    }
+    expect(session.clearUserStop).not.toHaveBeenCalled();
+    expect(runSingleTurnFn).toHaveBeenCalledTimes(blocked || source === "autonomous_tick" ? 0 : 1);
+  });
+
   it.each([
     {
       label: "a compact failure",

--- a/runtime/tests/conversation/close-dangling-tool-calls.test.ts
+++ b/runtime/tests/conversation/close-dangling-tool-calls.test.ts
@@ -27,6 +27,7 @@ function makeSession(conversationId = "conv-resumed") {
     conversationId,
     state,
     emit: vi.fn(),
+    restoreUserStopFromRollout: vi.fn(),
     seedInternalSubId: vi.fn((next: number) => {
       subId = Math.max(subId, next);
     }),

--- a/runtime/tests/conversation/thread-manager.contract.test.ts
+++ b/runtime/tests/conversation/thread-manager.contract.test.ts
@@ -70,6 +70,7 @@ function makeSession(conversationId = "root-thread") {
   return {
     conversationId,
     seedInternalSubId: vi.fn(),
+    restoreUserStopFromRollout: vi.fn(),
     roleWorkspace: ROLE_WORKSPACE,
     state,
     agentStatus: {

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -77,6 +77,7 @@ const HOSTED_FND_TEST_FILES = [
 const KERNEL_TEST_FILES = [
   "tests/sandbox/landlock-seccomp.kernel.test.ts",
   "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
+  "tests/sandbox/readonly-delegation.kernel.test.ts",
 ] as const;
 
 const POWERSHELL_TEST_FILES = [

--- a/runtime/tests/permissions/cron-approval-risk.test.tsx
+++ b/runtime/tests/permissions/cron-approval-risk.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../src/tui/ink.js", async (importOriginal) => ({
   useInput: () => {},
 }));
 vi.mock("../../src/tui/keybindings/useKeybinding.js", () => ({
+  useInputCapture: () => {},
   useKeybindings: (handlers: Record<string, () => unknown>) => { bindings.handlers = handlers; },
 }));
 

--- a/runtime/tests/permissions/readonly-inspection.test.ts
+++ b/runtime/tests/permissions/readonly-inspection.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { assertReadOnlyInspectionInvocation, attachReadOnlyInspectionInvocation, inspectReadOnlyCommand, prepareReadOnlyInspectionInvocation, readReadOnlyInspectionInvocation } from "../../src/permissions/readonly-inspection.js";
+import { analyzeShellRuntimeAccess } from "../../src/tools/runtimes/shell.js";
+import type { Tool } from "../../src/tools/types.js";
+import { restrictedFileSystemPolicy } from "../../src/sandbox/engine/index.js";
+import type { UnifiedExecRuntimeSandbox } from "../../src/unified-exec/types.js";
+import { UnifiedExecProcessManager } from "../../src/unified-exec/process-manager.js";
+
+const cwd = "/project";
+
+describe("read-only shell inspection", () => {
+  it.each([
+    "pwd", "ls -la", "cat 'file with spaces.txt'", "head -n 50 README.md",
+    "tail -n 20 README.md", "wc -l README.md", "grep -rn TODO src",
+    "rg --files src", "rg -n 'unsafe\\(' src", "git log --oneline -5", "git show HEAD:README.md",
+    "git branch --list 'fix/*'", "git ls-files", "git rev-parse --show-toplevel",
+  ])("accepts literal inspection: %s", (cmd) => {
+    expect(inspectReadOnlyCommand("exec_command", { cmd }, cwd)).toMatchObject({ allowed: true });
+  });
+
+  it.each([
+    "git branch new-branch", "git branch -- -l", "git branch --abbrev 8",
+    "git branch -D old", "git diff --output=result.patch", "git -c core.fsmonitor=evil status",
+    "git --exec-path=/project/tools status", "git fetch", "git status; touch marker",
+    "sort -o output input", "rg --pre=sh text script", "rg -z text archive.gz",
+    "rg --pre text", "ls | head", "cat <(touch marker)", "cat $(touch marker)",
+    "cat $HOME/secret", "cat *.ts", "PATH=. git status", "env git status",
+    "./git status", "/project/bin/git status", "bash -c 'cat README.md'",
+    "node -e 'require(\"fs\").writeFileSync(\"marker\",\"x\")'", "curl https://example.com",
+    "find . -exec touch marker ';'", "cat ../../outside", "tail -f README.md", "git log --format=%G?", "git show --pretty=raw", "git branch -l new-branch", "git status --short", "git diff --stat",
+  ])("refuses mutation or unbounded execution: %s", (cmd) => {
+    expect(inspectReadOnlyCommand("exec_command", { cmd }, cwd)).toMatchObject({ allowed: false });
+  });
+
+  it.each([
+    { shell: "/bin/bash" }, { login: true }, { tty: true },
+    { sandbox_permissions: "require_escalated" }, { additional_permissions: { file_system: { write: ["/"] } } },
+    { workdir: "/elsewhere" },
+  ])("rejects execution overrides: %j", (extra) => {
+    expect(inspectReadOnlyCommand("exec_command", { cmd: "cat README.md", ...extra }, cwd)).toMatchObject({ allowed: false });
+  });
+
+  it("normalizes direct bash arguments without hiding path operands", () => {
+    expect(inspectReadOnlyCommand("system.bash", { command: "cat", args: ["README.md"] }, cwd)).toMatchObject({ allowed: true, invocation: { readPaths: [cwd, "/project/README.md"] } });
+    expect(inspectReadOnlyCommand("system.bash", { command: "cat", args: ["/elsewhere/secret"] }, cwd)).toMatchObject({ allowed: false });
+  });
+
+  it.each(["git branch new-branch", "sort -o output input", "rg --pre=sh pattern script"])(
+    "runtime access analysis does not call mutating argv read-only: %s", (cmd) => {
+      const tool = { name: "exec_command" } as Tool;
+      expect(analyzeShellRuntimeAccess(tool, { cmd }, cwd)).toMatchObject({ knownSafeWhenTargetless: false, indeterminateWrite: true });
+    },
+  );
+
+  it("separates semantic read targets from child workspace containment", () => {
+    expect(inspectReadOnlyCommand("exec_command", { cmd: "cat /etc/passwd" }, cwd)).toMatchObject({ allowed: false });
+    expect(analyzeShellRuntimeAccess({ name: "exec_command" } as Tool, { cmd: "cat /etc/passwd" }, cwd)).toMatchObject({ knownSafeWhenTargetless: true, indeterminateRead: false, readTargets: [cwd, "/etc/passwd"] });
+  });
+
+  it.skipIf(process.platform === "win32")("uses installed native executables and disables Git callbacks without inherited environment", () => {
+    const sandbox: UnifiedExecRuntimeSandbox = { preference: "require", permissionProfile: { fileSystem: restrictedFileSystemPolicy([{ path: { kind: "special", value: { kind: "root" } }, access: "read" }]), network: "disabled" } };
+    const inspected = inspectReadOnlyCommand("exec_command", { cmd: "git log --oneline -5" }, process.cwd());
+    if (!inspected.allowed) throw new Error(inspected.reason);
+    const invocation = prepareReadOnlyInspectionInvocation(inspected.invocation, sandbox);
+    expect(invocation.program).toMatch(/^\/(usr\/)?(?:local\/)?bin\/git$/);
+    expect(invocation.args).toEqual(expect.arrayContaining(["--no-pager", "core.fsmonitor=false", "core.hooksPath=/dev/null", "--no-ext-diff", "--no-textconv"]));
+    for (const name of ["BASH_ENV", "ENV", "NODE_OPTIONS", "LD_PRELOAD", "GIT_CONFIG_COUNT", "GIT_EXEC_PATH", "RIPGREP_CONFIG_PATH"]) expect(invocation.env).not.toHaveProperty(name);
+    expect(invocation.env).toMatchObject({ GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null", GIT_NO_LAZY_FETCH: "1", GIT_OPTIONAL_LOCKS: "0" });
+    const args = { cmd: "git log --oneline -5" };
+    attachReadOnlyInspectionInvocation(args, invocation);
+    expect(readReadOnlyInspectionInvocation(args)).toBe(invocation);
+    expect(readReadOnlyInspectionInvocation({ ...args })).toBeUndefined();
+    expect(() => assertReadOnlyInspectionInvocation({ ...invocation })).toThrow(/authority is missing/);
+    expect(() => prepareReadOnlyInspectionInvocation(inspected.invocation, { ...sandbox, preference: "auto" })).toThrow(/mandatory/);
+  });
+
+  it.skipIf(process.platform === "win32")("passes prepared argv directly to process spawn without shell profiles", async () => {
+    const sandbox: UnifiedExecRuntimeSandbox = { preference: "require", permissionProfile: { fileSystem: restrictedFileSystemPolicy([{ path: { kind: "special", value: { kind: "root" } }, access: "read" }]), network: "disabled" } };
+    const inspected = inspectReadOnlyCommand("exec_command", { cmd: "cat 'file with spaces.txt'" }, process.cwd());
+    if (!inspected.allowed) throw new Error(inspected.reason);
+    const invocation = prepareReadOnlyInspectionInvocation(inspected.invocation, sandbox);
+    const manager = new UnifiedExecProcessManager({ cwd: process.cwd() });
+    const wrapped = manager as unknown as { buildSpawnCommand: (input: unknown) => unknown; spawnProcess: (input: unknown) => Promise<never> };
+    const build = vi.spyOn(wrapped, "buildSpawnCommand").mockImplementation((input) => input);
+    const spawn = vi.spyOn(wrapped, "spawnProcess").mockRejectedValue(new Error("captured before physical execution"));
+    await expect(manager.execCommand({ cmd: "cat 'file with spaces.txt'", runtimeSandbox: sandbox, directInvocation: invocation, login: false })).rejects.toThrow("captured before physical execution");
+    expect(build).toHaveBeenCalledWith(expect.objectContaining({ program: invocation.program, args: ["file with spaces.txt"], cwd: process.cwd(), env: invocation.env }));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    build.mockRestore();
+    spawn.mockRestore();
+  });
+});

--- a/runtime/tests/permissions/review-decision.test.ts
+++ b/runtime/tests/permissions/review-decision.test.ts
@@ -48,6 +48,11 @@ describe("ReviewDecision — 7 tagged variants", () => {
 });
 
 describe("reviewDecisionIsAllow", () => {
+  test("denial feedback does not grant authority or enter telemetry labels", () => {
+    const decision: ReviewDecision = { kind: "denied", reason: "Private operator feedback" };
+    expect(reviewDecisionIsAllow(decision)).toBe(false);
+    expect(reviewDecisionOpaqueString(decision)).toBe("denied");
+  });
   test("all approve-shaped decisions → true", () => {
     expect(reviewDecisionIsAllow(APPROVED)).toBe(true);
     expect(reviewDecisionIsAllow(APPROVED_FOR_SESSION)).toBe(true);

--- a/runtime/tests/sandbox/execution-ingress.architecture.test.ts
+++ b/runtime/tests/sandbox/execution-ingress.architecture.test.ts
@@ -20,7 +20,7 @@ function productionMethodCalls(
   methods: readonly string[],
 ): string[] {
   const pattern = new RegExp(
-    `\\.(${methods.join("|")})\\s*\\(`,
+    `\\.(${methods.join("|")})\\s*(?:\\?\\.)?\\s*\\(`,
     "gu",
   );
   return sourceFiles(sourceRoot)
@@ -37,11 +37,13 @@ function productionMethodCalls(
 describe("sandbox execution ingress architecture", () => {
   test("enumerates every production command, runtime sandbox, and child-broker ingress", () => {
     expect(
-      productionMethodCalls(["prepareSpawn", "runtimeSandbox", "forkForCwd"]),
+      productionMethodCalls(["prepareSpawn", "runtimeSandbox", "forkForCwd", "forkForReadOnlyInspection"]),
     ).toEqual([
       "agents/delegate.ts:forkForCwd",
       "agents/delegate.ts:forkForCwd",
       "agents/run-agent.ts:forkForCwd",
+      "agents/run-agent.ts:forkForReadOnlyInspection",
+      "agents/run-agent.ts:runtimeSandbox",
       "agents/worktree.ts:prepareSpawn",
       "app-server/workflow/session-adapters.ts:forkForCwd",
       "app-server/workflow/session-adapters.ts:prepareSpawn",
@@ -57,6 +59,7 @@ describe("sandbox execution ingress architecture", () => {
       "session/agenc-delegate.ts:forkForCwd",
       "session/turn-compat.ts:forkForCwd",
       "tools/system/apply-runtime-sandbox.ts:prepareSpawn",
+      "tools/system/bash.ts:prepareSpawn",
       "tools/system/coding-common.ts:prepareSpawn",
       "tools/system/exec-command.ts:runtimeSandbox",
       "tools/worktree-sandbox-boundary.ts:prepareSpawn",

--- a/runtime/tests/sandbox/readonly-delegation.kernel.test.ts
+++ b/runtime/tests/sandbox/readonly-delegation.kernel.test.ts
@@ -1,0 +1,62 @@
+import { expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { buildToolRegistry } from "../../src/tool-registry.js";
+import { buildFilteredRegistry } from "../../src/agents/run-agent.js";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { UnifiedExecProcessManager } from "../../src/unified-exec/process-manager.js";
+import type { Session } from "../../src/session/session.js";
+
+it("runs real constrained commands and native search without profiles, writes, callbacks, or denied-file reads", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "agenc-readonly-delegation-"));
+  const manager = new UnifiedExecProcessManager({ cwd, env: { BASH_ENV: join(cwd, "shell-profile") } });
+  try {
+    const broker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd });
+    const status = broker.forkForReadOnlyInspection(cwd).status();
+    expect(status.kind, status.reason).toBe("ready");
+    await writeFile(join(cwd, "README.md"), "needle public\n");
+    await writeFile(join(cwd, "secret.txt"), "needle private\n");
+    await writeFile(join(cwd, "shell-profile"), "printf MALICIOUS; touch marker\n");
+    await writeFile(join(cwd, ".gitattributes"), "*.md filter=malicious\n");
+    execFileSync("git", ["init", "--quiet"], { cwd });
+    execFileSync("git", ["add", "README.md"], { cwd });
+    execFileSync("git", ["-c", "user.name=Inspection", "-c", "user.email=inspection@example.test", "commit", "--quiet", "-m", "inspection fixture"], { cwd });
+    execFileSync("git", ["config", "core.fsmonitor", "sh shell-profile"], { cwd });
+    execFileSync("git", ["config", "filter.malicious.clean", "sh shell-profile"], { cwd });
+    execFileSync("git", ["config", "filter.malicious.process", "sh shell-profile"], { cwd });
+    const permissionContext = createEmptyToolPermissionContext({ mode: "bypassPermissions" });
+    const constraint = { kind: "read-only" as const, ownerThreadId: "root", deniedRules: [`FileRead(${join(cwd, "secret.txt")})`] };
+    const session = { conversationId: "inspection-child", sessionConfiguration: { cwd }, permissionModeRegistry: { current: () => permissionContext }, services: { readOnlyDelegation: constraint, sandboxExecutionBroker: broker } } as Session;
+    const base = buildToolRegistry({ workspaceRoot: cwd, unifiedExecManager: manager, requireAdmission: false });
+    const registry = buildFilteredRegistry(base, { childConversationId: session.conversationId, executionConstraint: constraint, sandboxExecutionBroker: broker, getSession: () => session });
+    const execute = registry.tools.find((tool) => tool.name === "exec_command")!;
+    const content = await execute.execute({ cmd: "cat README.md", yield_time_ms: 1000 });
+    expect(content.isError, content.content).not.toBe(true);
+    expect(content.content).toContain("needle public");
+    const statusResult = await execute.execute({ cmd: "git show HEAD:secret.txt", yield_time_ms: 1000 });
+    expect(statusResult.isError).toBe(true);
+    expect(statusResult.content).toContain("repository objects");
+    expect((await execute.execute({ cmd: "cat secret.txt" })).isError).toBe(true);
+    expect((await execute.execute({ cmd: "touch marker" })).isError).toBe(true);
+    const search = registry.tools.find((tool) => tool.name === "Grep")!;
+    const found = await search.execute({ pattern: "needle", path: cwd, output_mode: "content" });
+    expect(found.isError, found.content).not.toBe(true);
+    expect(found.content).toContain("needle public");
+    expect(found.content).not.toContain("needle private");
+    expect(found.content).not.toContain("secret.txt");
+    const gitConstraint = { kind: "read-only" as const, ownerThreadId: "git-owner" };
+    const gitSession = { ...session, conversationId: "git-child", services: { ...session.services, readOnlyDelegation: gitConstraint } } as Session;
+    const gitRegistry = buildFilteredRegistry(base, { childConversationId: gitSession.conversationId, executionConstraint: gitConstraint, sandboxExecutionBroker: broker, getSession: () => gitSession });
+    const gitTool = gitRegistry.tools.find((tool) => tool.name === "exec_command")!;
+    const gitResult = await gitTool.execute({ cmd: "git log --oneline -5", yield_time_ms: 1000 });
+    expect(gitResult.isError, gitResult.content).not.toBe(true);
+    expect(gitResult.content).not.toContain("MALICIOUS");
+    await expect(readFile(join(cwd, "marker"))).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await manager.closeAll();
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/runtime/tests/sandbox/readonly-delegation.kernel.test.ts
+++ b/runtime/tests/sandbox/readonly-delegation.kernel.test.ts
@@ -22,7 +22,7 @@ it("runs real constrained commands and native search without profiles, writes, c
     await writeFile(join(cwd, "shell-profile"), "printf MALICIOUS; touch marker\n");
     await writeFile(join(cwd, ".gitattributes"), "*.md filter=malicious\n");
     execFileSync("git", ["init", "--quiet"], { cwd });
-    execFileSync("git", ["add", "README.md"], { cwd });
+    execFileSync("git", ["add", "README.md", "secret.txt"], { cwd });
     execFileSync("git", ["-c", "user.name=Inspection", "-c", "user.email=inspection@example.test", "commit", "--quiet", "-m", "inspection fixture"], { cwd });
     execFileSync("git", ["config", "core.fsmonitor", "sh shell-profile"], { cwd });
     execFileSync("git", ["config", "filter.malicious.clean", "sh shell-profile"], { cwd });
@@ -54,6 +54,29 @@ it("runs real constrained commands and native search without profiles, writes, c
     const gitResult = await gitTool.execute({ cmd: "git log --oneline -5", yield_time_ms: 1000 });
     expect(gitResult.isError, gitResult.content).not.toBe(true);
     expect(gitResult.content).not.toContain("MALICIOUS");
+    const publicBlob = await gitTool.execute({ cmd: "git show HEAD:README.md", yield_time_ms: 1000 });
+    expect(publicBlob.isError, publicBlob.content).not.toBe(true);
+    expect(publicBlob.content).toContain("needle public");
+    const unrestrictedSecretBlob = await gitTool.execute({ cmd: "git show HEAD:secret.txt", yield_time_ms: 1000 });
+    expect(unrestrictedSecretBlob.isError, unrestrictedSecretBlob.content).not.toBe(true);
+    expect(unrestrictedSecretBlob.content).toContain("needle private");
+    for (const kind of ["path", "glob"] as const) {
+      const deniedBroker = new SandboxExecutionBroker({ mode: "danger_full_access", cwd, permissionProfile: {
+        fileSystem: { kind: "restricted", entries: [
+          { path: { kind: "special", value: { kind: "root" } }, access: "write" },
+          { path: kind === "path" ? { kind: "path", path: join(cwd, "secret.txt") } : { kind: "glob", pattern: join(cwd, "*.txt") }, access: "none" },
+        ] }, network: "enabled",
+      } });
+      const deniedSession = { ...gitSession, conversationId: `sandbox-denied-${kind}`, services: { ...gitSession.services, sandboxExecutionBroker: deniedBroker } } as Session;
+      const deniedRegistry = buildFilteredRegistry(base, { childConversationId: deniedSession.conversationId, executionConstraint: gitConstraint, sandboxExecutionBroker: deniedBroker, getSession: () => deniedSession });
+      const deniedReader = deniedRegistry.tools.find(tool => tool.name === "FileRead")!;
+      expect((await deniedReader.execute({ file_path: join(cwd, "secret.txt") })).isError).toBe(true);
+      const deniedGit = deniedRegistry.tools.find(tool => tool.name === "exec_command")!;
+      const secretBlob = await deniedGit.execute({ cmd: "git show HEAD:secret.txt", yield_time_ms: 1000 });
+      expect(secretBlob.isError, secretBlob.content).toBe(true);
+      expect(secretBlob.content).toContain("repository objects");
+      expect(secretBlob.content).not.toContain("needle private");
+    }
     await expect(readFile(join(cwd, "marker"))).rejects.toMatchObject({ code: "ENOENT" });
   } finally {
     await manager.closeAll();

--- a/runtime/tests/session/child-followup-admission.test.ts
+++ b/runtime/tests/session/child-followup-admission.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkSession } from "../fixtures.js";
+import type { RolloutItem } from "../../src/session/rollout-item.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+describe("child follow-up admission", () => {
+  it("keeps the stop fence through default, edit, plan, and YOLO mode transitions", async () => {
+    const { session } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const submit = vi.fn(async () => {});
+    session.installTurnDriverHooks({ submit });
+    session.markStoppedByUser();
+    for (const mode of ["default", "acceptEdits", "plan", "bypassPermissions", "default"] as const) {
+      await session.permissionModeRegistry.update({ ...session.permissionModeRegistry.current(), mode });
+      expect(await session.submitChildFollowup()).toBe(false);
+      expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    }
+    expect(submit).not.toHaveBeenCalled();
+    session.clearUserStop();
+    expect(await session.submitChildFollowup()).toBe(true);
+  });
+
+  it("rejects old-instance followups after shutdown without affecting a fresh session", async () => {
+    const original = mkSession().session;
+    const restored = mkSession().session;
+    cleanups.push(() => restored.shutdown());
+    const oldSubmit = vi.fn(async () => {});
+    const newSubmit = vi.fn(async () => {});
+    original.installTurnDriverHooks({ submit: oldSubmit });
+    restored.installTurnDriverHooks({ submit: newSubmit });
+    await original.shutdown();
+    expect(await original.submitChildFollowup()).toBe(false);
+    await expect(original.submit("ordinary input")).rejects.toThrow("shutting down");
+    expect(oldSubmit).not.toHaveBeenCalled();
+    expect(newSubmit).not.toHaveBeenCalled();
+    expect(await restored.submitChildFollowup()).toBe(true);
+  });
+
+  it.each([false, true])("restores a denied owner without replaying receipts until a fresh human admission (%s)", async (freshAdmission) => {
+    const { session } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const items: RolloutItem[] = [{ type: "event_msg", payload: { id: "denial", msg: { type: "permission_decision", payload: {
+      runId: session.conversationId, callId: "denied", toolName: "exec_command", turnId: "turn-denied", requestEventId: "request-denied", requestEventSeq: 1,
+      decision: "denied", source: "resolver", recordedAt: "2026-09-10T00:00:00.000Z",
+    } } } }];
+    items.push({ type: "response_item", payload: { role: "user", content: "child receipt represented as context" } });
+    items.push({ type: "event_msg", payload: { id: "hidden-shell", msg: { type: "message_submission", payload: {
+      messageId: "shell", streamId: "session.shell.execute", acceptedAt: "2026-09-10T00:00:01.000Z", contentFingerprint: "shell-context",
+    } } } });
+    if (freshAdmission) items.push({ type: "event_msg", payload: { id: "new-human", msg: { type: "user_message", payload: {
+      message: "New instructions", messageId: "new-human", acceptedAt: "2026-09-10T00:00:02.000Z", streamId: "human-client-stream",
+    } } } });
+    session.restoreUserStopFromRollout(items);
+    expect(session.stoppedByUserSinceLastPrompt).toBe(!freshAdmission);
+    const submit = vi.fn(async () => {});
+    session.installTurnDriverHooks({ submit });
+    expect(submit).not.toHaveBeenCalled();
+    expect(await session.submitChildFollowup()).toBe(freshAdmission);
+    expect(submit).toHaveBeenCalledTimes(freshAdmission ? 1 : 0);
+  });
+
+  it.each([false, true])("rejects a queued receipt after a stop even if fresh input clears the latch (%s)", async (clearStop) => {
+    const { session } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const first = Promise.withResolvers<void>();
+    const submit = vi.fn(async () => { await first.promise; });
+    session.installTurnDriverHooks({ submit });
+    const active = session.submit("first user prompt");
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledOnce());
+    const receipt = session.submitChildFollowup();
+    session.markStoppedByUser();
+    if (clearStop) session.clearUserStop();
+    first.resolve();
+    await active;
+    expect(await receipt).toBe(false);
+    expect(submit).toHaveBeenCalledOnce();
+    await session.submit("fresh user prompt");
+    expect(submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not clear a stop for cron, autonomous ticks, or anonymous submissions", async () => {
+    const { session } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const submit = vi.fn(async () => {});
+    session.installTurnDriverHooks({ submit });
+    session.markStoppedByUser();
+    await session.submit("cron", { displayUserMessage: null });
+    await session.submit("tick", { source: "autonomous_tick" });
+    await session.submit("unspecified source");
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(await session.submitChildFollowup()).toBe(false);
+    expect(submit).toHaveBeenCalledTimes(3);
+  });
+
+  it("suppresses queued child followups when shutdown closes ingress", async () => {
+    const { session } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const activeTurn = Promise.withResolvers<void>();
+    const submit = vi.fn(async () => { await activeTurn.promise; });
+    session.installTurnDriverHooks({ submit });
+    const active = session.submit("active human prompt");
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledOnce());
+    const receipt = session.submitChildFollowup();
+    session.beginShutdown();
+    activeTurn.resolve();
+    await active;
+    expect(await receipt).toBe(false);
+    expect(submit).toHaveBeenCalledOnce();
+  });
+
+  it("checks a stop after asynchronous turn preparation before sampling", async () => {
+    const { session, events } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const preparing = Promise.withResolvers<void>();
+    const prepared = Promise.withResolvers<void>();
+    const sample = vi.spyOn(session.services.provider, "chatStream");
+    session.installTurnDriverHooks({ submit: async () => {
+      preparing.resolve();
+      await prepared.promise;
+      for await (const event of session.runTurn("child result", { displayUserMessage: null })) void event;
+    } });
+    const receipt = session.submitChildFollowup();
+    await preparing.promise;
+    session.markStoppedByUser();
+    session.clearUserStop();
+    prepared.resolve();
+    expect(await receipt).toBe(false);
+    expect(sample).not.toHaveBeenCalled();
+    expect(events.some((event) => event.msg.type === "turn_started")).toBe(false);
+  });
+
+  it("does not carry child generation authority into an independent automatic submission", async () => {
+    const { session } = mkSession();
+    cleanups.push(() => session.shutdown());
+    const timerReady = Promise.withResolvers<void>();
+    const timerCompleted = Promise.withResolvers<void>();
+    const sample = vi.spyOn(session.services.provider, "chatStream");
+    session.installTurnDriverHooks({ submit: async (message) => {
+      if (message === "") {
+        void timerReady.promise.then(async () => {
+          await session.submit("independent scheduled turn", { source: "autonomous_tick" });
+        }).then(timerCompleted.resolve, timerCompleted.reject);
+        return;
+      }
+      for await (const event of session.runTurn(message, { displayUserMessage: null })) void event;
+    } });
+    expect(await session.submitChildFollowup()).toBe(true);
+    session.markStoppedByUser();
+    timerReady.resolve();
+    await timerCompleted.promise;
+    expect(sample).toHaveBeenCalledOnce();
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+  });
+});

--- a/runtime/tests/session/local-user-stop-admission.test.ts
+++ b/runtime/tests/session/local-user-stop-admission.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { drain, mkCtx, mkSession } from "../fixtures.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { parseRolloutLine, type RolloutItem } from "../../src/session/rollout-item.js";
+import { runTurn, type RunTurnOptions } from "../../src/session/run-turn.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), "agenc-local-stop-admission-"));
+  cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
+  const session = mkSession({ cwd: directory }).session;
+  cleanups.push(() => session.shutdown());
+  const store = new RolloutStore({ cwd: directory, sessionId: session.conversationId, agencHome: join(directory, "home"), sessionTempRoot: join(directory, "scratch"), agencVersion: "0.17.0", autoStartScheduler: false });
+  store.open({ sessionId: session.conversationId, timestamp: new Date().toISOString(), cwd: directory, originator: "local-stop-test", agencVersion: "0.17.0", model: "test-model", modelProvider: "test" });
+  session.mountRolloutStore(store);
+  cleanups.push(() => { session.mountRolloutStore(null); store.close(); });
+  const read = (): RolloutItem[] => readFileSync(store.rolloutPath, "utf8").trim().split("\n").map(line => parseRolloutLine(line)!).filter(Boolean);
+  session.markStoppedByUser();
+  const run = (options: RunTurnOptions & { userStopGenerationToRelease?: number }) => drain(runTurn(session, mkCtx({ cwd: directory }), "fresh human instruction", options));
+  return { session, store, read, run };
+}
+
+describe("local human stop release admission", () => {
+  it("persists exactly one real instruction before releasing the stop", async () => {
+    const state = fixture();
+    const clear = state.session.clearUserStop.bind(state.session);
+    const release = vi.spyOn(state.session, "clearUserStop").mockImplementation(() => {
+      expect(state.read().filter(item => item.type === "response_item" && item.payload.role === "user")).toHaveLength(1);
+      expect(JSON.stringify(state.read())).toContain("fresh human instruction");
+      clear();
+    });
+    await state.run({ userStopGenerationToRelease: state.session.userStopGeneration });
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(false);
+    expect(state.read().filter(item => item.type === "event_msg" && item.payload.msg.type === "user_message")).toHaveLength(1);
+  });
+
+  it("keeps the stop closed when the instruction durability barrier fails", async () => {
+    const state = fixture();
+    const release = vi.spyOn(state.session, "clearUserStop");
+    vi.spyOn(state.store, "flushDurable").mockImplementation(() => { throw new Error("instruction fsync failed"); });
+    await expect(state.run({ userStopGenerationToRelease: state.session.userStopGeneration })).rejects.toThrow("instruction fsync failed");
+    expect(release).not.toHaveBeenCalled();
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(state.read().filter(item => item.type === "session_state" && item.payload.userStop?.stopped === false)).toHaveLength(0);
+  });
+
+  it("never persists a release marker without the preceding durable instruction even if release fails", async () => {
+    const state = fixture();
+    const append = state.store.appendRollout.bind(state.store);
+    vi.spyOn(state.store, "appendRollout").mockImplementation((item, options) => {
+      append(item, options);
+      if (item.type === "session_state" && item.payload.userStop?.stopped === false) throw new Error("release fsync failed after write");
+    });
+    await expect(state.run({ userStopGenerationToRelease: state.session.userStopGeneration })).rejects.toThrow("release fsync failed after write");
+    const items = state.read();
+    const instructionIndex = items.findIndex(item => item.type === "response_item" && item.payload.role === "user");
+    const releaseIndex = items.findIndex(item => item.type === "session_state" && item.payload.userStop?.stopped === false);
+    expect(instructionIndex).toBeGreaterThanOrEqual(0);
+    expect(releaseIndex).toBeGreaterThan(instructionIndex);
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(true);
+  });
+
+  it.each([undefined, 0])("does not release for absent or stale human ingress generation %s", async userStopGenerationToRelease => {
+    const state = fixture();
+    const release = vi.spyOn(state.session, "clearUserStop");
+    await state.run({ userStopGenerationToRelease });
+    expect(release).not.toHaveBeenCalled();
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(true);
+  });
+
+  it("cannot release a persisted stop without its canonical rollout store", async () => {
+    const state = fixture();
+    state.session.mountRolloutStore(null);
+    const release = vi.spyOn(state.session, "clearUserStop");
+    await expect(state.run({ userStopGenerationToRelease: state.session.userStopGeneration })).rejects.toThrow("requires a durable human instruction");
+    expect(release).not.toHaveBeenCalled();
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(true);
+  });
+});

--- a/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
+++ b/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
@@ -167,6 +167,48 @@ function orphanWithCheckpoint(args: CheckpointArgs): RolloutItem[] {
 }
 
 describe("reconstruction durable resume descriptors", () => {
+  test.each([false, true])("an owner stop invalidates its existing turn even after later human release (%s)", (clearStop) => {
+    const buildId = pinBuild("build-owner-stop");
+    const items = orphanWithCheckpoint({ turnId: "before-stop", buildId, prefix: [{ role: "user", content: "Inspect with a child" }] });
+    items.push({ type: "session_state", payload: { userStop: { stopped: true, generation: 1 } } });
+    if (clearStop) {
+      items.push({ type: "session_state", payload: { userStop: { stopped: false, generation: 1 } } });
+      const laterCheckpoint = orphanWithCheckpoint({ turnId: "before-stop", buildId, prefix: [{ role: "user", content: "Inspect with a child" }], checkpointSeq: 2 }).at(-1)!;
+      items.push(laterCheckpoint);
+    }
+    const reconstruction = reconstruct(items);
+    expect(reconstruction.resumableTurns).toEqual([]);
+    expect(reconstruction.orphanedTurnIds).toEqual(["before-stop"]);
+  });
+
+  test("a distinct human turn after release can resume without reviving the denied turn", () => {
+    const buildId = pinBuild("build-owner-stop");
+    const items = orphanWithCheckpoint({ turnId: "before-stop", buildId, prefix: [{ role: "user", content: "Old instructions" }] });
+    items.push({ type: "session_state", payload: { userStop: { stopped: true, generation: 1 } } });
+    items.push({ type: "session_state", payload: { userStop: { stopped: false, generation: 1 } } });
+    const resumedItems = orphanWithCheckpoint({ turnId: "after-stop", buildId, prefix: [
+      { role: "user", content: "Old instructions" },
+      { role: "user", content: "New instructions" },
+    ] });
+    items.push(...resumedItems.filter((item) => item.type !== "response_item" || item.payload.content !== "Old instructions"));
+    const reconstruction = reconstruct(items);
+    expect(reconstruction.resumableTurns.map((turn) => turn.turnId)).toEqual(["after-stop"]);
+    expect(reconstruction.resumableTurns[0]).toMatchObject({ buildMatches: true, historyPrefixValid: true });
+    expect(reconstruction.orphanedTurnIds).toEqual(expect.arrayContaining(["before-stop", "after-stop"]));
+  });
+
+  test("does not resume a checkpoint after a durable resolver denial without a terminal", () => {
+    const buildId = pinBuild("build-denied");
+    const items = orphanWithCheckpoint({ turnId: "denied-turn", buildId, prefix: [{ role: "user", content: "Run the command" }] });
+    items.push({ type: "event_msg", payload: { id: "denied-decision", seq: 3, msg: { type: "permission_decision", payload: {
+      runId: "test-run", callId: "denied-call", toolName: "exec_command", turnId: "denied-turn", requestEventId: "approval-request", requestEventSeq: 2,
+      decision: "denied", source: "resolver", recordedAt: new Date().toISOString(),
+    } } } });
+    const reconstruction = reconstruct(items);
+    expect(reconstruction.resumableTurns).toEqual([]);
+    expect(reconstruction.orphanedTurnIds).toEqual(["denied-turn"]);
+  });
+
   test("orphan + valid checkpoint + matching build → resumable, gates pass", () => {
     const buildId = pinBuild("build-A");
     const prefix: ResponseItem[] = [

--- a/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
+++ b/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
@@ -167,6 +167,86 @@ function orphanWithCheckpoint(args: CheckpointArgs): RolloutItem[] {
 }
 
 describe("reconstruction durable resume descriptors", () => {
+  const legacyStops: ReadonlyArray<{ readonly name: string; readonly item: RolloutItem }> = [
+    {
+      name: "interrupted turn",
+      item: { type: "event_msg", payload: { id: "legacy-stop", msg: { type: "turn_aborted", payload: { turnId: "other-turn", reason: "interrupted" } } } },
+    },
+    {
+      name: "unscoped interruption",
+      item: { type: "event_msg", payload: { id: "legacy-stop", msg: { type: "turn_aborted", payload: { reason: "interrupted" } } } },
+    },
+    {
+      name: "owner resolver denial",
+      item: { type: "event_msg", payload: { id: "legacy-stop", msg: { type: "permission_decision", payload: {
+        runId: "test-run", callId: "denied-call", toolName: "exec_command", turnId: "other-turn", requestEventId: "approval-request", requestEventSeq: 2,
+        decision: "denied", source: "resolver", recordedAt: "2026-09-10T00:00:00.000Z",
+      } } } },
+    },
+  ];
+
+  test.each(legacyStops)("legacy $name invalidates an older orphan without a userStop slot", ({ item }) => {
+    const buildId = pinBuild("build-legacy-stop");
+    const items = orphanWithCheckpoint({ turnId: "older-orphan", buildId, prefix: [{ role: "user", content: "Old instructions" }] });
+    items.push(item);
+    expect(reconstruct(items).resumableTurns).toEqual([]);
+  });
+
+  test.each(legacyStops)("legacy $name blocks a later orphan until human admission", ({ item }) => {
+    const buildId = pinBuild("build-legacy-stop");
+    const items = [item, ...orphanWithCheckpoint({ turnId: "automatic-followup", buildId, prefix: [{ role: "user", content: "Child receipt" }] })];
+    expect(reconstruct(items).resumableTurns).toEqual([]);
+  });
+
+  test.each(legacyStops)("legacy $name permits a new human turn without reviving earlier work", ({ item }) => {
+    const buildId = pinBuild("build-legacy-stop");
+    const items = orphanWithCheckpoint({ turnId: "older-orphan", buildId, prefix: [] });
+    items.push(item, { type: "event_msg", payload: { id: "human-admission", msg: { type: "user_message", payload: {
+      message: "New instructions", messageId: "human-message", acceptedAt: "2026-09-10T00:01:00.000Z",
+    } } } });
+    items.push(...orphanWithCheckpoint({ turnId: "new-human-turn", buildId, prefix: [{ role: "user", content: "New instructions" }] }));
+    expect(reconstruct(items).resumableTurns.map(turn => turn.turnId)).toEqual(["new-human-turn"]);
+  });
+
+  test("an explicit stop blocks post-stop checkpoints until the durable clear", () => {
+    const buildId = pinBuild("build-explicit-stop");
+    const items: RolloutItem[] = [
+      { type: "session_state", payload: { userStop: { stopped: true, generation: 1 } } },
+      { type: "event_msg", payload: { id: "unadmitted-human", msg: { type: "user_message", payload: {
+        message: "Unadmitted instructions", messageId: "failed-human-message", acceptedAt: "2026-09-10T00:01:00.000Z",
+      } } } },
+      ...orphanWithCheckpoint({ turnId: "unadmitted-turn", buildId, prefix: [] }),
+    ];
+    expect(reconstruct(items).resumableTurns).toEqual([]);
+    items.push({ type: "session_state", payload: { userStop: { stopped: false, generation: 1 } } });
+    items.push(...orphanWithCheckpoint({ turnId: "new-human-turn", buildId, prefix: [] }));
+    expect(reconstruct(items).resumableTurns.map(turn => turn.turnId)).toEqual(["new-human-turn"]);
+  });
+
+  test("a foreign resolver denial does not hold this session's unrelated orphan", () => {
+    const buildId = pinBuild("build-foreign-denial");
+    const items = orphanWithCheckpoint({ turnId: "owner-orphan", buildId, prefix: [] });
+    items.push({ type: "event_msg", payload: { id: "foreign-denial", msg: { type: "permission_decision", payload: {
+      runId: "foreign-run", callId: "foreign-call", toolName: "exec_command", turnId: "foreign-turn", requestEventId: "approval-request", requestEventSeq: 2,
+      decision: "denied", source: "resolver", recordedAt: "2026-09-10T00:00:00.000Z",
+    } } } });
+    expect(reconstruct(items).resumableTurns.map(turn => turn.turnId)).toEqual(["owner-orphan"]);
+  });
+
+  test("a human turn started before its durable release can resume a checkpoint written after release", () => {
+    const buildId = pinBuild("build-human-release");
+    const [started, ...admittedTurn] = orphanWithCheckpoint({ turnId: "human-turn", buildId, prefix: [{ role: "user", content: "New instructions" }] });
+    const items: RolloutItem[] = [
+      { type: "session_state", payload: { userStop: { stopped: true, generation: 1 } } },
+      started!,
+      { type: "session_state", payload: { userStop: { stopped: false, generation: 1 } } },
+      ...admittedTurn,
+    ];
+    expect(reconstruct(items).resumableTurns).toEqual([expect.objectContaining({
+      turnId: "human-turn", buildMatches: true, historyPrefixValid: true,
+    })]);
+  });
+
   test.each([false, true])("an owner stop invalidates its existing turn even after later human release (%s)", (clearStop) => {
     const buildId = pinBuild("build-owner-stop");
     const items = orphanWithCheckpoint({ turnId: "before-stop", buildId, prefix: [{ role: "user", content: "Inspect with a child" }] });

--- a/runtime/tests/session/run-turn.workflow-regressions.test.ts
+++ b/runtime/tests/session/run-turn.workflow-regressions.test.ts
@@ -6,6 +6,7 @@ import { runTurn } from "../../src/session/run-turn.js";
 import type { ToolRegistry } from "../../src/tool-registry.js";
 import type { Tool } from "../../src/tools/types.js";
 import { drain, mkCtx, mkProvider, mkSession } from "../fixtures.js";
+import { markWorkflowApprovalSession } from "../../src/permissions/approval-failure.js";
 
 function registryFor(tool: Tool): ToolRegistry {
   return {
@@ -19,6 +20,24 @@ function registryFor(tool: Tool): ToolRegistry {
 }
 
 describe("workflow turn boundaries", () => {
+  test.each([false, true])("keeps denial feedback in tool results and terminal text (workflow=%s)", async (workflow) => {
+    const reason = "Do not commit. Explain the pending changes instead.";
+    const registry = registryFor({ name: "approved_action", description: "Action requiring approval", inputSchema: { type: "object" }, requiresApproval: true, execute: vi.fn(async () => ({ content: "must not run" })) });
+    const provider = mkProvider({ content: "Requesting approval", toolCalls: [{ id: "feedback-call", name: "approved_action", arguments: "{}" }], finishReason: "tool_calls" });
+    const { session, events } = mkSession({ provider, registry, services: { approvalResolver: { request: async () => ({ kind: "denied", reason }) } } });
+    const unmark = workflow ? markWorkflowApprovalSession(session) : () => {};
+    try {
+      await drain(runTurn(session, mkCtx({ approvalPolicy: { value: "on_request" }, sandboxPolicy: { value: "workspace_write" } }), "Run the action"));
+      const closure = events.find((event) => event.msg.type === "tool_call_completed");
+      expect(closure?.msg).toMatchObject({ payload: { isError: true, metadata: { approvalFailure: { decision: "denied", source: "resolver", reason } } } });
+      expect(session.snapshotHistoryMessages().at(-1)?.content).toContain(reason);
+      expect(registry.tools[0]!.execute).not.toHaveBeenCalled();
+    } finally {
+      unmark();
+      await session.shutdown();
+    }
+  });
+
   test("ends an inspection turn after its conditional offer without executing the proposed work", async () => {
     const execute = vi.fn(async () => ({ content: "must not write" }));
     const registry = registryFor({ name: "write_notes", description: "Write the notes CLI", inputSchema: { type: "object" }, execute });
@@ -81,6 +100,7 @@ describe("workflow turn boundaries", () => {
     expect(session.snapshotHistoryMessages().at(-1)).toMatchObject({ role: "assistant", content: expect.stringMatching(/approval.*denied/i) });
     expect(findToolTurnValidationIssue(session.snapshotHistoryMessages())).toBeNull();
     expect(session.abortController.signal.aborted).toBe(false);
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
 
     provider.chatStream = mkProvider({ content: "Finished the allowed follow-up." }).chatStream;
     const previousEvents = events.length;
@@ -114,6 +134,7 @@ describe("workflow turn boundaries", () => {
     expect(closure?.msg).toMatchObject({ payload: { isError: true } });
     if (closure?.msg.type === "tool_call_completed") expect(closure.msg.payload.metadata?.approvalDenied).toBeUndefined();
     expect(events.some((event) => event.msg.type === "turn_failed")).toBe(false);
+    expect(session.stoppedByUserSinceLastPrompt).toBe(false);
     expect(events.map((event) => classifyTurnTerminal(event.msg)))
       .toContainEqual(expect.objectContaining({ outcome: "completed", message: "No approval resolver is available, so I made no changes." }));
   });

--- a/runtime/tests/session/user-stop-durability.test.ts
+++ b/runtime/tests/session/user-stop-durability.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkSession } from "../fixtures.js";
+import { LiveApprovalBroker } from "../../src/app-server/live-approval-broker.js";
+import { registerChildApprovalSession, revokeChildApprovalSession } from "../../src/agents/child-approval-context.js";
+import { requestApproval } from "../../src/permissions/guardian/arbiter.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { parseRolloutLine, serializeRolloutItem, sessionStateUpdateAddressesSlot, type RolloutItem } from "../../src/session/rollout-item.js";
+import type { Session } from "../../src/session/session.js";
+import { isCanonicalRolloutPayload } from "../../src/state/recovery-journal-schema.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), "agenc-stop-durability-"));
+  cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
+  const session = mkSession({ cwd: directory }).session;
+  cleanups.push(() => session.shutdown());
+  const store = new RolloutStore({
+    cwd: directory, sessionId: session.conversationId, agencHome: join(directory, "home"),
+    sessionTempRoot: join(directory, "scratch"), agencVersion: "0.17.0", autoStartScheduler: false,
+  });
+  store.open({ sessionId: session.conversationId, timestamp: new Date().toISOString(), cwd: directory, originator: "user-stop-test", agencVersion: "0.17.0", model: "test-model", modelProvider: "test" });
+  session.mountRolloutStore(store);
+  cleanups.push(() => { session.mountRolloutStore(null); store.close(); });
+  const read = (): RolloutItem[] => readFileSync(store.rolloutPath, "utf8").trim().split("\n").map(line => parseRolloutLine(line)!).filter(Boolean);
+  const restored = (): Session => {
+    const next = mkSession({ cwd: directory }).session;
+    cleanups.push(() => next.shutdown());
+    next.restoreUserStopFromRollout(read());
+    return next;
+  };
+  return { session, store, read, restored };
+}
+
+describe("durable user-stop authority", () => {
+  it("commits a child denial to the owner journal before resolving the request", async () => {
+    const state = fixture();
+    const child = mkSession({ cwd: state.session.sessionConfiguration.cwd }).session;
+    Object.defineProperty(child, "conversationId", { value: "child-stop-fixture" });
+    cleanups.push(() => child.shutdown());
+    const childStore = new RolloutStore({ cwd: state.session.sessionConfiguration.cwd, sessionId: child.conversationId, agencHome: state.store.store.agencHome, sessionTempRoot: join(state.session.sessionConfiguration.cwd, "child-scratch"), agencVersion: "0.17.0", autoStartScheduler: false });
+    childStore.open({ sessionId: child.conversationId, timestamp: new Date().toISOString(), cwd: child.sessionConfiguration.cwd, originator: "child-stop-test", agencVersion: "0.17.0", model: "test-model", modelProvider: "test" });
+    child.mountRolloutStore(childStore);
+    cleanups.push(() => { child.mountRolloutStore(null); childStore.close(); });
+    const broker = new LiveApprovalBroker();
+    cleanups.push(broker.register(state.session, { isActive: () => true }));
+    registerChildApprovalSession(child, state.session);
+    cleanups.push(() => revokeChildApprovalSession(child));
+    const pending = requestApproval({ ctx: { callId: "child-call", toolName: "exec_command", turnId: "child-turn", invocation: { callId: "child-call", session: child, payload: { kind: "function", name: "exec_command", arguments: '{"cmd":"git commit"}' }, turn: { subId: "child-turn" } } as never }, resolver: state.session.services.approvalResolver, args: { cmd: "git commit" }, getActiveTurnId: () => "child-turn" });
+    await vi.waitFor(() => expect(broker.list(state.session.conversationId)).toHaveLength(1));
+    expect(broker.resolve(state.session.conversationId, broker.list(state.session.conversationId)[0]!.requestId, { kind: "denied" })).toBe(true);
+    expect(state.read()).toContainEqual(expect.objectContaining({ type: "session_state", payload: { userStop: { stopped: true, generation: 1 } } }));
+    expect((await pending).decision.kind).toBe("denied");
+    const resumed = state.restored();
+    resumed.installTurnDriverHooks({ submit: vi.fn(async () => {}) });
+    expect(resumed.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(await resumed.submitChildFollowup()).toBe(false);
+  });
+
+  it("records an accepted local human release without relying on daemon message IDs", () => {
+    const state = fixture();
+    state.session.markStoppedByUser();
+    state.session.clearUserStop();
+    expect(state.restored().stoppedByUserSinceLastPrompt).toBe(false);
+    expect(state.read()).toContainEqual(expect.objectContaining({ type: "session_state", payload: { userStop: { stopped: false, generation: 1 } } }));
+  });
+
+  it("restores stop generations without appending state during replay", () => {
+    const state = fixture();
+    state.session.markStoppedByUser();
+    state.session.clearUserStop();
+    state.session.markStoppedByUser();
+    const append = vi.spyOn(state.store, "appendRollout");
+    const items = state.read();
+    state.session.restoreUserStopFromRollout(items);
+    expect(state.session.userStopGeneration).toBe(2);
+    expect(append).not.toHaveBeenCalled();
+    expect(state.restored().userStopGeneration).toBe(2);
+  });
+
+  it.each(["stop", "clear"])("keeps a stop effective when its %s durability boundary fails", (operation) => {
+    const state = fixture();
+    if (operation === "clear") state.session.markStoppedByUser();
+    vi.spyOn(state.store, "appendRollout").mockImplementation(() => { throw new Error("fsync failed"); });
+    expect(() => operation === "stop" ? state.session.markStoppedByUser() : state.session.clearUserStop()).toThrow("fsync failed");
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(true);
+  });
+
+  it.each([null, {}, { stopped: "false", generation: 1 }, { stopped: false, generation: -1 }, { stopped: false, generation: 1.5 }, { stopped: false, generation: Number.MAX_SAFE_INTEGER + 1 }])("fails closed on a malformed persisted stop slot: %j", (userStop) => {
+    const session = mkSession().session;
+    cleanups.push(() => session.shutdown());
+    const item = { type: "session_state", payload: { userStop } } as unknown as RolloutItem;
+    expect(isCanonicalRolloutPayload("session_state", item.payload)).toBe(false);
+    expect(() => session.restoreUserStopFromRollout([item])).toThrow(/user.stop/i);
+    expect(session.stoppedByUserSinceLastPrompt).toBe(true);
+  });
+
+  it("round-trips stop state without clearing unrelated session slots", () => {
+    const item = { type: "session_state", payload: { userStop: { stopped: true, generation: 2 } } } as unknown as RolloutItem;
+    const parsed = parseRolloutLine(serializeRolloutItem(item))!;
+    expect(parsed).toMatchObject(item);
+    expect(isCanonicalRolloutPayload("session_state", parsed.payload)).toBe(true);
+    if (parsed.type !== "session_state") throw new Error("Wrong rollout item type");
+    expect(sessionStateUpdateAddressesSlot(parsed.payload, "agentTask")).toBe(false);
+    expect(sessionStateUpdateAddressesSlot(parsed.payload, "memoryExtraction")).toBe(false);
+  });
+});

--- a/runtime/tests/session/user-stop-durability.test.ts
+++ b/runtime/tests/session/user-stop-durability.test.ts
@@ -84,6 +84,37 @@ describe("durable user-stop authority", () => {
     expect(state.restored().userStopGeneration).toBe(2);
   });
 
+  it.each(["user_message", "message_submission"] as const)("does not release an explicit stop for a merely journaled %s", (eventType) => {
+    const state = fixture();
+    state.session.markStoppedByUser();
+    const admission = {
+      type: "event_msg", payload: { id: "unadmitted", msg: { type: eventType, payload: {
+        message: "continue", contentFingerprint: "test-fingerprint", messageId: "unadmitted",
+        streamId: "stream_1", acceptedAt: "2026-09-10T00:00:00.000Z",
+      } } },
+    } as unknown as RolloutItem;
+    const restored = state.restored();
+    restored.restoreUserStopFromRollout([...state.read(), admission]);
+    expect(restored.stoppedByUserSinceLastPrompt).toBe(true);
+    expect(restored.userStopGeneration).toBe(1);
+    state.session.clearUserStop();
+    restored.restoreUserStopFromRollout([...state.read(), admission]);
+    expect(restored.stoppedByUserSinceLastPrompt).toBe(false);
+  });
+
+  it("retains implicit human release for legacy journals without explicit stop state", () => {
+    const state = fixture();
+    const items = [
+      { type: "event_msg", payload: { id: "stop", msg: { type: "turn_aborted", payload: { reason: "interrupted" } } } },
+      { type: "event_msg", payload: { id: "human", msg: { type: "user_message", payload: {
+        message: "continue", messageId: "human", streamId: "stream_1", acceptedAt: "2026-09-10T00:00:00.000Z",
+      } } } },
+    ] as unknown as RolloutItem[];
+    state.session.restoreUserStopFromRollout(items);
+    expect(state.session.stoppedByUserSinceLastPrompt).toBe(false);
+    expect(state.session.userStopGeneration).toBe(1);
+  });
+
   it.each(["stop", "clear"])("keeps a stop effective when its %s durability boundary fails", (operation) => {
     const state = fixture();
     if (operation === "clear") state.session.markStoppedByUser();

--- a/runtime/tests/tools/shell-preflight.test.ts
+++ b/runtime/tests/tools/shell-preflight.test.ts
@@ -1,0 +1,195 @@
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ToolRouter } from "../../src/tools/router.js";
+import { executeToolDispatch } from "../../src/tools/execution.js";
+import type { Tool } from "../../src/tools/types.js";
+import type { ToolInvocation } from "../../src/tools/context.js";
+import { EventLog } from "../../src/session/event-log.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import { createExecCommandTool } from "../../src/tools/system/exec-command.js";
+import { createBashTool } from "../../src/tools/system/bash.js";
+import { createWriteStdinTool } from "../../src/tools/system/write-stdin.js";
+import { classifyShellWorkspaceWritePolicy } from "../../src/llm/shell-write-policy.js";
+import type { ReviewDecision } from "../../src/permissions/review-decision.js";
+
+let workspace = "";
+beforeEach(async () => { workspace = await mkdtemp(join(tmpdir(), "agenc-shell-preflight-")); });
+afterEach(async () => { await rm(workspace, { recursive: true, force: true }); });
+
+function shellTool(name: string, command: string): { tool: Tool; args: Record<string, unknown> } {
+  if (name === "system.bash") {
+    return { tool: createBashTool({ cwd: workspace, unrestricted: true }), args: { command } };
+  }
+  if (name === "write_stdin") {
+    return { tool: createWriteStdinTool({ cwd: workspace }), args: { session_id: 17, chars: command } };
+  }
+  return { tool: createExecCommandTool({ cwd: workspace }), args: { cmd: command } };
+}
+
+function dispatchFixture(tool: Tool, args: Record<string, unknown>) {
+  const execute = vi.spyOn(tool, "execute");
+  const session = {
+    eventLog: new EventLog(),
+    services: { admissionRequired: false, runtimeOptions: resolveAgentRuntimeOptions({}) },
+  } as unknown as ToolInvocation["session"];
+  const turn = { subId: "shell-preflight", cwd: workspace } as ToolInvocation["turn"];
+  const resolver = { request: vi.fn(async (): Promise<ReviewDecision> => ({ kind: "denied" })) };
+  const canUseTool = vi.fn(async () => ({ behavior: "ask" as const, message: "approval required" }));
+  const options = {
+    session, turn,
+    tracker: { appendFileDiff: () => {}, snapshot: () => [], clear: () => {} },
+    approvalPolicy: "untrusted" as const,
+    sandboxMode: "workspace_write" as const,
+    approvalResolver: resolver, canUseTool, permissionContext: {} as never,
+  };
+  const rawArgs = JSON.stringify(args);
+  const invocation: ToolInvocation = {
+    ...options, callId: "shell-policy-call", toolName: { name: tool.name },
+    payload: { kind: "function", arguments: rawArgs }, source: "direct",
+  };
+  const router = new ToolRouter([{ tool, supportsParallelToolCalls: false }]);
+  return { execute, resolver, canUseTool, options, rawArgs, invocation, router };
+}
+
+describe("shell policy before approval", () => {
+  const blockedCommands = [
+    "git commit -m \"$(cat <<'EOF'\naudit commit\nEOF\n)\"",
+    "printf changed > src.js",
+    "rm -rf .git",
+  ];
+  for (const name of ["exec_command", "system.bash", "write_stdin"]) {
+    for (const route of ["model", "direct", "executor"]) {
+      test.each(blockedCommands)(`${name} ${route} rejects %s without asking`, async (command) => {
+        const { tool, args } = shellTool(name, command);
+        const fixture = dispatchFixture(tool, args);
+        const result = route === "model"
+          ? await fixture.router.dispatchModelToolCall({ id: "shell-policy-call", name, arguments: fixture.rawArgs }, fixture.options)
+          : route === "direct"
+            ? await fixture.router.dispatchToolCall(fixture.invocation, args, fixture.options)
+            : await executeToolDispatch({ tool, currentTurnId: "shell-preflight", rawArgs: fixture.rawArgs, invocation: fixture.invocation, approvalResolver: fixture.resolver });
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("shell_workspace_");
+        expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+        expect(fixture.resolver.request).not.toHaveBeenCalled();
+        expect(fixture.canUseTool).not.toHaveBeenCalled();
+        expect(fixture.execute).not.toHaveBeenCalled();
+      });
+    }
+    test.each(["rm src.js", "mv src.js renamed.js", "git status", "node --test"])(`${name} leaves authorizable %s to permission evaluation`, (command) => {
+      const { tool, args } = shellTool(name, command);
+      expect(tool.preflight?.(args)).toBeNull();
+    });
+  }
+
+  test("model hook rewrites are checked before approval", async () => {
+    const { tool, args } = shellTool("exec_command", "git status");
+    const fixture = dispatchFixture(tool, args);
+    const result = await fixture.router.dispatchModelToolCall({ id: "rewritten-shell", name: tool.name, arguments: fixture.rawArgs }, {
+      ...fixture.options,
+      preHooks: [async () => ({ kind: "continue", args: { cmd: "printf changed > src.js" } })],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("shell_workspace_");
+    expect(fixture.resolver.request).not.toHaveBeenCalled();
+    expect(fixture.execute).not.toHaveBeenCalled();
+  });
+
+  test("direct argv validation runs before approval without weakening its policy", () => {
+    const tool = createBashTool({ cwd: workspace, unrestricted: true });
+    expect(tool.preflight?.({ command: "git", args: ["commit", "-m", "$(literal message)"] })?.message).toContain("Invalid direct-mode args");
+    expect(tool.preflight?.({ command: "git", args: ["commit", "-m", "literal message"] })).toBeNull();
+  });
+
+  test("empty stdin polling has no shell policy rejection", () => {
+    const { tool, args } = shellTool("write_stdin", "");
+    expect(tool.preflight?.(args)).toBeNull();
+  });
+
+  test("normal interactive shells retain their existing execution path", () => {
+    const { tool } = shellTool("exec_command", "bash");
+    expect(tool.preflight?.({ cmd: "bash", tty: true })).toBeNull();
+  });
+
+  test.each(["exec_command", "system.bash", "write_stdin"])("%s preflight cannot grant deletion authority", (name) => {
+    const decision = classifyShellWorkspaceWritePolicy({
+      toolName: name, args: { command: "rm src.js" }, workspaceRoot: workspace,
+      validationPhase: "preflight",
+    });
+    expect(decision.blocked).toBe(false);
+    expect(decision.deletionTargets).toEqual([]);
+    const execution = classifyShellWorkspaceWritePolicy({
+      toolName: name, args: { command: "rm src.js" }, workspaceRoot: workspace,
+    });
+    expect(execution.blocked).toBe(true);
+    expect(execution.message).toContain("requires_approval");
+    expect(classifyShellWorkspaceWritePolicy({
+      toolName: name, args: { command: "rm src.js" }, workspaceRoot: workspace,
+      allowWorkspaceDeletions: true,
+    }).blocked).toBe(false);
+  });
+
+  test("workdir outside the captured scope is refused before approval", async () => {
+    const { tool } = shellTool("exec_command", "git status");
+    const args = { cmd: "git status", workdir: join(workspace, "..") };
+    const fixture = dispatchFixture(tool, args);
+    const result = await fixture.router.dispatchModelToolCall({ id: "outside-workspace", name: tool.name, arguments: fixture.rawArgs }, fixture.options);
+    expect(result.content).toContain("outside allowed workspace paths");
+    expect(fixture.resolver.request).not.toHaveBeenCalled();
+    expect(fixture.execute).not.toHaveBeenCalled();
+  });
+
+  test("workdir identity is checked again when its symlink changes", async () => {
+    const link = join(workspace, "inspection");
+    await symlink(workspace, link, "dir");
+    const { tool } = shellTool("exec_command", "git status");
+    const args = { cmd: "git status", workdir: link };
+    expect(tool.preflight?.(args)).toBeNull();
+    await rm(link);
+    await symlink(join(workspace, ".."), link, "dir");
+    expect(tool.preflight?.(args)?.code).toBe("workdir-validation");
+    const result = await tool.execute(args);
+    expect(result.isError).toBe(true);
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  });
+
+  test("approval cannot authorize a changed working-directory identity", async () => {
+    const link = join(workspace, "inspection");
+    await symlink(workspace, link, "dir");
+    const { tool } = shellTool("exec_command", "git status");
+    const fixture = dispatchFixture(tool, { cmd: "git status", workdir: link });
+    fixture.execute.mockResolvedValue({ content: "must not execute" });
+    fixture.resolver.request.mockImplementationOnce(async () => {
+      await rm(link);
+      await symlink(join(workspace, ".."), link, "dir");
+      return { kind: "approved" };
+    });
+    const result = await fixture.router.dispatchModelToolCall({ id: "shell-policy-call", name: tool.name, arguments: fixture.rawArgs }, {
+      ...fixture.options, sandboxMode: "danger_full_access",
+    });
+    expect(fixture.resolver.request).toHaveBeenCalledOnce();
+    expect(result.content).toContain("outside allowed workspace paths");
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    expect(fixture.execute).not.toHaveBeenCalled();
+  });
+
+  test("missing workdir cannot hide traversal behind a workspace prefix", () => {
+    const { tool } = shellTool("exec_command", "git status");
+    expect(tool.preflight?.({ cmd: "git status", workdir: `${workspace}/../missing-outside` })?.code).toBe("workdir-validation");
+  });
+
+  test("system.bash rejects a missing working directory before approval", () => {
+    const { tool } = shellTool("system.bash", "git status");
+    expect(tool.preflight?.({ command: "git status", cwd: join(workspace, "missing") })?.message).toContain("does not exist");
+  });
+
+  test("MCP placeholders are refused before approval", async () => {
+    const { tool, args } = shellTool("exec_command", "mcp.server.tool");
+    const fixture = dispatchFixture(tool, args);
+    const result = await fixture.router.dispatchModelToolCall({ id: "mcp-placeholder", name: tool.name, arguments: fixture.rawArgs }, fixture.options);
+    expect(result.content).toContain("MCP tools are not shell commands");
+    expect(fixture.resolver.request).not.toHaveBeenCalled();
+    expect(fixture.execute).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/tools/system/readonly-search-guard.test.ts
+++ b/runtime/tests/tools/system/readonly-search-guard.test.ts
@@ -1,0 +1,210 @@
+import { mkdir, mkdtemp, rename, rm, symlink, truncate, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createGrepTool } from "../../../src/tools/system/grep.js";
+import { createGlobTool } from "../../../src/tools/system/glob.js";
+import { createFileReadTool } from "../../../src/tools/system/file-read.js";
+import { attachReadOnlyDelegationReadGuard } from "../../../src/permissions/readonly-read-guard.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+import { sha256, workspaceMutationCoordinators } from "../../../src/workspace/mutation-coordinator.js";
+import { clearSessionReadState, getSessionReadSnapshot, signSessionId } from "../../../src/tools/system/filesystem.js";
+import { MAX_GREP_DECODED_BYTES } from "../../../src/tools/system/ripgrep-protocol.js";
+
+let workspace = "";
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "agenc-readonly-search-"));
+  await mkdir(join(workspace, "private"));
+  await writeFile(join(workspace, "public.ts"), "needle public\n");
+  await writeFile(join(workspace, "secret.ts"), "needle secret\n");
+  await writeFile(join(workspace, "private", "nested.ts"), "needle nested\n");
+});
+afterEach(async () => {
+  clearSessionReadState("readonly-search-session");
+  workspaceMutationCoordinators.clearForTests();
+  await rm(workspace, { recursive: true, force: true });
+});
+
+function guarded(args: Record<string, unknown>): Record<string, unknown> {
+  attachReadOnlyDelegationReadGuard(args, path => !path.endsWith("secret.ts") && !path.includes(`${workspace}/private`) && !path.endsWith(".ignore"));
+  return args;
+}
+
+describe("read-only delegated search authority", () => {
+  it("refuses FileRead after live authority changes at the final path boundary", async () => {
+    let allowed = true;
+    const tool = createFileReadTool({ allowedPaths: [workspace], __testAfterFinalPathCheck: () => { allowed = false; } });
+    const args = { file_path: join(workspace, "public.ts") };
+    attachReadOnlyDelegationReadGuard(args, () => allowed);
+    const result = await tool.execute(args);
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("needle public");
+  });
+
+  it("refuses denied FileRead content even after a previous authorized read", async () => {
+    const tool = createFileReadTool({ allowedPaths: [workspace] });
+    const args = {
+      file_path: join(workspace, "public.ts"),
+      __agencSessionId: "readonly-search-session",
+      __agencSessionIdSig: signSessionId("readonly-search-session"),
+    };
+    let allowed = true;
+    attachReadOnlyDelegationReadGuard(args, () => allowed);
+    expect((await tool.execute(args)).content).toContain("needle public");
+    const snapshot = getSessionReadSnapshot("readonly-search-session", args.file_path);
+    expect(snapshot?.content).toContain("needle public");
+    allowed = false;
+    const denied = await tool.execute(args);
+    expect(denied.isError).toBe(true);
+    expect(denied.content).not.toContain("needle public");
+    expect(getSessionReadSnapshot("readonly-search-session", args.file_path)).toEqual(snapshot);
+  });
+
+  it("rechecks FileRead authority before exposing a captured dirty snapshot", async () => {
+    const coordinator = workspaceMutationCoordinators.getOrCreate(workspace);
+    const lease = coordinator.acquire({ workspaceRoot: workspace, editorInstanceId: "readonly-file-editor" });
+    const content = "needle unsaved public\n";
+    coordinator.sync({
+      workspaceRoot: workspace, editorInstanceId: lease.editorInstanceId, leaseToken: lease.leaseToken, epoch: lease.epoch, sequence: 0,
+      buffers: [{ path: join(workspace, "public.ts"), bufferHandle: 7, changedtick: 1, contentSha256: sha256(content), dirty: true, content }],
+    });
+    let allowed = true;
+    const tool = createFileReadTool({ allowedPaths: [workspace], __testAfterFinalPathCheck: () => { allowed = false; } });
+    const args = {
+      file_path: join(workspace, "public.ts"),
+      __agencSessionId: "readonly-search-session",
+      __agencSessionIdSig: signSessionId("readonly-search-session"),
+    };
+    attachReadOnlyDelegationReadGuard(args, () => allowed);
+    const result = await tool.execute(args);
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("unsaved public");
+    expect(getSessionReadSnapshot("readonly-search-session", args.file_path)).toBeUndefined();
+  });
+
+  it("rejects unauthorized FileRead bytes after final leaf replacement", async () => {
+    const file = join(workspace, "public.ts");
+    let exchanged = false;
+    const tool = createFileReadTool({
+      allowedPaths: [workspace],
+      __testAfterFinalPathCheck: async () => {
+        try {
+          await rename(file, join(workspace, "held.ts"));
+          await symlink(join(workspace, "secret.ts"), file);
+          exchanged = true;
+        } catch (error) {
+          if (process.platform !== "win32" || !["EPERM", "EACCES", "EBUSY"].includes((error as NodeJS.ErrnoException).code ?? "")) throw error;
+        }
+      },
+    });
+    const result = await tool.execute(guarded({ file_path: file }));
+    expect(exchanged || process.platform === "win32").toBe(true);
+    if (exchanged) expect(result.isError).toBe(true);
+    else expect(result.content).toContain("needle public");
+    expect(result.content).not.toContain("needle secret");
+  });
+
+  it("refuses delegated PDF helpers without a descriptor-safe input path", async () => {
+    const file = join(workspace, "public.pdf");
+    await writeFile(file, "%PDF-1.4\n");
+    const result = await createFileReadTool({ allowedPaths: [workspace] }).execute(guarded({ file_path: file }));
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("held file descriptor");
+  });
+
+  it.each(["content", "files_with_matches", "count"])("checks each Grep candidate before reading in %s mode", async output_mode => {
+    const reads: string[] = [];
+    const tool = bindExplicitDangerBoundary(createGrepTool({
+      allowedPaths: [workspace],
+      __testProtectedTaskObserver: event => { if (event.phase === "start") reads.push(event.source); },
+    }));
+    const result = await tool.execute(guarded({ pattern: "needle", path: workspace, output_mode }));
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain("public.ts");
+    expect(result.content).not.toContain("secret");
+    expect(result.content).not.toContain("nested");
+    expect(reads).toEqual(["disk"]);
+  });
+
+  it.each(["root", "cwd", "absolute-pattern"])("checks Glob candidate paths with %s selection", async selection => {
+    const tool = bindExplicitDangerBoundary(createGlobTool({ allowedPaths: [workspace] }));
+    const args = selection === "cwd" ? { pattern: "**/*.ts", cwd: workspace }
+      : selection === "absolute-pattern" ? { pattern: join(workspace, "**/*.ts") }
+      : { pattern: "**/*.ts", path: workspace };
+    const result = await tool.execute(guarded(args));
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toBe("public.ts");
+  });
+
+  it("does not read denied ignore-file bytes while matching allowed content", async () => {
+    await writeFile(join(workspace, ".ignore"), "public.ts\n");
+    const tool = bindExplicitDangerBoundary(createGrepTool({ allowedPaths: [workspace] }));
+    const result = await tool.execute(guarded({ pattern: "needle", path: workspace }));
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain("public.ts");
+  });
+
+  it("revalidates already-read Grep candidates before returning results", async () => {
+    let allowed = true;
+    const tool = bindExplicitDangerBoundary(createGrepTool({
+      allowedPaths: [workspace],
+      beforeAuthoritativeSnapshotValidation: () => { allowed = false; },
+    }));
+    const args = { pattern: "needle", path: join(workspace, "public.ts"), output_mode: "content" };
+    attachReadOnlyDelegationReadGuard(args, () => allowed);
+    const result = await tool.execute(args);
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("needle public");
+  });
+
+  it("bounds descriptor input bytes for constrained Grep", async () => {
+    const file = join(workspace, "large.ts");
+    await writeFile(file, "needle large\n");
+    await truncate(file, MAX_GREP_DECODED_BYTES + 1);
+    const tool = bindExplicitDangerBoundary(createGrepTool({ allowedPaths: [workspace] }));
+    const result = await tool.execute(guarded({ pattern: "needle", path: file, output_mode: "content" }));
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("needle large");
+  });
+
+  it("does not search or copy denied authoritative dirty snapshots", async () => {
+    const coordinator = workspaceMutationCoordinators.getOrCreate(workspace);
+    const lease = coordinator.acquire({ workspaceRoot: workspace, editorInstanceId: "readonly-search-editor" });
+    const content = "needle unsaved secret\n";
+    coordinator.sync({
+      workspaceRoot: workspace, editorInstanceId: lease.editorInstanceId, leaseToken: lease.leaseToken, epoch: lease.epoch, sequence: 0,
+      buffers: [{ path: join(workspace, "secret.ts"), bufferHandle: 7, changedtick: 1, contentSha256: sha256(content), dirty: true, content }],
+    });
+    await coordinator.flushQuarantinePersistence();
+    const sources: string[] = [];
+    const tool = bindExplicitDangerBoundary(createGrepTool({
+      allowedPaths: [workspace],
+      __testProtectedTaskObserver: event => { if (event.phase === "start") sources.push(event.source); },
+    }));
+    const result = await tool.execute(guarded({ pattern: "needle", path: workspace, output_mode: "content" }));
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain("public.ts");
+    expect(result.content).not.toContain("secret");
+    expect(sources).toEqual(["disk"]);
+    const capture = coordinator.authoritativeDirtySnapshotsUnderIdentity(workspace, path => !path.endsWith("secret.ts"));
+    expect(capture).toEqual([]);
+  });
+
+  it.each(["cwd", "absolute-pattern"])("refuses a denied Glob root selected by %s", async selection => {
+    const tool = bindExplicitDangerBoundary(createGlobTool({ allowedPaths: [workspace] }));
+    const args = selection === "cwd" ? { pattern: "**/*.ts", cwd: join(workspace, "private") }
+      : { pattern: join(workspace, "private", "**/*.ts") };
+    const result = await tool.execute(guarded(args));
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Access denied");
+  });
+
+  it.each(["content", "files_with_matches", "count"])("retains authorized pagination in %s mode", async output_mode => {
+    await writeFile(join(workspace, "another.ts"), "needle another\n");
+    const tool = bindExplicitDangerBoundary(createGrepTool({ allowedPaths: [workspace] }));
+    const result = await tool.execute(guarded({ pattern: "needle", path: workspace, output_mode, offset: 1, head_limit: 1, glob: "*.ts" }));
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain("public.ts");
+    expect(result.content).not.toContain("another.ts");
+  });
+});

--- a/runtime/tests/tui/approval-confirmation-routing.test.tsx
+++ b/runtime/tests/tui/approval-confirmation-routing.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../src/tui/ink.js", async (importOriginal) => ({
   useInput: () => {},
 }));
 vi.mock("../../src/tui/keybindings/useKeybinding.js", () => ({
+  useInputCapture: () => {},
   useKeybindings: (handlers: Record<string, () => unknown>) => { bindings.handlers = handlers; },
 }));
 

--- a/runtime/tests/tui/approval-selection.integration.test.tsx
+++ b/runtime/tests/tui/approval-selection.integration.test.tsx
@@ -1,0 +1,107 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { ConfigStore } from "../../src/config/store.js";
+import { createRoot } from "../../src/tui/ink.js";
+import { KeybindingSetup } from "../../src/tui/keybindings/KeybindingProviderSetup.js";
+import { AgenCPermissionOverlay, type PendingRequest } from "../../src/tui/permission-requests.js";
+import { AppStateProvider, getDefaultAppState } from "../../src/tui/state/AppState.js";
+import type { ReviewDecision } from "../../src/permissions/review-decision.js";
+
+async function tick(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 35));
+}
+
+describe("ordinary approval keyboard ownership", () => {
+  it("requires the complete destructive confirmation word even with batched shortcut keys", async () => {
+    const stdin = Object.assign(new PassThrough(), { isTTY: true, ref() {}, unref() {}, setRawMode() {} });
+    const stdout = Object.assign(new PassThrough(), { columns: 120, rows: 40, isTTY: true });
+    stdout.resume();
+    const root = await createRoot({ stdin: stdin as unknown as NodeJS.ReadStream, stdout: stdout as unknown as NodeJS.WriteStream, patchConsole: false, exitOnCtrlC: false });
+    const decisions: ReviewDecision[] = [];
+    const request: PendingRequest = {
+      id: "typed-transfer", input: { command: "agenc transfer --amount 5" }, description: "Transfer fixture",
+      ctx: { callId: "typed-transfer", toolName: "Bash", turnId: "turn-first" } as PendingRequest["ctx"],
+      resolve: decision => decisions.push(decision),
+    };
+    try {
+      root.render(<AppStateProvider initialState={getDefaultAppState()}>
+        <KeybindingSetup configStore={new ConfigStore({ env: {} })}>
+          <AgenCPermissionOverlay request={request} tools={[{ name: "Bash" }]} />
+        </KeybindingSetup>
+      </AppStateProvider>);
+      await tick();
+      stdin.write("\ryn\r");
+      await tick();
+      expect(decisions).toEqual([]);
+      stdin.write("\x7f\x7f");
+      await tick();
+      stdin.write("transfer\r");
+      await tick();
+      expect(decisions).toEqual([{ kind: "approved" }]);
+      stdin.write("\r");
+      await tick();
+      expect(decisions).toHaveLength(1);
+    } finally {
+      root.unmount(); stdin.end(); stdout.end();
+    }
+  });
+
+  it.each([
+    ["\x1b[B\x1b[B\r", "denied"],
+    ["\x1b[B\r", "approved_for_session"],
+    ["\r", "approved"],
+    ["y", "approved"],
+    ["n", "denied"],
+    ["2\r2\r", "approved_for_session"],
+    ["3\r1\r", "denied"],
+  ].flatMap(([input, kind]) => ["default", "acceptEdits", "plan", "bypassPermissions"].map(mode => [input, kind, mode] as const)))("settles %j as %s exactly once in %s mode", async (input, kind, mode) => {
+    const stdin = Object.assign(new PassThrough(), {
+      isTTY: true, ref() {}, unref() {}, setRawMode() {},
+    });
+    const stdout = Object.assign(new PassThrough(), { columns: 120, rows: 40, isTTY: true });
+    stdout.resume();
+    const root = await createRoot({ stdin: stdin as unknown as NodeJS.ReadStream, stdout: stdout as unknown as NodeJS.WriteStream, patchConsole: false, exitOnCtrlC: false });
+    const decisions: ReviewDecision[] = [];
+    const signal = new AbortController();
+    const request: PendingRequest = {
+      id: "approval-first", input: { file_path: "/tmp/approval-fixture" }, description: "Read a fixture",
+      ctx: { callId: "approval-first", toolName: "Read", turnId: "turn-first", signal: signal.signal } as PendingRequest["ctx"],
+      resolve: decision => decisions.push(decision),
+    };
+    const configStore = new ConfigStore({ env: {} });
+    const initialState = getDefaultAppState();
+    initialState.toolPermissionContext.mode = mode as typeof initialState.toolPermissionContext.mode;
+    const renderRequest = (pending: PendingRequest) => root.render(
+      <AppStateProvider initialState={initialState}>
+        <KeybindingSetup configStore={configStore}>
+          <AgenCPermissionOverlay request={pending} tools={[{ name: "Read" }]} />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    );
+    try {
+      renderRequest(request);
+      await tick();
+      stdin.write(input);
+      await tick();
+      stdin.write("\r1\r");
+      await tick();
+      expect(decisions).toEqual([{ kind }]);
+      renderRequest({ ...request, id: "approval-next" });
+      await tick();
+      stdin.write("2\r");
+      await tick();
+      expect(decisions).toEqual([{ kind }, { kind: "approved_for_session" }]);
+      renderRequest({ ...request, id: "approval-cancelled" });
+      await tick();
+      signal.abort();
+      stdin.write("y\r");
+      await tick();
+      expect(decisions).toEqual([{ kind }, { kind: "approved_for_session" }]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -4880,6 +4880,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
               { workspaceView: "agent" },
             );
             expect(session.submit).toHaveBeenCalledWith("", {
+              source: "user",
               clientMessageId: expect.any(String),
               displayUserMessage: input,
             });
@@ -5084,6 +5085,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         }),
       );
       expect(session.submit).toHaveBeenCalledWith("", {
+        source: "user",
         clientMessageId: expect.any(String),
         displayUserMessage: "$reviewer audit this",
       });
@@ -5231,6 +5233,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
 
         expect(session.submit).toHaveBeenCalledWith("inspect the project", {
+          source: "user",
           clientMessageId: expect.any(String),
           displayUserMessage: "inspect the project",
         });
@@ -6493,6 +6496,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
 
         expect(submit).toHaveBeenCalledTimes(1);
         expect(submit).toHaveBeenCalledWith("ordinary message", {
+          source: "user",
           clientMessageId: expect.any(String),
           displayUserMessage: "ordinary message",
         });
@@ -7105,6 +7109,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           1,
           "Fix the selected value.",
           expect.objectContaining({
+            source: "user",
             clientMessageId: expect.any(String),
             displayUserMessage: "Fix the selected value.",
             editorInteraction: expect.objectContaining({
@@ -7165,6 +7170,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         await staleEditorRenderSubmit!("Inspect the repository.", helpers);
 
         expect(submit).toHaveBeenCalledWith("Inspect the repository.", {
+          source: "user",
           clientMessageId: expect.any(String),
           displayUserMessage: "Inspect the repository.",
         });
@@ -7246,6 +7252,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           { workspaceView: "agent" },
         );
         expect(session.submit).toHaveBeenCalledWith("inspect this attachment", {
+          source: "user",
           clientMessageId: expect.any(String),
           displayUserMessage: "inspect this attachment",
         });
@@ -7381,6 +7388,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
             expect(submit).toHaveBeenCalledWith(
               `queued from ${scenario.queuedView}`,
               {
+                source: "user",
                 clientMessageId: expect.any(String),
                 displayUserMessage: `queued from ${scenario.queuedView}`,
                 ...(scenario.queuedInteraction !== undefined
@@ -7715,6 +7723,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
             expect.objectContaining({
               clientMessageId: expect.any(String),
               displayUserMessage: "Explain the delayed selection.",
+              source: "user",
               editorInteraction: expect.objectContaining({
                 kind: "ask",
                 policy: "read_only",
@@ -8777,6 +8786,10 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           });
           expect(readOnboardingState({ agencHome }).completed).toBe(true);
           expect(session.submit).toHaveBeenCalledTimes(1);
+          expect(session.submit).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ source: "user" }),
+          );
           expect(output()).toContain("spinner:requesting:");
         },
       );

--- a/runtime/tests/tui/components/MessageSelector.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.coverage.test.tsx
@@ -16,7 +16,7 @@ type CapturedSelectProps = {
 
 const harness = vi.hoisted(() => ({
   appState: {
-    fileHistory: { entries: [] },
+    fileHistory: { snapshots: [{ messageId: 'user-1' }], trackedFiles: new Set(), snapshotSequence: 1 },
     settings: { fileCheckpointingEnabled: true },
   },
   diffStats: {

--- a/runtime/tests/tui/components/MessageSelector.coverage2.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.coverage2.test.tsx
@@ -6,7 +6,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 const harness = vi.hoisted(() => ({
   appState: {
-    fileHistory: { entries: [] },
+    fileHistory: { snapshots: [], trackedFiles: new Set(), snapshotSequence: 0 },
     settings: { fileCheckpointingEnabled: true },
   },
 }))

--- a/runtime/tests/tui/components/MessageSelector.render.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.render.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const harness = vi.hoisted(() => ({
   appState: {
-    fileHistory: { entries: [] },
+    fileHistory: { snapshots: [{ messageId: 'user-1' }], trackedFiles: new Set(), snapshotSequence: 1 },
     settings: { fileCheckpointingEnabled: true },
   },
   diffStats: {

--- a/runtime/tests/tui/coverage-swarm/swarm-012-components-MessageSelector.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-012-components-MessageSelector.test.tsx
@@ -19,7 +19,7 @@ type CapturedSelectProps = {
 
 const harness = vi.hoisted(() => ({
   appState: {
-    fileHistory: { entries: [] },
+    fileHistory: { snapshots: [{ messageId: 'user-1' }, { messageId: 'user-2' }], trackedFiles: new Set(), snapshotSequence: 2 },
     settings: { fileCheckpointingEnabled: true },
   },
   canRestore: true,

--- a/runtime/tests/tui/markdown-intrinsic-layout.test.tsx
+++ b/runtime/tests/tui/markdown-intrinsic-layout.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { Box } from "../../src/tui/ink.js";
+import { Markdown, StreamingMarkdown } from "../../src/tui/components/markdown/Markdown.js";
+import { AppStateProvider, getDefaultAppState } from "../../src/tui/state/AppState.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+
+const DOCUMENT = `# Intrinsic document
+
+This paragraph must remain before the table. Its long descriptive words wrap across narrow terminals without table cells replacing the text. **Bold text** and plain text share these rows.
+
+## Files
+
+- task.js contains the command implementation
+- task.test.js contains independent regression tests
+
+| Command | Arguments | Behavior |
+| --- | --- | --- |
+| add | one or more words | Append a task and print the assigned ID |
+| list | no arguments | Display stored tasks and their completion status |
+| done | integer ID | Mark the matching task as completed |
+
+## Verification
+
+Run the test suite and inspect the resulting JSON file.
+`;
+
+async function renderDocument(columns: number, height: number | undefined, streaming: boolean): Promise<string[]> {
+  const initialState = getDefaultAppState();
+  const Content = streaming ? StreamingMarkdown : Markdown;
+  const output = await renderToString(
+    <AppStateProvider initialState={{ ...initialState, settings: { ...initialState.settings, syntaxHighlightingDisabled: true } }}>
+      <Box flexDirection="column" maxHeight={height} overflow="hidden">
+        <Content>{DOCUMENT}</Content>
+      </Box>
+    </AppStateProvider>,
+    { columns, rows: 80 },
+  );
+  return output.trimEnd().split("\n");
+}
+
+describe("bounded Markdown document flow", () => {
+  it.each([40, 80, 140])("clips intrinsic rows without squeezing blocks at %i columns", async columns => {
+    for (const streaming of [false, true]) {
+      const full = await renderDocument(columns, undefined, streaming);
+      for (const height of [6, 14, 22]) {
+        const bounded = await renderDocument(columns, height, streaming);
+        expect(bounded).toEqual(full.slice(0, height).join("\n").trimEnd().split("\n"));
+      }
+    }
+  });
+});

--- a/runtime/tests/tui/message-selector-authority.test.tsx
+++ b/runtime/tests/tui/message-selector-authority.test.tsx
@@ -1,0 +1,89 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MessageSelector, buildMessageSelectorFileHistoryMetadata } from "../../src/tui/components/MessageSelector.js";
+import { AppStateProvider, getDefaultAppState } from "../../src/tui/state/AppState.js";
+import { createRoot } from "../../src/tui/ink.js";
+import { enterCanonicalSettingsAuthority, getCanonicalSettingsAuthority, resetCanonicalSettingsAuthorityForTesting } from "../../src/utils/settings/canonicalAuthority.js";
+import type { UserMessage } from "../../src/types/message.js";
+
+const message = { type: "user", uuid: "message-one", timestamp: "2026-09-10T00:00:00Z", message: { role: "user", content: [{ type: "text", text: "Make a file" }] } } as UserMessage;
+
+describe("message selector daemon authority", () => {
+  it("loads only visible daemon rows and discards results from a replaced preview", async () => {
+    const initialState = getDefaultAppState();
+    const messages = Array.from({ length: 20 }, (_, index) => ({ ...message, uuid: `message-${index}` })) as UserMessage[];
+    const pending: Array<(value: { filesChanged: string[]; insertions: number; deletions: number }) => void> = [];
+    const oldPreview = vi.fn(() => new Promise<{ filesChanged: string[]; insertions: number; deletions: number }>(resolve => { pending.push(resolve); }));
+    const newPreview = vi.fn(async () => ({ filesChanged: ["/tmp/current-preview.ts"], insertions: 4, deletions: 0 }));
+    const stdin = Object.assign(new PassThrough(), { isTTY: true, ref() {}, unref() {}, setRawMode() {} });
+    const stdout = Object.assign(new PassThrough(), { columns: 100, rows: 40 });
+    let output = "";
+    stdout.on("data", chunk => { output += chunk.toString(); });
+    const root = await createRoot({ stdin: stdin as unknown as NodeJS.ReadStream, stdout: stdout as unknown as NodeJS.WriteStream, patchConsole: false });
+    const renderPreview = (preview: typeof oldPreview | typeof newPreview) => root.render(
+      <AppStateProvider initialState={initialState}>
+        <MessageSelector messages={messages} onPreviewRewind={preview} onPreRestore={() => {}}
+          onRestoreMessage={async () => {}} onRestoreCode={async () => {}}
+          onSummarize={async () => {}} onClose={() => {}} />
+      </AppStateProvider>,
+    );
+    try {
+      renderPreview(oldPreview);
+      await new Promise(resolve => setTimeout(resolve, 40));
+      expect(oldPreview.mock.calls.length).toBeGreaterThan(0);
+      expect(oldPreview.mock.calls.length).toBeLessThanOrEqual(7);
+      renderPreview(newPreview);
+      await new Promise(resolve => setTimeout(resolve, 40));
+      for (const resolve of pending) resolve({ filesChanged: ["/tmp/stale-preview.ts"], insertions: 1, deletions: 0 });
+      await new Promise(resolve => setTimeout(resolve, 40));
+      expect(output).toContain("current-preview.ts");
+      expect(output).not.toContain("stale-preview.ts");
+      expect(output).not.toContain("ERROR");
+    } finally {
+      root.unmount(); stdin.end(); stdout.end();
+    }
+  });
+
+  it("derives local snapshot metadata without ambient execution settings", () => {
+    const previous = getCanonicalSettingsAuthority();
+    resetCanonicalSettingsAuthorityForTesting();
+    try {
+      const metadata = buildMessageSelectorFileHistoryMetadata({
+        messageOptions: [message], messages: [message], currentUUID: "current" as never,
+        fileHistory: { snapshots: [{ messageId: message.uuid }] } as never,
+        isFileHistoryEnabled: true,
+      });
+      expect(metadata[message.uuid]).toEqual({ filesChanged: [], insertions: 0, deletions: 0 });
+    } finally {
+      if (previous !== null) enterCanonicalSettingsAuthority(previous);
+    }
+  });
+
+  it("treats an undefined daemon preview as authoritative without local fallback", async () => {
+    const initialState = getDefaultAppState();
+    const previous = getCanonicalSettingsAuthority();
+    const preview = vi.fn(async () => undefined);
+    const stdin = Object.assign(new PassThrough(), { isTTY: true, ref() {}, unref() {}, setRawMode() {} });
+    const stdout = Object.assign(new PassThrough(), { columns: 100, rows: 35 });
+    let output = "";
+    stdout.on("data", chunk => { output += chunk.toString(); });
+    resetCanonicalSettingsAuthorityForTesting();
+    const root = await createRoot({ stdin: stdin as unknown as NodeJS.ReadStream, stdout: stdout as unknown as NodeJS.WriteStream, patchConsole: false });
+    try {
+      root.render(<AppStateProvider initialState={initialState}>
+        <MessageSelector messages={[message]} preselectedMessage={message} onPreviewRewind={preview}
+          onPreRestore={() => {}} onRestoreMessage={async () => {}} onRestoreCode={async () => {}}
+          onSummarize={async () => {}} onClose={() => {}} />
+      </AppStateProvider>);
+      await new Promise(resolve => setTimeout(resolve, 80));
+      expect(preview).toHaveBeenCalledWith(message);
+      expect(output).not.toContain("Canonical settings authority");
+      expect(output).toContain("Restore conversation");
+      expect(output).not.toContain("Restore code and conversation");
+    } finally {
+      root.unmount(); stdin.end(); stdout.end();
+      if (previous !== null) enterCanonicalSettingsAuthority(previous);
+    }
+  });
+});

--- a/runtime/tests/tui/retry-identity-regression.test.ts
+++ b/runtime/tests/tui/retry-identity-regression.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { collapseReadSearchGroups } from "../../src/utils/collapseReadSearch.js";
+import { shellOperationIdentity } from "../../src/tui/shell-operation-identity.js";
+import { isFixedRerunSuccess } from "../../src/tui/message-renderers/fixedRerunLink.js";
+
+function attempt(id: string, name: string, input: unknown): never {
+  return { type: "assistant", uuid: id, message: { role: "assistant", content: [{ type: "tool_use", id, name, input }] } } as never;
+}
+
+function failure(id: string): never {
+  return { type: "user", uuid: `${id}-result`, message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, is_error: true, content: "failed" }] } } as never;
+}
+
+describe("retry identity", () => {
+  it("preserves shell effect arguments and accepts reordered JSON objects", () => {
+    const original = shellOperationIdentity("exec_command", { cmd: "node --test", workdir: "/project", env: { MODE: "test", FLAG: "1" } });
+    expect(shellOperationIdentity("exec_command", { env: { FLAG: "1", MODE: "test" }, workdir: "/project", cmd: "node --test", justification: "retry", yield_time_ms: 30000 })).toBe(original);
+    expect(shellOperationIdentity("exec_command", { cmd: "node --test", workdir: "/project", env: { MODE: "production", FLAG: "1" } })).not.toBe(original);
+    expect(shellOperationIdentity("Run", { command: "node", args: ["one.js"] })).not.toBe(shellOperationIdentity("Run", { command: "node", args: ["two.js"] }));
+    const recursive: Record<string, unknown> = { cmd: "node" };
+    recursive.self = recursive;
+    expect(shellOperationIdentity("exec_command", recursive)).toBeNull();
+  });
+
+  it("uses the same scoped identity for fixed rerun annotations", () => {
+    const previous = { id: "previous", name: "exec_command", input: { cmd: "node --test", workdir: "/first" } };
+    const current = { id: "current", name: "exec_command", input: { cmd: "node --test", workdir: "/second" } };
+    const lookups = { toolUseByToolUseID: new Map([[previous.id, previous], [current.id, current]]), resolvedToolUseIDs: new Set([previous.id, current.id]), erroredToolUseIDs: new Set([previous.id]) };
+    expect(isFixedRerunSuccess(current, lookups as never)).toBe(false);
+    expect(isFixedRerunSuccess({ ...current, input: previous.input }, lookups as never)).toBe(true);
+  });
+
+  it.each([
+    ["exec_command", { cmd: "node --test" }, { cmd: "git status" }],
+    ["exec_command", { cmd: "node --test", workdir: "/first" }, { cmd: "node --test", workdir: "/second" }],
+    ["Bash", { command: "node --test", cwd: "/first" }, { command: "node --test", cwd: "/second" }],
+    ["Run", { command: ["node", "--test"] }, { command: ["node", "app.js"] }],
+    ["custom_tool", { query: "first" }, { query: "second" }],
+    ["exec_command", {}, {}],
+  ])("does not merge distinct or unidentifiable %s calls", (name, first, second) => {
+    const rows = collapseReadSearchGroups([attempt("first", name, first), failure("first"), attempt("second", name, second)], [{ name }] as never, false);
+    expect(rows.filter(row => row.type === "assistant")).toHaveLength(2);
+  });
+});

--- a/runtime/tests/tui/retry-status-regression.test.tsx
+++ b/runtime/tests/tui/retry-status-regression.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AssistantToolUseMessage } from "../../src/tui/message-renderers/AssistantToolUseMessage.js";
+import { AppStateProvider, getDefaultAppState } from "../../src/tui/state/AppState.js";
+import { renderToString } from "../../src/utils/staticRender.js";
+import type { Tool } from "../../src/tools/Tool.js";
+import { buildMessageLookups } from "../../src/utils/messages.js";
+
+vi.mock("../../src/utils/classifierApprovalsHook.js", () => ({ useIsClassifierChecking: () => false }));
+
+describe("retry status follows canonical completion", () => {
+  it.each(["queued", "running", "done", "failed"])("renders %s without inventing success", async status => {
+    const param = { type: "tool_use" as const, id: "retry-last", name: "exec_command", input: { cmd: "node --test" }, retriedFailureCount: 2 };
+    const tool = {
+      name: "exec_command", inputSchema: { safeParse: (input: unknown) => ({ success: true, data: input }) },
+      userFacingName: () => "Run", renderToolUseMessage: () => "node --test",
+      renderToolUseProgressMessage: () => null,
+    } as unknown as Tool;
+    const completed = status === "done" || status === "failed";
+    const output = await renderToString(<AppStateProvider initialState={getDefaultAppState()}>
+      <AssistantToolUseMessage param={param} addMargin={false} tools={[tool]} commands={[]} verbose={false}
+        inProgressToolUseIDs={new Set(status === "running" ? [param.id] : [])} progressMessagesForMessage={[]}
+        shouldAnimate={false} shouldShowDot={false}
+        lookups={{ ...buildMessageLookups([], []), resolvedToolUseIDs: new Set(completed ? [param.id] : []), erroredToolUseIDs: new Set(status === "failed" ? [param.id] : []) }} />
+    </AppStateProvider>, 100);
+    expect(output).not.toContain("ERROR");
+    expect(output).not.toContain("TypeError");
+    if (status === "done") expect(output).toContain("succeeded after 2 attempts");
+    else expect(output).not.toContain("succeeded");
+    if (status === "queued" || status === "running") expect(output).toContain(`attempt 2 · ${status}`);
+  });
+});

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -142,6 +142,7 @@ export const HOSTED_FND_TEST_INCLUDE = Object.freeze([
 export const KERNEL_TEST_INCLUDE = Object.freeze([
   "tests/sandbox/landlock-seccomp.kernel.test.ts",
   "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
+  "tests/sandbox/readonly-delegation.kernel.test.ts",
 ]);
 
 /** PowerShell integration tests executed by the pinned hosted capability lane. */


### PR DESCRIPTION
## Changes

- Make Enter honor the selected approval, retain denial feedback, and resolve approvals by canonical conversation owner.
- Keep cancelled and denied turns stopped across child receipts, queued work, restart, and durable recovery. Continue interrupting descendants if recording the stop fails.
- Allow plan-mode delegation with inherited read-only authority, trusted native tools, guarded reads, and mandatory shell isolation. Switching the parent to YOLO does not widen an existing planning worker.
- Restore cold-start workflow controls and daemon-backed rewind previews.
- Correct Markdown sizing and retry identities, and reject deterministic shell-policy failures before asking for approval.
- Add regression tests, a real-kernel constrained-worker test, and a PTY Escape test with foreground and descendant processes.

## Verification

- Post-rebase runtime run passed 25,727 of 25,730 tests. The clean-worktree fuzzy benchmark passes. Remaining failures are two pre-existing inventory checks and stale FND evidence.
- Runtime and SDK builds, typechecks, generated SDK parity, agent-surface checks, startup in normal and combined YOLO mode, real PTY Escape cancellation, and Linux read-only integration passed.
- Independent review completed. Three later review concerns were confirmed and corrected before merge: stop release now happens only at durable human admission; legacy stops also fence unrelated or later automatic orphan turns; constrained workers retain role instructions without gaining authority.
- Revert-sensitive tests cover all three corrections. The daemon/recovery gate passes 431 tests and the role/delegation gate passes 112.
- Final full runtime verification passed 25,761 of 25,764 tests across 2,414 files, with no skips. Only the two known inventory checks and stale FND evidence fail. Final build, default/combined-YOLO startup, and foreground/descendant Escape cancellation also pass.
- A fourth security finding is fixed: constrained Git object reads now require unrestricted original filesystem read authority. A real native regression reproduced the prior disclosure; the corrected native test and 232 related tests pass. Independent review found no remaining blocker.
- FND evidence capture requires a source revision already on the default branch. A follow-up evidence refresh will use the merged source, without editing recorded hashes.
- Existing launcher configuration and AppArmor profile-name assertions remain documented failures. Native kernel observations confirmed filesystem and network restrictions; no host security rule was weakened.
- macOS and Windows native execution and the fresh live Grok session are not yet verified. Windows constrained shell inspection fails closed; native readers remain available.

Hosted CI stays disabled. No release workflow is dispatched.
