### PR TITLE
fix(routines): allow safe Mac diagnostics and report permission-blocked runs

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1585,14 +1585,17 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       throw new Error("Cannot finish a routine while its Core session is busy or stopping.");
     }
     const stopReason = submission.terminalStopReason;
-    const code = stopReason === "cancelled" ? 130 : stopReason !== undefined && stopReason !== "completed" ? 1 : result.terminal?.code;
-    if (code === undefined) throw new Error("Cannot finish a routine without a terminal message outcome.");
+    const turnCode = stopReason === "cancelled" ? 130
+      : stopReason !== undefined && stopReason !== "completed" ? 1 : result.terminal?.code;
+    if (turnCode === undefined) throw new Error("Cannot finish a routine without a terminal message outcome.");
+    const code = turnCode === 0 && submission.permissionDenied === true ? 1 : turnCode;
     // Close ingress before selecting the canonical terminal. No caller-supplied
     // success flag can override the result recorded by the owning turn.
     active.ingressClosed = true;
     active.pendingTerminal = {
       runId: agentId, status: code === 0 ? "completed" : code === 130 ? "cancelled" : "failed",
-      exitCode: code, stopReason: code === 0 ? "routine_completed" : code === 130 ? "routine_cancelled" : "routine_failed",
+      exitCode: code, stopReason: code === 0 ? "routine_completed" : code === 130 ? "routine_cancelled"
+        : submission.permissionDenied === true ? "routine_permission_denied" : "routine_failed",
       finalMessage: this.#assistantTextByAgent.get(agentId) ?? null,
       usage: terminalUsageForActiveAgent(active), lastSequence: null, finishedAt: this.#now(),
     };
@@ -4700,6 +4703,13 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     active: ActiveBackgroundAgent,
     event: BackgroundAgentDaemonEvent,
   ): void {
+    if (event.type === "error" && typeof event.payload?.cause === "string" &&
+        event.payload.cause.startsWith("permission_denied:") &&
+        active.messageSubmission !== undefined &&
+        (event.clientMessageId === undefined || event.clientMessageId === active.messageSubmission.clientMessageId) &&
+        (event.turnId === undefined || active.messageSubmission.turnId === undefined || event.turnId === active.messageSubmission.turnId)) {
+      active.messageSubmission.permissionDenied = true;
+    }
     if (event.statusProjection === "session_only") return;
     const payload = event.payload;
     const terminal = classifyTurnTerminal(event, {

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -764,6 +764,8 @@ interface ActiveMessageSubmission {
   terminal?: AgenCBackgroundAgentMessageTerminal;
   /** Owning phase outcome; conversational turn_complete alone also includes bounded failures. */
   terminalStopReason?: string;
+  /** A final answer after a permission refusal is not an unqualified routine success. */
+  permissionDenied?: boolean;
   readonly promise: Promise<AgenCBackgroundAgentMessageResult>;
   settled: boolean;
 }

--- a/runtime/src/prompts/permissions-prompt.ts
+++ b/runtime/src/prompts/permissions-prompt.ts
@@ -303,7 +303,10 @@ export function getPermissionsSection(
       : "(none)";
     return [
       "# Permission Mode: unattended",
-      "This background agent runs without an attached human client. Tools on the unattended denylist are rejected automatically. Tools on the unattended allowlist are approved automatically. Any other tool pauses the agent and surfaces a permission request to an attached client.",
+      policy.readOnly
+        ? "This routine runs without an attached human client. Tools on the unattended denylist are rejected automatically. Tools on the unattended allowlist are approved automatically. Other calls may proceed only when Core verifies them as read-only and within the run's allowed scope. Calls that need approval are refused, not paused. Never request bypass permissions or retry a refused operation. Preserve partial findings and identify anything that could not be collected."
+        : "This background agent runs without an attached human client. Tools on the unattended denylist are rejected automatically. Tools on the unattended allowlist are approved automatically. Any other tool pauses the agent and surfaces a permission request to an attached client.",
+      ...(policy.readOnly ? ["For system diagnostics, use one bounded native command per call, without shell wrappers, substitutions, redirections or chaining. On macOS, prefer sw_vers, sysctl -n with specific hardware keys, vm_stat, df -h, top -l 1 -n 5 -stats pid,command,cpu,mem, pmset -g batt, and system_profiler SPPowerDataType -detailLevel mini -timeout 10. Use ifconfig or ipconfig getifaddr en0 for local network state. These queries do not authorize changing settings or reading arbitrary files outside the project."] : []),
       `Unattended allowlist: ${allow}`,
       `Unattended denylist: ${deny}`,
     ].join("\n\n");

--- a/runtime/src/tools/BashTool/bashSecurity.ts
+++ b/runtime/src/tools/BashTool/bashSecurity.ts
@@ -145,7 +145,9 @@ function extractQuotedContent(command: string, isJq = false): QuoteExtraction {
 }
 
 function stripSafeRedirections(content: string): string {
-  // SECURITY: All three patterns MUST have a trailing boundary (?=\s|$).
+  // SECURITY: All three patterns MUST have a trailing shell-token boundary.
+  // An unquoted ;, | or & also ends /dev/null (common in batched diagnostics).
+  // Escaped separators and suffixes such as /dev/nullo must never match.
   // Without it, `> /dev/nullo` matches `/dev/null` as a PREFIX, strips
   // `> /dev/null` leaving `o`, so `echo hi > /dev/nullo` becomes `echo hi o`.
   // validateRedirections then sees no `>` and passes. The file write to
@@ -153,9 +155,9 @@ function stripSafeRedirections(content: string): string {
   // Main bashPermissions flow is protected (checkPathConstraints validates the
   // original command), but speculation.ts uses checkReadOnlyConstraints alone.
   return content
-    .replace(/\s+2\s*>&\s*1(?=\s|$)/g, '')
-    .replace(/[012]?\s*>\s*\/dev\/null(?=\s|$)/g, '')
-    .replace(/\s*<\s*\/dev\/null(?=\s|$)/g, '')
+    .replace(/\s+2\s*>&\s*1(?=\s|[;|&]|$)/g, '')
+    .replace(/[012]?\s*>\s*\/dev\/null(?=\s|[;|&]|$)/g, '')
+    .replace(/\s*<\s*\/dev\/null(?=\s|[;|&]|$)/g, '')
 }
 
 /**

--- a/runtime/src/tools/BashTool/macosReadOnlyCommands.ts
+++ b/runtime/src/tools/BashTool/macosReadOnlyCommands.ts
@@ -1,0 +1,100 @@
+import type { ExternalCommandConfig } from '../../utils/shell/readOnlyCommandValidation.js'
+
+// These are macOS diagnostic invocations, not blanket grants for these binaries.
+// In particular sysctl, pmset, memory_pressure and ifconfig can also mutate the
+// host. The surrounding shell-safety and project-path checks still apply.
+const systemKeys = new Set([
+  'hw.ncpu', 'hw.activecpu', 'hw.physicalcpu', 'hw.physicalcpu_max',
+  'hw.logicalcpu', 'hw.logicalcpu_max', 'hw.memsize', 'hw.pagesize',
+  'hw.model', 'hw.machine', 'hw.cputype', 'hw.cpusubtype',
+  'machdep.cpu.brand_string', 'kern.hostname', 'kern.boottime',
+  'kern.osrelease', 'kern.osversion', 'kern.ostype', 'vm.loadavg',
+  'vm.swapusage', 'kern.memorystatus_vm_pressure_level',
+])
+const bounded = (max: number) => (value: string) =>
+  /^[1-9]\d*$/.test(value) && Number(value) <= max
+const oneOf = (...values: string[]) => (value: string) => values.includes(value)
+
+function invalidOptions(
+  args: string[],
+  options: Record<string, (value: string) => boolean>,
+  required: string[] = [],
+): boolean {
+  const seen = new Set<string>()
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index]!
+    const value = args[index + 1]
+    if (seen.has(flag) || value === undefined || !options[flag]?.(value)) return true
+    seen.add(flag)
+  }
+  return required.some(flag => !seen.has(flag))
+}
+
+const commands: Record<string, ExternalCommandConfig> = {
+  sw_vers: {
+    safeFlags: { '-productName': 'none', '-productVersion': 'none', '-buildVersion': 'none' },
+    additionalCommandIsDangerousCallback: (_, args) => args.length > 1 || args.some(arg =>
+      !['-productName', '-productVersion', '-buildVersion'].includes(arg)),
+  },
+  sysctl: {
+    safeFlags: { '-n': 'none', '-h': 'none' },
+    additionalCommandIsDangerousCallback: (_, args) =>
+      !args.some(arg => systemKeys.has(arg)) || args.some(arg =>
+        arg !== '-n' && arg !== '-h' && !systemKeys.has(arg)),
+  },
+  vm_stat: { safeFlags: {}, additionalCommandIsDangerousCallback: (_, args) => args.length !== 0 },
+  pagesize: { safeFlags: {}, additionalCommandIsDangerousCallback: (_, args) => args.length !== 0 },
+  memory_pressure: { safeFlags: {}, additionalCommandIsDangerousCallback: (_, args) => args.length !== 0 },
+  mount: { safeFlags: {}, additionalCommandIsDangerousCallback: (_, args) => args.length !== 0 },
+  pmset: {
+    safeFlags: { '-g': 'none' },
+    additionalCommandIsDangerousCallback: (_, args) => args[0] !== '-g' || args.length > 2 ||
+      (args.length === 2 && !['batt', 'ps', 'custom', 'cap', 'therm', 'assertions'].includes(args[1]!)),
+  },
+  top: {
+    safeFlags: { '-l': 'number', '-n': 'number', '-s': 'number', '-stats': 'string', '-o': 'string', '-O': 'string' },
+    additionalCommandIsDangerousCallback: (_, args) => invalidOptions(args, {
+      '-l': bounded(5), '-n': bounded(20), '-s': bounded(5),
+      '-stats': value => value.split(',').every(oneOf('pid', 'command', 'cpu', 'mem', 'threads', 'time', 'state', 'uid', 'user')),
+      '-o': oneOf('cpu', 'mem', 'pid', 'time'), '-O': oneOf('cpu', 'mem', 'pid', 'time'),
+    }, ['-l']),
+  },
+  system_profiler: {
+    safeFlags: { '-detailLevel': 'string', '-timeout': 'number', '-json': 'none', '-xml': 'none' },
+    additionalCommandIsDangerousCallback: (_, args) => {
+      let types = 0
+      for (let i = 0; i < args.length; i++) {
+        const arg = args[i]!
+        if (['SPPowerDataType', 'SPHardwareDataType', 'SPSoftwareDataType', 'SPNetworkDataType'].includes(arg)) types++
+        else if (arg === '-json' || arg === '-xml') continue
+        else if (arg === '-detailLevel' && ['mini', 'basic'].includes(args[++i] ?? '')) continue
+        else if (arg === '-timeout' && bounded(30)(args[++i] ?? '')) continue
+        else return true
+      }
+      return types === 0
+    },
+  },
+  ifconfig: {
+    safeFlags: { '-a': 'none', '-l': 'none' },
+    additionalCommandIsDangerousCallback: (_, args) => args.length > 1 ||
+      args.some(arg => !/^(?:-a|-l|(?:en|lo|bridge|utun)\d+)$/.test(arg)),
+  },
+  ipconfig: {
+    safeFlags: {},
+    additionalCommandIsDangerousCallback: (_, args) =>
+      args.length !== 2 || args[0] !== 'getifaddr' || !/^en\d+$/.test(args[1]!),
+  },
+}
+
+// Accept only the system locations, never a project executable with the same basename.
+const systemPaths: Record<string, string> = {
+  sw_vers: '/usr/bin/sw_vers', sysctl: '/usr/sbin/sysctl', vm_stat: '/usr/bin/vm_stat',
+  pagesize: '/usr/bin/pagesize', memory_pressure: '/usr/bin/memory_pressure',
+  mount: '/sbin/mount', pmset: '/usr/bin/pmset', top: '/usr/bin/top',
+  system_profiler: '/usr/sbin/system_profiler', ifconfig: '/sbin/ifconfig', ipconfig: '/usr/sbin/ipconfig',
+}
+
+export const MACOS_READ_ONLY_COMMANDS: Record<string, ExternalCommandConfig> = {
+  ...commands,
+  ...Object.fromEntries(Object.entries(systemPaths).map(([name, path]) => [path, commands[name]!])),
+}

--- a/runtime/src/tools/BashTool/readOnlyValidation.ts
+++ b/runtime/src/tools/BashTool/readOnlyValidation.ts
@@ -30,6 +30,7 @@ import {
   type PathCommand,
 } from './pathValidation.js'
 import { sedCommandIsAllowedByAllowlist } from './sedValidation.js'
+import { MACOS_READ_ONLY_COMMANDS } from './macosReadOnlyCommands.js'
 
 // Unified command validation configuration system
 type CommandConfig = {
@@ -1150,6 +1151,9 @@ const COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
 
 function getCommandAllowlist(): Record<string, CommandConfig> {
   let allowlist: Record<string, CommandConfig> = COMMAND_ALLOWLIST
+  if (getPlatform() === 'macos') {
+    allowlist = { ...allowlist, ...MACOS_READ_ONLY_COMMANDS }
+  }
   // On Windows, xargs can be used as a data-to-code bridge: if a file contains
   // a UNC path, `cat file | xargs cat` feeds that path to cat, triggering SMB
   // resolution. Since the UNC path is in file contents (not the command string),

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -4868,6 +4868,31 @@ describe("AgenC delegate background-agent runner", () => {
     await expect(runner.getAgentSnapshot(agentId)).resolves.toBeNull();
   });
 
+  it.each(["completed", "cancelled"] as const)("keeps permission-denied routine outcome honest after a %s answer", async (stopReason) => {
+    const agentId = "session-routine-denied";
+    const { runner, rolloutItems, control, session } = makeTopLevelRunner({ conversationId: agentId });
+    await runner.startAgent({ objective: "one routine", deferInitialTurn: true, unattendedAllow: [], unattendedDeny: [] });
+    control.sendInput.mockImplementationOnce(async () => {
+      session.emit({ id: "blocked-call", msg: { type: "error", payload: {
+        cause: "permission_denied:permission_mode", message: "This run has nobody attached to approve it.",
+      } } });
+      session.emitPhaseEvent({ type: "assistant_text", content: "Only a partial report is available." });
+      session.emitPhaseEvent({ type: "turn_complete", content: "Only a partial report is available.", stopReason, usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } });
+    });
+    await runner.submitAgentMessage(agentId, { sessionId: agentId, content: "inspect", originalContent: "inspect", messageId: "routine-message", streamId: "routine-stream", acceptedAt: "2026-05-09T00:00:00.000Z" });
+    const status = stopReason === "cancelled" ? "cancelled" : "failed";
+    expect(await runner.finishAgentRun(agentId, "routine-message")).toBe(status);
+    const terminals = rolloutItems.flatMap(item => {
+      const event = (item as { payload?: { msg?: { type?: string; payload?: unknown } } }).payload?.msg;
+      return event?.type === "run_terminal" ? [event.payload] : [];
+    });
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]).toMatchObject({ status, exitCode: status === "cancelled" ? 130 : 1,
+      stopReason: status === "cancelled" ? "routine_cancelled" : "routine_permission_denied",
+      finalMessage: "Only a partial report is available.",
+    });
+  });
+
   it("suspends a daemon-shutdown idle run without poisoning it terminal", async () => {
     let clock = "2026-05-09T00:00:00.000Z";
     const { runner, rolloutItems, rolloutStore } = makeTopLevelRunner({

--- a/runtime/tests/prompts/permissions-prompt.test.ts
+++ b/runtime/tests/prompts/permissions-prompt.test.ts
@@ -230,6 +230,18 @@ describe("getPermissionsSection", () => {
     expect(out).toContain("Unattended denylist: (none)");
   });
 
+  test("routine read-only policy describes refusals and bounded diagnostics, not interactive approval", () => {
+    const context = createEmptyToolPermissionContext({ mode: "unattended",
+      unattendedPolicy: { allowlist: [], denylist: [], readOnly: true },
+    });
+    const out = getPermissionsSection(context, WORKSPACE_AUTHORITY)!;
+    expect(out).toContain("Calls that need approval are refused, not paused");
+    expect(out).toContain("one bounded native command per call");
+    expect(out).toContain("pmset -g batt");
+    expect(out).toContain("Never request bypass permissions");
+    expect(out).not.toContain("Any other tool pauses the agent");
+  });
+
   test("composition uses a blank line between heading, sandbox, and approval", () => {
     const out = permissionsSection("default");
     expect(out).not.toBeNull();

--- a/runtime/tests/tools/bash-macos-read-only.test.ts
+++ b/runtime/tests/tools/bash-macos-read-only.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { checkReadOnlyConstraints } from '../../src/tools/BashTool/readOnlyValidation.js'
+import { shellCallIsGranted } from '../../src/permissions/read-only-grant.js'
+import { checkPathConstraints } from '../../src/tools/BashTool/pathValidation.js'
+import { createEmptyToolPermissionContext } from '../permissions/types.js'
+
+const platform = vi.hoisted(() => ({ value: 'macos' }))
+vi.mock('../../src/utils/platform.js', async importOriginal => ({
+  ...await importOriginal<typeof import('../../src/utils/platform.js')>(),
+  getPlatform: () => platform.value,
+}))
+const checkReadOnly = (input: { command: string }) => checkReadOnlyConstraints(input as never, false)
+const behavior = (command: string) => checkReadOnly({ command }).behavior
+beforeEach(() => { platform.value = 'macos' })
+
+const diagnostics = [
+  'sw_vers', 'sw_vers -productVersion', '/usr/bin/sw_vers',
+  'sysctl -n hw.ncpu hw.physicalcpu machdep.cpu.brand_string kern.hostname kern.boottime vm.loadavg',
+  'sysctl -n hw.memsize', '/usr/sbin/sysctl -n vm.swapusage',
+  'vm_stat', 'pagesize', 'memory_pressure', 'df -h', 'mount',
+  'top -l 1 -n 5 -stats pid,command,cpu,mem',
+  'top -l 2 -n 8 -stats pid,command,cpu,mem,threads -s 1',
+  'pmset -g batt', 'pmset -g', 'pmset -g therm',
+  'system_profiler SPPowerDataType', 'system_profiler SPPowerDataType -detailLevel mini',
+  'system_profiler -json SPPowerDataType -timeout 10',
+  'ifconfig', 'ifconfig -a', 'ifconfig en0', 'ipconfig getifaddr en0',
+  'date && hostname && sw_vers && uptime && sysctl -n hw.memsize',
+  'vm_stat && pagesize && memory_pressure',
+  'pmset -g batt 2>/dev/null; pmset -g 2>/dev/null | head -40',
+  'sw_vers 2>/dev/null|head -5', 'sw_vers 2>/dev/null&&uptime',
+  'top -l 2 -n 8 -stats pid,command,cpu,mem,threads -s 1 2>/dev/null | tail -40',
+]
+
+describe('macOS diagnostic commands', () => {
+  it.each(diagnostics)('grants %s through the real unattended shell and path gates', command => {
+    expect(behavior(command), command).toBe('allow')
+    expect(shellCallIsGranted('exec_command', { cmd: command }, process.cwd(),
+      createEmptyToolPermissionContext({ mode: 'unattended' }), {
+        checkReadOnly,
+        checkPaths: (input, cwd, context) => checkPathConstraints(input as never, cwd, context),
+      }), command).toEqual({ ok: true })
+  })
+
+  it.each([
+    'sysctl -w kern.hostname=changed', 'sysctl kern.hostname=changed', 'sysctl -f config',
+    'sysctl -n kern.hostname = changed', 'sysctl -a', 'sysctl -- -w kern.hostname=changed',
+    'pmset sleepnow', 'pmset -a sleep 0', 'pmset -g batt sleepnow', 'pmset -g pslog',
+    'memory_pressure -l critical', 'memory_pressure -p 1', 'memory_pressure -S -l warn',
+    'mount -uw /', 'mount /dev/disk1 /mnt', 'ifconfig en0 down', 'ipconfig set en0 DHCP',
+    'top', 'top -l 0', 'top -l 1 -l 0', 'top -l 999999', 'top -l 1 -s 9999',
+    'vm_stat 1', 'system_profiler', 'system_profiler SPApplicationsDataType',
+    'system_profiler SPPowerDataType -timeout 0', 'system_profiler SPPowerDataType -detailLevel full',
+    'sw_vers > report.txt', 'sysctl -n hw.memsize; touch changed',
+    'sw_vers 2>/dev/nullo; uptime', 'sw_vers 2>/dev/null\\;report; uptime',
+    'sw_vers 2>"/dev/null;report"; uptime', 'sw_vers 2>/dev/null; touch changed',
+    'sw_vers 2>/dev/null&>report', 'sw_vers 2>/dev/null$(echo report)',
+    'sw_vers $(touch changed)', 'sw_vers $FLAGS', 'sysctl -n hw.*',
+    './sw_vers', '/tmp/sw_vers', 'sudo sw_vers',
+  ])('does not grant %s', command => {
+    expect(behavior(command)).not.toBe('allow')
+  })
+
+  it.each(['linux', 'windows', 'wsl'])('does not apply macOS semantics on %s', value => {
+    platform.value = value
+    expect(behavior('sw_vers')).not.toBe('allow')
+    expect(behavior('top -l 1 -n 5')).not.toBe('allow')
+    expect(behavior('pmset -g batt')).not.toBe('allow')
+  })
+
+  it.skipIf(process.platform !== 'darwin')('collects real macOS diagnostics with the admitted bounded invocations', async () => {
+    const exec = promisify(execFile)
+    for (const [program, args, output] of [
+      ['/usr/bin/sw_vers', [], /ProductVersion/],
+      ['/usr/sbin/sysctl', ['-n', 'hw.memsize'], /^\d+\s*$/],
+      ['/usr/bin/vm_stat', [], /Pages free/],
+      ['/usr/bin/pmset', ['-g', 'batt'], /Now drawing from/],
+      ['/usr/bin/top', ['-l', '1', '-n', '5', '-stats', 'pid,command,cpu,mem'], /Processes:/],
+    ] as const) {
+      const command = [program, ...args].join(' ')
+      expect(behavior(command), command).toBe('allow')
+      const { stdout } = await exec(program, [...args], {
+        timeout: 10_000, maxBuffer: 128 * 1024,
+        env: { PATH: '/usr/bin:/bin:/usr/sbin:/sbin', LANG: 'C' },
+      })
+      expect(stdout).toMatch(output)
+    }
+  }, 30_000)
+})


### PR DESCRIPTION
## Summary

Fix the failure observed in a read-only Mac health routine: native diagnostic commands were refused and the partial response was nevertheless recorded as a completed run.

- Admit specific, bounded macOS diagnostic invocations through the existing unattended read-only shell and path gates. Mutation flags, unbounded streaming, unsafe paths and shell payloads remain refused.
- Recognize shell separators after safe `/dev/null` redirections without accepting escaped separators or filename suffixes.
- Record permission-denied routine invocations as failed even if the model finishes a partial answer. Preserve cancellation and retain the partial report.
- Explain the actual read-only unattended policy and recommend bounded, separate diagnostic calls.

Desktop integration and the previously requested hidden composer scrollbar are included in https://github.com/tetsuo-ai/agenc-desktop/pull/241.

Synced with main `215ac0522`, including the managed DeepSeek output budget fix. Desktop pins the combined source commit `69ea6b4fa6e4ae609551859030ca6d92a4048967`.

## Local validation

Private repository CI is not being treated as proof. Local macOS validation:

- Type checking, test-support type checking and production build: passed.
- Focused routine, runner and read-only grant suite: 347 passed (before adding the native diagnostic smoke case).
- Final macOS command suite: 74 passed, including real `sw_vers`, `sysctl`, `vm_stat`, `pmset` and bounded `top` executions on this Mac.
- Permission prompt, shell AST and unattended security regressions: 172 passed.
- Broader permissions, shell, routines and runner suite: 1,729 passed; 3 existing failures listed below.
- Desktop/Core routine wire roundtrip, bridge and safety tests: 25 passed, including failed state persistence and reconnect.
- After syncing main: 345 passed across the full runner contract, native macOS diagnostics, permission prompt and managed DeepSeek regressions; type checking and build rerun.

### Existing baseline failures, reproduced on unchanged main de33e0185245

- `tests/permissions/donor-stack-import-boundary.test.ts`: existing compatibility import from `permissions/read-only-grant.ts`.
- `tests/permissions/permission-audit-log.test.ts`: `/tmp` versus `/private/tmp` path expectation on macOS.
- `tests/permissions/rpc/request-permissions.test.ts`: special temporary path grant expectation.
- `npm run test:fast -- --base origin/main` stops on `tests/app-server/daemon-cli.contract.test.ts`, required PID path expectation (`/home/test` versus `/System/Volumes/Data/home/test`). The identical test fails on unchanged main.

The overall gate is not green. These baseline failures are documented, not bypassed or edited in this PR. The routine roundtrip uses a deterministic executor; no claim is made that a live paid-provider routine was rerun. No existing user routine, permission setting, or stored report was modified.
