### PR TITLE
Keep MCP servers from separate plugin directories

### DIFF
--- a/runtime/src/services/mcp/config.ts
+++ b/runtime/src/services/mcp/config.ts
@@ -128,12 +128,15 @@ function getServerUrl(config: McpServerConfig): string | null {
  * Two configs with the same signature are considered "the same server" for
  * plugin deduplication. Ignores env (plugins always inject AGENC_PLUGIN_ROOT)
  * and headers (same URL = same server regardless of auth).
+ * Stdio identity includes cwd: identical relative commands in different plugin
+ * roots launch different servers. An unspecified cwd is not an explicit one.
  * Returns null only for configs with neither command nor url (sdk type).
  */
 export function getMcpServerSignature(config: McpServerConfig): string | null {
   const cmd = getServerCommandArray(config)
   if (cmd) {
-    return `stdio:${jsonStringify(cmd)}`
+    const cwd = (config as McpStdioServerConfig).cwd ?? null
+    return `stdio:${jsonStringify([cmd, cwd])}`
   }
   const url = getServerUrl(config)
   if (url) {

--- a/runtime/src/services/mcp/desktop-management.ts
+++ b/runtime/src/services/mcp/desktop-management.ts
@@ -67,7 +67,8 @@ export async function mcpDesktopInventory(context: ManagementContext) {
       ...(editable ? { revision: revision(raw[name]) } : {}),
     };
   });
-  return { schemaVersion: 1, servers, errors: result.errors.length ? ["Some MCP definitions could not be loaded. Run MCP doctor for details."] : [] };
+  const loadErrors = result.errors.filter(error => error.type !== "mcp-server-suppressed-duplicate");
+  return { schemaVersion: 1, servers, errors: loadErrors.length ? ["Some MCP definitions could not be loaded. Run MCP doctor for details."] : [] };
 }
 
 const PATCH_KEYS = new Set(["revision", "originalName", "name", "transport", "command", "args", "url", "env", "envPassthrough", "cwd", "oauth"]);

--- a/runtime/tests/services/mcp/config.test.ts
+++ b/runtime/tests/services/mcp/config.test.ts
@@ -7,6 +7,41 @@ import {
 import type { ScopedMcpServerConfig } from "../../../src/services/mcp/types.js";
 
 describe("MCP config plugin duplicate suppression", () => {
+  test("keeps identical relative entry points from different plugin directories", () => {
+    const common = { scope: "dynamic" as const, command: "node", args: ["./server/main.mjs"] };
+    const plugins = {
+      "plugin:first:api": { ...common, cwd: "/plugins/first" },
+      "plugin:second:api": { ...common, cwd: "/plugins/second" },
+    };
+    const result = dedupPluginMcpServers(plugins, {});
+    expect(result.servers).toEqual(plugins);
+    expect(result.suppressed).toEqual([]);
+  });
+
+  test.each([undefined, "/workspaces/project"])(
+    "does not equate a plugin directory with a manual cwd of %s",
+    (cwd) => {
+      const plugin: ScopedMcpServerConfig = {
+        scope: "dynamic", command: "node", args: ["server.mjs"], cwd: "/plugins/sample",
+      };
+      const result = dedupPluginMcpServers({ plugin }, {
+        manual: { scope: "user", command: "node", args: ["server.mjs"], ...(cwd === undefined ? {} : { cwd }) },
+      });
+      expect(result.servers).toEqual({ plugin });
+      expect(result.suppressed).toEqual([]);
+    },
+  );
+
+  test("still suppresses duplicate launches with the same explicit directory", () => {
+    const plugin: ScopedMcpServerConfig = {
+      scope: "dynamic", command: "node", args: ["server.mjs"], cwd: "/plugins/sample",
+    };
+    expect(dedupPluginMcpServers({ first: plugin, second: plugin }, {}).suppressed)
+      .toMatchObject([{ name: "second", duplicateOf: "first" }]);
+    expect(dedupPluginMcpServers({ plugin }, { manual: { ...plugin, scope: "user" } }).suppressed)
+      .toMatchObject([{ name: "plugin", duplicateOf: "manual" }]);
+  });
+
   test("reports raw plugin server identity for normalized scoped keys", () => {
     const pluginServer: ScopedMcpServerConfig = {
       scope: "dynamic",

--- a/runtime/tests/services/mcp/desktop-management.test.ts
+++ b/runtime/tests/services/mcp/desktop-management.test.ts
@@ -110,6 +110,38 @@ describe("desktop MCP contract", () => {
     expect((await mcpDesktopInventory(context)).servers.find((item) => item.name === entry.name)?.enabled).toBe(true);
     expect(() => patch({ originalName: entry.name })).toThrow();
   });
+  test("loads separate plugins that both use node ./server/main.mjs", async () => {
+    mutateCanonicalUserConfigSync(authority.homeContext.configTomlPath, (raw) => { raw.plugins = { enabled: true }; });
+    await authority.reload();
+    for (const name of ["first-plugin", "second-plugin"]) {
+      const plugin = join(context.pluginStorageRoot, name);
+      await mkdir(join(plugin, ".agenc-plugin"), { recursive: true });
+      await mkdir(join(plugin, "server"));
+      await writeFile(join(plugin, "server", "main.mjs"), "// Inventory must not execute this server.\n");
+      await writeFile(join(plugin, ".agenc-plugin", "plugin.json"), JSON.stringify({
+        name, mcpServers: { api: { transport: "stdio", command: "node", args: ["./server/main.mjs"] } },
+      }));
+    }
+    const inventory = await mcpDesktopInventory(context);
+    expect(inventory.errors).toEqual([]);
+    expect(inventory.servers.map(server => server.pluginId).sort()).toEqual(["first-plugin", "second-plugin"]);
+    for (const server of inventory.servers) {
+      expect(server.cwd).toBe(join(context.pluginStorageRoot, server.pluginId!));
+    }
+  });
+  test("does not report an intentional duplicate suppression as a load failure", async () => {
+    await seed("manual", { transport: "http", endpoint: "https://example.test/mcp" });
+    mutateCanonicalUserConfigSync(authority.homeContext.configTomlPath, (raw) => { raw.plugins = { enabled: true }; });
+    await authority.reload();
+    const plugin = join(context.pluginStorageRoot, "duplicate-plugin");
+    await mkdir(join(plugin, ".agenc-plugin"), { recursive: true });
+    await writeFile(join(plugin, ".agenc-plugin", "plugin.json"), JSON.stringify({
+      name: "duplicate-plugin", mcpServers: { api: { transport: "http", endpoint: "https://example.test/mcp" } },
+    }));
+    const inventory = await mcpDesktopInventory(context);
+    expect(inventory.servers.map(server => server.name)).toEqual(["manual"]);
+    expect(inventory.errors).toEqual([]);
+  });
   test("logout removes only exact-server OAuth state and client secret", async () => {
     const config = { type: "http" as const, url: "https://example.test/mcp", oauth: {} };
     await seed("sample", { transport: "http", endpoint: config.url, oauth: {} });


### PR DESCRIPTION
Installing Motor3D and Stonks Copilot together dropped Stonks from MCP discovery because both launch `node ./server/main.mjs`. Include the working directory in stdio server identity so relative entry points in different plugin roots remain separate.

Keep genuine duplicate suppression, and exclude its informational diagnostic from the Desktop load-error banner. Actual configuration errors still appear.

Validation: 21 focused MCP tests passed, including installed-plugin discovery and duplicate/error reporting; runtime and test-support typechecks passed; runtime build and package contracts passed. The compiled CLI discovered both MCP servers in the existing three-plugin local installation with zero inventory errors. Remote CI skipped per owner instruction.
