### PR TITLE
fix(daemon): repair attachment and shutdown ownership [skip ci]

### DIFF
--- a/docs/design/daemon-session-control-plane-followup-audit.md
+++ b/docs/design/daemon-session-control-plane-followup-audit.md
@@ -1,0 +1,72 @@
+# Daemon/session control-plane follow-up audit
+
+Date: 2026-09-11. Baseline: `de33e0185245179a0a7f3f2fcf4e25eeaa3b2689`.
+
+## Scope
+
+Three parallel investigations audited daemon shutdown and transport scheduling,
+session attachment authority, and SDK/TUI submission ownership. Integration review
+followed those operations across real dispatch, routing, session lifecycle, and
+local transports. This extends the [initial audit](daemon-session-control-plane-audit.md).
+
+## Confirmed defects and repairs
+
+| Boundary | Reproduction | Repair |
+| --- | --- | --- |
+| Attachment acquisition → rollback | A creator blocks on its runner snapshot; another attach succeeds; the creator fails and removes the adopted attachment or entire client. | Session lifecycle tracks pending owners and committed adoption. Routing shares the acquisition token, and client removal checks other sessions and pending attachments atomically. |
+| Concurrent acquisition → failure | Two attempts acquire one provisional attachment, then both fail in either order. | The last failing owner releases uncommitted state. A successful adoption remains valid independently of other failures. Revoked attachments cannot commit. |
+| Capability replay → session termination | Replay blocks, a session terminates and shifts its buffer, a new action arrives, then replay succeeds. Positional deletion removes the new action. | Completion retires exactly the buffered objects in the replay receipt. New actions survive for the next capable client. |
+| SDK attach replay → prompt admission | Historical events for a reused message ID arrive during attach, invoking stale approvals or settling a new prompt before the daemon validates it. | Prompt-scoped listeners become active at that prompt's submission dispatch boundary. Duplicate and conflicting submissions receive the daemon's current decision. |
+| TUI submission → input restoration | One submission fails after an editor submission consumes or rolls back entries retained in the shared input queue. | Failure restores only entries drained by that submission and retained entries still present. It preserves later arrivals and queue order. |
+| Initialization → priority scheduling | A second initialize queues behind a running stream and replaces the barrier that cancellation waits on. Priority traffic can also accumulate without transport queue accounting during authentication. | The first initialize establishes the barrier once. Separate bounded priority and control lanes preserve cancellation capacity before dispatcher admission. |
+| Shutdown acceptance → cleanup | An acknowledgement never settles, or a noncancellable snapshot waits for runner teardown while transport shutdown waits for that snapshot. | Acknowledgement waiting has a deadline. Connection cancellation, command cleanup, and runner shutdown precede transport handler draining, which has a bounded daemon fallback. |
+
+## Ownership rules
+
+The session manager is the attachment authority; multiplexer routes project that
+state. Internal symbol tokens never enter protocol payloads. Repeated acquisition
+within one attach uses the same token. Commit records successful adoption;
+rollback releases only that attempt's claim. Neither route creation nor client
+registration alone proves that a failing attempt still owns the resource.
+
+Shutdown fences ingress before draining work. Actor teardown precedes handlers
+that can depend on it. Default standalone transport close still waits for its
+handlers; the foreground daemon explicitly applies a five-second drain deadline
+after actor cleanup. It retains ownership of actor teardown until that work
+settles, rather than abandoning live work when a timer expires. Shutdown selects
+known actors directly without first waiting for diagnostic runner snapshots.
+Cleanup reports drain failures while proceeding through the remaining registry.
+
+## Verification
+
+Regression tests use explicit gates to establish the failing interleavings.
+Connected SDK/TUI cases compose in-process transport, dispatcher, multiplexer,
+and session lifecycle. Transport cases use real local sockets; foreground tests
+exercise daemon cleanup and authority release.
+
+```sh
+npm run validate:runtime
+npm run build --workspace=@tetsuo-ai/agenc-sdk
+npm --workspace=@tetsuo-ai/runtime test -- tests/app-server tests/app-server-client tests/sdk-package tests/tui/daemon-session --maxWorkers=2
+```
+
+Final results on Node 26.5.0. The runtime validation and Docker suite were
+repeated after rebasing onto `e17f0df990605ade7cd4e49915ac3529bde489b0`:
+
+| Check | Result |
+| --- | --- |
+| Linux Docker control-plane boundary | 135 files, 1,792 tests passed; expected-red boundary probe passed. |
+| Runtime and test-support TypeScript checks | Passed. |
+| Runtime build, package entrypoints, generated protocol checks | Passed. |
+| SDK build and TypeScript check | Passed. |
+| Built runtime/TUI imports and PTY startup | Passed in normal and bypass modes at 148×40, 120×30, and 80×24. |
+| Local required-gate tests | 162 passed. |
+| Patch whitespace check | `git diff --check` passed. |
+
+The earlier shared checkout's worktree status remained unchanged. Its existing
+`AGENTS.md` was preserved. GitHub CI was not run.
+
+These checks exercise local lifecycle behavior with deterministic runner/provider
+fixtures; they do not establish live provider reliability or behavior on untested
+hosts. An uncooperative runner still requires its actual teardown to settle
+before daemon stores close; transport deadlines do not abandon that ownership.

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -1367,7 +1367,9 @@ export class AgencClient {
     };
 
     const unsubscribe = this.onSessionNotification(sessionId, (message) => {
-      if (finishing) return;
+      // session.attach replays prior submissions before message.send can
+      // validate this one's content and identity. Replay is not its admission.
+      if (finishing || !submissionDispatched) return;
       const observedClientMessageId =
         userMessageClientMessageIdFromNotification(message);
       if (!submissionObserved) {

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -1589,6 +1589,7 @@ export class AgenCDaemonAgentManager {
     params: AgentAttachParams,
     registerSessionRoute: (
       sessionId: string,
+      attachmentOwner?: symbol,
     ) => Promise<() => Promise<void> | void> | (() => Promise<void> | void),
   ): Promise<AgentAttachResult> {
     if (this.#sessionManager === undefined) {
@@ -1634,13 +1635,13 @@ export class AgenCDaemonAgentManager {
       );
     }
 
-    const { attachment, created: attachmentCreated } = await this.#sessionManager.attachSessionWithOwnership({
+    const { attachment, owner: attachmentOwner } = await this.#sessionManager.attachSessionWithOwnership({
       sessionId: session.sessionId,
       ...(params.clientId !== undefined ? { clientId: params.clientId } : {}),
     });
     let rollbackRoute: (() => Promise<void> | void) | undefined;
     try {
-      rollbackRoute = await registerSessionRoute(session.sessionId);
+      rollbackRoute = await registerSessionRoute(session.sessionId, attachmentOwner);
       const runnerSnapshot = await this.#runner.getAgentSnapshot(target.agentId);
       if (
         runnerSnapshot?.runtimeSettings === undefined ||
@@ -1680,7 +1681,7 @@ export class AgenCDaemonAgentManager {
           return { ...activeSession, cwd };
         }),
       );
-      return {
+      const result: AgentAttachResult = {
         agentId: target.agentId,
         attachmentId: attachment.attachmentId,
         sessionIds: orderedSessionIds,
@@ -1692,16 +1693,21 @@ export class AgenCDaemonAgentManager {
         runtimeSessionId: target.agentId,
         sessions: attachedSessions,
       };
+      if (!await this.#sessionManager.commitSessionAttachment(attachment, attachmentOwner)) {
+        throw new AgenCDaemonAgentLifecycleError(
+          "AGENT_NOT_FOUND",
+          `AgenC daemon session attachment is no longer active: ${session.sessionId}`,
+        );
+      }
+      return result;
     } catch (error) {
       await Promise.resolve(rollbackRoute?.()).catch(() => {});
-      if (attachmentCreated) {
-        await this.#sessionManager
-          .detachSession({
-            sessionId: session.sessionId,
-            attachmentId: attachment.attachmentId,
-          })
-          .catch(() => {});
-      }
+      await this.#sessionManager
+        .rollbackSessionAttachment({
+          sessionId: session.sessionId,
+          attachmentId: attachment.attachmentId,
+        }, attachmentOwner)
+        .catch(() => {});
       throw error;
     }
   }
@@ -2297,8 +2303,9 @@ export class AgenCDaemonAgentManager {
       withTimeout(task.result, AGENT_LIFECYCLE_OPERATION_TIMEOUT_MS,
         `agent ${agentId} in-flight stop timed out during daemon shutdown`),
     ));
-    // Shutdown must reach every retained runner even when a status read fails.
-    await this.#refreshAgentsFromRunner().catch(() => {});
+    // Snapshot reads can hold runtime locks that only teardown releases.
+    // Lifecycle state selects retained actors; each runner owns the live
+    // stop/suspend decision, so diagnostics must not precede shutdown.
     const targets = await this.#state.with((state) => {
       return [...state.agents.values()].filter(isActiveAgent).map((agent) => ({
         agentId: agent.agentId,

--- a/runtime/src/app-server/client-multiplexer.ts
+++ b/runtime/src/app-server/client-multiplexer.ts
@@ -232,7 +232,7 @@ export class AgenCDaemonClientMultiplexer {
     const {
       registration,
       replay,
-      replayCounts,
+      replayItems,
       statusReplay,
       statusReplayEvents,
     } = await this.#state.with((state) => {
@@ -287,12 +287,12 @@ export class AgenCDaemonClientMultiplexer {
         }
       }
       const replayEvents: JsonObject[] = [];
-      const replayCounts = new Map<string, number>();
+      const replayItems = new Map<string, BufferedCapabilityEvent[]>();
       for (const capability of client.capabilities) {
         if (state.capabilityReplayInFlight.has(capability)) continue;
         const buffered = state.capabilityBuffers.get(capability) ?? [];
         if (buffered.length === 0) continue;
-        replayCounts.set(capability, buffered.length);
+        replayItems.set(capability, [...buffered]);
         for (const item of buffered) {
           replayEvents.push(item.event);
         }
@@ -333,7 +333,7 @@ export class AgenCDaemonClientMultiplexer {
       );
       options.onRegistered?.({ clientId });
       state.clients.set(clientId, client);
-      for (const capability of replayCounts.keys()) {
+      for (const capability of replayItems.keys()) {
         state.capabilityReplayInFlight.add(capability);
       }
       if (statusReplayBatch.length > 0) {
@@ -360,7 +360,7 @@ export class AgenCDaemonClientMultiplexer {
       return {
         registration: { clientId },
         replay,
-        replayCounts,
+        replayItems,
         statusReplay,
         statusReplayEvents,
       };
@@ -369,16 +369,21 @@ export class AgenCDaemonClientMultiplexer {
     if (replay.length > 0) {
       const replayResult = await settleDeliveries(replay);
       await this.#state.with((state) => {
-        for (const capability of replayCounts.keys()) {
+        for (const capability of replayItems.keys()) {
           state.capabilityReplayInFlight.delete(capability);
         }
         if (replayResult.failed.length === 0) {
-          for (const [capability, count] of replayCounts) {
+          for (const [capability, items] of replayItems) {
             const buffered = state.capabilityBuffers.get(capability);
             if (buffered === undefined) continue;
-            buffered.splice(0, count);
-            if (buffered.length === 0) {
+            // Termination can replace this buffer while replay is blocked.
+            // Retire only the leased objects, never new actions by position.
+            const delivered = new Set(items);
+            const retained = buffered.filter((item) => !delivered.has(item));
+            if (retained.length === 0) {
               state.capabilityBuffers.delete(capability);
+            } else {
+              state.capabilityBuffers.set(capability, retained);
             }
           }
         }
@@ -412,6 +417,7 @@ export class AgenCDaemonClientMultiplexer {
     sessionId: string,
     clientId: string,
     onAttached?: (created: boolean) => void,
+    attachmentOwner?: symbol,
   ): Promise<SessionAttachResult> {
     // Replay reserves its complete bounded batch before attachment. This keeps
     // a blocked client's queued closures within the same byte/count caps as
@@ -429,10 +435,10 @@ export class AgenCDaemonClientMultiplexer {
           this.#maxPendingDeliveryBytesPerClient,
           this.#maxPendingDeliveryCountPerClient,
         );
-        const attachment = await this.#sessionManager.attachSession({
-          sessionId,
-          clientId,
-        });
+        const params = { sessionId, clientId };
+        const attachment = attachmentOwner === undefined
+          ? await this.#sessionManager.attachSession(params)
+          : (await this.#sessionManager.attachSessionWithOwnership(params, attachmentOwner)).attachment;
         const route = getOrCreateRoute(state, sessionId);
 
         client.sessionIds.add(sessionId);
@@ -476,6 +482,48 @@ export class AgenCDaemonClientMultiplexer {
     }
 
     return attachment;
+  }
+
+  /** Undo a speculative attach only when no other attempt has acquired it. */
+  async rollbackClientAttachment(
+    sessionId: string,
+    clientId: string,
+    attachmentOwner: symbol,
+    expectedDeliveryKey: string,
+  ): Promise<void> {
+    await this.#state.with(async (state) => {
+      const client = state.clients.get(clientId);
+      const route = state.sessions.get(sessionId);
+      const attachmentId = route?.clientAttachmentIds.get(clientId);
+      if (client?.deliveryKey !== expectedDeliveryKey || attachmentId === undefined) return;
+      // Session lifecycle owns acquisition and commit. Routing is a projection
+      // of that authority, so pending or committed adopters retain their route.
+      const removed = await this.#sessionManager.rollbackSessionAttachment(
+        { sessionId, attachmentId }, attachmentOwner,
+      );
+      if (!removed) return;
+      route!.clientAttachmentIds.delete(clientId);
+      client.sessionIds.delete(sessionId);
+      deleteRouteIfEmpty(state, route!);
+    });
+  }
+
+  /** The ownership callback runs under the routing lock before removal. */
+  async removeClientIfUnused(
+    clientId: string,
+    expectedDeliveryKey: string,
+    releaseOwnership: () => boolean,
+  ): Promise<boolean> {
+    return this.#state.with((state) => {
+      const client = state.clients.get(clientId);
+      if (
+        client?.deliveryKey !== expectedDeliveryKey ||
+        client.sessionIds.size > 0 ||
+        !releaseOwnership()
+      ) return false;
+      state.clients.delete(clientId);
+      return true;
+    });
   }
 
   async detachClientFromSession(

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -502,9 +502,14 @@ export class AgenCDaemonRpcShutdownCoordinator {
   #pendingAcknowledgements = 0;
   #completed = false;
   readonly #onShutdownReady: () => void;
+  readonly #acknowledgementTimeoutMs: number;
 
-  constructor(onShutdownReady: () => void) {
+  constructor(onShutdownReady: () => void, acknowledgementTimeoutMs = 5_000) {
+    if (!Number.isSafeInteger(acknowledgementTimeoutMs) || acknowledgementTimeoutMs <= 0) {
+      throw new TypeError("daemon shutdown acknowledgement timeout must be a positive integer");
+    }
     this.#onShutdownReady = onShutdownReady;
+    this.#acknowledgementTimeoutMs = acknowledgementTimeoutMs;
   }
 
   get blocksRequests(): boolean {
@@ -528,8 +533,21 @@ export class AgenCDaemonRpcShutdownCoordinator {
       message.method === "daemon.shutdown" &&
       !isDaemonErrorResponse(response) &&
       this.#pendingAcknowledgements > 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      await send(response);
+      const sending = send(response);
+      if (acceptedShutdown) {
+        await Promise.race([
+          sending,
+          new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(() => reject(new Error(
+              `daemon shutdown acknowledgement exceeded ${this.#acknowledgementTimeoutMs} ms`,
+            )), this.#acknowledgementTimeoutMs);
+          }),
+        ]);
+      } else {
+        await sending;
+      }
     } catch (error) {
       if (acceptedShutdown && !this.#completed) {
         // Shutdown acceptance already fenced daemon ingress and cannot be
@@ -543,6 +561,8 @@ export class AgenCDaemonRpcShutdownCoordinator {
         }
       }
       throw error;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
     }
     if (!acceptedShutdown || this.#completed) return;
 
@@ -3345,9 +3365,10 @@ async function runAgenCDaemonForegroundLocked(
       sessionTempRoot: resolveSessionTempRootAtIngress(host.env),
       allowGpu: activeConfig.sandbox?.allow_gpu === true,
     });
-    cleanup.register("daemon-command-exec", async () => {
+    const closeCommandExec = async () => {
       await commandExec.closeAll("daemon_shutdown");
-    });
+    };
+    const unregisterCommandExecCleanup = cleanup.register("daemon-command-exec", closeCommandExec);
     const csvAgentJobsRepositories = new CsvAgentJobsRepositoryAuthority({
       agencHome: authStartup.daemonHome,
     });
@@ -3626,11 +3647,12 @@ async function runAgenCDaemonForegroundLocked(
     cleanup.register("daemon-snapshots", async () => {
       await agentManager.flushSnapshots("daemon_shutdown");
     });
-    cleanup.register("daemon-agents", async () => {
+    const stopAgents = async () => {
       await agentManager.stopAll("daemon_shutdown", {
         disposition: "suspend_idle",
       });
-    });
+    };
+    const unregisterAgentsCleanup = cleanup.register("daemon-agents", stopAgents);
     codePrediction =
       runner.resolveCodePredictionSource === undefined
         ? undefined
@@ -4118,20 +4140,12 @@ async function runAgenCDaemonForegroundLocked(
     cleanup.register("daemon-fuzzy-file-index", async () => {
       await dispatcher.close();
     });
-    cleanup.register("daemon-connections", async () => {
-      const activeConnections = [...connections.values()];
-      connections.clear();
-      socketConnections.clear();
-      await Promise.all(
-        activeConnections.map((connection) => connection.close()),
-      );
-    });
     cleanup.register("daemon-authority", async () => {
       await options.beforeDaemonAuthorityCleanup?.();
       await runAgenCDaemonAuthorityCleanup({
         host,
         lifecycleLockHeld: !lifecycleLockReleased,
-        closeSocket: () => socketServer.close(),
+        closeSocket: () => socketServer.close({ drainTimeoutMs: 5_000 }),
         removeMetadata: () =>
           removeOwnedForegroundDaemonMetadata({
             expected: daemonIdentity,
@@ -4141,10 +4155,34 @@ async function runAgenCDaemonForegroundLocked(
       });
     });
     cleanup.register("daemon-websocket", async () => {
-      await webSocketServer.close();
+      await webSocketServer.close({ drainTimeoutMs: 5_000 });
     });
     cleanup.register("daemon-mcp-server", async () => {
       await activeMcpServer.close();
+    });
+    // Shutdown already fenced new RPC work. Cancel connection jobs and stop
+    // daemon-owned execution before transport.close drains their handlers;
+    // otherwise a runner-backed request waits for a stop scheduled behind it.
+    // Keep the earlier registrations until construction reaches this point so
+    // startup failures still release partially constructed actors.
+    unregisterAgentsCleanup();
+    cleanup.register("daemon-agents", stopAgents);
+    unregisterCommandExecCleanup();
+    cleanup.register("daemon-command-exec", closeCommandExec);
+    cleanup.register("daemon-connections", async () => {
+      const activeConnections = [...connections.values()];
+      connections.clear();
+      socketConnections.clear();
+      const results = await Promise.allSettled(
+        activeConnections.map((connection) => connection.close()),
+      );
+      const failed = results.filter((result) => result.status === "rejected");
+      if (failed.length > 0) {
+        throw new AggregateError(
+          failed.map((result) => result.reason),
+          "daemon connection cleanup failed",
+        );
+      }
     });
 
     const signalProcess = options.signalProcess ?? process;

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -586,6 +586,8 @@ export interface AgenCDaemonDispatcherOptions {
     | "detachClientFromSession"
     | "detachSession"
     | "registerClient"
+    | "rollbackClientAttachment"
+    | "removeClientIfUnused"
     | "terminateSession"
     | "removeClient"
   >;
@@ -640,7 +642,17 @@ export interface AgenCDaemonDispatcherOptions {
 export type AgenCDaemonInitializeAuthResult =
   boolean | AuthDaemonSocketIdentity | null | undefined;
 
+interface AttachmentClientOwnership {
+  pendingAttachments: number;
+  registeredHere: boolean;
+  registration: Promise<unknown>;
+}
+
 export class AgenCDaemonJsonRpcDispatcher {
+  readonly #attachmentClients = new WeakMap<
+    AgenCDaemonJsonRpcConnection,
+    Map<string, AttachmentClientOwnership>
+  >();
   readonly #agentManager: Pick<
     AgenCDaemonAgentManager,
     | "approveTool"
@@ -698,6 +710,8 @@ export class AgenCDaemonJsonRpcDispatcher {
         | "detachClientFromSession"
         | "detachSession"
         | "registerClient"
+        | "rollbackClientAttachment"
+        | "removeClientIfUnused"
         | "terminateSession"
         | "removeClient"
       >
@@ -834,6 +848,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     connection: AgenCDaemonJsonRpcConnection,
   ): Promise<void> {
     return connection.runClose(async () => {
+      this.#attachmentClients.delete(connection);
       this.#routineSubscriptions.get(connection)?.();
       this.#routineSubscriptions.delete(connection);
       connection.cancelAllInFlightRequests("connection closed");
@@ -1815,8 +1830,8 @@ export class AgenCDaemonJsonRpcDispatcher {
     const attachParams = validateAgentAttachParams(params);
     const result = await this.#agentManager.attachAgent(
       attachParams,
-      (sessionId) =>
-        this.#registerAttachedClient(connection, attachParams, sessionId),
+      (sessionId, attachmentOwner) =>
+        this.#registerAttachedClient(connection, attachParams, sessionId, attachmentOwner),
     );
     return successResponse(id, result);
   }
@@ -1891,16 +1906,14 @@ export class AgenCDaemonJsonRpcDispatcher {
     connection: AgenCDaemonJsonRpcConnection,
     params: AgentAttachParams,
     sessionId: string,
+    attachmentOwner = Symbol("agent attachment"),
   ): Promise<() => Promise<void>> {
     const clientId = params.clientId;
-    const wasTracked =
-      clientId !== undefined && connection.trackedClientIds.includes(clientId);
-    let createdRoute = false;
     const attachment = await this.#attachTrackedClientToSession(
       connection,
       clientId,
       sessionId,
-      (created) => { createdRoute = created; },
+      attachmentOwner,
     );
     return async () => {
       if (
@@ -1910,15 +1923,10 @@ export class AgenCDaemonJsonRpcDispatcher {
       ) {
         return;
       }
-      if (!wasTracked) {
-        connection.untrackClientId(clientId);
-        await this.#clientMultiplexer.removeClient(clientId, connection.cancellationScope).catch(() => {});
-        return;
-      }
-      if (!createdRoute) return;
       await this.#clientMultiplexer
-        .detachClientFromSession(sessionId, clientId, connection.cancellationScope)
+        .rollbackClientAttachment(sessionId, clientId, attachmentOwner, connection.cancellationScope)
         .catch(() => {});
+      await this.#removeUnusedAttachmentClient(connection, clientId);
     };
   }
 
@@ -1983,7 +1991,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     connection: AgenCDaemonJsonRpcConnection,
     clientId: string | undefined,
     sessionId: string,
-    onAttached?: (created: boolean) => void,
+    attachmentOwner?: symbol,
   ): Promise<SessionAttachResult | undefined> {
     if (
       this.#clientMultiplexer === undefined ||
@@ -1993,44 +2001,79 @@ export class AgenCDaemonJsonRpcDispatcher {
       return undefined;
     }
     connection.assertOpen();
-    let registeredHere = false;
-    try {
+    let clients = this.#attachmentClients.get(connection);
+    if (clients === undefined) {
+      clients = new Map();
+      this.#attachmentClients.set(connection, clients);
+    }
+    let ownership = clients.get(clientId);
+    if (ownership === undefined) {
+      ownership = { pendingAttachments: 0, registeredHere: false, registration: Promise.resolve() };
+      clients.set(clientId, ownership);
       if (!connection.trackedClientIds.includes(clientId)) {
-        await this.#clientMultiplexer
-          .registerClient({
-            clientId,
-            deliveryKey: connection.cancellationScope,
-            send: (message) => connection.sendNotification!(message),
-            acceptsSessionEvent: (event) => connection.acceptsSessionEvent(event),
-            onRegistered: () => {
-              connection.trackClientId(clientId);
-              registeredHere = true;
-            },
-          })
-          .catch((error) => {
-            if ((error as { code?: string }).code === "CLIENT_ALREADY_REGISTERED") {
-              throw invalidParams(`daemon client is already registered: ${clientId}`);
-            }
-            throw error;
-          });
-        registeredHere = true;
-        // Track ownership before attachment/replay yields, so close can detach
-        // it even if replay is backpressured indefinitely.
-        connection.trackClientId(clientId);
+        const registrationOwner = ownership;
+        // Concurrent attaches on one physical connection share registration.
+        // A logical id registered by another connection still rejects below.
+        ownership.registration = this.#clientMultiplexer.registerClient({
+          clientId,
+          deliveryKey: connection.cancellationScope,
+          send: (message) => connection.sendNotification!(message),
+          acceptsSessionEvent: (event) => connection.acceptsSessionEvent(event),
+          onRegistered: () => {
+            connection.trackClientId(clientId);
+            registrationOwner.registeredHere = true;
+          },
+        }).catch((error) => {
+          if ((error as { code?: string }).code === "CLIENT_ALREADY_REGISTERED") {
+            throw invalidParams(`daemon client is already registered: ${clientId}`);
+          }
+          throw error;
+        });
       }
+    }
+    ownership.pendingAttachments += 1;
+    let failed = false;
+    try {
+      await ownership.registration;
       connection.assertOpen();
-      const result = await this.#clientMultiplexer.attachClientToSession(sessionId, clientId, onAttached);
+      const result = await this.#clientMultiplexer.attachClientToSession(sessionId, clientId, undefined, attachmentOwner);
       connection.assertOpen();
       return result;
     } catch (error) {
-      if (registeredHere) {
-        connection.untrackClientId(clientId);
-        // A reconnect may already have reused the logical id. Cleanup belongs
-        // only to this physical connection's registration.
-        await this.#clientMultiplexer.removeClient(clientId, connection.cancellationScope).catch(() => {});
+      failed = true;
+      if (attachmentOwner !== undefined) {
+        await this.#clientMultiplexer.rollbackClientAttachment(
+          sessionId, clientId, attachmentOwner, connection.cancellationScope,
+        ).catch(() => {});
       }
       throw error;
+    } finally {
+      ownership.pendingAttachments -= 1;
+      if (failed) await this.#removeUnusedAttachmentClient(connection, clientId);
     }
+  }
+
+  async #removeUnusedAttachmentClient(
+    connection: AgenCDaemonJsonRpcConnection,
+    clientId: string,
+  ): Promise<void> {
+    const clients = this.#attachmentClients.get(connection);
+    const ownership = clients?.get(clientId);
+    if (ownership === undefined || ownership.pendingAttachments > 0) return;
+    if (!ownership.registeredHere || connection.closed) {
+      clients!.delete(clientId);
+      return;
+    }
+    await this.#clientMultiplexer?.removeClientIfUnused(
+      clientId, connection.cancellationScope, () => {
+        // Check again under the routing lock: a new attach may have started
+        // while this cleanup waited. Release both owners without yielding.
+        if (ownership.pendingAttachments > 0 || clients!.get(clientId) !== ownership) return false;
+        clients!.delete(clientId);
+        connection.untrackClientId(clientId);
+        return true;
+      },
+    );
   }
 
   async #sendMessage(

--- a/runtime/src/app-server/session-lifecycle.ts
+++ b/runtime/src/app-server/session-lifecycle.ts
@@ -142,6 +142,10 @@ export class AgenCDaemonSessionManager {
   readonly #onSessionTerminated:
     ((sessionId: string) => void | Promise<void>) | undefined;
   readonly #terminationTasks = new Map<string, Promise<void>>();
+  readonly #attachmentClaims = new WeakMap<AgenCSessionAttachment, {
+    readonly owners: Set<symbol>;
+    committed: boolean;
+  }>();
 
   constructor(options: AgenCSessionLifecycleOptions = {}) {
     this.#createSessionId =
@@ -468,13 +472,25 @@ export class AgenCDaemonSessionManager {
   async attachSession(
     params: SessionAttachParams,
   ): Promise<SessionAttachResult> {
-    return (await this.attachSessionWithOwnership(params)).attachment;
+    const receipt = await this.attachSessionWithOwnership(params);
+    if (!await this.commitSessionAttachment(receipt.attachment, receipt.owner)) {
+      throw new AgenCSessionLifecycleError(
+        "SESSION_CLOSED",
+        `AgenC daemon session attachment is no longer active: ${params.sessionId}`,
+      );
+    }
+    return receipt.attachment;
   }
 
-  /** Internal receipt: rollback may release only attachments this call created. */
+  /** Internal lease: concurrent attempts share provisional attachment state. */
   async attachSessionWithOwnership(
     params: SessionAttachParams,
-  ): Promise<{ readonly attachment: SessionAttachResult; readonly created: boolean }> {
+    owner = Symbol("session attachment owner"),
+  ): Promise<{
+    readonly attachment: SessionAttachResult;
+    readonly created: boolean;
+    readonly owner: symbol;
+  }> {
     return this.#state.with((state) => {
       const session = this.#requireOpenSession(state, params.sessionId);
       const existing =
@@ -483,7 +499,8 @@ export class AgenCDaemonSessionManager {
           : undefined;
 
       if (existing !== undefined) {
-        return { attachment: toAttachResult(session, existing), created: false };
+        this.#attachmentClaims.get(existing)!.owners.add(owner);
+        return { attachment: toAttachResult(session, existing), created: false, owner };
       }
 
       const attachment: AgenCSessionAttachment = {
@@ -493,7 +510,40 @@ export class AgenCDaemonSessionManager {
         ...(params.clientId !== undefined ? { clientId: params.clientId } : {}),
       };
       session.attachments.set(attachment.attachmentId, attachment);
-      return { attachment: toAttachResult(session, attachment), created: true };
+      this.#attachmentClaims.set(attachment, { owners: new Set([owner]), committed: false });
+      return { attachment: toAttachResult(session, attachment), created: true, owner };
+    });
+  }
+
+  /** Publish one successful adoption independently of other pending attempts. */
+  async commitSessionAttachment(
+    params: { readonly sessionId: string; readonly attachmentId: string },
+    owner: symbol,
+  ): Promise<boolean> {
+    return this.#state.with((state) => {
+      const attachment = state.sessions.get(params.sessionId)?.attachments.get(params.attachmentId);
+      const claims = attachment === undefined ? undefined : this.#attachmentClaims.get(attachment);
+      if (claims === undefined || !claims.owners.delete(owner)) return false;
+      claims.committed = true;
+      return true;
+    });
+  }
+
+  /** Last failing owner removes only an attachment nobody committed. */
+  async rollbackSessionAttachment(
+    params: { readonly sessionId: string; readonly attachmentId: string },
+    owner: symbol,
+  ): Promise<boolean> {
+    return this.#state.with((state) => {
+      const session = state.sessions.get(params.sessionId);
+      const attachment = session?.attachments.get(params.attachmentId);
+      const claims = attachment === undefined ? undefined : this.#attachmentClaims.get(attachment);
+      if (attachment === undefined || claims === undefined || !claims.owners.delete(owner)) {
+        return false;
+      }
+      if (claims.committed || claims.owners.size > 0) return false;
+      session!.attachments.delete(attachment.attachmentId);
+      return true;
     });
   }
 

--- a/runtime/src/app-server/transport/request-drain.ts
+++ b/runtime/src/app-server/transport/request-drain.ts
@@ -1,0 +1,31 @@
+export interface AgenCTransportCloseOptions {
+  /** Bound handler draining after the listener and its peers have closed. */
+  readonly drainTimeoutMs?: number;
+}
+
+export async function drainAgenCTransportRequests(
+  pending: readonly Promise<void>[],
+  options: AgenCTransportCloseOptions,
+): Promise<void> {
+  const timeoutMs = options.drainTimeoutMs;
+  if (timeoutMs === undefined) {
+    await Promise.allSettled(pending);
+    return;
+  }
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("daemon transport drain timeout must be a positive integer");
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(pending),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(
+          `daemon transport request drain exceeded ${timeoutMs} ms`,
+        )), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/runtime/src/app-server/transport/stdio.ts
+++ b/runtime/src/app-server/transport/stdio.ts
@@ -16,6 +16,7 @@ import type { Readable, Writable } from "node:stream";
 import type { JsonObject, JsonValue } from "../protocol/index.js";
 import {
   daemonOverloadErrorResponse,
+  isDaemonPreemptiveMessage,
   isDaemonPriorityMessage,
   maxQueuedRequestsFromOptions,
 } from "../overload.js";
@@ -46,6 +47,11 @@ export class AgenCStdioTransport {
   // Priority requests may bypass a streaming turn, but never the initialize
   // request that authenticates and establishes connection state.
   #initializeBarrier: Promise<void> = Promise.resolve();
+  // Repeated initialize frames must not move controls behind a running turn.
+  #hasInitializeBarrier = false;
+  // Reserve decision/cancellation capacity separately from health/status work.
+  // Both are bounded before initialize can release dispatcher admission.
+  readonly #queuedPriorityMessages = { priority: 0, control: 0 };
   #queuedNormalMessages = 0;
   #reader: BoundedJsonLineReader | null = null;
 
@@ -95,6 +101,15 @@ export class AgenCStdioTransport {
     }
 
     if (isDaemonPriorityMessage(message)) {
+      const lane = isDaemonPreemptiveMessage(message) ? "control" : "priority";
+      const maxQueuedRequests = maxQueuedRequestsFromOptions(this.#options);
+      if (this.#queuedPriorityMessages[lane] >= maxQueuedRequests) {
+        void this.send(daemonOverloadErrorResponse(
+          message, "TOO_MANY_QUEUED_REQUESTS", { maxQueuedRequests, lane },
+        )).catch((error) => this.#options.onError?.(asError(error), line));
+        return;
+      }
+      this.#queuedPriorityMessages[lane] += 1;
       // Control-plane requests must NOT queue behind a full model stream.
       // Dispatch them off-chain while keeping ordinary, order-dependent work
       // FIFO. The promise is still tracked so close() drains it.
@@ -114,6 +129,7 @@ export class AgenCStdioTransport {
       }
       this.#pendingMessages.add(pending);
       pending.finally(() => {
+        this.#queuedPriorityMessages[lane] -= 1;
         this.#pendingMessages.delete(pending);
       });
       return;
@@ -152,7 +168,8 @@ export class AgenCStdioTransport {
         }
       },
     ));
-    if (message.method === "initialize") {
+    if (message.method === "initialize" && !this.#hasInitializeBarrier) {
+      this.#hasInitializeBarrier = true;
       this.#initializeBarrier = pending;
     }
     this.#pendingMessages.add(pending);

--- a/runtime/src/app-server/transport/unix-socket.ts
+++ b/runtime/src/app-server/transport/unix-socket.ts
@@ -24,6 +24,7 @@ import {
 import type { JsonObject, JsonValue } from "../protocol/index.js";
 import { resolveHomeContext } from "../../config/home.js";
 import { AgenCStdioTransport, writeJsonLine } from "./stdio.js";
+import { drainAgenCTransportRequests, type AgenCTransportCloseOptions } from "./request-drain.js";
 import {
   loadAgenCNativePeerCredentialBinding,
   type AgenCNativePeerCredentialBinding,
@@ -94,6 +95,7 @@ export interface AgenCUnixSocketServerOptions {
     context: AgenCUnixSocketMessageContext,
   ) => boolean | Promise<boolean>;
   readonly acceptAuthenticationTimeoutMs?: number;
+  readonly maxQueuedRequests?: number;
   readonly onAuthenticationFailed?: (
     message: JsonObject,
     context: AgenCUnixSocketMessageContext,
@@ -248,7 +250,7 @@ export class AgenCUnixSocketServer {
     return socketPath;
   }
 
-  async close(): Promise<void> {
+  async close(options: AgenCTransportCloseOptions = {}): Promise<void> {
     const server = this.#server;
     const boundSocketIdentity = this.#boundSocketIdentity;
     this.#server = null;
@@ -262,9 +264,7 @@ export class AgenCUnixSocketServer {
     for (const { socket } of activeConnections) {
       socket.destroy();
     }
-    await Promise.allSettled(
-      activeConnections.map(({ transport }) => transport.close()),
-    );
+    const pending = activeConnections.map(({ transport }) => transport.close());
     this.#connections.clear();
 
     if (server !== null) {
@@ -283,6 +283,7 @@ export class AgenCUnixSocketServer {
       await this.#options.beforeSocketPathRemoval?.();
       await removeSocketPathIfIdentity(this.socketPath, boundSocketIdentity);
     }
+    await drainAgenCTransportRequests(pending, options);
   }
 
   #acceptConnection(socket: Socket): void {
@@ -349,6 +350,7 @@ export class AgenCUnixSocketServer {
     const transport = new AgenCStdioTransport({
       input: socket,
       output: socket,
+      maxQueuedRequests: this.#options.maxQueuedRequests,
       onMessage: async (message) => {
         // Parsed frames can still be queued behind an active request after
         // disconnect. They must never recreate a daemon connection or start

--- a/runtime/src/app-server/transport/websocket.ts
+++ b/runtime/src/app-server/transport/websocket.ts
@@ -28,10 +28,12 @@ import WebSocket, { WebSocketServer, type RawData } from "ws";
 import type { JsonObject, JsonValue } from "../protocol/index.js";
 import {
   daemonOverloadErrorResponse,
+  isDaemonPreemptiveMessage,
   isDaemonPriorityMessage,
   maxQueuedRequestsFromOptions,
 } from "../overload.js";
 import { isRecord } from "../../utils/record.js";
+import { drainAgenCTransportRequests, type AgenCTransportCloseOptions } from "./request-drain.js";
 
 export const AGENC_WEBSOCKET_DEFAULT_HOST = "127.0.0.1";
 export const AGENC_WEBSOCKET_DEFAULT_PATH = "/";
@@ -110,6 +112,10 @@ interface ActiveWebSocketConnection {
   // Priority requests can bypass model turns only after initialize/auth state
   // for this connection has settled.
   initializeBarrier: Promise<void>;
+  // Only the first handshake can gate priority requests behind normal work.
+  hasInitializeBarrier: boolean;
+  // A health/status backlog cannot consume decision/cancellation capacity.
+  readonly queuedPriorityMessages: { priority: number; control: number };
   // gaphunt3 #47: accept-auth teardown state. `accepted` is true once an
   // authenticator-approved message is seen (or when no authenticator is
   // configured). `authTimeout` is the armed teardown timer; it is cleared on
@@ -224,7 +230,7 @@ export class AgenCWebSocketServer {
     }
   }
 
-  async close(): Promise<void> {
+  async close(options: AgenCTransportCloseOptions = {}): Promise<void> {
     const webSocketServer = this.#webSocketServer;
     const httpServer = this.#server;
     this.#webSocketServer = null;
@@ -241,11 +247,7 @@ export class AgenCWebSocketServer {
       }
     }
     await Promise.allSettled(closed);
-    await Promise.allSettled(
-      activeConnections.flatMap((connection) => [
-        ...connection.pendingMessages,
-      ]),
-    );
+    const pending = activeConnections.flatMap((connection) => [...connection.pendingMessages]);
     this.#connections.clear();
 
     if (webSocketServer !== null) {
@@ -254,6 +256,7 @@ export class AgenCWebSocketServer {
     if (httpServer !== null) {
       await closeHttpServer(httpServer);
     }
+    await drainAgenCTransportRequests(pending, options);
   }
 
   #handleHttpRequest(
@@ -316,6 +319,8 @@ export class AgenCWebSocketServer {
       pendingMessages: new Set(),
       dispatchChain: Promise.resolve(),
       initializeBarrier: Promise.resolve(),
+      hasInitializeBarrier: false,
+      queuedPriorityMessages: { priority: 0, control: 0 },
       // gaphunt3 #47: only require auth when an authenticator is configured;
       // otherwise the connection is accepted immediately (legacy behavior).
       accepted: this.#options.acceptAuthenticator === undefined,
@@ -466,6 +471,15 @@ export class AgenCWebSocketServer {
     }
 
     if (isDaemonPriorityMessage(message)) {
+      const lane = isDaemonPreemptiveMessage(message) ? "control" : "priority";
+      const maxQueuedRequests = maxQueuedRequestsFromOptions(this.#options);
+      if (active.queuedPriorityMessages[lane] >= maxQueuedRequests) {
+        void context.send(daemonOverloadErrorResponse(
+          message, "TOO_MANY_QUEUED_REQUESTS", { maxQueuedRequests, lane },
+        )).catch((error) => this.#options.onError?.(asError(error), context.connectionId));
+        return;
+      }
+      active.queuedPriorityMessages[lane] += 1;
       // Control-plane requests must NOT queue behind a full model stream.
       // Dispatch them off-chain while keeping ordinary, order-dependent work
       // FIFO. The promise is still tracked so close() drains it.
@@ -494,6 +508,7 @@ export class AgenCWebSocketServer {
       }
       active.pendingMessages.add(pending);
       pending.finally(() => {
+        active.queuedPriorityMessages[lane] -= 1;
         active.pendingMessages.delete(pending);
       });
       return;
@@ -535,7 +550,8 @@ export class AgenCWebSocketServer {
       this.#options.onError?.(asError(error), context.connectionId);
     }));
     active.pendingMessages.add(pending);
-    if (message.method === "initialize") {
+    if (message.method === "initialize" && !active.hasInitializeBarrier) {
+      active.hasInitializeBarrier = true;
       active.initializeBarrier = pending;
     }
     pending.finally(() => {
@@ -706,6 +722,9 @@ function closeHttpServer(server: HttpServer): Promise<void> {
       }
       resolve();
     });
+    // Upgraded peers were terminated separately. Incomplete HTTP requests
+    // must not retain the listener while daemon shutdown drains RPC handlers.
+    server.closeAllConnections();
   });
 }
 

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -1423,13 +1423,17 @@ export function createDaemonTuiSession<
         // submit re-sends them.
         if (queuedEntries.length > 0) {
           const originalEntries = new Set(queuedInputsBeforeSubmission);
+          // Retained entries can be consumed or rolled back while this RPC is
+          // pending. Restore only this submission's entries, preserving the
+          // order of retained entries that still belong to the live queue.
+          const restorableEntries = new Set([...queuedInputs, ...queuedEntries]);
           const admittedAfterSubmission = queuedInputs.filter(
             (entry) => !originalEntries.has(entry),
           );
           queuedInputs.splice(
             0,
             queuedInputs.length,
-            ...queuedInputsBeforeSubmission,
+            ...queuedInputsBeforeSubmission.filter((entry) => restorableEntries.has(entry)),
             ...admittedAfterSubmission,
           );
           queuedInputCount += submittedInputCount;

--- a/runtime/tests/app-server/agent-attachment-adoption.contract.test.ts
+++ b/runtime/tests/app-server/agent-attachment-adoption.contract.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { AgenCBackgroundAgentSnapshot } from "../../src/app-server/background-agent-runner.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+
+describe("concurrent attachment adoption", () => {
+  it("rejects an ordinary attachment revoked before its commit", async () => {
+    const sessions = new AgenCDaemonSessionManager();
+    const session = await sessions.createSession({ cwd: process.cwd() });
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const acquire = sessions.attachSessionWithOwnership.bind(sessions);
+    vi.spyOn(sessions, "attachSessionWithOwnership").mockImplementation(async (...args) => {
+      const receipt = await acquire(...args);
+      entered.resolve();
+      await release.promise;
+      return receipt;
+    });
+    const attaching = sessions.attachSession({ sessionId: session.sessionId, clientId: "client" });
+    const rejected = expect(attaching).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    try {
+      await entered.promise;
+      await sessions.terminateSession({ sessionId: session.sessionId });
+    } finally {
+      release.resolve();
+    }
+    await rejected;
+    expect((await sessions.getSession(session.sessionId))?.activeAttachmentIds).toBeUndefined();
+  });
+
+  it.each([
+    { label: "successful agent.attach adopter", adopterMethod: "agent.attach", failureOrder: null, sameSession: true },
+    { label: "successful session.attach adopter", adopterMethod: "session.attach", failureOrder: null, sameSession: true },
+    { label: "successful different-session adopter", adopterMethod: "session.attach", failureOrder: null, sameSession: false },
+    { label: "both fail, creator first", adopterMethod: "agent.attach", failureOrder: "creator", sameSession: true },
+    { label: "both fail, adopter first", adopterMethod: "agent.attach", failureOrder: "adopter", sameSession: true },
+  ] as const)(
+    "settles shared attachment ownership: $label", async ({ adopterMethod, failureOrder, sameSession }) => {
+      const sessions = new AgenCDaemonSessionManager();
+      const session = await sessions.createSession({
+        agentId: "agent", cwd: process.cwd(),
+        metadata: { runtimeOptions: resolveAgentRuntimeOptions({}) },
+      });
+      const adopterSessionId = sameSession ? session.sessionId : (
+        await sessions.createSession({ agentId: "other-agent", cwd: process.cwd() })
+      ).sessionId;
+      const snapshot: AgenCBackgroundAgentSnapshot = {
+        status: "idle", lastActiveAt: "2026-09-11T00:00:00.000Z",
+        runtimeSettingsEventId: "runtime-settings:agent:1",
+        runtimeSettings: {
+          permissionMode: "default", prePlanMode: null, autoModeActive: false,
+          autoModeAvailable: true, bypassPermissionsModeAvailable: false,
+          bypassPermissionsWorkspace: null, bypassPermissionsConsentWorkspace: null,
+          model: "grok-5", provider: "grok", profile: null, reasoningEffort: null,
+          modelVerbosity: null, serviceTier: null, hooksDisabled: false,
+        },
+      };
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<AgenCBackgroundAgentSnapshot>();
+      const adopterEntered = Promise.withResolvers<void>();
+      const releaseAdopter = Promise.withResolvers<AgenCBackgroundAgentSnapshot>();
+      let snapshotsRead = 0;
+      const getAgentSnapshot = vi.fn(async () => {
+        if (++snapshotsRead === 2) {
+          entered.resolve();
+          return release.promise;
+        }
+        if (snapshotsRead === 4 && failureOrder !== null) {
+          adopterEntered.resolve();
+          return releaseAdopter.promise;
+        }
+        return snapshot;
+      });
+      const agents = new AgenCDaemonAgentManager({
+        sessionManager: sessions,
+        runner: { startAgent: vi.fn(), getAgentSnapshot },
+      });
+      await agents.restoreAgent({
+        agentId: "agent", objective: "adopt attachment", sessionIds: [session.sessionId], runtimeAvailable: true,
+      });
+      const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+      const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+        agentManager: agents, sessionManager: sessions, clientMultiplexer: multiplexer,
+      });
+      const send = vi.fn();
+      const connection = dispatcher.createConnection({ sendNotification: send });
+      let first: ReturnType<typeof connection.dispatch> | undefined;
+      let adopter: ReturnType<typeof connection.dispatch> | undefined;
+      try {
+        await connection.dispatch({
+          jsonrpc: "2.0", id: "initialize", method: "initialize", params: { protocol: { version: "1.9.0" } },
+        });
+        first = connection.dispatch({
+          jsonrpc: "2.0", id: "creator", method: "agent.attach", params: { agentId: "agent", clientId: "client" },
+        });
+        await entered.promise;
+        adopter = connection.dispatch({
+          jsonrpc: "2.0", id: "adopter", method: adopterMethod,
+          params: adopterMethod === "agent.attach"
+            ? { agentId: "agent", clientId: "client" }
+            : { sessionId: adopterSessionId, clientId: "client" },
+        });
+        if (failureOrder === null) await expect(adopter).resolves.toHaveProperty("result");
+        else await adopterEntered.promise;
+        const adopted = await sessions.getSession(adopterSessionId);
+        if (failureOrder === "adopter") {
+          releaseAdopter.resolve({ status: "idle", lastActiveAt: snapshot.lastActiveAt });
+          await expect(adopter).resolves.toHaveProperty("error");
+          expect((await sessions.getSession(session.sessionId))?.activeAttachmentIds)
+            .toEqual(adopted?.activeAttachmentIds);
+        }
+        release.resolve({ status: "idle", lastActiveAt: snapshot.lastActiveAt });
+        await expect(first).resolves.toHaveProperty("error");
+        if (failureOrder === "creator") {
+          expect((await sessions.getSession(session.sessionId))?.activeAttachmentIds)
+            .toEqual(adopted?.activeAttachmentIds);
+          releaseAdopter.resolve({ status: "idle", lastActiveAt: snapshot.lastActiveAt });
+          await expect(adopter).resolves.toHaveProperty("error");
+        }
+        expect((await sessions.getSession(adopterSessionId))?.activeAttachmentIds)
+          .toEqual(failureOrder === null ? adopted?.activeAttachmentIds : undefined);
+        expect(await multiplexer.attachedClientIds(adopterSessionId))
+          .toEqual(failureOrder === null ? ["client"] : []);
+        if (!sameSession) {
+          expect((await sessions.getSession(session.sessionId))?.activeAttachmentIds).toBeUndefined();
+          expect(await multiplexer.attachedClientIds(session.sessionId)).toEqual([]);
+        }
+        const event = { type: "after_creator_rollback" };
+        await multiplexer.broadcastSessionEvent(adopterSessionId, event);
+        if (failureOrder === null) expect(send).toHaveBeenCalledExactlyOnceWith(event);
+        else expect(send).not.toHaveBeenCalled();
+      } finally {
+        release.resolve(snapshot);
+        releaseAdopter.resolve(snapshot);
+        await first;
+        await adopter;
+        await dispatcher.close();
+      }
+    },
+  );
+});

--- a/runtime/tests/app-server/agent-lifecycle-locks.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle-locks.contract.test.ts
@@ -48,8 +48,14 @@ describe("daemon lifecycle lock boundaries", () => {
         (error: unknown) => error,
       );
       try {
-        await entered.promise;
-        await vi.advanceTimersByTimeAsync(30_000);
+        if (method === "stopAgent") {
+          await entered.promise;
+          await vi.advanceTimersByTimeAsync(30_000);
+        } else {
+          // Global shutdown owns every retained runner and must reach it
+          // without first waiting for diagnostic snapshot availability.
+          await setImmediate();
+        }
         expect(stopAgent).toHaveBeenCalledWith(
           "stalled-snapshot",
           expect.any(String),

--- a/runtime/tests/app-server/agent-shutdown-read-dependency.contract.test.ts
+++ b/runtime/tests/app-server/agent-shutdown-read-dependency.contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { settleWithinMicrotasks } from "../helpers/controlled-async.js";
+
+describe("daemon shutdown execution ownership", () => {
+  it.each(["cancel", "suspend_idle"] as const)(
+    "reaches %s teardown while an existing snapshot waits for that teardown", async (disposition) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const getAgentSnapshot = vi.fn(async () => {
+        entered.resolve();
+        await release.promise;
+        return { status: "running" as const, lastActiveAt: "2026-09-11T00:00:00.000Z" };
+      });
+      const stopAgent = vi.fn(async () => { release.resolve(); });
+      const suspendIdleAgentForDaemonShutdown = vi.fn(async () => {
+        release.resolve();
+        return { disposition: "cancelled" as const };
+      });
+      const manager = new AgenCDaemonAgentManager({
+        runner: { startAgent: vi.fn(), getAgentSnapshot, stopAgent, suspendIdleAgentForDaemonShutdown },
+      });
+      await manager.restoreAgent({
+        agentId: "agent", objective: "held settings read", runtimeAvailable: true,
+      });
+      const reading = manager.getAgent("agent");
+      await entered.promise;
+      const stopping = manager.stopAll("daemon_shutdown", { disposition });
+      try {
+        await expect(settleWithinMicrotasks(stopping)).resolves.toMatchObject({
+          status: "fulfilled", value: 1,
+        });
+        expect(getAgentSnapshot).toHaveBeenCalledOnce();
+        expect(disposition === "cancel" ? stopAgent : suspendIdleAgentForDaemonShutdown)
+          .toHaveBeenCalledOnce();
+      } finally {
+        release.resolve();
+        await Promise.all([reading, stopping]);
+      }
+      await expect(manager.getAgent("agent")).resolves.toMatchObject({ status: "stopped" });
+    },
+  );
+});

--- a/runtime/tests/app-server/attachment-registration-concurrency.contract.test.ts
+++ b/runtime/tests/app-server/attachment-registration-concurrency.contract.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { AgenCBackgroundAgentSnapshot } from "../../src/app-server/background-agent-runner.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import { drainMicrotasks } from "../helpers/controlled-async.js";
+
+function request(id: string, method: string, params: JsonObject = {}): JsonObject {
+  return { jsonrpc: "2.0", id, method, params: method === "initialize" ? { protocol: { version: "1.9.0" } } : params };
+}
+
+async function harness(runner?: ConstructorParameters<typeof AgenCDaemonAgentManager>[0]["runner"]) {
+  const sessions = new AgenCDaemonSessionManager();
+  const first = await sessions.createSession({
+    agentId: "agent", cwd: process.cwd(), metadata: { runtimeOptions: resolveAgentRuntimeOptions({}) },
+  });
+  const second = await sessions.createSession({ agentId: "other-agent", cwd: process.cwd() });
+  const agents = new AgenCDaemonAgentManager({ sessionManager: sessions, runner });
+  const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: agents, sessionManager: sessions, clientMultiplexer: multiplexer });
+  const send = vi.fn();
+  const connection = dispatcher.createConnection({ sendNotification: send });
+  await connection.dispatch(request("init", "initialize"));
+  return { sessions, agents, multiplexer, dispatcher, connection, send, first, second };
+}
+
+describe("attachment registration concurrency", () => {
+  it.each([false, true])("shares unresolved registration across simultaneous session attaches (different sessions: %s)", async (differentSessions) => {
+    const h = await harness();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const original = h.multiplexer.registerClient.bind(h.multiplexer);
+    const register = vi.spyOn(h.multiplexer, "registerClient").mockImplementation(async (options) => {
+      entered.resolve();
+      await release.promise;
+      return original(options);
+    });
+    const pending: Array<ReturnType<typeof h.connection.dispatch>> = [];
+    try {
+      pending.push(h.connection.dispatch(request("first", "session.attach", { sessionId: h.first.sessionId, clientId: "shared-client" })));
+      await entered.promise;
+      const secondSessionId = differentSessions ? h.second.sessionId : h.first.sessionId;
+      pending.push(h.connection.dispatch(request("second", "session.attach", { sessionId: secondSessionId, clientId: "shared-client" })));
+      await drainMicrotasks(12);
+      expect(register).toHaveBeenCalledTimes(1);
+      expect(h.connection.trackedClientIds).toEqual([]);
+      release.resolve();
+      const responses = await Promise.all(pending);
+      for (const response of responses) expect(response).toHaveProperty("result");
+      if (!differentSessions) {
+        expect(responses[0]).toMatchObject({ result: { attachmentId: (responses[1] as { result: { attachmentId: string } }).result.attachmentId } });
+      }
+      expect(h.connection.trackedClientIds).toEqual(["shared-client"]);
+      for (const sessionId of new Set([h.first.sessionId, secondSessionId])) {
+        expect(await h.multiplexer.attachedClientIds(sessionId)).toEqual(["shared-client"]);
+        expect((await h.sessions.getSession(sessionId))?.activeAttachmentIds).toHaveLength(1);
+        await h.multiplexer.broadcastSessionEvent(sessionId, { type: "live_after_shared_registration" });
+      }
+      expect(h.send).toHaveBeenCalledTimes(differentSessions ? 2 : 1);
+      await h.connection.close();
+      expect(await h.multiplexer.attachedClientIds(h.first.sessionId)).toEqual([]);
+      expect(await h.multiplexer.attachedClientIds(h.second.sessionId)).toEqual([]);
+    } finally {
+      release.resolve();
+      await Promise.allSettled(pending);
+      register.mockRestore();
+      await h.connection.close();
+      await h.dispatcher.close();
+    }
+  });
+
+  it("does not remove a replacement connection when shared delayed registration finishes after close", async () => {
+    const h = await harness();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const original = h.multiplexer.registerClient.bind(h.multiplexer);
+    const register = vi.spyOn(h.multiplexer, "registerClient").mockImplementationOnce(async (options) => {
+      entered.resolve();
+      await release.promise;
+      return original(options);
+    });
+    const replacement = h.dispatcher.createConnection({ sendNotification: () => {} });
+    const pending: Array<ReturnType<typeof h.connection.dispatch>> = [];
+    try {
+      pending.push(h.connection.dispatch(request("first", "session.attach", { sessionId: h.first.sessionId, clientId: "shared-client" })));
+      await entered.promise;
+      pending.push(h.connection.dispatch(request("second", "session.attach", { sessionId: h.second.sessionId, clientId: "shared-client" })));
+      await drainMicrotasks(12);
+      expect(register).toHaveBeenCalledTimes(1);
+      await h.connection.close();
+      await replacement.dispatch(request("replacement-init", "initialize"));
+      await expect(replacement.dispatch(request("replacement-attach", "session.attach", { sessionId: h.first.sessionId, clientId: "shared-client" }))).resolves.toHaveProperty("result");
+      release.resolve();
+      for (const response of await Promise.all(pending)) expect(response).toHaveProperty("error");
+      expect(await h.multiplexer.attachedClientIds(h.first.sessionId)).toEqual(["shared-client"]);
+      expect((await h.sessions.getSession(h.first.sessionId))?.activeAttachmentIds).toHaveLength(1);
+      expect(replacement.trackedClientIds).toEqual(["shared-client"]);
+    } finally {
+      release.resolve();
+      await Promise.allSettled(pending);
+      register.mockRestore();
+      await h.connection.close();
+      await replacement.close();
+      await h.dispatcher.close();
+    }
+  });
+
+  it.each([false, true])("preserves a pending different-session attach while creator rollback runs (adopter fails: %s)", async (adopterFails) => {
+    const snapshot: AgenCBackgroundAgentSnapshot = {
+      status: "idle", lastActiveAt: "2026-09-11T00:00:00.000Z", runtimeSettingsEventId: "settings:1",
+      runtimeSettings: {
+        permissionMode: "default", prePlanMode: null, autoModeActive: false, autoModeAvailable: true,
+        bypassPermissionsModeAvailable: false, bypassPermissionsWorkspace: null, bypassPermissionsConsentWorkspace: null,
+        model: "grok-5", provider: "grok", profile: null, reasoningEffort: null, modelVerbosity: null, serviceTier: null, hooksDisabled: false,
+      },
+    };
+    const snapshotEntered = Promise.withResolvers<void>();
+    const snapshotRelease = Promise.withResolvers<AgenCBackgroundAgentSnapshot>();
+    let reads = 0;
+    const h = await harness({ startAgent: vi.fn(), getAgentSnapshot: async () => {
+      if (++reads === 2) { snapshotEntered.resolve(); return snapshotRelease.promise; }
+      return snapshot;
+    } });
+    await h.agents.restoreAgent({ agentId: "agent", objective: "attachment test", sessionIds: [h.first.sessionId], runtimeAvailable: true });
+    const adopterEntered = Promise.withResolvers<void>();
+    const adopterRelease = Promise.withResolvers<void>();
+    const originalAttach = h.multiplexer.attachClientToSession.bind(h.multiplexer);
+    const attach = vi.spyOn(h.multiplexer, "attachClientToSession").mockImplementation(async (...args) => {
+      if (args[0] === h.second.sessionId) {
+        adopterEntered.resolve();
+        await adopterRelease.promise;
+        if (adopterFails) throw new Error("adopter attach failed");
+      }
+      return originalAttach(...args);
+    });
+    const register = vi.spyOn(h.multiplexer, "registerClient");
+    const pending: Array<ReturnType<typeof h.connection.dispatch>> = [];
+    try {
+      pending.push(h.connection.dispatch(request("creator", "agent.attach", { agentId: "agent", clientId: "shared-client" })));
+      await snapshotEntered.promise;
+      pending.push(h.connection.dispatch(request("adopter", "session.attach", { sessionId: h.second.sessionId, clientId: "shared-client" })));
+      await adopterEntered.promise;
+      snapshotRelease.resolve({ status: "idle", lastActiveAt: snapshot.lastActiveAt });
+      await expect(pending[0]).resolves.toHaveProperty("error");
+      expect(await h.multiplexer.attachedClientIds(h.first.sessionId)).toEqual([]);
+      expect(h.connection.trackedClientIds).toEqual(["shared-client"]);
+      adopterRelease.resolve();
+      await expect(pending[1]).resolves.toHaveProperty(adopterFails ? "error" : "result");
+      expect(await h.multiplexer.attachedClientIds(h.second.sessionId)).toEqual(adopterFails ? [] : ["shared-client"]);
+      expect(h.connection.trackedClientIds).toEqual(adopterFails ? [] : ["shared-client"]);
+      expect(register).toHaveBeenCalledTimes(1);
+      if (adopterFails) {
+        attach.mockRestore();
+        await expect(h.connection.dispatch(request("retry", "session.attach", { sessionId: h.second.sessionId, clientId: "shared-client" }))).resolves.toHaveProperty("result");
+        expect(register).toHaveBeenCalledTimes(2);
+      }
+    } finally {
+      snapshotRelease.resolve(snapshot);
+      adopterRelease.resolve();
+      await Promise.allSettled(pending);
+      attach.mockRestore();
+      register.mockRestore();
+      await h.connection.close();
+      await h.dispatcher.close();
+    }
+  });
+});

--- a/runtime/tests/app-server/capability-replay-ownership.test.ts
+++ b/runtime/tests/app-server/capability-replay-ownership.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+
+describe("capability replay ownership", () => {
+  it.each([false, true])(
+    "retains an undelivered action when termination shifts replay (partial buffer: %s)",
+    async (partial) => {
+      const sessions = new AgenCDaemonSessionManager();
+      const original = await sessions.createSession({ cwd: process.cwd() });
+      const next = await sessions.createSession({ cwd: process.cwd() });
+      const multiplexer = new AgenCDaemonClientMultiplexer({
+        sessionManager: sessions,
+        maxBufferedEventsPerSession: 3,
+      });
+      const capability = "portal.ledger.solana.sign.v1";
+      const first = { actionId: "first" };
+      const pending = { actionId: "pending" };
+      const surviving = { actionId: "surviving" };
+      await multiplexer.broadcastCapabilityEvent(original.sessionId, capability, first);
+      if (partial) await multiplexer.broadcastCapabilityEvent(next.sessionId, capability, surviving);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const received: JsonObject[] = [];
+      const registering = multiplexer.registerClient({
+        clientId: "original-phone", capabilities: { [capability]: true },
+        send: async (event) => {
+          received.push(event);
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      try {
+        await entered.promise;
+        await multiplexer.disconnectClient("original-phone");
+        await multiplexer.terminateSession({ sessionId: original.sessionId });
+        await multiplexer.broadcastCapabilityEvent(next.sessionId, capability, pending);
+        release.resolve();
+        await registering;
+        const replacement: JsonObject[] = [];
+        await multiplexer.registerClient({
+          clientId: "replacement-phone", capabilities: { [capability]: true },
+          send: (event) => { replacement.push(event); },
+        });
+        expect(received).toEqual(partial ? [first, surviving] : [first]);
+        expect(replacement).toEqual([pending]);
+        const later: JsonObject[] = [];
+        await multiplexer.registerClient({
+          clientId: "later-phone", capabilities: { [capability]: true },
+          send: (event) => { later.push(event); },
+        });
+        expect(later).toEqual([]);
+      } finally {
+        release.resolve();
+        await registering;
+        await Promise.all([
+          multiplexer.terminateSession({ sessionId: original.sessionId }),
+          multiplexer.terminateSession({ sessionId: next.sessionId }),
+        ]);
+      }
+    },
+  );
+});

--- a/runtime/tests/app-server/client-submission-ownership.contract.test.ts
+++ b/runtime/tests/app-server/client-submission-ownership.contract.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { AgenCInProcessDaemonTransport } from "../../src/app-server/transport/in-process.js";
+import type { AgenCDaemonSessionNotification, JsonObject } from "../../src/app-server/protocol/index.js";
+import { createAgencClient, type AgencTransport } from "../../../packages/agenc-sdk/src/index.js";
+import type { AgenCDaemonTuiClient } from "../../src/tui/daemon-session.js";
+import { createDaemonTuiSessionFixture } from "../helpers/daemon-tui-session.js";
+
+const sessionId = "submission-ownership-session";
+const interaction = {
+  interactionId: "editor-input", kind: "explain" as const, policy: "read_only" as const,
+  editorInstanceId: "editor-1", bufferHandle: 7, changedtick: 3,
+  contentSha256: "a".repeat(64), path: "src/value.ts",
+  range: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+};
+
+async function connectedDaemon(stream: (params: JsonObject) => Promise<unknown>) {
+  const sessions = new AgenCDaemonSessionManager();
+  await sessions.restoreSession({ sessionId, agentId: "agent_1", cwd: process.cwd() });
+  const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+  const approvals: JsonObject[] = [];
+  const submissions: JsonObject[] = [];
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+    sessionManager: sessions,
+    clientMultiplexer: multiplexer,
+    agentManager: {
+      streamAgentMessage: async (params: JsonObject) => {
+        submissions.push(params);
+        return stream(params);
+      },
+      approveTool: async (params: JsonObject) => {
+        approvals.push(params);
+        return { requestId: params.requestId, decision: "approved" };
+      },
+      getSessionTranscriptV2: async () => ({
+        schemaVersion: 2, sessionId, runId: "run_1", historyEpoch: "initial",
+        asOfSequence: 0, messages: [],
+      }),
+    } as never,
+  });
+  const listeners = new Set<(notification: JsonObject) => void>();
+  const transport = new AgenCInProcessDaemonTransport({
+    dispatcher,
+    sendNotification: (notification) => {
+      for (const listener of listeners) listener(notification);
+    },
+  });
+  let nextRequestId = 0;
+  const tuiClient = {
+    async request(method: string, params?: JsonObject) {
+      const response = await transport.dispatch({
+        jsonrpc: "2.0", id: ++nextRequestId, method, ...(params === undefined ? {} : { params }),
+      });
+      if ("error" in response) throw new Error(response.error.message);
+      return response.result;
+    },
+    subscribeToSessionEvents(_sessionId: string, listener: (notification: JsonObject) => void) {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+  } as AgenCDaemonTuiClient;
+  return {
+    transport, multiplexer, listeners, tuiClient, submissions, approvals,
+    close: async () => { await transport.close(); await dispatcher.close(); },
+  };
+}
+
+describe("connected client submission ownership", () => {
+  it.each(["submitted", "rolled_back"] as const)(
+    "does not restore editor input %s while another submission fails",
+    async (editorOutcome) => {
+      const entered = Promise.withResolvers<void>();
+      const failFirst = Promise.withResolvers<void>();
+      const daemon = await connectedDaemon(async (params) => {
+        if (params.messageId === "agent-first") {
+          entered.resolve();
+          await failFirst.promise;
+          throw new Error("agent submission rejected");
+        }
+        return { disposition: "started", acceptedAt: params.acceptedAt, terminal: { code: 0 } };
+      });
+      try {
+        await daemon.transport.initialize();
+        await daemon.tuiClient.request("session.attach", { sessionId, clientId: "tui-owner" });
+        const session = createDaemonTuiSessionFixture({
+          baseSession: { conversationId: sessionId, services: {} },
+          client: daemon.tuiClient, sessionId, clientId: "tui-owner",
+        });
+        session.enqueueIdleInput({ role: "user", content: "agent attachment" });
+        const editorAdmission = session.enqueueIdleInputBatchOwned!([
+          { role: "user", content: "editor attachment" },
+        ], { workspaceView: "editor", editorInteractionId: interaction.interactionId });
+        const first = session.submit("agent prompt", { clientMessageId: "agent-first" });
+        const failed = expect(first).rejects.toThrow("agent submission rejected");
+        await entered.promise;
+        if (editorOutcome === "submitted") {
+          await session.submit("editor prompt", { clientMessageId: "editor-first", editorInteraction: interaction });
+        } else {
+          expect(session.rollbackIdleInputAdmission!(editorAdmission.token)).toBe(true);
+        }
+        session.enqueueIdleInput({ role: "user", content: "new agent attachment" });
+        failFirst.resolve();
+        await failed;
+        await session.submit("retry agent", { clientMessageId: "agent-retry" });
+        expect(daemon.submissions.at(-1)?.content).toEqual([
+          { type: "text", text: "agent attachment" },
+          { type: "text", text: "new agent attachment" },
+          { type: "text", text: "retry agent" },
+        ]);
+        await session.submit("next editor prompt", { clientMessageId: "editor-next", editorInteraction: interaction });
+        expect(daemon.submissions.at(-1)?.content).toBe("next editor prompt");
+        expect(session.enqueueIdleInput({ role: "user", content: "next attachment" })).toBe(1);
+      } finally {
+        failFirst.resolve();
+        await daemon.close();
+      }
+    },
+  );
+
+  it.each(["conflict", "duplicate"] as const)(
+    "does not treat attach replay as admission of an SDK %s submission",
+    async (outcome) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const daemon = await connectedDaemon(async (params) => {
+        entered.resolve();
+        await release.promise;
+        if (outcome === "conflict") throw new Error("submission content conflicts");
+        return {
+          disposition: "duplicate", duplicateState: "completed", acceptedAt: params.acceptedAt,
+          turnId: "original-turn", terminal: { code: 0, message: "canonical duplicate result" },
+        };
+      });
+      const permission = vi.fn(() => ({ behavior: "allow" as const }));
+      const client = createAgencClient({
+        transport: daemon.transport as unknown as AgencTransport,
+        clientId: "sdk-owner", onPermissionRequest: permission,
+      });
+      daemon.listeners.add((notification) => client.dispatchNotification(notification));
+      try {
+        await client.initialize();
+        const notifications: AgenCDaemonSessionNotification[] = [
+          { jsonrpc: "2.0", method: "event.session_event", params: {
+            sessionId, eventId: "old-user", event: { id: "old-user", type: "user_message", payload: { messageId: "reused-message", message: "original content" } },
+          } },
+          { jsonrpc: "2.0", method: "event.agent_status", params: { sessionId, eventId: "old-start", turnId: "original-turn", status: "running" } },
+          { jsonrpc: "2.0", method: "event.permission_request", params: { sessionId, eventId: "old-permission", requestId: "old-permission", turnId: "original-turn", permissions: [] } },
+          { jsonrpc: "2.0", method: "event.agent_status", params: { sessionId, eventId: "old-terminal", turnId: "original-turn", status: "idle", runStatus: "completed", message: "stale replay result" } },
+        ];
+        for (const notification of notifications) {
+          await daemon.multiplexer.broadcastSessionNotification(sessionId, notification);
+        }
+        const run = client.runPrompt(sessionId, outcome === "conflict" ? "different content" : "original content", {
+          clientMessageId: "reused-message", includeUsage: false,
+        });
+        let settled = false;
+        void run.result().then(() => { settled = true; }, () => { settled = true; });
+        await entered.promise;
+        expect(permission).not.toHaveBeenCalled();
+        expect(daemon.approvals).toEqual([]);
+        expect(settled).toBe(false);
+        release.resolve();
+        if (outcome === "conflict") {
+          await expect(run.accepted).rejects.toThrow("submission content conflicts");
+          await expect(run.result()).rejects.toThrow("submission content conflicts");
+        } else {
+          await expect(run.result()).resolves.toMatchObject({ finalMessage: "canonical duplicate result" });
+          await expect(run.accepted).resolves.toMatchObject({ clientMessageId: "reused-message" });
+        }
+      } finally {
+        release.resolve();
+        await client.close();
+        await daemon.close();
+      }
+    },
+  );
+});

--- a/runtime/tests/app-server/daemon-shutdown-liveness.contract.test.ts
+++ b/runtime/tests/app-server/daemon-shutdown-liveness.contract.test.ts
@@ -1,0 +1,145 @@
+import { EventEmitter, once } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import {
+  AgenCDaemonRpcShutdownCoordinator,
+  runAgenCDaemonCli,
+  readAgenCDaemonPid,
+  resolveAgenCDaemonPidPath,
+  resolveAgenCDaemonSocketPath,
+  resolveAgenCDaemonCookiePath,
+  type AgenCDaemonCliHost,
+  type AgenCDaemonCliIo,
+} from "../../src/app-server/daemon-cli.js";
+import type { AgenCBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
+import { readDaemonRuntimeInfo, resolveAgenCDaemonRuntimeInfoPath } from "../../src/app-server/daemon-runtime-info.js";
+import { AGENC_DAEMON_PROTOCOL_VERSION, type JsonObject } from "../../src/app-server/protocol/index.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import { AsyncQueue } from "../../src/utils/async-queue.js";
+
+describe("daemon shutdown progress", () => {
+  it.each([1, 2])("completes shutdown when %i acknowledgement writes never settle", async (count) => {
+    const completed = vi.fn();
+    const coordinator = new AgenCDaemonRpcShutdownCoordinator(completed, 20);
+    const sends = Array.from({ length: count }, (_, id) => {
+      const result = coordinator.accept("stalled-instance");
+      return coordinator.send(
+        { jsonrpc: "2.0", id, method: "daemon.shutdown" },
+        { jsonrpc: "2.0", id, result },
+        () => new Promise<void>(() => {}),
+      );
+    });
+    expect(coordinator.blocksRequests).toBe(true);
+    const results = await Promise.allSettled(sends);
+    expect(results).toEqual(Array.from({ length: count }, () => ({
+      status: "rejected", reason: new Error("daemon shutdown acknowledgement exceeded 20 ms"),
+    })));
+    expect(completed).toHaveBeenCalledTimes(1);
+    expect(coordinator.blocksRequests).toBe(true);
+  });
+
+  it.each(["unix", "websocket"])("stops runner work before draining a held %s snapshot RPC", async (kind) => {
+    const home = await mkdtemp(join(tmpdir(), "agenc-shutdown-progress-"));
+    const env = { AGENC_HOME: home, AGENC_DAEMON_WEBSOCKET_PORT: "0" };
+    const host: AgenCDaemonCliHost = {
+      env, userHome: home, pid: 4100,
+      entrypointPath: "/opt/agenc/bin/agenc.js", execPath: process.execPath,
+      readCurrentRuntimeBuild: () => ({ runtimeVersion: "test", commit: "test", buildTime: "test" }),
+      readProcessIdentity: (pid) => `test:${pid}`,
+      isPidRunning: () => false,
+      spawnDetachedDaemon: () => { throw new Error("unexpected detached spawn"); },
+      terminatePid: () => {}, sleep: async () => {},
+    };
+    let logs = "";
+    const sink = { write: (chunk: string | Uint8Array) => { logs += String(chunk); return true; } } as Pick<NodeJS.WriteStream, "write">;
+    const io: AgenCDaemonCliIo = { stdout: sink, stderr: sink };
+    const signal = new EventEmitter();
+    const snapshotStarted = Promise.withResolvers<void>();
+    const releaseSnapshot = Promise.withResolvers<void>();
+    let snapshotHeld = false;
+    const stopped = vi.fn(async () => { releaseSnapshot.resolve(); });
+    const runner: AgenCBackgroundAgentRunner = {
+      startAgent: async () => ({ agentId: "agent-held-snapshot", startedAt: "2026-05-01T12:00:00.000Z", status: "running" }),
+      getAgentSnapshot: async () => {
+        // Diagnostic reads share the blocked runtime in this fixture. A
+        // shutdown refresh must not precede the stop that releases it.
+        if (snapshotHeld) await releaseSnapshot.promise;
+        return { status: "running", lastActiveAt: "2026-05-01T12:00:00.000Z" };
+      },
+      stopAgent: stopped,
+      snapshotAgentSession: async (_agentId, { sessionId }) => {
+        snapshotHeld = true;
+        snapshotStarted.resolve();
+        await releaseSnapshot.promise;
+        return {
+          sessionId, turnCount: 0,
+          tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+          cacheStats: { requestCount: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0, cacheTotalInputTokens: 0, hitRate: null },
+        };
+      },
+    };
+    const running = runAgenCDaemonCli({ kind: "command", action: "run" }, { host, io, signalProcess: signal, runner });
+    let socket: Socket | WebSocket | undefined;
+    try {
+      const pidPath = resolveAgenCDaemonPidPath(env, home);
+      await expect.poll(() => readAgenCDaemonPid(pidPath), { timeout: 5_000, message: logs }).toBe(4100);
+      const authCookie = (await readFile(resolveAgenCDaemonCookiePath(env, home), "utf8")).trim();
+      const info = readDaemonRuntimeInfo(resolveAgenCDaemonRuntimeInfoPath(home));
+      socket = kind === "unix"
+        ? createConnection(resolveAgenCDaemonSocketPath(env, home))
+        : new WebSocket(info!.webSocketUrl!);
+      const peer = socket;
+      const messages = new AsyncQueue<JsonObject>();
+      if (peer instanceof WebSocket) {
+        peer.on("message", (data) => { messages.send(JSON.parse(data.toString())); });
+      } else {
+        let buffer = "";
+        peer.on("data", (data: Buffer) => {
+          buffer += data.toString();
+          let newline: number;
+          while ((newline = buffer.indexOf("\n")) !== -1) {
+            messages.send(JSON.parse(buffer.slice(0, newline)));
+            buffer = buffer.slice(newline + 1);
+          }
+        });
+      }
+      peer.on("close", () => messages.close());
+      await once(peer, peer instanceof WebSocket ? "open" : "connect");
+      const request = async (method: string, params: JsonObject) => {
+        const payload = JSON.stringify({ jsonrpc: "2.0", id: method, method, params });
+        if (peer instanceof WebSocket) peer.send(payload);
+        else peer.write(`${payload}\n`);
+        for (;;) {
+          const response = await messages.recv();
+          if (response === null) throw new Error("daemon connection closed");
+          if (response.id !== method) continue;
+          if (response.error !== undefined) throw new Error(JSON.stringify(response.error));
+          return response.result as JsonObject;
+        }
+      };
+      await request("initialize", { protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION, authCookie, capabilities: {} });
+      const agent = await request("agent.create", { cwd: process.cwd(), objective: "hold snapshot until shutdown", runtimeOptions: resolveAgentRuntimeOptions({}) });
+      const snapshot = request("session.snapshot", { sessionId: agent.sessionId! }).catch(() => undefined);
+      await snapshotStarted.promise;
+      signal.emit("SIGTERM");
+      // The old ordering never invokes stopAgent because socket draining is
+      // awaiting this very snapshot. No timing-based release hides that cycle.
+      await expect.poll(() => stopped.mock.calls.length, { timeout: 1_000 }).toBe(1);
+      await expect(running).resolves.toBe(0);
+      await snapshot;
+      await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+      expect(logs).not.toContain("request drain exceeded");
+    } finally {
+      releaseSnapshot.resolve();
+      if (socket instanceof WebSocket) socket.terminate();
+      else socket?.destroy();
+      signal.emit("SIGTERM");
+      await running;
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/runtime/tests/app-server/transport-control-liveness.contract.test.ts
+++ b/runtime/tests/app-server/transport-control-liveness.contract.test.ts
@@ -1,0 +1,200 @@
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+import { AgenCStdioTransport } from "../../src/app-server/transport/stdio.js";
+import { AgenCUnixSocketServer, agenCDaemonLocalEndpoint } from "../../src/app-server/transport/unix-socket.js";
+import { AgenCWebSocketServer } from "../../src/app-server/transport/websocket.js";
+
+type Kind = "stdio" | "unix" | "websocket";
+
+async function createHarness(
+  kind: Kind,
+  onMessage: (message: JsonObject) => Promise<void>,
+  overrides: { acceptAuthenticator?: () => Promise<boolean> } = {},
+) {
+  const directory = await mkdtemp(join(tmpdir(), "agenc-control-liveness-"));
+  const responses: JsonObject[] = [];
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const options = { onMessage, maxQueuedRequests: 2, ...overrides };
+  const server = kind === "stdio"
+    ? new AgenCStdioTransport({ ...options, input, output })
+    : kind === "unix"
+      ? new AgenCUnixSocketServer({ ...options, socketPath: agenCDaemonLocalEndpoint(directory) })
+      : new AgenCWebSocketServer(options);
+  let client: Socket | WebSocket | undefined;
+  const collectLines = (source: PassThrough | Socket) => {
+    let pending = "";
+    source.on("data", (chunk: Buffer) => {
+      pending += chunk.toString();
+      let newline: number;
+      while ((newline = pending.indexOf("\n")) !== -1) {
+        responses.push(JSON.parse(pending.slice(0, newline)));
+        pending = pending.slice(newline + 1);
+      }
+    });
+  };
+  if (server instanceof AgenCStdioTransport) {
+    collectLines(output);
+    server.start();
+  } else {
+    await server.listen();
+    client = server instanceof AgenCUnixSocketServer
+      ? createConnection(server.socketPath)
+      : new WebSocket(server.listenAddress!.url);
+    if (client instanceof WebSocket) {
+      client.on("message", (message) => responses.push(JSON.parse(message.toString())));
+      await once(client, "open");
+    } else {
+      collectLines(client);
+      await once(client, "connect");
+    }
+  }
+  return {
+    responses,
+    server,
+    send(method: string, id: number) {
+      const payload = JSON.stringify({ jsonrpc: "2.0", method, id });
+      if (client instanceof WebSocket) client.send(payload);
+      else (client ?? input).write(`${payload}\n`);
+    },
+    async cleanup() {
+      if (client instanceof WebSocket) client.terminate();
+      else client?.destroy();
+      await server.close();
+      input.destroy();
+      output.destroy();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+describe.each<Kind>(["stdio", "unix", "websocket"])("%s control request scheduling", (kind) => {
+  it("does not let a duplicate initialize move cancellation behind an active stream", async () => {
+    const stream = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    const methods: string[] = [];
+    const harness = await createHarness(kind, async (message) => {
+      methods.push(String(message.method));
+      if (message.method === "message.stream") {
+        started.resolve();
+        await stream.promise;
+      } else if (message.method === "run.cancel") {
+        stream.resolve();
+      }
+    });
+    try {
+      harness.send("initialize", 1);
+      await expect.poll(() => methods).toEqual(["initialize"]);
+      harness.send("message.stream", 2);
+      await started.promise;
+      harness.send("initialize", 3);
+      harness.send("run.cancel", 4);
+      await expect.poll(() => methods).toEqual([
+        "initialize", "message.stream", "run.cancel", "initialize",
+      ]);
+    } finally {
+      stream.resolve();
+      await harness.cleanup();
+    }
+  });
+
+  it("bounds priority backlog before initialization while reserving control capacity", async () => {
+    const initialize = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    const methods: string[] = [];
+    const harness = await createHarness(kind, async (message) => {
+      methods.push(String(message.method));
+      if (message.method === "initialize") {
+        started.resolve();
+        await initialize.promise;
+      }
+    });
+    try {
+      harness.send("initialize", 1);
+      await started.promise;
+      for (let id = 10; id < 15; id += 1) harness.send("health.ping", id);
+      for (let id = 20; id < 25; id += 1) harness.send("request.cancel", id);
+      await expect.poll(() => harness.responses.length).toBe(6);
+      expect(harness.responses.map((response) => response.id)).toEqual([12, 13, 14, 22, 23, 24]);
+      for (const response of harness.responses) {
+        expect(response).toMatchObject({ error: { data: { code: "TOO_MANY_QUEUED_REQUESTS", maxQueuedRequests: 2 } } });
+      }
+      expect(methods).toEqual(["initialize"]);
+      initialize.resolve();
+      await expect.poll(() => methods.length).toBe(5);
+      expect(methods.filter((method) => method === "request.cancel")).toHaveLength(2);
+      // Settled requests release their lane's capacity.
+      harness.send("health.ping", 30);
+      await expect.poll(() => methods.length).toBe(6);
+      expect(harness.responses).toHaveLength(6);
+    } finally {
+      initialize.resolve();
+      await harness.cleanup();
+    }
+  });
+});
+
+describe.each(["unix", "websocket"] as const)("%s bounded shutdown drain", (kind) => {
+  it.each(["handler", "authentication"])("closes its listener before reporting a stalled %s drain deadline", async (phase) => {
+    const release = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    const pending = async () => {
+      started.resolve();
+      await release.promise;
+      return true;
+    };
+    const harness = await createHarness(
+      kind, async () => { await pending(); },
+      phase === "authentication" ? { acceptAuthenticator: pending } : {},
+    );
+    try {
+      harness.send("initialize", 1);
+      await started.promise;
+      if (harness.server instanceof AgenCStdioTransport) throw new Error("network transport required");
+      const address = harness.server instanceof AgenCWebSocketServer ? harness.server.listenAddress : null;
+      await expect(harness.server.close({ drainTimeoutMs: 20 })).rejects.toThrow("request drain exceeded 20 ms");
+      // close() has already released the listening endpoint, not just dropped
+      // its connection registry while leaving the network server alive.
+      if (harness.server instanceof AgenCUnixSocketServer) {
+        const client = createConnection(harness.server.socketPath);
+        await expect(once(client, "connect")).rejects.toMatchObject({ code: "ENOENT" });
+        client.destroy();
+      } else {
+        expect(harness.server.listenAddress).toBeNull();
+        const client = createConnection({ host: address!.host, port: address!.port });
+        await expect(once(client, "connect")).rejects.toMatchObject({ code: "ECONNREFUSED" });
+        client.destroy();
+      }
+    } finally {
+      release.resolve();
+      await harness.cleanup();
+    }
+  });
+});
+
+it("closes HTTP peers waiting for an incomplete request body", async () => {
+  const server = new AgenCWebSocketServer({ onMessage: async () => {} });
+  const address = await server.listen();
+  const peer = createConnection({ host: address.host, port: address.port });
+  let closing: Promise<void> | undefined;
+  try {
+    await once(peer, "connect");
+    const response = once(peer, "data");
+    peer.write("POST /healthz HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n\r\nx");
+    await response;
+    let closed = false;
+    closing = server.close().then(() => { closed = true; });
+    await expect.poll(() => closed, { timeout: 1_000 }).toBe(true);
+  } finally {
+    peer.destroy();
+    await closing;
+    await server.close();
+  }
+});


### PR DESCRIPTION
Concurrent attachment attempts can share one client/session, then a failed attempt can revoke another attempt's successful attachment. Replayed notifications can likewise settle a new SDK prompt before admission, while daemon shutdown can wait on snapshot or transport work that requires teardown to proceed.

This change gives session lifecycle explicit pending attachment claims and a commit boundary. Registration is shared within a physical connection, and rollback preserves adopted attachments, other session routes, and pending registration users. Capability replay removes only the delivered buffer entries; SDK and TUI submission handling preserve ownership through replay and failure.

Shutdown now cancels connections and stops owned execution before transport draining, without first waiting for diagnostic runner snapshots. Accepted shutdown acknowledgements and daemon transport draining have five-second deadlines. The first initialize establishes the priority barrier once, and separate bounded priority/control queues keep duplicate initialization and backlog from trapping cancellation. Runner teardown remains awaited before stores close.

Validation was performed locally with Node 26.5.0:

- Linux Docker connected control-plane suite: 1,792 tests across 135 files, plus the expected-red boundary probe.
- Runtime/test-support TypeScript checks, runtime build, package entrypoints, and generated protocol checks passed after rebasing onto current main.
- SDK build/TypeScript check and 162 local gate tests passed during the audit.
- Runtime/TUI import checks and startup at 148x40, 120x30, and 80x24 passed in normal and bypass modes.
- git diff --check passed.

GitHub CI is intentionally skipped at the repository owner's request. The audit report and deterministic regressions are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes concurrent attach rollback, shutdown teardown order, and SDK/TUI prompt admission—core daemon lifecycle paths where races previously caused lost attachments or stuck shutdown.
> 
> **Overview**
> This PR hardens the daemon/session **control plane** after a follow-up audit: attachment authority, replay/submission ownership, transport scheduling, and shutdown ordering.
> 
> **Session attachment** now uses provisional leases with **commit/rollback** (`symbol` owners in session lifecycle, shared through agent attach and multiplexer routing). A failed attach no longer tears down another attempt’s adopted attachment; concurrent attaches on one connection share registration and roll back only their claim.
> 
> **Replay and clients:** Capability replay retires **leased buffer objects**, not a positional count, so new actions survive session termination during blocked replay. The SDK ignores session notifications until **`message.send`** dispatches, so attach replay cannot admit or settle prompts early. The TUI restores only queue entries still owned after a failed submission.
> 
> **Shutdown and transport:** Daemon cleanup stops agents and command exec **before** connection close and applies **5s** deadlines on shutdown acks and socket/WebSocket handler drain. `stopAll` no longer blocks on diagnostic runner snapshot refresh. Stdio/WS/unix transports pin the **first** `initialize` barrier, bound **priority vs control** queues, and forward `maxQueuedRequests` on unix connections.
> 
> Adds **`docs/design/daemon-session-control-plane-followup-audit.md`** and contract/regression tests for these interleavings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf565a2341c5563d077ee505db2ab7fa25794e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->