### PR TITLE
fix(daemon): enforce session control-plane ownership [skip ci]

### DIFF
--- a/docs/design/daemon-session-control-plane-audit.md
+++ b/docs/design/daemon-session-control-plane-audit.md
@@ -1,0 +1,73 @@
+# Daemon/session control-plane audit
+
+Date: 2026-09-10
+
+## Scope and ownership
+
+This implementation audit followed transport ingress, JSON-RPC dispatch,
+session/agent lifecycle, notification routing, TUI cancellation, and SDK prompt
+completion. Three parallel investigations covered daemon transports, session
+authority, and clients; integration review covered their shared boundaries.
+
+The ownership chain is:
+
+1. A physical connection owns authentication, RPC requests, and logical clients.
+2. A logical client owns session attachments and notification delivery.
+3. The daemon owns the live agent and its explicitly bound sessions.
+4. A turn ID identifies the execution a cancellation may interrupt.
+5. Session closure revokes ingress; resource finalization establishes cleanup
+   completion and may need retrying.
+
+## Confirmed defects and repairs
+
+| Boundary | Defect | Repaired invariant |
+| --- | --- | --- |
+| Transport → dispatcher | Queued frames or delayed authentication dispatched after disconnect. | Socket closure and authentication deadlines permanently fence further dispatch. Unix shutdown closes all peers before draining handlers. |
+| Dispatcher → attachments | Initialization and registration could complete after close; late cleanup could remove a reconnect's reused client ID. | Connection closure is terminal, initialization is reserved synchronously, registration records ownership before replay, cleanup checks the physical connection identity, and failed repeat attachment preserves preexisting resources. |
+| Session → routing | Finalization ran under the global routing mutex. | Resource callbacks run outside that mutex, allowing callbacks and unrelated clients to use routing. |
+| Session → resources | Closed sessions skipped a failed finalizer; concurrent termination could report success before cleanup. | Termination closes once, shares pending finalization, and permits retry after failure without replacing the original close reason. |
+| Agent → runtime | Concurrent stops could duplicate teardown; stopping state suppressed canonical runner terminal evidence. | Stop has one owner, shutdown drains that owner, and terminal evidence remains authoritative during stopping. |
+| Session → agent | An unbound session could name another live agent and reach its runtime. | Runtime operations require membership in the agent's authoritative session list. |
+| TUI → turn | Session-wide ESC could cancel a successor; stale status could clear a newer active turn. | Cancellation names an observed turn; pre-start intent waits for its own submission correlation. Stale terminal status cannot clear another turn; a validated terminal RPC result settles missing live completion. |
+| SDK → prompt | Client closure left prompt results pending; delayed approval callbacks could act after completion. | Closure settles local waiters, and completion revokes deferred prompt callbacks. Closing a client does not itself request daemon turn termination. |
+| Shutdown/eviction → socket | Failed shutdown acknowledgements stranded the daemon; eviction removed maps without closing the socket. | Accepted shutdown completes after acknowledgement attempts settle; eviction terminates the actual transport. |
+
+## Verification strategy
+
+Regression tests control authentication, registration, runner teardown, and
+submission ordering with explicit gates. Socket tests exercise real local Unix
+and WebSocket connections, including foreground-daemon eviction. SDK composition
+tests connect the real SDK, in-process transport, dispatcher, session manager,
+and multiplexer with deterministic runner behavior.
+
+Run the connected control-plane suites with the repository's hermetic boundary:
+
+```sh
+npm --workspace=@tetsuo-ai/runtime test -- tests/app-server tests/app-server-client tests/sdk-package tests/tui/daemon-session --maxWorkers=2
+npm run typecheck
+npm run build
+npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
+```
+
+Final verification results:
+
+| Check | Result |
+| --- | --- |
+| Linux Docker control-plane boundary, command above | 128 files, 1,754 tests passed; expected-red boundary probe also passed. |
+| Runtime typecheck and test-support typecheck | Passed. |
+| Runtime build, package entrypoints, generated SDK protocol checks | Passed. |
+| SDK build and TypeScript check | Passed. |
+| Built runtime/TUI import proofs and PTY startup | Passed in normal and bypass modes at 148×40, 120×30, and 80×24. |
+| `npm run test:required-gates` | 162 tests passed. |
+| Launcher suite | 235 of 236 passed; one preexisting installer-site configuration assertion failed. |
+
+The launcher failure is outside these changes:
+[`runtime-release-contract.test.mjs`](../../packages/agenc/test/runtime-release-contract.test.mjs)
+expects only `headers` and `redirects`, while the committed
+[`installer configuration`](../../packaging/get-agenc-ag/vercel.json) also has
+`git`. Both files were unchanged by this work; the same mismatch exists at HEAD.
+
+These checks cover local control-plane behavior. They do not establish live
+provider reliability or platform-specific kernel behavior on hosts not exercised
+by the test run. Existing detached-session replay and stdio EOF-drain contracts
+remain part of the regression suite.

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -7,6 +7,32 @@ agents) attach over a local socket and speak JSON-RPC.
 Architecture map: [`../ARCHITECTURE.md`](../ARCHITECTURE.md). Embedding API:
 [`../sdk.md`](../sdk.md).
 
+## Connection and session ownership
+
+Closing a connection permanently rejects new RPC work and removes its logical
+clients and attachments. Authentication or attachment work completing afterward
+cannot restore that connection. A reconnect may reuse a logical client ID;
+cleanup from the previous physical connection cannot detach the replacement.
+
+A session's `agentId` alone does not grant runtime control. Prompt, cancellation,
+and runtime inspection/mutation require the session to belong to the agent's
+authoritative session list. Use `agent.create` and `agent.attach` for a live
+runtime binding.
+
+Use `session.cancelTurn` with `expectedTurnId` to interrupt the observed turn.
+The TUI defers pre-start cancellation until it correlates its own submitted
+message with a daemon turn. Closing an SDK client settles its local prompt
+waiters without issuing turn cancellation.
+
+Session termination revokes new attachments immediately and awaits resource
+cleanup. Concurrent terminators share cleanup; a later termination request can
+retry a failed finalizer. Agent stop likewise shares teardown, and daemon
+shutdown waits for existing stops. An accepted daemon shutdown still completes
+if its acknowledgement cannot reach the requester.
+
+Implementation findings and regression strategy:
+[`daemon/session control-plane audit`](../design/daemon-session-control-plane-audit.md).
+
 ## Process ownership
 
 | Piece       | Package / path                        | Role                                                                                |
@@ -157,7 +183,7 @@ parsing or dispatch, including when the terminating newline arrives in the
 chunk that crosses the limit. Multiple bounded lines can share a chunk.
 
 - Envelope: **JSON-RPC 2.0** over newline-delimited messages.
-- Protocol version constant: **`1.9.0`**
+- Protocol version constant: **`1.12.0`**
   (`AGENC_DAEMON_PROTOCOL_VERSION` in `runtime/src/app-server/protocol/index.ts`).
 - Clients send `initialize` with the protocol version. Negotiation compares the
   numeric major and minor versions: the server accepts the same major when the

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -800,6 +800,7 @@ export class AgencClient {
     string,
     { readonly clientMessageId: string; turnId?: string }
   >();
+  readonly #closeListeners = new Set<(error: Error) => void>();
   #initializeResult: InitializeResult | undefined;
   #negotiatedClientProtocolVersion: string | undefined;
   #initialized = false;
@@ -914,8 +915,20 @@ export class AgencClient {
         ? { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method }
         : { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method, params }
     ) as AgencDaemonRequest<Method>;
-    const response = await this.#transport.request(request);
-    return parseResponse(response, method, id);
+    let rejectOnClose!: (error: Error) => void;
+    const closed = new Promise<never>((_resolve, reject) => {
+      rejectOnClose = reject;
+    });
+    this.#closeListeners.add(rejectOnClose);
+    try {
+      const response = await Promise.race([
+        this.#transport.request(request),
+        closed,
+      ]);
+      return parseResponse(response, method, id);
+    } finally {
+      this.#closeListeners.delete(rejectOnClose);
+    }
   }
 
   async initialize(params: InitializeParams = {}): Promise<InitializeResult> {
@@ -1177,6 +1190,7 @@ export class AgencClient {
     content: MessageContent,
     options: AgencPromptOptions = {},
   ): AgencPromptRun {
+    if (this.#closed) throw new Error("AgenC SDK client is closed");
     const clientMessageId = normalizeClientMessageId(options.clientMessageId);
     const existingRun = this.#activePromptRuns.get(sessionId);
     if (existingRun !== undefined) {
@@ -1213,6 +1227,7 @@ export class AgencClient {
 
     const flushDeferredCancellation = (): Promise<void> => {
       if (
+        finishing ||
         cancellationPromise !== undefined ||
         deferredCancellationReason === undefined ||
         !submissionObserved ||
@@ -1231,6 +1246,7 @@ export class AgencClient {
     };
 
     const requestScopedCancellation = (reason: string): Promise<void> => {
+      if (finishing) return Promise.resolve();
       if (!submissionDispatched) {
         cancelBeforeDispatchReason = reason;
         return Promise.resolve();
@@ -1255,6 +1271,7 @@ export class AgencClient {
       finishing = true;
       unsubscribe();
       removeAbortListener();
+      this.#closeListeners.delete(fail);
       releaseReservation();
       let usageFields: Pick<AgencPromptResult, "usage"> = {};
       if (options.includeUsage !== false) {
@@ -1300,6 +1317,7 @@ export class AgencClient {
           };
         }
       }
+      if (finishing) return;
       try {
         if (decision.behavior === "allow") {
           await this.request("tool.approve", {
@@ -1332,7 +1350,7 @@ export class AgencClient {
       } catch {
         return;
       }
-      if (response === null) return;
+      if (response === null || finishing) return;
       try {
         await this.request("elicitation.respond", {
           sessionId,
@@ -1349,6 +1367,7 @@ export class AgencClient {
     };
 
     const unsubscribe = this.onSessionNotification(sessionId, (message) => {
+      if (finishing) return;
       const observedClientMessageId =
         userMessageClientMessageIdFromNotification(message);
       if (!submissionObserved) {
@@ -1410,6 +1429,17 @@ export class AgencClient {
       const terminal = terminalStatusFromNotification(message, reservation.turnId);
       if (terminal !== null) void finish(terminal);
     });
+
+    const fail = (error: unknown): void => {
+      if (finishing) return;
+      finishing = true;
+      unsubscribe();
+      removeAbortListener();
+      this.#closeListeners.delete(fail);
+      releaseReservation();
+      channel.fail(error instanceof Error ? error : new Error(String(error)));
+    };
+    this.#closeListeners.add(fail);
 
     if (options.signal !== undefined) {
       const signal = options.signal;
@@ -1499,12 +1529,7 @@ export class AgencClient {
           : {}),
       };
     })();
-    accepted.catch((error: unknown) => {
-      unsubscribe();
-      removeAbortListener();
-      releaseReservation();
-      channel.fail(error instanceof Error ? error : new Error(String(error)));
-    });
+    accepted.catch(fail);
 
     return {
       sessionId,
@@ -1520,6 +1545,9 @@ export class AgencClient {
   async close(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
+    const error = new Error("AgenC SDK client is closed");
+    for (const listener of this.#closeListeners) listener(error);
+    this.#closeListeners.clear();
     this.#notificationListeners.clear();
     this.#sessionListeners.clear();
     this.#activePromptRuns.clear();

--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -479,7 +479,12 @@ export async function connect(
       signal: deadline.signal,
       connectTimeoutMs: deadline.remainingMs(),
       onNotification: (message) => client?.dispatchNotification(message),
-      onClose: (error) => options.onDisconnect?.(error),
+      onClose: (error) => {
+        // Closing the transport rejects RPCs; closing the client also settles
+        // accepted legacy prompts still waiting for a terminal notification.
+        void client?.close().catch(() => {});
+        options.onDisconnect?.(error);
+      },
     });
     deadline.assertActive();
     client = new AgencClient({

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -552,6 +552,10 @@ export class AgenCDaemonAgentManager {
     PendingCanonicalRunCancellation
   >();
   readonly #runCancellationTasks = new Map<string, Promise<RunCancelResult>>();
+  readonly #agentStopTasks = new Map<string, {
+    readonly result: Promise<AgentStopResult>;
+    finalizationError?: unknown;
+  }>();
   readonly #state = new AsyncLock<AgentLifecycleState>({
     agents: new Map(),
   });
@@ -733,10 +737,12 @@ export class AgenCDaemonAgentManager {
           );
         }
         if (
-          existing !== undefined &&
-          isActiveAgent(existing) &&
-          !isRecoveredRuntimeUnavailable(existing) &&
-          !isStaleAgent(existing)
+          this.#agentStopTasks.has(resumeSessionId) ||
+          existing?.status === "stopping" ||
+          (existing !== undefined &&
+            isActiveAgent(existing) &&
+            !isRecoveredRuntimeUnavailable(existing) &&
+            !isStaleAgent(existing))
         ) {
           throw new AgenCDaemonAgentLifecycleError(
             "CANONICAL_SESSION_ALREADY_ACTIVE",
@@ -1628,7 +1634,7 @@ export class AgenCDaemonAgentManager {
       );
     }
 
-    const attachment = await this.#sessionManager.attachSession({
+    const { attachment, created: attachmentCreated } = await this.#sessionManager.attachSessionWithOwnership({
       sessionId: session.sessionId,
       ...(params.clientId !== undefined ? { clientId: params.clientId } : {}),
     });
@@ -1688,12 +1694,14 @@ export class AgenCDaemonAgentManager {
       };
     } catch (error) {
       await Promise.resolve(rollbackRoute?.()).catch(() => {});
-      await this.#sessionManager
-        .detachSession({
-          sessionId: session.sessionId,
-          attachmentId: attachment.attachmentId,
-        })
-        .catch(() => {});
+      if (attachmentCreated) {
+        await this.#sessionManager
+          .detachSession({
+            sessionId: session.sessionId,
+            attachmentId: attachment.attachmentId,
+          })
+          .catch(() => {});
+      }
       throw error;
     }
   }
@@ -1809,6 +1817,21 @@ export class AgenCDaemonAgentManager {
   async stopAgent(params: AgentStopParams): Promise<AgentStopResult> {
     const agentId = normalizeRequiredAgentId(params.agentId, "agent.stop");
     const reason = normalizeNonEmpty(params.reason) ?? "agent.stop";
+    const pending = this.#agentStopTasks.get(agentId);
+    if (pending !== undefined) return pending.result;
+    const task = this.#stopAgentOnce(agentId, reason);
+    const operation = { result: task };
+    this.#agentStopTasks.set(agentId, operation);
+    try {
+      return await task;
+    } finally {
+      if (this.#agentStopTasks.get(agentId) === operation) {
+        this.#agentStopTasks.delete(agentId);
+      }
+    }
+  }
+
+  async #stopAgentOnce(agentId: string, reason: string): Promise<AgentStopResult> {
     const runner = this.#runner;
     const stopRunner = runner?.stopAgent?.bind(runner);
     let transitionAt: string | undefined;
@@ -1892,6 +1915,8 @@ export class AgenCDaemonAgentManager {
         );
         throw error;
       }
+      const finalizationError = this.#agentStopTasks.get(agentId)?.finalizationError;
+      if (finalizationError !== undefined) throw finalizationError;
     }
 
     const stoppedAt = transitionAt ?? this.#now();
@@ -2179,7 +2204,10 @@ export class AgenCDaemonAgentManager {
   ): RunnerTerminationTarget | null {
     const agent = state.agents.get(agentId);
     if (agent === undefined) return null;
-    if (!isActiveAgent(agent)) return null;
+    // Explicit stop has already revoked ingress by publishing "stopping".
+    // Its runner still owns the canonical terminal and must project it before
+    // the ordinary stopped status can be persisted.
+    if (!isActiveAgent(agent) && agent.status !== "stopping") return null;
     const sessionIds = [...agent.sessionIds];
     const route = snapshotRouteForAgent(agent);
     applyAgentSnapshot(agent, snapshot);
@@ -2227,6 +2255,9 @@ export class AgenCDaemonAgentManager {
         // durable terminal projection failed. The canonical JSONL event can
         // be replayed on restart/query and remains the recovery authority.
         this.#onSnapshotError(error);
+        const explicitStop = this.#agentStopTasks.get(agentId);
+        if (explicitStop !== undefined) explicitStop.finalizationError = error;
+        await this.#terminateAgentSessions(target.sessionIds, "runner_terminated");
         return;
       }
     }
@@ -2259,6 +2290,13 @@ export class AgenCDaemonAgentManager {
     } catch (error) {
       createDrainFailure = error;
     }
+    // A stop that already owns teardown is absent from the active-agent list.
+    // Shutdown must drain those operations before it can close daemon stores.
+    const stopping = [...this.#agentStopTasks.entries()];
+    const stopResults = await Promise.allSettled(stopping.map(([agentId, task]) =>
+      withTimeout(task.result, AGENT_LIFECYCLE_OPERATION_TIMEOUT_MS,
+        `agent ${agentId} in-flight stop timed out during daemon shutdown`),
+    ));
     // Shutdown must reach every retained runner even when a status read fails.
     await this.#refreshAgentsFromRunner().catch(() => {});
     const targets = await this.#state.with((state) => {
@@ -2274,6 +2312,11 @@ export class AgenCDaemonAgentManager {
     }> = [];
     if (createDrainFailure !== undefined) {
       failures.push({ agentId: "pending agent.create", error: createDrainFailure });
+    }
+    for (const [index, result] of stopResults.entries()) {
+      if (result.status === "rejected") {
+        failures.push({ agentId: stopping[index]![0], error: result.reason });
+      }
     }
     let stopped = 0;
     for (const target of targets) {
@@ -2794,6 +2837,7 @@ export class AgenCDaemonAgentManager {
       return (
         refreshed !== undefined &&
         isActiveAgent(refreshed) &&
+        refreshed.sessionIds.includes(params.sessionId) &&
         !isRecoveredRuntimeUnavailable(refreshed)
       );
     });
@@ -3755,6 +3799,7 @@ export class AgenCDaemonAgentManager {
           inactiveAgentMessage(session.agentId, refreshed),
         );
       }
+      assertAgentSessionBinding(refreshed, params.sessionId);
       return {
         recoveredRuntimeUnavailable: isRecoveredRuntimeUnavailable(refreshed),
         route: snapshotRouteForAgent(refreshed),
@@ -4045,6 +4090,7 @@ export class AgenCDaemonAgentManager {
           inactiveAgentMessage(session.agentId, refreshed),
         );
       }
+      assertAgentSessionBinding(refreshed, sessionId);
       if (isRecoveredRuntimeUnavailable(refreshed)) {
         throw new AgenCDaemonAgentLifecycleError(
           "BACKGROUND_RUNNER_UNAVAILABLE",
@@ -5266,6 +5312,14 @@ function isActiveAgent(agent: MutableAgent): boolean {
     agent.status !== "stopping" &&
     agent.status !== "stopped" &&
     agent.status !== "error"
+  );
+}
+
+function assertAgentSessionBinding(agent: MutableAgent, sessionId: string): void {
+  if (agent.sessionIds.includes(sessionId)) return;
+  throw new AgenCDaemonAgentLifecycleError(
+    "AGENT_NOT_FOUND",
+    `AgenC daemon session ${sessionId} is not bound to agent ${agent.agentId}`,
   );
 }
 

--- a/runtime/src/app-server/client-multiplexer.ts
+++ b/runtime/src/app-server/client-multiplexer.ts
@@ -74,9 +74,11 @@ export interface AgenCClientMultiplexerOptions {
    * cannot tear down the transport itself; the daemon supplies this callback to
    * `socket.destroy()` the slow consumer. The client has already been removed
    * from the multiplexer and detached from its sessions by the time this fires.
+   * The delivery key identifies the evicted physical connection even if a
+   * reconnect has already reused the logical client id.
    * It can reconnect later through the normal detached-buffer/replay path.
    */
-  readonly onClientEvicted?: (clientId: string) => void;
+  readonly onClientEvicted?: (clientId: string, deliveryKey?: string) => void;
 }
 
 /**
@@ -97,6 +99,8 @@ export interface RegisterAgenCClientOptions {
   /** Physical delivery identity; logical clients on one socket share this key. */
   readonly deliveryKey?: string;
   readonly send: AgenCClientSend;
+  /** Claim connection ownership synchronously before registration/replay commits. */
+  readonly onRegistered?: (registration: AgenCClientRegistration) => void;
   /**
    * Connection-negotiated filter for ordinary session notifications. This is
    * evaluated both for live fan-out and detached replay so an older client is
@@ -173,6 +177,11 @@ interface EnqueuedDelivery {
   readonly delivered: Promise<void>;
 }
 
+interface EvictedClient {
+  readonly clientId: string;
+  readonly deliveryKey: string;
+}
+
 export class AgenCDaemonClientMultiplexer {
   readonly #sessionManager: AgenCDaemonSessionManager;
   readonly #createClientId: () => string;
@@ -180,7 +189,7 @@ export class AgenCDaemonClientMultiplexer {
   readonly #maxBufferedBytesPerSession: number;
   readonly #maxPendingDeliveryBytesPerClient: number;
   readonly #maxPendingDeliveryCountPerClient: number;
-  readonly #onClientEvicted?: (clientId: string) => void;
+  readonly #onClientEvicted?: (clientId: string, deliveryKey?: string) => void;
   readonly #state = new AsyncLock<MultiplexerState>({
     clients: new Map(),
     sessions: new Map(),
@@ -322,6 +331,7 @@ export class AgenCDaemonClientMultiplexer {
         this.#maxPendingDeliveryBytesPerClient,
         this.#maxPendingDeliveryCountPerClient,
       );
+      options.onRegistered?.({ clientId });
       state.clients.set(clientId, client);
       for (const capability of replayCounts.keys()) {
         state.capabilityReplayInFlight.add(capability);
@@ -401,6 +411,7 @@ export class AgenCDaemonClientMultiplexer {
   async attachClientToSession(
     sessionId: string,
     clientId: string,
+    onAttached?: (created: boolean) => void,
   ): Promise<SessionAttachResult> {
     // Replay reserves its complete bounded batch before attachment. This keeps
     // a blocked client's queued closures within the same byte/count caps as
@@ -425,7 +436,9 @@ export class AgenCDaemonClientMultiplexer {
         const route = getOrCreateRoute(state, sessionId);
 
         client.sessionIds.add(sessionId);
+        const created = !route.clientAttachmentIds.has(clientId);
         route.clientAttachmentIds.set(clientId, attachment.attachmentId);
+        onAttached?.(created);
         const replayDelivery = enqueueReplayDelivery(
           client,
           replayedEvents,
@@ -468,11 +481,15 @@ export class AgenCDaemonClientMultiplexer {
   async detachClientFromSession(
     sessionId: string,
     clientId: string,
+    expectedDeliveryKey?: string,
   ): Promise<SessionDetachResult> {
     return this.#state.with(async (state) => {
       const client = requireClient(state, clientId);
       const route = state.sessions.get(sessionId);
-      if (route === undefined || !route.clientAttachmentIds.has(clientId)) {
+      if (
+        (expectedDeliveryKey !== undefined && client.deliveryKey !== expectedDeliveryKey) ||
+        route === undefined || !route.clientAttachmentIds.has(clientId)
+      ) {
         throw new AgenCClientMultiplexerError(
           "CLIENT_NOT_ATTACHED",
           `AgenC daemon client ${clientId} is not attached to session ${sessionId}`,
@@ -511,37 +528,43 @@ export class AgenCDaemonClientMultiplexer {
   async terminateSession(
     params: SessionTerminateParams,
   ): Promise<SessionTerminateResult> {
-    return this.#state.with(async (state) => {
-      try {
-        const terminated = await this.#sessionManager.terminateSession(params);
-        removeSessionRouting(state, params.sessionId);
-        return terminated;
-      } catch (error) {
-        const stillLive = await this.#isSessionLive(params.sessionId).catch(() => true);
-        if (!stillLive) {
-          removeSessionRouting(state, params.sessionId);
-        }
-        throw error;
+    // Finalizers may broadcast or dispose resources that call this multiplexer.
+    // Never hold the global routing lock across session finalization.
+    try {
+      const terminated = await this.#sessionManager.terminateSession(params);
+      await this.#state.with((state) => removeSessionRouting(state, params.sessionId));
+      return terminated;
+    } catch (error) {
+      const stillLive = await this.#isSessionLive(params.sessionId).catch(() => true);
+      if (!stillLive) {
+        await this.#state.with((state) => removeSessionRouting(state, params.sessionId));
       }
-    });
+      throw error;
+    }
   }
 
-  async removeClient(clientId: string): Promise<readonly string[]> {
-    return this.disconnectClient(clientId);
+  async removeClient(clientId: string, expectedDeliveryKey?: string): Promise<readonly string[]> {
+    return this.disconnectClient(clientId, expectedDeliveryKey);
   }
 
-  async disconnectClient(clientId: string): Promise<readonly string[]> {
+  async disconnectClient(clientId: string, expectedDeliveryKey?: string): Promise<readonly string[]> {
     return this.#state.with(async (state) => {
       const client = requireClient(state, clientId);
+      if (expectedDeliveryKey !== undefined && client.deliveryKey !== expectedDeliveryKey) return [];
       const detachedSessionIds = [...client.sessionIds];
-
       state.clients.delete(clientId);
+      const failures: unknown[] = [];
       for (const sessionId of detachedSessionIds) {
         const route = state.sessions.get(sessionId);
         route?.clientAttachmentIds.delete(clientId);
-        await this.#sessionManager.detachSession({ sessionId, clientId });
+        try {
+          await this.#sessionManager.detachSession({ sessionId, clientId });
+        } catch (error) {
+          failures.push(error);
+        }
       }
-
+      client.sessionIds.clear();
+      if (failures.length > 0) throw new AggregateError(failures, "daemon client detach failed");
       return detachedSessionIds;
     });
   }
@@ -554,15 +577,15 @@ export class AgenCDaemonClientMultiplexer {
    * so the transport can `socket.destroy()` the stuck connection. The client can
    * reconnect later through the normal detached-buffer/replay path.
    */
-  async #evictSlowClients(clientIds: readonly string[]): Promise<void> {
-    if (clientIds.length === 0) return;
-    for (const clientId of clientIds) {
+  async #evictSlowClients(clients: readonly EvictedClient[]): Promise<void> {
+    if (clients.length === 0) return;
+    for (const { clientId, deliveryKey } of clients) {
       try {
-        await this.disconnectClient(clientId);
+        await this.disconnectClient(clientId, deliveryKey);
       } catch {
         // Client may already be gone (concurrent disconnect); ignore.
       }
-      this.#onClientEvicted?.(clientId);
+      this.#onClientEvicted?.(clientId, deliveryKey);
     }
   }
 
@@ -585,7 +608,7 @@ export class AgenCDaemonClientMultiplexer {
         event,
       );
     }
-    const evictedClientIds: string[] = [];
+    const evictedClientIds: EvictedClient[] = [];
     const rejectedDeliveries: AgenCSessionBroadcastFailure[] = [];
     const isMobileStatus = isMobileStatusPushEvent(event);
     const { deliveries, hadLiveTargets, bufferedWithoutTarget } =
@@ -731,7 +754,7 @@ export class AgenCDaemonClientMultiplexer {
     capability: string,
     event: JsonObject,
   ): Promise<AgenCSessionBroadcastResult> {
-    const evictedClientIds: string[] = [];
+    const evictedClientIds: EvictedClient[] = [];
     const rejectedDeliveries: AgenCSessionBroadcastFailure[] = [];
     const { deliveries, bufferAfterDelivery } = await this.#state.with(
       async (state) => {
@@ -998,7 +1021,7 @@ function enqueueDelivery(
   event: JsonObject,
   maxPendingBytes: number,
   maxPendingCount: number,
-  evictedClientIds: string[],
+  evictedClientIds: EvictedClient[],
   rejectedDeliveries: AgenCSessionBroadcastFailure[],
 ): EnqueuedDelivery | null {
   if (client === undefined || client.evicted) return null;
@@ -1007,7 +1030,7 @@ function enqueueDelivery(
   if (eventBytes > maxPendingBytes || maxPendingCount < 1) {
     const error = deliveryLimitError(eventBytes, maxPendingBytes);
     client.evicted = true;
-    evictedClientIds.push(client.clientId);
+    evictedClientIds.push({ clientId: client.clientId, deliveryKey: client.deliveryKey });
     rejectedDeliveries.push({
       clientId: client.clientId,
       message: error.message,
@@ -1023,7 +1046,7 @@ function enqueueDelivery(
       client.pendingDeliveryCount + 1 > maxPendingCount)
   ) {
     client.evicted = true;
-    evictedClientIds.push(client.clientId);
+    evictedClientIds.push({ clientId: client.clientId, deliveryKey: client.deliveryKey });
     rejectedDeliveries.push({
       clientId: client.clientId,
       message:

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -501,10 +501,10 @@ export interface AgenCDaemonWebSocketListenOptions {
 export class AgenCDaemonRpcShutdownCoordinator {
   #pendingAcknowledgements = 0;
   #completed = false;
-  readonly #onAcknowledgementFlushed: () => void;
+  readonly #onShutdownReady: () => void;
 
-  constructor(onAcknowledgementFlushed: () => void) {
-    this.#onAcknowledgementFlushed = onAcknowledgementFlushed;
+  constructor(onShutdownReady: () => void) {
+    this.#onShutdownReady = onShutdownReady;
   }
 
   get blocksRequests(): boolean {
@@ -532,20 +532,26 @@ export class AgenCDaemonRpcShutdownCoordinator {
       await send(response);
     } catch (error) {
       if (acceptedShutdown && !this.#completed) {
-        // Release only this response's acceptance. Another concurrent
-        // acknowledgement remains counted and continues to block requests.
+        // Shutdown acceptance already fenced daemon ingress and cannot be
+        // rolled back by a disconnected requester. Give any other pending
+        // acknowledgement its flush opportunity; if none remain, clean up
+        // even though every requester lost its connection.
         this.#pendingAcknowledgements -= 1;
+        if (this.#pendingAcknowledgements === 0) {
+          this.#completed = true;
+          this.#onShutdownReady();
+        }
       }
       throw error;
     }
     if (!acceptedShutdown || this.#completed) return;
 
     // The transport's write callback is the causal flush barrier. Cleanup
-    // cannot begin before at least one authenticated acknowledgement reaches
-    // it, and a failed concurrent send cannot reopen a completed shutdown.
+    // waits for an acknowledgement to reach it or for all sends to fail. A
+    // failed concurrent send cannot reopen a completed shutdown.
     this.#pendingAcknowledgements -= 1;
     this.#completed = true;
-    this.#onAcknowledgementFlushed();
+    this.#onShutdownReady();
   }
 }
 
@@ -3327,11 +3333,11 @@ async function runAgenCDaemonForegroundLocked(
     // the multiplexer ask the transport to tear down a slow consumer's socket
     // when that client's pending delivery backlog trips the per-client cap.
     let destroyEvictedClientConnection:
-      ((clientId: string) => void) | undefined;
+      ((clientId: string, deliveryKey?: string) => void) | undefined;
     const clientMultiplexer = new AgenCDaemonClientMultiplexer({
       sessionManager,
-      onClientEvicted: (clientId) => {
-        destroyEvictedClientConnection?.(clientId);
+      onClientEvicted: (clientId, deliveryKey) => {
+        destroyEvictedClientConnection?.(clientId, deliveryKey);
       },
     });
     const commandExec = new AgenCCommandExecService({
@@ -3932,7 +3938,10 @@ async function runAgenCDaemonForegroundLocked(
     const connections = new Map<string, AgenCDaemonJsonRpcConnection>();
     const socketConnections = new Map<
       string,
-      { readonly send: (message: JsonObject) => Promise<void> }
+      {
+        readonly send: (message: JsonObject) => Promise<void>;
+        readonly terminate: () => void;
+      }
     >();
     const connectionFor = (
       connectionKey: string,
@@ -3952,9 +3961,6 @@ async function runAgenCDaemonForegroundLocked(
       connections.delete(connectionKey);
       socketConnections.delete(connectionKey);
       void connection?.close().catch(() => {});
-      for (const clientId of connection?.trackedClientIds ?? []) {
-        void clientMultiplexer.removeClient(clientId).catch(() => {});
-      }
     };
     // Tear down the transport for a slow consumer the multiplexer evicted for an
     // unbounded pending delivery backlog. The multiplexer already removed the
@@ -3966,13 +3972,17 @@ async function runAgenCDaemonForegroundLocked(
     // co-located clients) untouched. Destroying the socket ends the backpressured
     // peer so it stops pinning daemon heap; it can reconnect and replay through
     // the normal detached-buffer path.
-    destroyEvictedClientConnection = (clientId: string): void => {
+    destroyEvictedClientConnection = (clientId, deliveryKey): void => {
       for (const [connectionKey, connection] of connections) {
-        if (!connection.trackedClientIds.includes(clientId)) {
+        if (
+          (deliveryKey !== undefined && connection.cancellationScope !== deliveryKey) ||
+          !connection.trackedClientIds.includes(clientId)
+        ) {
           continue;
         }
         const wasSoleClient = connection.untrackClientId(clientId);
         if (wasSoleClient) {
+          socketConnections.get(connectionKey)?.terminate();
           closeConnection(connectionKey);
         }
         return;
@@ -4031,6 +4041,7 @@ async function runAgenCDaemonForegroundLocked(
         );
         socketConnections.set(connectionKey, {
           send: (notification) => context.send(notification),
+          terminate: () => context.terminate(),
         });
         const connection = connectionFor(connectionKey);
         const verifiedIdentity = daemonVerifiedIdentityForContext(context);
@@ -4078,6 +4089,7 @@ async function runAgenCDaemonForegroundLocked(
         );
         socketConnections.set(connectionKey, {
           send: (notification) => context.send(notification),
+          terminate: () => context.terminate(),
         });
         const response = await connectionFor(connectionKey).dispatch(message);
         await rpcShutdown.send(message, response, context.send);

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -833,20 +833,28 @@ export class AgenCDaemonJsonRpcDispatcher {
   async closeConnection(
     connection: AgenCDaemonJsonRpcConnection,
   ): Promise<void> {
-    this.#routineSubscriptions.get(connection)?.();
-    this.#routineSubscriptions.delete(connection);
-    connection.cancelAllInFlightRequests("connection closed");
-    if (this.#clientMultiplexer !== undefined) {
-      for (const clientId of connection.trackedClientIds) {
-        await this.#clientMultiplexer.removeClient(clientId).catch((error) => {
-          if ((error as { code?: string }).code === "CLIENT_NOT_FOUND") {
-            return;
+    return connection.runClose(async () => {
+      this.#routineSubscriptions.get(connection)?.();
+      this.#routineSubscriptions.delete(connection);
+      connection.cancelAllInFlightRequests("connection closed");
+      // One failed detach must not strand the other clients or command jobs.
+      const cleanup = await Promise.allSettled([
+        ...connection.trackedClientIds.map(async (clientId) => {
+          try {
+            await this.#clientMultiplexer?.removeClient(clientId, connection.cancellationScope);
+          } catch (error) {
+            if ((error as { code?: string }).code !== "CLIENT_NOT_FOUND") throw error;
+          } finally {
+            connection.untrackClientId(clientId);
           }
-          throw error;
-        });
+        }),
+        this.#commandExec.closeConnection(connection.cancellationScope),
+      ]);
+      const failures = cleanup.filter((result) => result.status === "rejected");
+      if (failures.length > 0) {
+        throw new AggregateError(failures.map((result) => result.reason), "daemon connection cleanup failed");
       }
-    }
-    await this.#commandExec.closeConnection(connection.cancellationScope);
+    });
   }
 
   async dispatchForConnection(
@@ -854,6 +862,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     message: JsonObject,
   ): Promise<AgenCDaemonResponse> {
     const id = requestIdFromMessage(message);
+    if (connection.closed) return mapDispatchError(id, new AgenCDaemonConnectionClosedError());
     if (message.jsonrpc !== JSON_RPC_VERSION) {
       return errorResponse(id, -32600, "invalid JSON-RPC version");
     }
@@ -867,6 +876,7 @@ export class AgenCDaemonJsonRpcDispatcher {
       try {
         const params = objectParams(message.params);
         await connection.remoteAccess.authorize(message.method, params);
+        connection.assertOpen();
         if (message.method !== "initialize" && !connection.initialized) throw new RemoteError("CONNECTION_NOT_INITIALIZED");
         if (message.method === "session.list") return successResponse(id, await connection.remoteAccess.sessions());
         if (message.method === "session.create") return successResponse(id, await connection.remoteAccess.createSession(params));
@@ -885,61 +895,67 @@ export class AgenCDaemonJsonRpcDispatcher {
     try {
       const params = objectParams(message.params);
       if (method === "initialize") {
-        const initializeParams = validateInitializeParams(connection.remoteAccess ? { protocol: params.protocol, capabilities: {} } : params);
-        if (connection.initialized) {
+        if (!connection.beginInitialization()) {
           return errorResponse(id, -32000, "Already initialized", {
             code: "CONNECTION_ALREADY_INITIALIZED",
           });
         }
-        const negotiated = negotiateInitializeProtocol(
-          initializeParams,
-          connection.remoteAccess ? {
-            ...this.#serverCapabilities,
-            [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: Object.fromEntries(Object.entries(this.#serverCapabilities[AGENC_DAEMON_METHOD_CAPABILITIES_KEY]).map(([key, value]) => [key, value && connection.remoteAccess!.allowsMethod(key)])) as AgenCDaemonMethodCapabilities,
-          } : this.#serverCapabilities,
-        );
-        if (!negotiated.supported) {
-          return errorResponse(id, -32000, "Unsupported protocol version", {
-            code: "PROTOCOL_VERSION_UNSUPPORTED",
-            clientVersion: negotiated.clientVersion,
-            serverVersion: AGENC_DAEMON_PROTOCOL_VERSION,
-          });
-        }
-        if (
-          this.#initializeAuthenticator !== undefined &&
-          connection.remoteAccess === undefined &&
-          connection.daemonSocketIdentity === undefined
-        ) {
-          const authResult =
-            await this.#initializeAuthenticator(initializeParams);
-          if (!authResult) {
-            return errorResponse(
-              id,
-              -32000,
-              "daemon connection authentication failed",
-              { code: "CONNECTION_AUTHENTICATION_FAILED" },
+        try {
+          const initializeParams = validateInitializeParams(connection.remoteAccess ? { protocol: params.protocol, capabilities: {} } : params);
+          const negotiated = negotiateInitializeProtocol(
+            initializeParams,
+            connection.remoteAccess ? {
+              ...this.#serverCapabilities,
+              [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: Object.fromEntries(Object.entries(this.#serverCapabilities[AGENC_DAEMON_METHOD_CAPABILITIES_KEY]).map(([key, value]) => [key, value && connection.remoteAccess!.allowsMethod(key)])) as AgenCDaemonMethodCapabilities,
+            } : this.#serverCapabilities,
+          );
+          if (!negotiated.supported) {
+            return errorResponse(id, -32000, "Unsupported protocol version", {
+              code: "PROTOCOL_VERSION_UNSUPPORTED",
+              clientVersion: negotiated.clientVersion,
+              serverVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+            });
+          }
+          if (
+            this.#initializeAuthenticator !== undefined &&
+            connection.remoteAccess === undefined &&
+            connection.daemonSocketIdentity === undefined
+          ) {
+            const authResult =
+              await this.#initializeAuthenticator(initializeParams);
+            connection.assertOpen();
+            if (!authResult) {
+              return errorResponse(
+                id,
+                -32000,
+                "daemon connection authentication failed",
+                { code: "CONNECTION_AUTHENTICATION_FAILED" },
+              );
+            }
+            connection.markDaemonSocketIdentity(
+              authResult === true ? undefined : authResult,
             );
           }
-          connection.markDaemonSocketIdentity(
-            authResult === true ? undefined : authResult,
+          await this.#registerInitializedCapabilityClient(
+            connection,
+            negotiated.state.clientCapabilities,
           );
+          connection.markInitialized(negotiated.state);
+          return successResponse(id, {
+            type: "initialized",
+            protocolVersion: negotiated.state.serverProtocol.version,
+            protocol: negotiated.state.protocol,
+            capabilities: negotiated.state.serverCapabilities,
+            ...(connection.remoteAccess ? { remoteAccess: connection.remoteAccess.projection() } : {}),
+            ...(this.#daemonIdentity !== undefined && connection.remoteAccess === undefined
+              ? { daemonIdentity: this.#daemonIdentity }
+              : {}),
+          });
+        } finally {
+          connection.endInitialization();
         }
-        await this.#registerInitializedCapabilityClient(
-          connection,
-          negotiated.state.clientCapabilities,
-        );
-        connection.markInitialized(negotiated.state);
-        return successResponse(id, {
-          type: "initialized",
-          protocolVersion: negotiated.state.serverProtocol.version,
-          protocol: negotiated.state.protocol,
-          capabilities: negotiated.state.serverCapabilities,
-          ...(connection.remoteAccess ? { remoteAccess: connection.remoteAccess.projection() } : {}),
-          ...(this.#daemonIdentity !== undefined && connection.remoteAccess === undefined
-            ? { daemonIdentity: this.#daemonIdentity }
-            : {}),
-        });
       }
+
       if (!connection.initialized) {
         return errorResponse(id, -32000, "Not initialized", {
           code: "CONNECTION_NOT_INITIALIZED",
@@ -1879,10 +1895,12 @@ export class AgenCDaemonJsonRpcDispatcher {
     const clientId = params.clientId;
     const wasTracked =
       clientId !== undefined && connection.trackedClientIds.includes(clientId);
+    let createdRoute = false;
     const attachment = await this.#attachTrackedClientToSession(
       connection,
       clientId,
       sessionId,
+      (created) => { createdRoute = created; },
     );
     return async () => {
       if (
@@ -1894,11 +1912,12 @@ export class AgenCDaemonJsonRpcDispatcher {
       }
       if (!wasTracked) {
         connection.untrackClientId(clientId);
-        await this.#clientMultiplexer.removeClient(clientId).catch(() => {});
+        await this.#clientMultiplexer.removeClient(clientId, connection.cancellationScope).catch(() => {});
         return;
       }
+      if (!createdRoute) return;
       await this.#clientMultiplexer
-        .detachClientFromSession(sessionId, clientId)
+        .detachClientFromSession(sessionId, clientId, connection.cancellationScope)
         .catch(() => {});
     };
   }
@@ -1907,6 +1926,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     connection: AgenCDaemonJsonRpcConnection,
     capabilities: JsonObject,
   ): Promise<void> {
+    connection.assertOpen();
     if (capabilities["routine.updated.v1"] === true && this.#routines && connection.sendNotification && !this.#routineSubscriptions.has(connection)) {
       // Coalesce by routine while a client is slow, keeping at most 100 invalidations.
       const pending = new Map<string, RoutineUpdatedEvent>();
@@ -1943,19 +1963,27 @@ export class AgenCDaemonJsonRpcDispatcher {
       return;
     }
     const clientId = `initialized_${connection.cancellationScope}`;
-    await this.#clientMultiplexer.registerClient({
-      clientId,
-      deliveryKey: connection.cancellationScope,
-      send: (message) => connection.sendNotification!(message),
-      capabilities,
-    });
-    connection.trackClientId(clientId);
+    try {
+      await this.#clientMultiplexer.registerClient({
+        clientId,
+        deliveryKey: connection.cancellationScope,
+        send: (message) => connection.sendNotification!(message),
+        capabilities,
+        onRegistered: () => connection.trackClientId(clientId),
+      });
+      connection.assertOpen();
+    } catch (error) {
+      connection.untrackClientId(clientId);
+      await this.#clientMultiplexer.removeClient(clientId, connection.cancellationScope).catch(() => {});
+      throw error;
+    }
   }
 
   async #attachTrackedClientToSession(
     connection: AgenCDaemonJsonRpcConnection,
     clientId: string | undefined,
     sessionId: string,
+    onAttached?: (created: boolean) => void,
   ): Promise<SessionAttachResult | undefined> {
     if (
       this.#clientMultiplexer === undefined ||
@@ -1964,38 +1992,42 @@ export class AgenCDaemonJsonRpcDispatcher {
     ) {
       return undefined;
     }
+    connection.assertOpen();
     let registeredHere = false;
-    if (!connection.trackedClientIds.includes(clientId)) {
-      await this.#clientMultiplexer
-        .registerClient({
-          clientId,
-          deliveryKey: connection.cancellationScope,
-          send: (message) => connection.sendNotification!(message),
-          acceptsSessionEvent: (event) =>
-            connection.acceptsSessionEvent(event),
-        })
-        .catch((error) => {
-          if (
-            (error as { code?: string }).code === "CLIENT_ALREADY_REGISTERED"
-          ) {
-            throw invalidParams(
-              `daemon client is already registered: ${clientId}`,
-            );
-          }
-          throw error;
-        });
-      registeredHere = true;
-    }
     try {
-      const result = await this.#clientMultiplexer.attachClientToSession(
-        sessionId,
-        clientId,
-      );
-      if (registeredHere) connection.trackClientId(clientId);
+      if (!connection.trackedClientIds.includes(clientId)) {
+        await this.#clientMultiplexer
+          .registerClient({
+            clientId,
+            deliveryKey: connection.cancellationScope,
+            send: (message) => connection.sendNotification!(message),
+            acceptsSessionEvent: (event) => connection.acceptsSessionEvent(event),
+            onRegistered: () => {
+              connection.trackClientId(clientId);
+              registeredHere = true;
+            },
+          })
+          .catch((error) => {
+            if ((error as { code?: string }).code === "CLIENT_ALREADY_REGISTERED") {
+              throw invalidParams(`daemon client is already registered: ${clientId}`);
+            }
+            throw error;
+          });
+        registeredHere = true;
+        // Track ownership before attachment/replay yields, so close can detach
+        // it even if replay is backpressured indefinitely.
+        connection.trackClientId(clientId);
+      }
+      connection.assertOpen();
+      const result = await this.#clientMultiplexer.attachClientToSession(sessionId, clientId, onAttached);
+      connection.assertOpen();
       return result;
     } catch (error) {
       if (registeredHere) {
-        await this.#clientMultiplexer.removeClient(clientId).catch(() => {});
+        connection.untrackClientId(clientId);
+        // A reconnect may already have reused the logical id. Cleanup belongs
+        // only to this physical connection's registration.
+        await this.#clientMultiplexer.removeClient(clientId, connection.cancellationScope).catch(() => {});
       }
       throw error;
     }
@@ -2186,6 +2218,9 @@ export class AgenCDaemonJsonRpcConnection {
   readonly #inFlightRequests = new Map<string, AbortController>();
   readonly #limiter: AgenCDaemonConnectionLimiter;
   #initializeState: AgenCDaemonConnectionInitializeState | undefined;
+  #initializing = false;
+  #closed = false;
+  #closePromise: Promise<void> | undefined;
   #daemonSocketIdentity: AuthDaemonSocketIdentity | undefined;
 
   constructor(
@@ -2198,6 +2233,33 @@ export class AgenCDaemonJsonRpcConnection {
     this.#limiter = new AgenCDaemonConnectionLimiter(options.overloadLimits);
     nextConnectionId += 1;
     this.#cancellationScope = `connection_${nextConnectionId.toString(36)}`;
+  }
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  assertOpen(): void {
+    if (this.#closed) throw new AgenCDaemonConnectionClosedError();
+  }
+
+  beginInitialization(): boolean {
+    this.assertOpen();
+    if (this.initialized || this.#initializing) return false;
+    this.#initializing = true;
+    return true;
+  }
+
+  endInitialization(): void {
+    this.#initializing = false;
+  }
+
+  runClose(cleanup: () => Promise<void>): Promise<void> {
+    if (this.#closePromise !== undefined) return this.#closePromise;
+    // Closing is terminal before any asynchronous cleanup starts.
+    this.#closed = true;
+    this.#closePromise = Promise.resolve().then(cleanup);
+    return this.#closePromise;
   }
 
   get initialized(): boolean {
@@ -2213,12 +2275,14 @@ export class AgenCDaemonJsonRpcConnection {
   }
 
   markInitialized(state: AgenCDaemonConnectionInitializeState): void {
+    this.assertOpen();
     this.#initializeState = state;
   }
 
   markDaemonSocketIdentity(
     identity: AuthDaemonSocketIdentity | undefined,
   ): void {
+    this.assertOpen();
     this.#daemonSocketIdentity = identity;
   }
 
@@ -2242,6 +2306,7 @@ export class AgenCDaemonJsonRpcConnection {
   }
 
   trackClientId(clientId: string): void {
+    this.assertOpen();
     this.#clientIds.add(clientId);
   }
 
@@ -2264,6 +2329,7 @@ export class AgenCDaemonJsonRpcConnection {
     id: RequestId,
     run: (signal: AbortSignal) => Promise<T>,
   ): Promise<T> {
+    this.assertOpen();
     const key = requestIdKey(id);
     if (this.#inFlightRequests.has(key)) {
       throw invalidParams(`daemon request is already in flight: ${String(id)}`);
@@ -2332,6 +2398,7 @@ export class AgenCDaemonJsonRpcConnection {
   }
 
   async dispatch(message: JsonObject): Promise<AgenCDaemonResponse> {
+    if (this.#closed) return mapDispatchError(requestIdFromMessage(message), new AgenCDaemonConnectionClosedError());
     const admission = this.#limiter.tryStart(message);
     if (!admission.admitted) {
       return admission.response!;
@@ -2367,6 +2434,13 @@ function requestIdFromMessage(message: JsonObject): RequestId | null {
 
 function requestIdKey(id: RequestId): string {
   return `${typeof id}:${String(id)}`;
+}
+
+class AgenCDaemonConnectionClosedError extends Error {
+  constructor() {
+    super("daemon connection closed");
+    this.name = "AgenCDaemonConnectionClosedError";
+  }
 }
 
 class AgenCDaemonRequestCancelledError extends Error {
@@ -5770,6 +5844,9 @@ function mapDispatchError(
   id: RequestId | null,
   error: unknown,
 ): AgenCDaemonResponse {
+  if (error instanceof AgenCDaemonConnectionClosedError) {
+    return errorResponse(id, -32000, error.message, { code: "CONNECTION_CLOSED" });
+  }
   if (error instanceof WhisperError) return errorResponse(id, error.code === "WHISPER_INVALID_ARGUMENT" ? -32602 : -32000, error.message, { code: error.code });
   if (error instanceof RemoteError) return errorResponse(id, -32000, error.code, { code: error.code });
   if (error instanceof RoutineError) return errorResponse(id, -32602, error.message, { code: error.code });

--- a/runtime/src/app-server/session-lifecycle.ts
+++ b/runtime/src/app-server/session-lifecycle.ts
@@ -106,6 +106,7 @@ interface MutableSession {
   metadata?: JsonObject;
   closedAt?: string;
   terminationReason?: string;
+  terminationPending?: boolean;
   recoveredFromThreadStore?: boolean;
   attachments: Map<string, AgenCSessionAttachment>;
 }
@@ -140,6 +141,7 @@ export class AgenCDaemonSessionManager {
   readonly #threadStore: ThreadStore | undefined;
   readonly #onSessionTerminated:
     ((sessionId: string) => void | Promise<void>) | undefined;
+  readonly #terminationTasks = new Map<string, Promise<void>>();
 
   constructor(options: AgenCSessionLifecycleOptions = {}) {
     this.#createSessionId =
@@ -466,6 +468,13 @@ export class AgenCDaemonSessionManager {
   async attachSession(
     params: SessionAttachParams,
   ): Promise<SessionAttachResult> {
+    return (await this.attachSessionWithOwnership(params)).attachment;
+  }
+
+  /** Internal receipt: rollback may release only attachments this call created. */
+  async attachSessionWithOwnership(
+    params: SessionAttachParams,
+  ): Promise<{ readonly attachment: SessionAttachResult; readonly created: boolean }> {
     return this.#state.with((state) => {
       const session = this.#requireOpenSession(state, params.sessionId);
       const existing =
@@ -474,7 +483,7 @@ export class AgenCDaemonSessionManager {
           : undefined;
 
       if (existing !== undefined) {
-        return toAttachResult(session, existing);
+        return { attachment: toAttachResult(session, existing), created: false };
       }
 
       const attachment: AgenCSessionAttachment = {
@@ -484,7 +493,7 @@ export class AgenCDaemonSessionManager {
         ...(params.clientId !== undefined ? { clientId: params.clientId } : {}),
       };
       session.attachments.set(attachment.attachmentId, attachment);
-      return toAttachResult(session, attachment);
+      return { attachment: toAttachResult(session, attachment), created: true };
     });
   }
 
@@ -520,33 +529,64 @@ export class AgenCDaemonSessionManager {
       const session = this.#requireSession(state, params.sessionId);
 
       if (session.status === "closed") {
-        this.#archiveRecoveredThread(session);
         return toTerminateResult(session, false);
       }
 
       session.status = "closed";
+      session.terminationPending = true;
       session.closedAt = this.#now();
       session.attachments.clear();
       if (params.reason !== undefined)
         session.terminationReason = params.reason;
-      this.#archiveRecoveredThread(session);
       return toTerminateResult(session, true);
     });
-    if (result.terminated) {
-      await this.#onSessionTerminated?.(result.sessionId);
+    // Closing revokes new attachments immediately, but callers must also wait
+    // for resource disposal. Failed disposal remains retryable on a later
+    // terminate request; a closed projection alone is not cleanup completion.
+    let task = this.#terminationTasks.get(result.sessionId);
+    if (task === undefined) {
+      task = this.#finalizeSessionTermination(result.sessionId);
+      this.#terminationTasks.set(result.sessionId, task);
+    }
+    try {
+      await task;
+    } finally {
+      if (this.#terminationTasks.get(result.sessionId) === task) {
+        this.#terminationTasks.delete(result.sessionId);
+      }
     }
     return result;
   }
 
-  #archiveRecoveredThread(session: MutableSession): void {
-    if (!session.recoveredFromThreadStore || this.#threadStore === undefined) {
-      return;
+  async #finalizeSessionTermination(sessionId: string): Promise<void> {
+    const pending = await this.#state.with((state) => {
+      const session = this.#requireSession(state, sessionId);
+      return {
+        archive: session.recoveredFromThreadStore === true,
+        notify: session.terminationPending === true,
+      };
+    });
+    const errors: unknown[] = [];
+    if (pending.archive && this.#threadStore !== undefined) {
+      try {
+        this.#threadStore.archiveThread({ threadId: sessionId });
+      } catch (error) {
+        if (!(error instanceof ThreadNotFoundError)) errors.push(error);
+      }
     }
-    try {
-      this.#threadStore.archiveThread({ threadId: session.sessionId });
-    } catch (error) {
-      if (error instanceof ThreadNotFoundError) return;
-      throw error;
+    if (pending.notify) {
+      try {
+        await this.#onSessionTerminated?.(sessionId);
+        await this.#state.with((state) => {
+          this.#requireSession(state, sessionId).terminationPending = false;
+        });
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Session termination cleanup failed");
     }
   }
 

--- a/runtime/src/app-server/transport/unix-socket.ts
+++ b/runtime/src/app-server/transport/unix-socket.ts
@@ -71,6 +71,7 @@ export interface AgenCUnixSocketMessageContext {
   readonly privateSocketOwnerUid: number | null;
   send(message: JsonValue): Promise<void>;
   close(): void;
+  terminate(): void;
 }
 
 export interface AgenCUnixSocketServerOptions {
@@ -255,10 +256,15 @@ export class AgenCUnixSocketServer {
     this.#nativePeerCredentialBinding = null;
     this.#boundSocketIdentity = null;
 
-    for (const { socket, transport } of this.#connections.values()) {
+    const activeConnections = [...this.#connections.values()];
+    // Fence every peer before draining handlers: a blocked handler on one
+    // connection must not leave another connection accepting more work.
+    for (const { socket } of activeConnections) {
       socket.destroy();
-      await transport.close();
     }
+    await Promise.allSettled(
+      activeConnections.map(({ transport }) => transport.close()),
+    );
     this.#connections.clear();
 
     if (server !== null) {
@@ -280,6 +286,10 @@ export class AgenCUnixSocketServer {
   }
 
   #acceptConnection(socket: Socket): void {
+    if (this.#server === null) {
+      socket.destroy();
+      return;
+    }
     const connectionId = this.#nextConnectionId;
     this.#nextConnectionId += 1;
     const peerUid = resolveAgenCUnixSocketPeerUid(
@@ -299,6 +309,7 @@ export class AgenCUnixSocketServer {
       return;
     }
     let accepted = this.#options.acceptAuthenticator === undefined;
+    let closed = false;
     let closingUnauthenticated = false;
     let authenticationTimeout: NodeJS.Timeout | undefined;
     // The transport fires onMessage for each parsed line WITHOUT awaiting
@@ -327,13 +338,22 @@ export class AgenCUnixSocketServer {
       privateSocketOwnerUid: this.#privateSocketOwnerUid,
       send: (message) => writeJsonLine(socket, message),
       close: () => {
+        closed = true;
         socket.end();
+      },
+      terminate: () => {
+        closed = true;
+        socket.destroy();
       },
     };
     const transport = new AgenCStdioTransport({
       input: socket,
       output: socket,
       onMessage: async (message) => {
+        // Parsed frames can still be queued behind an active request after
+        // disconnect. They must never recreate a daemon connection or start
+        // work after its connection-scoped authority has been removed.
+        if (closed || socket.destroyed) return;
         // Two-step gate to handle line-batched [initialize, method]
         // messages that arrive in one TCP packet and trigger parallel
         // onMessage handlers. The transport fires handlers via
@@ -361,7 +381,7 @@ export class AgenCUnixSocketServer {
           // We waited for someone else's auth. They've already set
           // accepted / closingUnauthenticated. Fall through to dispatch
           // (or short-circuit if their auth failed).
-          if (closingUnauthenticated) return;
+          if (closed || socket.destroyed || closingUnauthenticated) return;
           if (!accepted) return; // sibling rejected; we should also stop
           await this.#options.onMessage(message, context);
           return;
@@ -379,11 +399,15 @@ export class AgenCUnixSocketServer {
               (await this.#options.acceptAuthenticator?.(message, context)) ===
               true;
           } catch (error) {
+            closingUnauthenticated = true;
             clearAuthenticationTimeout();
             this.#options.onError?.(asNodeError(error), connectionId);
             socket.destroy();
             return;
           }
+          // Authentication is asynchronous; disconnect or its deadline may
+          // have revoked this connection while the decision was in flight.
+          if (closed || socket.destroyed || closingUnauthenticated) return;
           if (!authenticated) {
             closingUnauthenticated = true;
             clearAuthenticationTimeout();
@@ -402,7 +426,10 @@ export class AgenCUnixSocketServer {
         await this.#options.onMessage(message, context);
       },
       onError: (error) => this.#options.onError?.(error, connectionId),
-      onClose: () => this.#connections.delete(connectionId),
+      onClose: () => {
+        closed = true;
+        this.#connections.delete(connectionId);
+      },
     });
 
     this.#connections.set(connectionId, { socket, transport });
@@ -413,6 +440,7 @@ export class AgenCUnixSocketServer {
       }, this.#options.acceptAuthenticationTimeoutMs ?? AGENC_DAEMON_SOCKET_ACCEPT_AUTH_TIMEOUT_MS);
     }
     socket.once("close", () => {
+      closed = true;
       clearAuthenticationTimeout();
       this.#connections.delete(connectionId);
       this.#options.onConnectionClosed?.(connectionId);

--- a/runtime/src/app-server/transport/websocket.ts
+++ b/runtime/src/app-server/transport/websocket.ts
@@ -58,6 +58,7 @@ export interface AgenCWebSocketMessageContext {
   readonly remoteAddress: string | undefined;
   send(message: JsonValue): Promise<void>;
   close(code?: number, reason?: string): void;
+  terminate(): void;
 }
 
 export interface AgenCWebSocketServerOptions {
@@ -333,6 +334,7 @@ export class AgenCWebSocketServer {
       close: (code, reason) => {
         socket.close(code, reason);
       },
+      terminate: () => socket.terminate(),
     };
 
     socket.on("message", (data, isBinary) => {
@@ -383,6 +385,12 @@ export class AgenCWebSocketServer {
     active: ActiveWebSocketConnection,
     context: AgenCWebSocketMessageContext,
   ): Promise<boolean> {
+    if (
+      active.socket.readyState !== WebSocket.OPEN ||
+      active.closingUnauthenticated
+    ) {
+      return false;
+    }
     if (active.accepted) {
       return !active.closingUnauthenticated;
     }
@@ -394,7 +402,11 @@ export class AgenCWebSocketServer {
     const inFlight = active.authResolution;
     if (inFlight !== resolvedWebSocketAuth) {
       await inFlight;
-      return active.accepted && !active.closingUnauthenticated;
+      return (
+        active.accepted &&
+        !active.closingUnauthenticated &&
+        active.socket.readyState === WebSocket.OPEN
+      );
     }
     let release: (() => void) | undefined;
     active.authResolution = new Promise<void>((resolve) => {
@@ -410,9 +422,15 @@ export class AgenCWebSocketServer {
         active.closingUnauthenticated = true;
         this.#options.onError?.(asError(error), context.connectionId);
         this.#connections.delete(context.connectionId);
-        if (active.socket.readyState !== WebSocket.CLOSED) {
-          active.socket.terminate();
-        }
+        active.socket.terminate();
+        return false;
+      }
+      // An accept decision cannot restore authority revoked by disconnect,
+      // server shutdown, or the authentication deadline while it awaited.
+      if (
+        active.socket.readyState !== WebSocket.OPEN ||
+        active.closingUnauthenticated
+      ) {
         return false;
       }
       if (!authenticated) {
@@ -459,7 +477,11 @@ export class AgenCWebSocketServer {
       const pending = Promise.resolve()
         .then(async () => {
           await initializeBarrier;
-          if (active.accepted && !active.closingUnauthenticated) {
+          if (
+            active.accepted &&
+            !active.closingUnauthenticated &&
+            active.socket.readyState === WebSocket.OPEN
+          ) {
             await this.#options.onMessage(message, context);
           }
         })
@@ -500,7 +522,7 @@ export class AgenCWebSocketServer {
           // gaphunt3 #47: gate dispatch on the accept-auth decision so an
           // accepted-but-unauthenticated connection cannot drive the dispatcher.
           const proceed = await this.#resolveAcceptance(message, active, context);
-          if (!proceed) return;
+          if (!proceed || active.socket.readyState !== WebSocket.OPEN) return;
           await this.#options.onMessage(message, context);
         } finally {
           active.queuedNormalMessages = Math.max(

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -806,7 +806,23 @@ export function createDaemonTuiSession<
   const eventReplay = new DaemonEventReplay(MAX_BUFFERED_SESSION_EVENTS_PER_SESSION);
   let activeTurnSnapshot: { readonly turnId: string } | null =
     options.transcriptSnapshot?.activeTurn ?? null;
-  let lastObservedTurnId: string | undefined;
+  let lastObservedTurnId = options.transcriptSnapshot?.activeTurn?.turnId;
+  type PendingDaemonSubmission = {
+    readonly clientMessageId: string;
+    dispatched: boolean;
+    cancellation?: { readonly reason?: string };
+  };
+  const pendingSubmissions = new Map<string, PendingDaemonSubmission>();
+  let observedSubmission: PendingDaemonSubmission | undefined;
+  const activeDaemonTurnId = (): string | undefined => {
+    const turnId = activeTurnSnapshot?.turnId === "daemon-turn"
+      ? lastObservedTurnId
+      : activeTurnSnapshot?.turnId;
+    return turnId !== undefined && turnId !== "daemon-turn" &&
+      !pendingSubmissions.has(turnId) && turnId === lastObservedTurnId
+      ? turnId
+      : undefined;
+  };
   let daemonTurnStartGeneration = 0;
   let inFlightShellExecutionCount = 0;
   const inFlightShellCommandIds = new Set<string>();
@@ -831,6 +847,49 @@ export function createDaemonTuiSession<
   >();
   let unsubscribeDaemonEvents: (() => void) | null = null;
   let runtimeSettingsAuthorityError: Error | null = null;
+  const cancelDaemonTurn = async (expectedTurnId: string, reason?: string): Promise<void> => {
+    try {
+      await client.request("session.cancelTurn", {
+        sessionId,
+        expectedTurnId,
+        ...(reason !== undefined ? { reason } : {}),
+      }, { signal: AbortSignal.timeout(5_000) });
+    } catch (error) {
+      const timedOut = error instanceof Error &&
+        (error.name === "TimeoutError" || error.name === "AbortError");
+      if (timedOut) {
+        broadcastDaemonEvent({
+          id: `agenc-daemon-cancel-unacked-${Date.now()}`,
+          type: "warning",
+          payload: {
+            cause: "daemon_delivery_failed",
+            action: "session.cancelTurn",
+            message:
+              "interrupt not acknowledged by the daemon (it may be unresponsive) — try ESC again, or restart the daemon",
+          },
+        });
+      }
+    }
+  };
+  const flushSubmissionCancellation = (event: unknown): void => {
+    if (isJsonObject(event)) {
+      const payload = isJsonObject(event.payload) ? event.payload : {};
+      const clientMessageId = event.clientMessageId ?? payload.clientMessageId;
+      if (clientMessageId !== undefined) {
+        observedSubmission = [...pendingSubmissions.values()].find(
+          (submission) => submission.clientMessageId === clientMessageId,
+        );
+      }
+    }
+    const turnId = activeDaemonTurnId();
+    if (
+      turnId === undefined || !observedSubmission?.dispatched ||
+      observedSubmission.cancellation === undefined
+    ) return;
+    const { reason } = observedSubmission.cancellation;
+    delete observedSubmission.cancellation;
+    void cancelDaemonTurn(turnId, reason);
+  };
   const markDaemonActivityActive = (event: unknown): void => {
     if (terminalDaemonTurnObserved) return;
     const payload = (event as { readonly payload?: unknown }).payload;
@@ -841,13 +900,23 @@ export function createDaemonTuiSession<
         ? payload.turnId
         : (activeTurnSnapshot?.turnId ?? "daemon-turn");
     activeTurnSnapshot = { turnId };
-    if (turnId !== "daemon-turn") lastObservedTurnId = turnId;
+    if (turnId !== "daemon-turn" && !pendingSubmissions.has(turnId)) {
+      lastObservedTurnId = turnId;
+    }
   };
   const noteDaemonActivity = (event: unknown): void => {
     if (typeof event !== "object" || event === null) {
       return;
     }
     const eventType = (event as { readonly type?: unknown }).type;
+    if (eventType === "user_message") {
+      const value = event as JsonObject;
+      const payload = isJsonObject(value.payload) ? value.payload : {};
+      const clientMessageId = value.clientMessageId ?? payload.messageId;
+      observedSubmission = [...pendingSubmissions.values()].find(
+        (submission) => submission.clientMessageId === clientMessageId,
+      );
+    }
     const terminal = typeof eventType === "string"
       ? classifyTurnTerminal({
           type: eventType,
@@ -861,12 +930,14 @@ export function createDaemonTuiSession<
     if (terminal !== undefined) {
       activeTurnSnapshot = null;
       terminalDaemonTurnObserved = true;
+      observedSubmission = undefined;
       return;
     }
     if (eventType === "turn_start" || eventType === "turn_started") {
       daemonTurnStartGeneration += 1;
       terminalDaemonTurnObserved = false;
       markDaemonActivityActive(event);
+      flushSubmissionCancellation(event);
       return;
     }
     if (
@@ -895,7 +966,17 @@ export function createDaemonTuiSession<
     const status = (payload as { readonly status?: unknown }).status;
     const turnId = (payload as { readonly turnId?: unknown }).turnId;
     if (typeof status !== "string") return;
+    const expectedTurnId = activeDaemonTurnId();
+    if (
+      expectedTurnId !== undefined &&
+      typeof turnId === "string" && turnId !== expectedTurnId &&
+      (status === "idle" || status === "completed" || status === "failed" ||
+        status === "error" || status === "cancelled" || status === "canceled")
+    ) return;
     if (status === "idle") {
+      if (typeof turnId === "string" && !pendingSubmissions.has(turnId)) {
+        lastObservedTurnId = turnId;
+      }
       activeTurnSnapshot = null;
       return;
     }
@@ -908,6 +989,7 @@ export function createDaemonTuiSession<
     ) {
       activeTurnSnapshot = null;
       terminalDaemonTurnObserved = true;
+      observedSubmission = undefined;
       return;
     }
     if (terminalDaemonTurnObserved) return;
@@ -920,6 +1002,7 @@ export function createDaemonTuiSession<
           ? turnId
           : "daemon-turn",
     };
+    flushSubmissionCancellation(event);
   };
   const broadcastDaemonEvent = (event: unknown): void => {
     noteDaemonActivity(event);
@@ -1184,8 +1267,22 @@ export function createDaemonTuiSession<
         activeTurnSnapshot ?? baseSession.activeTurn?.unsafePeek?.() ?? null,
     },
     submit: async (message, opts) => {
-      await runtimeSettingsAuthorityMutationTail;
-      await awaitRuntimeSettingsAuthority();
+      const clientMessageId = opts?.clientMessageId ?? randomUUID();
+      const streamId = `${clientId}:${randomUUID()}`;
+      const submission: PendingDaemonSubmission = { clientMessageId, dispatched: false };
+      pendingSubmissions.set(streamId, submission);
+      try {
+        await runtimeSettingsAuthorityMutationTail;
+        await awaitRuntimeSettingsAuthority();
+        if (submission.cancellation !== undefined) {
+          throw Object.assign(new Error(submission.cancellation.reason ?? "interrupted"), {
+            name: "AbortError",
+          });
+        }
+      } catch (error) {
+        pendingSubmissions.delete(streamId);
+        throw error;
+      }
       const queuedInputsBeforeSubmission = [...queuedInputs];
       const queuedEntries: DaemonQueuedInput[] = [];
       const retained: DaemonQueuedInput[] = [];
@@ -1211,11 +1308,12 @@ export function createDaemonTuiSession<
       );
       queuedInputCount = Math.max(0, queuedInputCount - submittedInputCount);
       queuedInputBytes = Math.max(0, queuedInputBytes - submittedInputBytes);
-      if (queued.length === 0 && message.length === 0) return;
+      if (queued.length === 0 && message.length === 0) {
+        pendingSubmissions.delete(streamId);
+        return;
+      }
       inFlightInputCount += submittedInputCount;
       inFlightInputBytes += submittedInputBytes;
-      const clientMessageId = opts?.clientMessageId ?? randomUUID();
-      const streamId = `${clientId}:${randomUUID()}`;
       if (activeTurnSnapshot === null) {
         terminalDaemonTurnObserved = false;
         activeTurnSnapshot = { turnId: streamId };
@@ -1230,6 +1328,10 @@ export function createDaemonTuiSession<
                 : []),
             ];
       let recovered: MessageStreamResult | undefined;
+      let completion: {
+        readonly turnId?: string;
+        readonly terminal: NonNullable<MessageStreamResult["terminal"]>;
+      } | undefined;
       try {
         const metadata: JsonObject = {
           ...(opts?.displayUserMessage !== undefined
@@ -1267,6 +1369,7 @@ export function createDaemonTuiSession<
               }
             : {}),
         };
+        submission.dispatched = true;
         const result = await client.request("message.stream", {
           sessionId,
           content,
@@ -1274,6 +1377,16 @@ export function createDaemonTuiSession<
           clientMessageId,
           streamId,
         } satisfies MessageStreamParams);
+        if (result.terminal !== undefined && (
+          !isJsonObject(result.terminal) ||
+          (result.terminal.code !== 0 && result.terminal.code !== 1 && result.terminal.code !== 130) ||
+          (result.terminal.message !== undefined && typeof result.terminal.message !== "string") ||
+          (result.turnId !== undefined && (
+            typeof result.turnId !== "string" || result.turnId.trim().length === 0
+          ))
+        )) {
+          throw new Error("daemon returned an invalid terminal submission result");
+        }
         if (result.disposition === "duplicate") {
           if (
             result.duplicateState !== "completed" ||
@@ -1291,6 +1404,8 @@ export function createDaemonTuiSession<
             activeTurnSnapshot = null;
             terminalDaemonTurnObserved = true;
           }
+        } else if (result.terminal !== undefined) {
+          completion = { turnId: result.turnId, terminal: result.terminal };
         }
         const submitted = new Set(queuedEntries);
         for (const [token, admission] of idleInputAdmissions) {
@@ -1323,6 +1438,8 @@ export function createDaemonTuiSession<
         if (activeTurnSnapshot?.turnId === streamId) activeTurnSnapshot = null;
         throw error;
       } finally {
+        pendingSubmissions.delete(streamId);
+        if (observedSubmission === submission) observedSubmission = undefined;
         inFlightInputCount = Math.max(
           0,
           inFlightInputCount - submittedInputCount,
@@ -1340,6 +1457,35 @@ export function createDaemonTuiSession<
             ...(recovered.turnId === undefined ? {} : { turnId: recovered.turnId }),
             ...recovered.terminal,
           },
+        });
+      }
+      if (completion !== undefined && !terminalDaemonTurnObserved && (
+        activeTurnSnapshot?.turnId === streamId ||
+        (completion.turnId !== undefined && (
+          activeDaemonTurnId() === completion.turnId ||
+          (activeTurnSnapshot === null && lastObservedTurnId === completion.turnId)
+        ))
+      )) {
+        // The response is a second authoritative terminal delivery path. Only
+        // reconcile its own turn; an older RPC may finish after a successor starts.
+        // Some submissions complete without starting a model turn. Their
+        // response can retire only the local placeholder, never a daemon turn.
+        const { terminal } = completion;
+        const turnId = completion.turnId ?? streamId;
+        activeTurnSnapshot = { turnId };
+        if (completion.turnId !== undefined) lastObservedTurnId = completion.turnId;
+        broadcastDaemonEvent({
+          id: `daemon-submission:${clientMessageId}:terminal`,
+          clientMessageId,
+          ...(terminal.code === 1
+            ? createTurnFailedEvent({
+                turnId,
+                code: "daemon_submission_failed",
+                message: terminal.message ?? "Daemon turn failed",
+              })
+            : terminal.code === 130
+              ? { type: "turn_aborted", payload: { turnId, reason: terminal.message ?? "interrupted" } }
+              : { type: "turn_complete", payload: { turnId, ...(terminal.message !== undefined ? { lastAgentMessage: terminal.message } : {}) } }),
         });
       }
     },
@@ -1444,40 +1590,19 @@ export function createDaemonTuiSession<
       }
     },
     cancelActiveTurn: async (reason?: string) => {
-      // Best-effort: a closed/disconnected daemon socket throws. The
-      // user pressed ESC — they want the turn to stop, but a thrown
-      // error here doesn't help them. Swallow and let the next health
-      // check / event surface the disconnection separately.
-      // Timeout: a WEDGED daemon (idle deadlock) never answers the RPC at
-      // all — without a deadline the ESC press vanishes silently and the
-      // UI keeps showing "Working…" forever. Give up after 5s and tell the
-      // user the interrupt could not be delivered.
-      try {
-        await client.request(
-          "session.cancelTurn",
-          {
-            sessionId,
-            ...(reason !== undefined ? { reason } : {}),
-          },
-          { signal: AbortSignal.timeout(5_000) },
-        );
-      } catch (error) {
-        const timedOut =
-          error instanceof Error &&
-          (error.name === "TimeoutError" || error.name === "AbortError");
-        if (timedOut) {
-          broadcastDaemonEvent({
-            id: `agenc-daemon-cancel-unacked-${Date.now()}`,
-            type: "warning",
-            payload: {
-              cause: "daemon_delivery_failed",
-              action: "session.cancelTurn",
-              message:
-                "interrupt not acknowledged by the daemon (it may be unresponsive) — try ESC again, or restart the daemon",
-            },
-          });
-        }
+      const expectedTurnId = activeDaemonTurnId();
+      if (expectedTurnId !== undefined) {
+        await cancelDaemonTurn(expectedTurnId, reason);
+        return;
       }
+      // A pending submission's stream id is local, not cancellation authority.
+      // Bind ESC to its durable user marker and subsequent daemon turn start;
+      // an unrelated client's turn must not inherit this cancellation.
+      const pending = (activeTurnSnapshot === null
+        ? undefined
+        : pendingSubmissions.get(activeTurnSnapshot.turnId)) ??
+        [...pendingSubmissions.values()].find((submission) => !submission.dispatched);
+      if (pending !== undefined) pending.cancellation = { reason };
     },
     partialCompactFromMessage: async (params) =>
       client.request(
@@ -3155,8 +3280,13 @@ function transcriptEventFromAgentStatus(params: JsonObject, activeTurnId?: strin
   return {
     id: daemonTranscriptEventId(params, turnId),
     type: "background_agent_status",
+    ...(typeof params.clientMessageId === "string"
+      ? { clientMessageId: params.clientMessageId }
+      : {}),
     payload: {
-      turnId,
+      ...(typeof params.turnId === "string" && params.turnId.length > 0
+        ? { turnId: params.turnId }
+        : {}),
       status,
       ...(typeof params.agentId === "string" && params.agentId.length > 0
         ? { agentId: params.agentId }

--- a/runtime/tests/app-server/agent-attachment-rollback.contract.test.ts
+++ b/runtime/tests/app-server/agent-attachment-rollback.contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { AgenCBackgroundAgentSnapshot } from "../../src/app-server/background-agent-runner.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+
+describe("agent attachment rollback ownership", () => {
+  it.each([false, true])(
+    "releases only attachment resources created by a failed request (previous attachment: %s)",
+    async (previousAttachment) => {
+      const sessions = new AgenCDaemonSessionManager();
+      const session = await sessions.createSession({
+        agentId: "agent", cwd: process.cwd(),
+        metadata: { runtimeOptions: resolveAgentRuntimeOptions({}) },
+      });
+      const snapshot: AgenCBackgroundAgentSnapshot = {
+        status: "idle", lastActiveAt: "2026-09-10T00:00:00.000Z",
+        runtimeSettingsEventId: "runtime-settings:agent:1",
+        runtimeSettings: {
+          permissionMode: "default", prePlanMode: null, autoModeActive: false,
+          autoModeAvailable: true, bypassPermissionsModeAvailable: false,
+          bypassPermissionsWorkspace: null, bypassPermissionsConsentWorkspace: null,
+          model: "grok-5", provider: "grok", profile: null, reasoningEffort: null,
+          modelVerbosity: null, serviceTier: null, hooksDisabled: false,
+        },
+      };
+      const getAgentSnapshot = vi.fn<() => Promise<AgenCBackgroundAgentSnapshot>>(async () => snapshot);
+      const agents = new AgenCDaemonAgentManager({
+        sessionManager: sessions,
+        runner: { startAgent: vi.fn(), getAgentSnapshot },
+      });
+      await agents.restoreAgent({
+        agentId: "agent", objective: "attachment rollback", sessionIds: [session.sessionId], runtimeAvailable: true,
+      });
+      const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+      const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+        agentManager: agents, sessionManager: sessions, clientMultiplexer: multiplexer,
+      });
+      const send = vi.fn();
+      const connection = dispatcher.createConnection({ sendNotification: send });
+      const attach = (id: string) => connection.dispatch({
+        jsonrpc: "2.0", id, method: "agent.attach", params: { agentId: "agent", clientId: "client" },
+      });
+      try {
+        await connection.dispatch({
+          jsonrpc: "2.0", id: "initialize", method: "initialize", params: { protocol: { version: "1.9.0" } },
+        });
+        if (previousAttachment) await expect(attach("initial")).resolves.toHaveProperty("result");
+        const original = await sessions.getSession(session.sessionId);
+        getAgentSnapshot.mockResolvedValueOnce(snapshot).mockResolvedValueOnce({
+          status: "idle", lastActiveAt: snapshot.lastActiveAt,
+        });
+        await expect(attach("failed")).resolves.toMatchObject({
+          error: { message: expect.stringContaining("no live runtime-settings authority") },
+        });
+        const current = await sessions.getSession(session.sessionId);
+        expect(current?.activeAttachmentIds).toEqual(original?.activeAttachmentIds);
+        expect(await multiplexer.attachedClientIds(session.sessionId))
+          .toEqual(previousAttachment ? ["client"] : []);
+        const event = { type: "after_failed_attach" };
+        await multiplexer.broadcastSessionEvent(session.sessionId, event);
+        if (previousAttachment) expect(send).toHaveBeenCalledExactlyOnceWith(event);
+        else expect(send).not.toHaveBeenCalled();
+      } finally {
+        await dispatcher.close();
+      }
+    },
+  );
+});

--- a/runtime/tests/app-server/agent-lifecycle-stop-ownership.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle-stop-ownership.contract.test.ts
@@ -1,0 +1,102 @@
+import { setImmediate } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { AgenCBackgroundAgentTerminalSnapshot } from "../../src/app-server/background-agent-runner.js";
+
+const timestamp = "2026-09-10T00:00:00.000Z";
+
+describe("daemon agent stop ownership", () => {
+  it.each(["agent.stop", "daemon shutdown"] as const)(
+    "%s waits for the existing teardown owner", async (operation) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const stopAgent = vi.fn(async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      const manager = new AgenCDaemonAgentManager({
+        runner: { startAgent: vi.fn(), stopAgent },
+      });
+      await manager.restoreAgent({ agentId: "agent", objective: "stop", runtimeAvailable: true });
+      const first = manager.stopAgent({ agentId: "agent", reason: "first reason" });
+      await entered.promise;
+      let completed = false;
+      const second = (operation === "agent.stop"
+        ? manager.stopAgent({ agentId: "agent", reason: "second reason" })
+        : manager.stopAll()).then((result) => {
+          completed = true;
+          return result;
+        });
+      try {
+        await setImmediate();
+        expect(completed).toBe(false);
+        expect(stopAgent).toHaveBeenCalledOnce();
+      } finally {
+        release.resolve();
+        await Promise.all([first, second]);
+      }
+      expect(await first).toEqual({ agentId: "agent", stopped: true });
+      if (operation === "agent.stop") expect(await second).toEqual(await first);
+      expect(stopAgent).toHaveBeenCalledOnce();
+      expect(stopAgent).toHaveBeenCalledWith("agent", "first reason");
+    },
+  );
+
+  it.each([false, true])(
+    "projects explicit-stop canonical evidence and closes sessions (projection failure: %s)",
+    async (failProjection) => {
+      const order: string[] = [];
+      const terminal: AgenCBackgroundAgentTerminalSnapshot = {
+        openedAt: timestamp,
+        epoch: 1,
+        eventId: "run-terminal:agent:1",
+        rolloutPath: "/tmp/agent.jsonl",
+        result: {
+          runId: "agent", status: "cancelled", exitCode: null,
+          stopReason: "operator", finalMessage: null, usage: null,
+          lastSequence: 2, finishedAt: timestamp,
+        },
+      };
+      const sessions = new AgenCDaemonSessionManager({
+        onSessionTerminated: () => { order.push("session_closed"); },
+      });
+      await sessions.restoreSession({ sessionId: "session", agentId: "agent" });
+      const recordRunTerminal = vi.fn(async () => {
+        order.push("canonical_projection");
+        if (failProjection) throw new Error("terminal projection failed");
+      });
+      const manager = new AgenCDaemonAgentManager({
+        sessionManager: sessions,
+        runner: {
+          startAgent: vi.fn(),
+          stopAgent: async () => {
+            order.push("canonical_terminal");
+            await manager.handleRunnerTerminated("agent", {
+              status: "stopped", lastActiveAt: timestamp, terminal,
+            });
+          },
+        },
+        recordRunTerminal,
+        recordAgentStatusTransition: (transition) => { order.push(transition.status); },
+      });
+      await manager.restoreAgent({
+        agentId: "agent", objective: "stop", sessionIds: ["session"], runtimeAvailable: true,
+      });
+      const stopped = manager.stopAgent({ agentId: "agent", reason: "operator" });
+      if (failProjection) {
+        await expect(stopped).rejects.toThrow("terminal projection failed");
+        expect(order).not.toContain("stopped");
+        expect(order).not.toContain("error");
+      } else {
+        await expect(stopped).resolves.toEqual({ agentId: "agent", stopped: true });
+        expect(order.indexOf("canonical_projection")).toBeLessThan(order.indexOf("stopped"));
+      }
+      expect(recordRunTerminal).toHaveBeenCalledExactlyOnceWith({
+        agentId: "agent", sessionId: "agent", ...terminal,
+      });
+      expect(order).toContain("session_closed");
+      await expect(sessions.getSession("session")).resolves.toMatchObject({ status: "closed" });
+    },
+  );
+});

--- a/runtime/tests/app-server/agent-session-binding.contract.test.ts
+++ b/runtime/tests/app-server/agent-session-binding.contract.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+
+describe("daemon runtime session binding", () => {
+  it("rejects an unbound session alias across prompt, cancellation, mutation and snapshot routes", async () => {
+    const sessions = new AgenCDaemonSessionManager();
+    const bound = await sessions.createSession({ agentId: "agent", cwd: process.cwd() });
+    const alias = await sessions.createSession({ agentId: "agent", cwd: process.cwd() });
+    const submitAgentMessage = vi.fn().mockResolvedValue({
+      disposition: "started", acceptedAt: "2026-09-10T00:00:00.000Z",
+    });
+    const interruptAgentTurn = vi.fn().mockResolvedValue(true);
+    const clearAgentSession = vi.fn().mockResolvedValue({ cleared: true });
+    const snapshotAgentSession = vi.fn().mockResolvedValue({ snapshot: true });
+    const manager = new AgenCDaemonAgentManager({
+      sessionManager: sessions,
+      runner: {
+        startAgent: vi.fn(), submitAgentMessage, interruptAgentTurn,
+        clearAgentSession, snapshotAgentSession,
+      },
+    });
+    await manager.restoreAgent({
+      agentId: "agent", objective: "bound runtime", sessionIds: [bound.sessionId], runtimeAvailable: true,
+    });
+    const prompt = {
+      content: "hello",
+      messageId: "message", streamId: "stream", acceptedAt: "2026-09-10T00:00:00.000Z",
+    };
+
+    await expect(manager.streamAgentMessage({ ...prompt, sessionId: alias.sessionId }))
+      .rejects.toMatchObject({ code: "AGENT_NOT_FOUND", message: expect.stringContaining("not bound") });
+    await expect(manager.cancelSessionTurn({ sessionId: alias.sessionId }))
+      .resolves.toMatchObject({ cancelled: false });
+    await expect(manager.clearSessionHistory({ sessionId: alias.sessionId }))
+      .rejects.toMatchObject({ code: "AGENT_NOT_FOUND" });
+    await expect(manager.snapshotSession({ sessionId: alias.sessionId }))
+      .rejects.toMatchObject({ code: "AGENT_NOT_FOUND" });
+    for (const method of [submitAgentMessage, interruptAgentTurn, clearAgentSession, snapshotAgentSession]) {
+      expect(method).not.toHaveBeenCalled();
+    }
+
+    await expect(manager.streamAgentMessage({ ...prompt, sessionId: bound.sessionId }))
+      .resolves.toMatchObject({ disposition: "started" });
+    await expect(manager.cancelSessionTurn({ sessionId: bound.sessionId }))
+      .resolves.toMatchObject({ cancelled: true });
+    await manager.clearSessionHistory({ sessionId: bound.sessionId });
+    await manager.snapshotSession({ sessionId: bound.sessionId });
+    for (const method of [submitAgentMessage, interruptAgentTurn, clearAgentSession, snapshotAgentSession]) {
+      expect(method).toHaveBeenCalledOnce();
+    }
+  });
+});

--- a/runtime/tests/app-server/agent-session-route-cleanup.contract.test.ts
+++ b/runtime/tests/app-server/agent-session-route-cleanup.contract.test.ts
@@ -94,7 +94,6 @@ async function expectRoutesCleaned(fixture: Awaited<ReturnType<typeof createComp
     const event: JsonObject = { method: "event.agent_status", params: { sessionId, status: "stopped" } };
     expect(await multiplexer.broadcastSessionEvent(sessionId, event)).toEqual({ sessionId, deliveredClientIds: [], failed: [] });
     expect(await multiplexer.broadcastCapabilityEvent(sessionId, CAPABILITY, event)).toEqual({ sessionId, deliveredClientIds: [], failed: [] });
-    expect(await multiplexer.terminateSession({ sessionId })).toMatchObject({ terminated: false, status: "closed" });
   }
   expect(statusSend).not.toHaveBeenCalled();
   expect(capabilitySend).toHaveBeenCalledTimes(1);
@@ -141,16 +140,55 @@ describe("agent-owned session route cleanup", () => {
     const fixture = await createComposition(path);
     await fixture.stop();
     await expectRoutesCleaned(fixture);
+    for (const sessionId of OWNED_SESSIONS) {
+      await expect(fixture.multiplexer.terminateSession({ sessionId }))
+        .resolves.toMatchObject({ terminated: false, status: "closed" });
+    }
     await expect(fixture.agents.stopAgent({ agentId: "agent_owner" })).resolves.toMatchObject({ stopped: false });
   });
 
-  it.each(STOP_PATHS)("cleans all owned sessions when a post-termination hook fails through %s", async (path) => {
+  it.each(STOP_PATHS)("cleans all owned routes while preserving persistent hook failures through %s", async (path) => {
     const failure = new Error("session termination hook failed");
-    const fixture = await createComposition(path, (sessionId) => {
+    const onSessionTerminated = vi.fn((sessionId: string) => {
       if (sessionId === OWNED_SESSIONS[0]) throw failure;
     });
+    const fixture = await createComposition(path, onSessionTerminated);
     await expect(fixture.stop()).rejects.toThrow();
     await expectRoutesCleaned(fixture);
+    await expect(fixture.multiplexer.terminateSession({ sessionId: OWNED_SESSIONS[0] }))
+      .rejects.toBe(failure);
+    await expect(fixture.multiplexer.terminateSession({ sessionId: OWNED_SESSIONS[1] }))
+      .resolves.toMatchObject({ terminated: false, status: "closed" });
+    expect(onSessionTerminated.mock.calls).toEqual([
+      [OWNED_SESSIONS[0]], [OWNED_SESSIONS[1]], [OWNED_SESSIONS[0]],
+    ]);
+    for (const sessionId of OWNED_SESSIONS) {
+      expect(await fixture.multiplexer.attachedClientIds(sessionId)).toEqual([]);
+    }
+  });
+
+  it.each(STOP_PATHS)("retries transient hook failure without repeating successful cleanup through %s", async (path) => {
+    let failedOnce = false;
+    const onSessionTerminated = vi.fn((sessionId: string) => {
+      if (sessionId === OWNED_SESSIONS[0] && !failedOnce) {
+        failedOnce = true;
+        throw new Error("transient termination hook failure");
+      }
+    });
+    const fixture = await createComposition(path, onSessionTerminated);
+    await expect(fixture.stop()).rejects.toThrow();
+    await expectRoutesCleaned(fixture);
+    for (const sessionId of OWNED_SESSIONS) {
+      const closed = await fixture.sessions.getSession(sessionId);
+      await expect(fixture.multiplexer.terminateSession({ sessionId, reason: "retry" }))
+        .resolves.toMatchObject({ terminated: false, status: "closed", closedAt: closed?.closedAt });
+      await expect(fixture.multiplexer.terminateSession({ sessionId }))
+        .resolves.toMatchObject({ terminated: false, status: "closed" });
+      expect(await fixture.multiplexer.attachedClientIds(sessionId)).toEqual([]);
+    }
+    expect(onSessionTerminated.mock.calls).toEqual([
+      [OWNED_SESSIONS[0]], [OWNED_SESSIONS[1]], [OWNED_SESSIONS[0]],
+    ]);
   });
 
   it("preserves live routing when termination fails before closing and permits a retry", async () => {
@@ -179,12 +217,21 @@ describe("agent-owned session route cleanup", () => {
   });
 
   it("reports every post-close hook error after cleaning every owned session", async () => {
-    const fixture = await createComposition("agent.stop", (sessionId) => {
+    const onSessionTerminated = vi.fn((sessionId: string) => {
       throw new Error(`hook failed for ${sessionId}`);
     });
+    const fixture = await createComposition("agent.stop", onSessionTerminated);
     await expect(fixture.stop()).rejects.toMatchObject({
       errors: OWNED_SESSIONS.map((sessionId) => new Error(`hook failed for ${sessionId}`)),
     });
     await expectRoutesCleaned(fixture);
+    for (const sessionId of OWNED_SESSIONS) {
+      await expect(fixture.multiplexer.terminateSession({ sessionId }))
+        .rejects.toThrow(`hook failed for ${sessionId}`);
+      expect(await fixture.multiplexer.attachedClientIds(sessionId)).toEqual([]);
+    }
+    expect(onSessionTerminated.mock.calls).toEqual(
+      [...OWNED_SESSIONS, ...OWNED_SESSIONS].map((sessionId) => [sessionId]),
+    );
   });
 });

--- a/runtime/tests/app-server/connection-lifecycle-races.test.ts
+++ b/runtime/tests/app-server/connection-lifecycle-races.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createControlledPromise, settleWithinMicrotasks } from "../helpers/controlled-async.js";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+import type { AgenCBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+
+const dispatchers: AgenCDaemonJsonRpcDispatcher[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(dispatchers.splice(0).map((dispatcher) => dispatcher.close()));
+});
+
+function request(id: string, method: string, params: JsonObject = {}): JsonObject {
+  return { jsonrpc: "2.0", id, method, params: method === "initialize" ? { protocol: { version: "1.9.0" }, ...params } : params };
+}
+
+function harness(
+  initializeAuthenticator?: () => Promise<boolean>,
+  runner?: AgenCBackgroundAgentRunner,
+) {
+  const sessions = new AgenCDaemonSessionManager();
+  const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+  const agentManager = new AgenCDaemonAgentManager({ sessionManager: sessions, runner });
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+    agentManager,
+    sessionManager: sessions,
+    clientMultiplexer: multiplexer,
+    initializeAuthenticator,
+  });
+  dispatchers.push(dispatcher);
+  const connection = dispatcher.createConnection({ sendNotification: () => {} });
+  return { sessions, multiplexer, dispatcher, connection, agentManager };
+}
+
+describe("daemon connection lifecycle races", () => {
+  it("does not initialize or register a capability client after close during authentication", async () => {
+    const authenticated = createControlledPromise<boolean>();
+    const entered = createControlledPromise<void>();
+    const h = harness(() => { entered.resolve(); return authenticated.promise; });
+    const register = vi.spyOn(h.multiplexer, "registerClient");
+    const initializing = h.connection.dispatch(request("init", "initialize", {
+      capabilities: { "portal.ledger.solana.sign.v1": true },
+    }));
+    await entered.promise;
+    await h.dispatcher.closeConnection(h.connection);
+    authenticated.resolve(true);
+    await expect(initializing).resolves.toMatchObject({ error: { data: { code: "CONNECTION_CLOSED" } } });
+    expect(h.connection.initialized).toBe(false);
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("admits only one initialize handshake while authentication is pending", async () => {
+    const authenticated = createControlledPromise<boolean>();
+    const entered = createControlledPromise<void>();
+    const authenticate = vi.fn(() => { entered.resolve(); return authenticated.promise; });
+    const h = harness(authenticate);
+    const first = h.connection.dispatch(request("first", "initialize"));
+    await entered.promise;
+    const second = h.connection.dispatch(request("second", "initialize"));
+    const outcome = await settleWithinMicrotasks(second);
+    expect(outcome).toMatchObject({ status: "fulfilled", value: { error: { data: { code: "CONNECTION_ALREADY_INITIALIZED" } } } });
+    authenticated.resolve(true);
+    await expect(first).resolves.toHaveProperty("result");
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    await h.connection.close();
+  });
+
+  it("rolls back registration that completes after its connection closes", async () => {
+    const h = harness();
+    await h.connection.dispatch(request("init", "initialize"));
+    const session = await h.sessions.createSession({ cwd: process.cwd() });
+    const registered = createControlledPromise<void>();
+    const release = createControlledPromise<void>();
+    const original = h.multiplexer.registerClient.bind(h.multiplexer);
+    vi.spyOn(h.multiplexer, "registerClient").mockImplementation(async (options) => {
+      const result = await original(options);
+      registered.resolve();
+      await release.promise;
+      return result;
+    });
+    const attaching = h.connection.dispatch(request("attach", "session.attach", {
+      sessionId: session.sessionId, clientId: "late-client",
+    }));
+    await registered.promise;
+    await h.connection.close();
+    expect(h.connection.trackedClientIds).toEqual([]);
+    await expect(h.multiplexer.removeClient("late-client")).rejects.toMatchObject({ code: "CLIENT_NOT_FOUND" });
+    release.resolve();
+    await expect(attaching).resolves.toMatchObject({ error: { data: { code: "CONNECTION_CLOSED" } } });
+    expect(h.connection.trackedClientIds).toEqual([]);
+    await expect(h.multiplexer.attachedClientIds(session.sessionId)).resolves.toEqual([]);
+    await expect(h.multiplexer.removeClient("late-client")).rejects.toMatchObject({ code: "CLIENT_NOT_FOUND" });
+  });
+
+  it("does not remove a reconnect's reused client id when an old attach unwinds", async () => {
+    const h = harness();
+    await h.connection.dispatch(request("init", "initialize"));
+    const session = await h.sessions.createSession({ cwd: process.cwd() });
+    const registered = createControlledPromise<void>();
+    const release = createControlledPromise<void>();
+    const original = h.multiplexer.registerClient.bind(h.multiplexer);
+    vi.spyOn(h.multiplexer, "registerClient").mockImplementationOnce(async (options) => {
+      const result = await original(options);
+      registered.resolve();
+      await release.promise;
+      return result;
+    });
+    const attaching = h.connection.dispatch(request("attach", "session.attach", {
+      sessionId: session.sessionId, clientId: "reused-client",
+    }));
+    await registered.promise;
+    await h.connection.close();
+    const reconnect = h.dispatcher.createConnection({ sendNotification: () => {} });
+    await reconnect.dispatch(request("init", "initialize"));
+    await expect(reconnect.dispatch(request("attach", "session.attach", {
+      sessionId: session.sessionId, clientId: "reused-client",
+    }))).resolves.toHaveProperty("result");
+    release.resolve();
+    await expect(attaching).resolves.toHaveProperty("error");
+    await expect(h.multiplexer.attachedClientIds(session.sessionId)).resolves.toEqual(["reused-client"]);
+    await reconnect.close();
+  });
+
+  it("rejects new work after close and coalesces concurrent cleanup", async () => {
+    const h = harness();
+    await h.connection.dispatch(request("init", "initialize"));
+    const session = await h.sessions.createSession({ cwd: process.cwd() });
+    await h.connection.dispatch(request("attach", "session.attach", {
+      sessionId: session.sessionId, clientId: "client",
+    }));
+    const remove = vi.spyOn(h.multiplexer, "removeClient");
+    const create = vi.spyOn(h.sessions, "createSession");
+    await Promise.all([h.connection.close(), h.dispatcher.closeConnection(h.connection)]);
+    await expect(h.connection.dispatch(request("late", "session.create", { cwd: process.cwd() })))
+      .resolves.toMatchObject({ error: { data: { code: "CONNECTION_CLOSED" } } });
+    expect(create).not.toHaveBeenCalled();
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(h.connection.trackedClientIds).toEqual([]);
+  });
+
+  it("does not detach a reconnect when a previously tracked agent attachment rolls back", async () => {
+    const entered = createControlledPromise<void>();
+    const release = Promise.withResolvers<void>();
+    const snapshot = { status: "running" as const, lastActiveAt: "2026-05-01T12:00:00.000Z" };
+    const getAgentSnapshot = vi.fn(async () => snapshot);
+    const h = harness(undefined, {
+      startAgent: async () => ({ agentId: "agent-rollback", status: "running", startedAt: snapshot.lastActiveAt }),
+      getAgentSnapshot,
+    });
+    await h.connection.dispatch(request("init", "initialize"));
+    const created = await h.agentManager.createAgent({
+      cwd: process.cwd(), objective: "verify attachment rollback ownership",
+      runtimeOptions: resolveAgentRuntimeOptions({}),
+    });
+    const sessionId = created.sessionId!;
+    await expect(h.connection.dispatch(request("first-attach", "session.attach", {
+      sessionId, clientId: "reused-client",
+    }))).resolves.toHaveProperty("result");
+    getAgentSnapshot
+      .mockImplementationOnce(async () => snapshot)
+      .mockImplementationOnce(async () => {
+        entered.resolve();
+        await release.promise;
+        throw new Error("runtime snapshot failed after disconnect");
+      });
+    const attaching = h.connection.dispatch(request("agent-attach", "agent.attach", {
+      agentId: created.agentId, clientId: "reused-client",
+    }));
+    await entered.promise;
+    await h.connection.close();
+    const reconnect = h.dispatcher.createConnection({ sendNotification: () => {} });
+    try {
+      await reconnect.dispatch(request("init", "initialize"));
+      await expect(reconnect.dispatch(request("reconnect-attach", "session.attach", {
+        sessionId, clientId: "reused-client",
+      }))).resolves.toHaveProperty("result");
+      release.resolve();
+      await expect(attaching).resolves.toHaveProperty("error");
+      await expect(h.multiplexer.attachedClientIds(sessionId)).resolves.toEqual(["reused-client"]);
+      expect((await h.sessions.getSession(sessionId))?.activeAttachmentIds).toHaveLength(1);
+    } finally {
+      release.resolve();
+      await attaching;
+      await reconnect.close();
+    }
+  });
+
+  it("keeps delayed eviction bound to the original physical connection", async () => {
+    const sessions = new AgenCDaemonSessionManager();
+    const evicted = vi.fn();
+    const multiplexer = new AgenCDaemonClientMultiplexer({
+      sessionManager: sessions, maxPendingDeliveryBytesPerClient: 64,
+      onClientEvicted: evicted,
+    });
+    const session = await sessions.createSession({ cwd: process.cwd() });
+    await multiplexer.registerClient({ clientId: "reused-client", deliveryKey: "old-connection", send: () => {} });
+    await multiplexer.attachClientToSession(session.sessionId, "reused-client");
+    const entered = createControlledPromise<void>();
+    const release = Promise.withResolvers<void>();
+    const disconnect = multiplexer.disconnectClient.bind(multiplexer);
+    vi.spyOn(multiplexer, "disconnectClient").mockImplementationOnce(async (clientId, deliveryKey) => {
+      entered.resolve();
+      await release.promise;
+      return disconnect(clientId, deliveryKey);
+    });
+    const broadcast = multiplexer.broadcastSessionEvent(session.sessionId, { text: "x".repeat(128) });
+    await entered.promise;
+    try {
+      await disconnect("reused-client", "old-connection");
+      await multiplexer.registerClient({ clientId: "reused-client", deliveryKey: "new-connection", send: () => {} });
+      await multiplexer.attachClientToSession(session.sessionId, "reused-client");
+      release.resolve();
+      await broadcast;
+      await expect(multiplexer.attachedClientIds(session.sessionId)).resolves.toEqual(["reused-client"]);
+      expect(evicted).toHaveBeenCalledExactlyOnceWith("reused-client", "old-connection");
+    } finally {
+      release.resolve();
+      await broadcast;
+      await multiplexer.removeClient("reused-client").catch(() => {});
+    }
+  });
+});
+
+describe("session termination routing", () => {
+  it("allows finalizers to use routing without blocking all daemon clients", async () => {
+    let multiplexer: AgenCDaemonClientMultiplexer;
+    const sessions = new AgenCDaemonSessionManager({
+      onSessionTerminated: async (sessionId) => {
+        await multiplexer.broadcastSessionEvent(sessionId, {
+          jsonrpc: "2.0", method: "event.closed", params: { sessionId },
+        });
+      },
+    });
+    multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+    const session = await sessions.createSession({ cwd: process.cwd() });
+    await multiplexer.registerClient({ clientId: "client", send: () => {} });
+    await multiplexer.attachClientToSession(session.sessionId, "client");
+    const result = await settleWithinMicrotasks(multiplexer.terminateSession({ sessionId: session.sessionId }));
+    expect(result).toMatchObject({ status: "fulfilled", value: { terminated: true } });
+    await expect(multiplexer.attachedClientIds(session.sessionId)).resolves.toEqual([]);
+  });
+});

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -38,8 +38,9 @@ import {
 } from "../session/runtime-options.js";
 import type { PendingProviderSwitch } from "../session/session.js";
 import { createAgenCJsonLineDaemonRequestClient } from "./agent-cli.js";
-import { AGENC_DAEMON_PROTOCOL_VERSION } from "./protocol/index.js";
+import { AGENC_DAEMON_PROTOCOL_VERSION, type JsonObject } from "./protocol/index.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
+import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { ensureAgenCDaemonAutostart } from "./daemon-autostart.js";
 import {
   AGENC_DAEMON_HEARTBEAT_FRESH_MS,
@@ -4518,6 +4519,155 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(coordinator.blocksRequests).toBe(true);
     expect(completed).toHaveBeenCalledTimes(1);
   });
+
+  it.each([1, 2])(
+    "completes accepted shutdown when all %i acknowledgement sends fail",
+    async (count) => {
+      const completed = vi.fn();
+      const coordinator = new AgenCDaemonRpcShutdownCoordinator(completed);
+      const attempts = Array.from({ length: count }, (_, id) => {
+        const result = coordinator.accept("instance-disconnected");
+        const gate = Promise.withResolvers<void>();
+        const message = {
+          jsonrpc: "2.0",
+          id,
+          method: "daemon.shutdown",
+          params: { instanceId: "instance-disconnected" },
+        } as const;
+        const sent = coordinator.send(
+          message,
+          { jsonrpc: "2.0", id, result },
+          () => gate.promise,
+        );
+        return { gate, sent };
+      });
+
+      for (const [index, attempt] of attempts.entries()) {
+        attempt.gate.reject(new Error("requester disconnected"));
+        await expect(attempt.sent).rejects.toThrow("requester disconnected");
+        expect(coordinator.blocksRequests).toBe(true);
+        expect(completed).toHaveBeenCalledTimes(index === count - 1 ? 1 : 0);
+      }
+    },
+  );
+
+  it.each(["unix", "websocket"])(
+    "terminates the %s peer when its sole attached client is evicted",
+    async (transport) => {
+      const agencHome = await tempAgencHome();
+      const host = createHost(agencHome);
+      const io = createIo();
+      const signalProcess = createSignalProcess();
+      const registered = vi.spyOn(
+        AgenCDaemonClientMultiplexer.prototype,
+        "registerClient",
+      );
+      const runner: AgenCBackgroundAgentRunner = {
+        startAgent: async () => ({
+          agentId: "agent-evicted-peer",
+          startedAt: "2026-05-01T12:00:00.500Z",
+          status: "running",
+        }),
+        getAgentSnapshot: async () => ({
+          status: "running",
+          lastActiveAt: "2026-05-01T12:00:00.500Z",
+          runtimeSettingsEventId: "settings:evicted-peer:initial",
+          runtimeSettings: {
+            permissionMode: "default",
+            prePlanMode: null,
+            autoModeActive: false,
+            autoModeAvailable: false,
+            bypassPermissionsModeAvailable: false,
+            bypassPermissionsWorkspace: null,
+            bypassPermissionsConsentWorkspace: null,
+            model: "grok-4",
+            provider: "grok",
+            profile: null,
+            reasoningEffort: null,
+            modelVerbosity: null,
+            serviceTier: null,
+            hooksDisabled: false,
+          },
+        }),
+      };
+      const running = runAgenCDaemonCli(
+        { kind: "command", action: "run" },
+        { host, io, signalProcess, runner },
+      );
+      let socket: Socket | WebSocket | undefined;
+      try {
+        await waitForPid(resolveAgenCDaemonPidPath(host.env, host.userHome));
+        const authCookie = (await readFile(
+          resolveAgenCDaemonCookiePath(host.env, host.userHome), "utf8",
+        )).trim();
+        socket = transport === "unix"
+          ? createConnection(resolveAgenCDaemonSocketPath(host.env, host.userHome))
+          : new WebSocket(await waitForDaemonWebSocketUrl(io));
+        const peer = socket;
+        const messages = new AsyncQueue<JsonObject>();
+        if (peer instanceof WebSocket) {
+          peer.on("message", (data) => { messages.send(JSON.parse(data.toString())); });
+        } else {
+          let buffer = "";
+          peer.on("data", (chunk: Buffer) => {
+            buffer += chunk.toString("utf8");
+            let newline: number;
+            while ((newline = buffer.indexOf("\n")) !== -1) {
+              messages.send(JSON.parse(buffer.slice(0, newline)));
+              buffer = buffer.slice(newline + 1);
+            }
+          });
+        }
+        let closed = false;
+        peer.once("close", () => { closed = true; messages.close(); });
+        await once(peer, peer instanceof WebSocket ? "open" : "connect");
+        const request = async (method: string, params: JsonObject) => {
+          const payload = JSON.stringify({ jsonrpc: "2.0", id: method, method, params });
+          if (peer instanceof WebSocket) peer.send(payload);
+          else peer.write(`${payload}\n`);
+          for (;;) {
+            const response = await messages.recv();
+            if (response === null) throw new Error("peer closed before response");
+            if (response.id !== method) continue;
+            expect(response.error).toBeUndefined();
+            return response.result as JsonObject;
+          }
+        };
+        await request("initialize", {
+          protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+          clientName: "agenc-eviction-contract",
+          authCookie,
+          capabilities: {},
+        });
+        const created = await request("agent.create", {
+          cwd: process.cwd(),
+          objective: "verify eviction closes transport",
+          runtimeOptions: TEST_RUNTIME_OPTIONS,
+        });
+        await request("agent.attach", {
+          agentId: created.agentId!,
+          clientId: "client-evicted-peer",
+        });
+        const multiplexer = registered.mock.contexts.at(-1);
+        expect(multiplexer).toBeDefined();
+        // Exceed the default 8 MiB per-client delivery cap before a socket
+        // write. This exercises real daemon eviction without timing-dependent
+        // kernel send-buffer saturation or a provider connection.
+        await multiplexer!.broadcastSessionEvent(String(created.sessionId), {
+          type: "session.delta",
+          text: "x".repeat(8 * 1024 * 1024),
+        });
+        await expect.poll(() => closed).toBe(true);
+      } finally {
+        if (socket instanceof WebSocket) socket.terminate();
+        else socket?.destroy();
+        signalProcess.emit("SIGTERM");
+        await running;
+        registered.mockRestore();
+        await rm(agencHome, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("foreground daemon instantiates AuthBackend for auth requests", async () => {
     const agencHome = await tempAgencHome();

--- a/runtime/tests/app-server/session-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/session-lifecycle.contract.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import { RolloutStore } from "../session/rollout-store.js";
@@ -40,6 +41,80 @@ function sequence(values: readonly string[]): () => string {
 }
 
 describe("AgenC daemon session lifecycle", () => {
+  it("awaits shared termination cleanup without blocking other sessions", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const onSessionTerminated = vi.fn(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    const manager = new AgenCDaemonSessionManager({ onSessionTerminated });
+    const cwd = await workspaces.create();
+    const session = await manager.createSession({ cwd });
+    const first = manager.terminateSession({
+      sessionId: session.sessionId,
+      reason: "first reason",
+    });
+    await entered.promise;
+    let repeatedFinished = false;
+    const repeated = manager.terminateSession({
+      sessionId: session.sessionId,
+      reason: "second reason",
+    }).then((result) => {
+      repeatedFinished = true;
+      return result;
+    });
+    try {
+      await setImmediate();
+      expect(repeatedFinished).toBe(false);
+      await expect(manager.createSession({ cwd })).resolves.toMatchObject({ status: "idle" });
+      await expect(manager.attachSession({ sessionId: session.sessionId }))
+        .rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    } finally {
+      release.resolve();
+      await Promise.all([first, repeated]);
+    }
+    expect(await first).toMatchObject({ terminated: true, reason: "first reason" });
+    expect(await repeated).toMatchObject({ terminated: false, reason: "first reason" });
+    expect(onSessionTerminated).toHaveBeenCalledOnce();
+  });
+
+  it("retries failed resource disposal while retaining the original closure", async () => {
+    const onSessionTerminated = vi.fn()
+      .mockRejectedValueOnce(new Error("resource disposal failed"))
+      .mockResolvedValue(undefined);
+    const manager = new AgenCDaemonSessionManager({ onSessionTerminated });
+    const session = await manager.createSession({ cwd: await workspaces.create() });
+    await expect(manager.terminateSession({ sessionId: session.sessionId, reason: "done" }))
+      .rejects.toThrow("resource disposal failed");
+    const closed = await manager.getSession(session.sessionId);
+    await expect(manager.terminateSession({ sessionId: session.sessionId, reason: "retry" }))
+      .resolves.toMatchObject({ terminated: false, reason: "done", closedAt: closed?.closedAt });
+    await manager.terminateSession({ sessionId: session.sessionId });
+    expect(onSessionTerminated).toHaveBeenCalledTimes(2);
+  });
+
+  it("disposes resources even when archival fails and retries only unfinished cleanup", async () => {
+    const onSessionTerminated = vi.fn(async () => {});
+    const archiveThread = vi.fn()
+      .mockImplementationOnce(() => { throw new Error("archive failed"); })
+      .mockReturnValue(undefined);
+    const manager = new AgenCDaemonSessionManager({
+      onSessionTerminated,
+      threadStore: {
+        readThread: () => storedThread("persisted", "2026-05-01T10:00:00.000Z"),
+        archiveThread,
+      } as unknown as ThreadStore,
+    });
+    await expect(manager.terminateSession({ sessionId: "persisted" }))
+      .rejects.toThrow("archive failed");
+    expect(onSessionTerminated).toHaveBeenCalledOnce();
+    await expect(manager.terminateSession({ sessionId: "persisted" }))
+      .resolves.toMatchObject({ terminated: false });
+    expect(onSessionTerminated).toHaveBeenCalledOnce();
+    expect(archiveThread).toHaveBeenCalledTimes(2);
+  });
+
   it("notifies resource owners exactly once when a session terminates", async () => {
     const onSessionTerminated = vi.fn(async () => {});
     const manager = new AgenCDaemonSessionManager({

--- a/runtime/tests/app-server/transport-disconnect.contract.test.ts
+++ b/runtime/tests/app-server/transport-disconnect.contract.test.ts
@@ -1,0 +1,177 @@
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+import {
+  AgenCUnixSocketServer,
+  agenCDaemonLocalEndpoint,
+} from "../../src/app-server/transport/unix-socket.js";
+import { AgenCWebSocketServer } from "../../src/app-server/transport/websocket.js";
+
+type TransportKind = "unix" | "websocket";
+
+async function createHarness(
+  kind: TransportKind,
+  options: {
+    onMessage(message: JsonObject): void | Promise<void>;
+    acceptAuthenticator?: () => Promise<boolean>;
+    acceptAuthenticationTimeoutMs?: number;
+  },
+) {
+  const directory = await mkdtemp(join(tmpdir(), "agenc-transport-close-"));
+  const closedConnections = new Set<number>();
+  const common = {
+    ...options,
+    onConnectionClosed: (id: number) => { closedConnections.add(id); },
+  };
+  const server = kind === "unix"
+    ? new AgenCUnixSocketServer({
+        ...common,
+        socketPath: agenCDaemonLocalEndpoint(directory),
+      })
+    : new AgenCWebSocketServer(common);
+  try {
+    await server.listen();
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true });
+    throw error;
+  }
+  const clients: { close(): void }[] = [];
+  return {
+    closedConnections,
+    async connect() {
+      const client = server instanceof AgenCUnixSocketServer
+        ? createConnection(server.socketPath)
+        : new WebSocket(server.listenAddress!.url);
+      const close = () => {
+        if (client instanceof WebSocket) client.terminate();
+        else client.destroy();
+      };
+      clients.push({ close });
+      await once(client, client instanceof WebSocket ? "open" : "connect");
+      return {
+        send(method: string, id: number) {
+          const payload = JSON.stringify({ jsonrpc: "2.0", id, method });
+          if (client instanceof WebSocket) client.send(payload);
+          else client.write(`${payload}\n`);
+        },
+        close,
+      };
+    },
+    closeServer: () => server.close(),
+    async cleanup() {
+      for (const client of clients) client.close();
+      await server.close();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+describe.each<TransportKind>(["unix", "websocket"])(
+  "%s daemon connection lifetime",
+  (kind) => {
+    it("discards queued normal and priority requests after disconnect", async () => {
+      const release = Promise.withResolvers<void>();
+      const initialized = Promise.withResolvers<void>();
+      const completed = Promise.withResolvers<void>();
+      const received: string[] = [];
+      const harness = await createHarness(kind, {
+        async onMessage(message) {
+          received.push(String(message.method));
+          if (message.method === "initialize") {
+            initialized.resolve();
+            await release.promise;
+            completed.resolve();
+          }
+        },
+      });
+      try {
+        const client = await harness.connect();
+        client.send("initialize", 1);
+        client.send("session.clear", 2);
+        client.send("agent.create", 3);
+        client.send("run.cancel", 4);
+        await initialized.promise;
+        client.close();
+        await expect.poll(() => harness.closedConnections.size).toBe(1);
+        release.resolve();
+        await completed.promise;
+        await nextTurn();
+        expect(received).toEqual(["initialize"]);
+      } finally {
+        release.resolve();
+        await harness.cleanup();
+      }
+    });
+
+    it.each(["disconnect", "authentication timeout"])(
+      "does not dispatch a late authentication success after %s",
+      async (reason) => {
+        const release = Promise.withResolvers<boolean>();
+        const started = Promise.withResolvers<void>();
+        const received: JsonObject[] = [];
+        const harness = await createHarness(kind, {
+          acceptAuthenticationTimeoutMs: reason === "disconnect" ? 60_000 : 30,
+          acceptAuthenticator: () => {
+            started.resolve();
+            return release.promise;
+          },
+          onMessage(message) { received.push(message); },
+        });
+        try {
+          const client = await harness.connect();
+          client.send("initialize", 1);
+          client.send("agent.create", 2);
+          await started.promise;
+          if (reason === "disconnect") client.close();
+          await expect.poll(() => harness.closedConnections.size).toBe(1);
+          release.resolve(true);
+          await nextTurn();
+          expect(received).toEqual([]);
+        } finally {
+          release.resolve(true);
+          await harness.cleanup();
+        }
+      },
+    );
+
+    it("closes every peer before draining active handlers and discards queued work", async () => {
+      const release = Promise.withResolvers<void>();
+      const started = Promise.withResolvers<void>();
+      const received: string[] = [];
+      const harness = await createHarness(kind, {
+        async onMessage(message) {
+          received.push(String(message.method));
+          if (message.method === "message.stream") {
+            started.resolve();
+            await release.promise;
+          }
+        },
+      });
+      let closing: Promise<void> | undefined;
+      try {
+        const first = await harness.connect();
+        await harness.connect();
+        first.send("message.stream", 1);
+        first.send("message.send", 2);
+        await started.promise;
+        let drained = false;
+        closing = harness.closeServer().then(() => { drained = true; });
+        await expect.poll(() => harness.closedConnections.size).toBe(2);
+        expect(drained).toBe(false);
+        release.resolve();
+        await closing;
+        expect(received).toEqual(["message.stream"]);
+      } finally {
+        release.resolve();
+        await closing;
+        await harness.cleanup();
+      }
+    });
+  },
+);

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -48,11 +48,13 @@ interface FakeDaemon {
   readonly pluginStorageRoot: string;
   readonly transport: AgenCInProcessDaemonTransport;
   readonly multiplexer: AgenCDaemonClientMultiplexer;
+  readonly sessionManager: AgenCDaemonSessionManager;
   readonly calls: {
     created: JsonObject[];
     streamed: JsonObject[];
     approved: JsonObject[];
     denied: JsonObject[];
+    cancelled: JsonObject[];
   };
   broadcast(
     sessionId: string,
@@ -93,6 +95,7 @@ async function createFakeDaemon(
     streamed: [],
     approved: [],
     denied: [],
+    cancelled: [],
   };
   const pluginStorageRoot = await workspaces.create();
 
@@ -236,6 +239,10 @@ async function createFakeDaemon(
         requestId: String(params.requestId),
         decision: "cancelled" as const,
       }),
+      cancelSessionTurn: async (params: JsonObject) => {
+        calls.cancelled.push(params);
+        return { sessionId: String(params.sessionId), cancelled: true };
+      },
       snapshotSession: async (params: JsonObject) => ({
         sessionId: String(params.sessionId),
         turnCount: 1,
@@ -245,6 +252,14 @@ async function createFakeDaemon(
           totalTokens: 18,
           costUsd: 0.0042,
         },
+      }),
+      getSessionTranscriptV2: async (params: JsonObject) => ({
+        schemaVersion: 2,
+        sessionId: String(params.sessionId),
+        runId: "run_1",
+        historyEpoch: "initial",
+        asOfSequence: 0,
+        messages: [],
       }),
     } as never,
     sessionManager,
@@ -270,6 +285,7 @@ async function createFakeDaemon(
     pluginStorageRoot,
     transport,
     multiplexer,
+    sessionManager,
     calls,
     broadcast: (sessionId, notification) =>
       multiplexer.broadcastSessionNotification(sessionId, notification),
@@ -301,6 +317,45 @@ function statusNotification(
 }
 
 describe("agenc-sdk client over the in-process transport", () => {
+  it("closing a prompt detaches its client and settles handles while the daemon session remains live", async () => {
+    let started!: () => void;
+    let release!: () => void;
+    const admitted = new Promise<void>((resolve) => { started = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let completed = false;
+    const daemon = await createFakeDaemon({
+      onStreamMessage: async () => {
+        started();
+        await gate;
+        completed = true;
+      },
+    });
+    try {
+      await daemon.client.initialize();
+      const session = await daemon.client.createSession({ pluginStorageRoot: daemon.pluginStorageRoot });
+      const run = session.prompt("keep running after detach", { includeUsage: false });
+      await admitted;
+      await expect(daemon.multiplexer.attachedClientIds(session.sessionId)).resolves.toEqual([daemon.client.clientId]);
+
+      await daemon.client.close();
+      await expect(run.accepted).rejects.toThrow("AgenC SDK client is closed");
+      await expect(run.result()).rejects.toThrow("AgenC SDK client is closed");
+      await expect(daemon.multiplexer.attachedClientIds(session.sessionId)).resolves.toEqual([]);
+      await expect(daemon.sessionManager.getSession(session.sessionId)).resolves.toMatchObject({
+        sessionId: session.sessionId,
+        status: "idle",
+      });
+      expect(daemon.calls.cancelled).toEqual([]);
+      expect(completed).toBe(false);
+      release();
+      await gate;
+      expect(completed).toBe(true);
+    } finally {
+      release();
+      await daemon.close();
+    }
+  });
+
   it("initializes, creates a session, and streams a typed prompt event stream", async () => {
     const cwd = await workspaces.create();
     const daemon = await createFakeDaemon({

--- a/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
+++ b/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
@@ -339,6 +339,89 @@ function resolveSend(
 }
 
 describe("agenc-sdk prompt race safety", () => {
+  it("settles both prompt handles when closing a client with a pending transport request", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+    const run = client.runPrompt("session_1", "pending", {
+      clientMessageId: "pending_close",
+      includeUsage: false,
+    });
+    await waitForSend(transport, 0);
+    await client.close();
+
+    await expect(run.accepted).rejects.toThrow("AgenC SDK client is closed");
+    await expect(run.result()).rejects.toThrow("AgenC SDK client is closed");
+    await expect(run[Symbol.asyncIterator]().next()).rejects.toThrow(
+      "AgenC SDK client is closed",
+    );
+    expect(transport.requests.some((request) => request.method === "session.cancelTurn")).toBe(false);
+  });
+
+  it("settles notification-driven prompt results when closing after acceptance", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+    const run = client.runPrompt("session_1", "legacy", {
+      clientMessageId: "accepted_close",
+      includeUsage: false,
+    });
+    const send = await waitForSend(transport, 0);
+    send.response.resolve(success(send.request, {
+      messageId: "accepted_close",
+      acceptedAt: "2026-08-17T00:00:00.000Z",
+      turnId: "accepted_turn",
+    }));
+    await run.accepted;
+    await client.close();
+
+    await expect(run.result()).rejects.toThrow("AgenC SDK client is closed");
+  });
+
+  it.each(["permission", "elicitation"] as const)(
+    "does not dispatch a delayed %s response after its prompt terminates",
+    async (kind) => {
+      const transport = new PromptTransport();
+      const client = await initializedClient(transport);
+      const decision = deferred<{ behavior: "allow"; action: "accept" }>();
+      let callbackStarted = false;
+      const respond = () => {
+        callbackStarted = true;
+        return decision.promise;
+      };
+      const run = client.runPrompt("session_1", "interactive", {
+        clientMessageId: "interactive_message",
+        includeUsage: false,
+        onPermissionRequest: respond,
+        onElicitationRequest: respond,
+      });
+      const send = await waitForSend(transport, 0);
+      transport.emit(userMessage("interactive_message"));
+      transport.emit(turnStarted("interactive_turn"));
+      transport.emit({
+        jsonrpc: "2.0",
+        method: kind === "permission" ? "event.permission_request" : "event.user_input_request",
+        params: {
+          sessionId: "session_1",
+          turnId: "interactive_turn",
+          requestId: "interactive_request",
+          permissions: [],
+          questions: [],
+        },
+      });
+      expect(callbackStarted).toBe(true);
+      transport.emit(terminal("interactive_turn"));
+      resolveSend(send, "interactive_turn");
+      await run.result();
+      decision.resolve({ behavior: "allow", action: "accept" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(transport.requests.filter((request) =>
+        request.method === "tool.approve" || request.method === "elicitation.respond",
+      )).toEqual([]);
+      await client.close();
+    },
+  );
+
   it.each([
     "1.0.0",
     "1.1.0",

--- a/runtime/tests/sdk-package/startup-connection.test.ts
+++ b/runtime/tests/sdk-package/startup-connection.test.ts
@@ -157,6 +157,32 @@ describe("SDK connection phases share the startup deadline", () => {
     }
   });
 
+  test("disconnect settles an accepted prompt whose terminal notification never arrives", async () => {
+    mocks.socket.mockImplementation(() => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      queueMicrotask(() => socket.emit("connect"));
+      socket.onWrite = (text) => {
+        const request = JSON.parse(text);
+        const result = request.method === "initialize"
+          ? { type: "initialized", protocolVersion: "1.1.0", protocol: { version: "1.1.0" }, capabilities: {} }
+          : request.method === "session.attach"
+            ? { sessionId: "session_1", attachmentId: "attachment_1" }
+            : { messageId: "message_1", acceptedAt: "2026-08-17T00:00:00.000Z" };
+        socket.emit("data", JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\n");
+      };
+      return socket;
+    });
+    const onDisconnect = vi.fn();
+    const client = await connect({ env: { AGENC_HOME: home }, onDisconnect });
+    const run = client.runPrompt("session_1", "legacy prompt", { includeUsage: false });
+    await run.accepted;
+    sockets[1]!.destroy();
+    await expect(run.result()).rejects.toThrow("AgenC SDK client is closed");
+    expect(onDisconnect).toHaveBeenCalledExactlyOnceWith(null);
+    await expect(client.request("health.ping", {})).rejects.toThrow("AgenC SDK client is closed");
+  });
+
   test("transport cancellation preserves the reason and ignores a late connect", async () => {
     const socket = new FakeSocket();
     sockets.push(socket);

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -1569,6 +1569,13 @@ describe("AgenC TUI daemon session adapter", () => {
     });
     expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "daemon-turn" });
 
+    await session.cancelActiveTurn?.("interrupt foreground tool");
+    expect(client.requests).toContainEqual({
+      method: "session.cancelTurn",
+      params: { sessionId: "session_1", expectedTurnId: "turn_1", reason: "interrupt foreground tool" },
+      signal: expect.any(AbortSignal),
+    });
+
     client.emit("session_1", {
       method: "event.session_event",
       params: {
@@ -1889,6 +1896,11 @@ describe("AgenC TUI daemon session adapter", () => {
       client,
       sessionId: "session_1",
       clientId: "tui_1",
+      transcriptSnapshot: {
+        schemaVersion: 2, sessionId: "session_1", runId: "run_1",
+        historyEpoch: "initial", asOfSequence: 0, messages: [],
+        activeTurn: { turnId: "observed_turn" },
+      },
     });
 
     await session.cancelActiveTurn?.("interrupted");
@@ -1896,7 +1908,7 @@ describe("AgenC TUI daemon session adapter", () => {
     expect(client.requests).toEqual([
       {
         method: "session.cancelTurn",
-        params: { sessionId: "session_1", reason: "interrupted" },
+        params: { sessionId: "session_1", reason: "interrupted", expectedTurnId: "observed_turn" },
         // The cancel RPC carries a 5s timeout signal so a wedged daemon can
         // never swallow an ESC silently.
         signal: expect.any(AbortSignal),
@@ -1911,6 +1923,11 @@ describe("AgenC TUI daemon session adapter", () => {
       client,
       sessionId: "session_1",
       clientId: "tui_1",
+      transcriptSnapshot: {
+        schemaVersion: 2, sessionId: "session_1", runId: "run_1",
+        historyEpoch: "initial", asOfSequence: 0, messages: [],
+        activeTurn: { turnId: "observed_turn" },
+      },
     });
 
     await session.cancelActiveTurn?.();
@@ -1918,7 +1935,7 @@ describe("AgenC TUI daemon session adapter", () => {
     expect(client.requests).toEqual([
       {
         method: "session.cancelTurn",
-        params: { sessionId: "session_1" },
+        params: { sessionId: "session_1", expectedTurnId: "observed_turn" },
         signal: expect.any(AbortSignal),
       },
     ]);
@@ -2321,7 +2338,7 @@ describe("AgenC TUI daemon session adapter", () => {
     expect(authority.currentMode()).toBe("plan");
   });
 
-  it("holds immediate input until an in-flight permission-mode change settles", async () => {
+  it.each([false, true])("holds immediate input until an in-flight permission-mode change settles (cancelled: %s)", async (cancelled) => {
     const authority = runtimeAuthorityBase();
     const client = createClient();
     const request = client.request.bind(client);
@@ -2362,7 +2379,14 @@ describe("AgenC TUI daemon session adapter", () => {
       "session.setPermissionMode",
     ]);
 
+    if (cancelled) await session.cancelActiveTurn?.("cancel before dispatch");
     releaseModeRequest.resolve();
+    if (cancelled) {
+      await expect(submission).rejects.toMatchObject({ name: "AbortError" });
+      await modeChange;
+      expect(client.requests.map((entry) => entry.method)).toEqual(["session.setPermissionMode"]);
+      return;
+    }
     await Promise.all([modeChange, submission]);
     expect(client.requests.map((entry) => entry.method)).toEqual([
       "session.setPermissionMode",

--- a/runtime/tests/tui/daemon-session.ihunt-error-clears-active-turn.test.ts
+++ b/runtime/tests/tui/daemon-session.ihunt-error-clears-active-turn.test.ts
@@ -125,15 +125,22 @@ function createBaseSession(): AgenCTuiBridgeSession {
   };
 }
 
-function createClient(): AgenCDaemonTuiClient & {
+function createClient(options: { readonly submit?: () => Promise<unknown> } = {}): AgenCDaemonTuiClient & {
+  readonly requests: Array<{ readonly method: string; readonly params?: JsonObject }>;
   emit(sessionId: string, event: JsonObject): void;
 } {
   const listeners = new Map<string, Set<(event: JsonObject) => void>>();
+  const requests: Array<{ readonly method: string; readonly params?: JsonObject }> = [];
   return {
+    requests,
     async request(
-      _method: AgenCDaemonMethod | AgenCDaemonInternalMethod,
-      _params?: JsonObject,
+      method: AgenCDaemonMethod | AgenCDaemonInternalMethod,
+      params?: JsonObject,
     ): Promise<AgenCDaemonResultByMethod[AgenCDaemonMethod]> {
+      requests.push({ method, params });
+      if (method === "message.stream" && options.submit !== undefined) {
+        return await options.submit() as AgenCDaemonResultByMethod[AgenCDaemonMethod];
+      }
       return {} as AgenCDaemonResultByMethod[AgenCDaemonMethod];
     },
     subscribeToSessionEvents: (sessionId, cb) => {
@@ -159,6 +166,170 @@ function createClient(): AgenCDaemonTuiClient & {
 }
 
 describe("daemon session activeTurn error handling (ihunt)", () => {
+  it.each([0, 1, 130] as const)(
+    "settles a submission from its authoritative terminal response (%s) when live completion is missing",
+    async (code) => {
+      const client = createClient({ submit: async () => ({
+        disposition: "started", turnId: "response-turn", terminal: { code, message: "recorded outcome" },
+      }) });
+      const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+      const events: unknown[] = [];
+      const unsubscribe = session.subscribeToEvents((event) => events.push(event));
+      await session.submit("input", { clientMessageId: "response-message" });
+      expect(session.activeTurn?.unsafePeek()).toBeNull();
+      expect(events).toContainEqual(expect.objectContaining({
+        type: code === 0 ? "turn_complete" : code === 1 ? "turn_failed" : "turn_aborted",
+        clientMessageId: "response-message",
+        payload: expect.objectContaining({ turnId: "response-turn" }),
+      }));
+      unsubscribe();
+    },
+  );
+
+  it("settles a response without a model turn only against its local submission placeholder", async () => {
+    const client = createClient({ submit: async () => ({ disposition: "started", terminal: { code: 0 } }) });
+    const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+    const events: unknown[] = [];
+    const unsubscribe = session.subscribeToEvents((event) => events.push(event));
+    await session.submit("input with no model turn", { clientMessageId: "no-model-message" });
+    expect(session.activeTurn?.unsafePeek()).toBeNull();
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "turn_complete", clientMessageId: "no-model-message",
+      payload: expect.objectContaining({ turnId: expect.stringMatching(/^tui_1:/u) }),
+    }));
+    await session.cancelActiveTurn?.("late interrupt");
+    expect(client.requests.filter((request) => request.method === "session.cancelTurn")).toEqual([]);
+    unsubscribe();
+  });
+
+  it.each([false, true])("does not let an old terminal response clear a successor turn (turn-scoped: %s)", async (turnScoped) => {
+    let resolveSubmit!: (value: unknown) => void;
+    const response = new Promise((resolve) => { resolveSubmit = resolve; });
+    const client = createClient({ submit: () => response });
+    const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+    const events: unknown[] = [];
+    const unsubscribe = session.subscribeToEvents((event) => events.push(event));
+    const submitted = session.submit("old input");
+    await vi.waitFor(() => expect(client.requests.some((request) => request.method === "message.stream")).toBe(true));
+    client.emit("session_1", {
+      method: "event.agent_status",
+      params: { eventId: "successor-start", status: "running", turnId: "successor-turn" },
+    });
+    resolveSubmit({ disposition: "started", ...(turnScoped ? { turnId: "old-turn" } : {}), terminal: { code: 0 } });
+    await submitted;
+    expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "successor-turn" });
+    expect(events).not.toContainEqual(expect.objectContaining({ type: "turn_complete" }));
+    unsubscribe();
+  });
+
+  it.each([
+    { turnId: "turn", terminal: { code: 2 } },
+    { turnId: "turn", terminal: { code: 0, message: 42 } },
+    { turnId: "turn", terminal: null },
+    { turnId: "", terminal: { code: 0 } },
+  ])("rejects malformed terminal submission results %#", async (result) => {
+    const client = createClient({ submit: async () => ({ disposition: "started", ...result }) });
+    const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+    await expect(session.submit("input")).rejects.toThrow("invalid terminal submission result");
+  });
+
+  it.each(["idle", "completed", "failed", "cancelled"])(
+    "ignores a stale %s agent status while a successor turn is active",
+    (status) => {
+      const client = createClient();
+      const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+      const unsubscribe = session.subscribeToEvents(() => undefined);
+      client.emit("session_1", {
+        method: "event.agent_status",
+        params: { eventId: "new-running", turnId: "new-turn", status: "running" },
+      });
+      client.emit("session_1", {
+        method: "event.agent_status",
+        params: { eventId: "stale-terminal", turnId: "old-turn", status },
+      });
+      expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "new-turn" });
+      unsubscribe();
+    },
+  );
+
+  it("does not send session-wide cancellation when no authoritative turn is visible", async () => {
+    const client = createClient();
+    const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+    await session.cancelActiveTurn?.("interrupt");
+    expect(client.requests).toEqual([]);
+    const unsubscribe = session.subscribeToEvents(() => undefined);
+    client.emit("session_1", {
+      method: "event.agent_status",
+      params: { eventId: "presentation-event-id", status: "running" },
+    });
+    await session.cancelActiveTurn?.("interrupt unknown turn");
+    expect(client.requests).toEqual([]);
+    unsubscribe();
+  });
+
+  it("defers pending cancellation to the matching submission instead of an external turn", async () => {
+    let resolveSubmit!: (value: unknown) => void;
+    const response = new Promise((resolve) => { resolveSubmit = resolve; });
+    const client = createClient({ submit: () => response });
+    const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+    const submitted = session.submit("pending input", { clientMessageId: "local-message" });
+    await vi.waitFor(() => expect(client.requests.some((request) => request.method === "message.stream")).toBe(true));
+    await session.cancelActiveTurn?.("interrupt pending");
+    const cancels = () => client.requests.filter((request) => request.method === "session.cancelTurn");
+    expect(cancels()).toEqual([]);
+
+    const emitUser = (messageId: string) => client.emit("session_1", {
+      method: "event.session_event",
+      params: { eventId: messageId, clientMessageId: messageId, event: { type: "user_message", payload: { messageId, message: "input" } } },
+    });
+    const emitStarted = (turnId: string, clientMessageId?: string) => client.emit("session_1", {
+      method: "event.agent_status",
+      params: { eventId: turnId, turnId, status: "running", ...(clientMessageId === undefined ? {} : { clientMessageId }) },
+    });
+    emitUser("external-message");
+    emitStarted("external-turn");
+    expect(cancels()).toEqual([]);
+    emitUser("local-message");
+    emitStarted("external-explicit-turn", "external-message");
+    expect(cancels()).toEqual([]);
+    emitUser("local-message");
+    emitStarted("local-turn");
+    expect(cancels()).toEqual([{
+      method: "session.cancelTurn",
+      params: { sessionId: "session_1", expectedTurnId: "local-turn", reason: "interrupt pending" },
+    }]);
+    resolveSubmit({ disposition: "started", turnId: "local-turn", terminal: { code: 130 } });
+    await submitted;
+  });
+
+  it.each(["rejected", "duplicate"] as const)(
+    "discards deferred cancellation after a %s submission settles",
+    async (outcome) => {
+      let resolveSubmit!: (value: unknown) => void;
+      let rejectSubmit!: (error: Error) => void;
+      const response = new Promise((resolve, reject) => {
+        resolveSubmit = resolve;
+        rejectSubmit = reject;
+      });
+      const client = createClient({ submit: () => response });
+      const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+      const submitted = session.submit("pending input", { clientMessageId: "settled-message" });
+      await vi.waitFor(() => expect(client.requests.some((request) => request.method === "message.stream")).toBe(true));
+      await session.cancelActiveTurn?.("interrupt pending");
+      if (outcome === "rejected") {
+        rejectSubmit(new Error("admission rejected"));
+      } else {
+        resolveSubmit({ disposition: "duplicate", duplicateState: "incomplete" });
+      }
+      await expect(submitted).rejects.toThrow();
+      client.emit("session_1", {
+        method: "event.agent_status",
+        params: { eventId: "later-start", status: "running", turnId: "later-turn", clientMessageId: "settled-message" },
+      });
+      expect(client.requests.filter((request) => request.method === "session.cancelTurn")).toEqual([]);
+    },
+  );
+
   it("closes only the matching explicit failed turn and permits the next turn", () => {
     const client = createClient();
     const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });


### PR DESCRIPTION
Daemon connections and session operations could outlive their owners: late attachment rollback or eviction could affect a reconnect, failed finalizers could be skipped, and stale TUI cancellation/completion could affect a successor turn. This change makes connection closure terminal, scopes cleanup to physical connection identity, enforces session-to-agent membership, and coalesces teardown with retryable session finalization.

TUI cancellation now requires observed turn authority, preserves pre-dispatch cancellation, and settles missing live completion from validated RPC results. SDK close/disconnect settles pending handles and fences delayed approval callbacks. Regression coverage exercises real Unix/WebSocket transports and connected SDK/dispatcher/session composition. The audit and verification details are in `docs/design/daemon-session-control-plane-audit.md`.

Local validation completed before publication:

- Linux Docker control-plane boundary: 1,754 tests across 128 files passed.
- Runtime and test-support typechecks, runtime/SDK builds, generated protocol checks, and TUI startup smoke passed.
- Repository gate tests: 162 passed.
- Launcher tests: 235/236 passed; the remaining installer-site configuration assertion already fails at the original base revision.

Validation ran in the working tree alongside unrelated provider edits; those edits are excluded from this PR. GitHub CI is intentionally skipped at the owner's request for this iterative fix. The source and squash-merge commit messages include `[skip ci]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, connection lifecycle, session/agent teardown, and turn cancellation across the local control plane—areas where races could affect the wrong session or leave resources stranded.
> 
> **Overview**
> Hardens the local daemon **session control plane** so connection closure is terminal, cleanup is scoped to physical connection identity, and runtime work requires an agent-bound session.
> 
> **Daemon/runtime:** JSON-RPC connections reject work after close and serialize initialize/auth; multiplexer detach/eviction uses `deliveryKey` so reconnects reusing a client ID are not torn down by stale cleanup; session termination finalizes resources outside the routing lock with shared, retryable cleanup; `agent.stop` is single-flight and shutdown drains in-flight stops; prompt/cancel/snapshot routes assert session membership on the agent; Unix/WebSocket ingress drops queued frames after disconnect; slow-client eviction destroys the transport; accepted `daemon.shutdown` completes even when ack sends fail.
> 
> **Clients:** SDK close/disconnect races pending RPCs and settles prompt handles without issuing `session.cancelTurn`; TUI ESC uses `expectedTurnId`, defers pre-dispatch cancel until submission correlates, and treats validated `message.stream` terminal results as authoritative.
> 
> **Docs:** Adds a control-plane audit write-up, expands daemon ownership semantics, and bumps the documented protocol constant to **1.12.0**. Broad contract/regression tests cover the above boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d07904bc44e73245119ac8c669b066bf3c0e819f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->