### PR TITLE
Give managed DeepSeek room for reasoning and tools [skip ci]

### DIFF
--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -535,14 +535,16 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       visibility: "list",
     })),
     // Reviewed AgenC route metadata; account discovery still controls access.
-    // Backend: docs/operations/deepseek-policy-refresh-20260910.md.
+    // Backend: docs/operations/managed-stream-liveness-20260911.md.
     {
       provider: "agenc",
       model: AGENC_DEEPSEEK_MODEL,
       displayName: "DeepSeek V4 Flash 0731",
       contextWindow: 1_048_576,
       maxContextWindow: 1_048_576,
-      maxOutputTokens: 8_192,
+      // Reasoning and tool arguments share this budget. An 8k allowance can
+      // finish entirely in reasoning and repeat the same truncation on recovery.
+      maxOutputTokens: 64_000,
       maxOutputTokensUpperLimit: 384_000,
       maxOutputTokensCappedDefault: true,
       inputModalities: TEXT_MODALITIES,

--- a/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
+++ b/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
@@ -7,8 +7,23 @@ import { chatCompletionsCapabilityHintsForProvider } from "../../../../src/llm/w
 import { buildChatCompletionsRequest } from "../../../../src/llm/wire/chat-completions.js";
 import { attachmentsToMessages } from "../../../../src/prompts/attachments/messages.js";
 import type { LLMMessage } from "../../../../src/llm/types.js";
+import { ModelMetadataResolver } from "../../../../src/llm/model-metadata.js";
+import { defaultConfig } from "../../../../src/config/schema.js";
 
 describe("AgenC DeepSeek promotion wire", () => {
+  it.each(["low", "high", "max"] as const)("reserves room for reasoning and tools at native %s effort while honoring explicit limits", reasoningEffort => {
+    const config = { ...defaultConfig(), model_provider: "agenc", model, reasoning_effort: reasoningEffort };
+    const resolver = new ModelMetadataResolver({ env: {} });
+    const metadata = resolver.resolveSync({ provider: "agenc", model, config });
+    expect(metadata).toMatchObject({ maxOutputTokens: 64_000, maxOutputTokensUpperLimit: 384_000, contextWindow: 1_048_576 });
+    const body = buildChatCompletionsRequest({ model, messages: [{ role: "user", content: "Complete the coding task" }], tools: [],
+      options: { maxOutputTokens: metadata.maxOutputTokens, reasoningEffort },
+      providerCapabilityHints: chatCompletionsCapabilityHintsForProvider("openrouter", model, { managedGateway: true }),
+    });
+    expect(body).toMatchObject({ max_tokens: 64_000, reasoning_effort: reasoningEffort });
+    expect(resolver.resolveSync({ provider: "agenc", model, config: { ...config, max_output_tokens: 4096 } }).maxOutputTokens).toBe(4096);
+  });
+
   it("keeps generated tool-discovery context in the tool loop without treating user text as runtime context", () => {
     const messages: LLMMessage[] = [
       { role: "user", content: "Read the skill, then use the discovered MCP tool." },
@@ -113,7 +128,7 @@ describe("AgenC DeepSeek promotion wire", () => {
 
   it("keeps route metadata hidden and does not change direct OpenRouter capabilities", () => {
     expect(resolveRegisteredModelCatalogEntry({ provider: "agenc", model })).toMatchObject({
-      contextWindow: 1_048_576, maxOutputTokens: 8_192, maxOutputTokensUpperLimit: 384_000,
+      contextWindow: 1_048_576, maxOutputTokens: 64_000, maxOutputTokensUpperLimit: 384_000,
       supportedReasoningLevels: ["low", "high", "max"], defaultReasoningLevel: "high", visibility: "none",
     });
     expect(deriveFlatCatalog().agenc ?? []).not.toContain(model);


### PR DESCRIPTION
Managed DeepSeek could spend its full 8,192-token output allowance on reasoning, then repeat the truncation during recovery. Set the exact AgenC DeepSeek V4 Flash 0731 model's default to 64,000, matching direct DeepSeek, while preserving explicit user limits, native Low/High/Max and the existing context/output ceilings.

Validation against current main: 185 provider, catalog, recovery and session/SDK tests in 17 files; typecheck, build, runtime entrypoints and generated SDK checks. A real Desktop coding generation used 11,878 tokens and produced the game changes; the completed game passed 14 independent Chromium checks. Final rebuilt clients completed a High greeting in 6.31 seconds and a fresh file/skill/MCP check in 60.67 seconds. The separately deployed backend fixes active-stream timeouts and uses the reviewed current rate.

Remote CI is skipped at the owner's request; merge is authorized on local checks.
