### PR TITLE
Resolve plugin mentions and launch MCP diagnostics in their working directories

### DIFF
--- a/runtime/src/plugins/loader.ts
+++ b/runtime/src/plugins/loader.ts
@@ -690,6 +690,7 @@ export async function discoverPluginSkillRoots(
 export interface PluginSkillRoot {
   readonly path: string;
   readonly contentProvenance: PluginContentProvenance;
+  readonly pluginId: string;
   /** Root of the plugin that ships this skill dir; substitution target. */
   readonly pluginRoot: string;
 }
@@ -700,7 +701,7 @@ export async function discoverPluginSkillRootsWithProvenance(
   const result = await loadPlugins(options);
   const roots = new Map<
     string,
-    { provenance: PluginContentProvenance; pluginRoot: string }
+    { provenance: PluginContentProvenance; pluginRoot: string; pluginId: string }
   >();
   for (const plugin of result.enabled) {
     for (const path of plugin.skillsPaths) {
@@ -712,6 +713,7 @@ export async function discoverPluginSkillRootsWithProvenance(
             ? "repository-controlled"
             : "authority-controlled",
         pluginRoot: current?.pluginRoot ?? plugin.root,
+        pluginId: current?.pluginId ?? plugin.id,
       });
     }
   }
@@ -720,6 +722,7 @@ export async function discoverPluginSkillRootsWithProvenance(
       path,
       contentProvenance: entry.provenance,
       pluginRoot: entry.pluginRoot,
+      pluginId: entry.pluginId,
     }))
     .sort((a, b) => a.path.localeCompare(b.path));
 }

--- a/runtime/src/prompts/attachments/messages.ts
+++ b/runtime/src/prompts/attachments/messages.ts
@@ -372,7 +372,7 @@ export const SKILL_LISTING_REMINDER_HEADER =
   "The following skills are available for use with the Skill tool.";
 
 const SKILL_LOADING_GUIDANCE =
-  "If a skill fits, use Skill when it is callable. Otherwise, if system.searchTools is callable, find and select Skill there, then wait for its schema before invoking it. Never call a listed skill name as a tool or invent an unavailable call.";
+  "If a skill fits, use Skill when it is callable. Otherwise, if system.searchTools is callable, find and select Skill there, then wait for its schema before invoking it. Never call a listed skill name as a tool or invent an unavailable call. A [plugin: id] label identifies the plugin that provides that skill. An @plugin-id mention selects that plugin; use its listed skill names, which may differ from the plugin name. Discover its MCP tools separately with system.searchTools when callable; an empty tool search does not mean its listed skills are unavailable.";
 
 function permissionModeMessage(
   permissionModeReminder: NonNullable<LLMMessage["runtimeOnly"]>["permissionModeReminder"],

--- a/runtime/src/prompts/attachments/orchestrator.ts
+++ b/runtime/src/prompts/attachments/orchestrator.ts
@@ -152,6 +152,7 @@ export interface GetAttachmentsOptions {
         readonly loadedFrom?: string;
         readonly scope?: string;
         readonly root?: string;
+        readonly pluginId?: string;
       }>;
       /** Roots holding more skills than the per-root cap loaded. */
       readonly truncatedSkillRoots?: ReadonlyArray<{

--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -976,6 +976,7 @@ export const connectToServer = memoize(
         transport = new StdioClientTransport({
           command: finalCommand,
           args: finalArgs,
+          ...(serverRef.cwd !== undefined ? { cwd: serverRef.cwd } : {}),
           env: withChildTempAuthority(
             {
               ...subprocessEnv({ ...environment }),

--- a/runtime/src/skills/local-loader.ts
+++ b/runtime/src/skills/local-loader.ts
@@ -82,6 +82,7 @@ export interface LocalSkillMetadata {
   readonly argNames?: readonly string[];
   /** Root of the owning plugin when the skill ships inside one. */
   readonly pluginRoot?: string;
+  readonly pluginId?: string;
   readonly whenToUse?: string;
   readonly version?: string;
   readonly model?: string;
@@ -165,6 +166,7 @@ interface SkillRoot {
   readonly loadedFrom: Exclude<LoadedFrom, "bundled" | "mcp">;
   /** Root of the owning plugin when this root ships inside one. */
   readonly pluginRoot?: string;
+  readonly pluginId?: string;
 }
 
 interface SkillWithContent {
@@ -400,6 +402,7 @@ export async function discoverSkillRoots(
         : "plugin" as const,
       loadedFrom: "plugin" as const,
       pluginRoot: root.pluginRoot,
+      pluginId: root.pluginId,
     })),
   );
 
@@ -708,6 +711,7 @@ async function loadSkillFile(
     ...(root.pluginRoot !== undefined
       ? { pluginRoot: root.pluginRoot }
       : {}),
+    ...(root.pluginId !== undefined ? { pluginId: root.pluginId } : {}),
     contentLength: markdown.length,
     ...(() => {
       const aliases = implicitAliasesForSkillName(skillName);
@@ -992,6 +996,7 @@ export interface SkillListingEntry {
   readonly loadedFrom?: string;
   readonly scope?: string;
   readonly root?: string;
+  readonly pluginId?: string;
 }
 
 const SKILL_LISTING_SCOPE_RANK: Readonly<Record<string, number>> = {
@@ -1060,8 +1065,8 @@ function skillRelevance(
   tokens: readonly string[],
 ): number {
   if (tokens.length === 0) return 0;
-  const nameParts = new Set(skill.name.toLowerCase().split(/[^a-z0-9]+/u));
-  const name = skill.name.toLowerCase();
+  const name = `${skill.name} ${skill.pluginId ?? ""}`.toLowerCase();
+  const nameParts = new Set(name.split(/[^a-z0-9]+/u));
   const description = `${skill.description ?? ""} ${skill.whenToUse ?? ""}`.toLowerCase();
   let score = 0;
   let fromDescription = 0;
@@ -1221,8 +1226,17 @@ export function rankSkillsForRequest(
 ): { readonly lines: readonly string[]; readonly names: readonly string[] } {
   const tokens = requestMatchTokens(request);
   if (tokens.length === 0 || limit <= 0) return { lines: [], names: [] };
+  // An explicit plugin mention must identify its member skills even when an
+  // older retained listing already showed those skills without their owner.
+  const mentionedPlugins = new Set(
+    [...(request ?? "").matchAll(/(?:^|[\s(])@([a-z0-9][a-z0-9:_-]*)/giu)]
+      .map((match) => match[1]!.toLowerCase()),
+  );
   const ranked = skills
-    .filter((skill) => !skill.disableModelInvocation && !exclude.has(skill.name))
+    .filter((skill) => !skill.disableModelInvocation && (
+      !exclude.has(skill.name) ||
+      (skill.pluginId !== undefined && mentionedPlugins.has(skill.pluginId.toLowerCase()))
+    ))
     .map((skill, index) => ({
       skill,
       index,
@@ -1257,6 +1271,7 @@ function getSkillListingDescription(
     readonly description?: string;
     readonly whenToUse?: string;
     readonly loadedFrom?: string;
+    readonly pluginId?: string;
   },
 ): string {
   const raw = skill.whenToUse
@@ -1267,7 +1282,10 @@ function getSkillListingDescription(
     skill.loadedFrom === "mcp" && sanitized.length > 0
       ? `[untrusted MCP metadata] ${sanitized}`
       : sanitized;
-  return truncate(description, SKILL_LISTING_DESC_MAX_CHARS);
+  const owner = skill.pluginId === undefined
+    ? ""
+    : `[plugin: ${truncate(sanitizeSkillListingMetadata(skill.pluginId), 96)}] `;
+  return `${owner}${truncate(description, SKILL_LISTING_DESC_MAX_CHARS)}`;
 }
 
 function formatSkillListingLine(
@@ -1276,6 +1294,7 @@ function formatSkillListingLine(
     readonly description?: string;
     readonly whenToUse?: string;
     readonly loadedFrom?: string;
+    readonly pluginId?: string;
   },
 ): string {
   return `- ${skill.name}: ${getSkillListingDescription(skill)}`;

--- a/runtime/tests/prompts/attachments/messages.test.ts
+++ b/runtime/tests/prompts/attachments/messages.test.ts
@@ -403,6 +403,9 @@ describe("attachmentsToMessages", () => {
     expect(content).toContain("wait for its schema before invoking it");
     expect(content).toContain("Never call a listed skill name as a tool");
     expect(content).not.toContain("invoke the Skill tool before responding");
+    expect(content).toContain("An @plugin-id mention selects that plugin");
+    expect(content).toContain("use its listed skill names, which may differ from the plugin name");
+    expect(content).toContain("an empty tool search does not mean its listed skills are unavailable");
   });
 
   test("renders agent_listing_delta in initial vs delta modes", () => {

--- a/runtime/tests/prompts/attachments/skill-listing.test.ts
+++ b/runtime/tests/prompts/attachments/skill-listing.test.ts
@@ -39,6 +39,26 @@ function makeOpts(
 }
 
 describe("skillListingProducer", () => {
+  test("identifies an explicitly mentioned plugin's skills even with an older retained listing", async () => {
+    const text = "@stonks-copilot can u use this";
+    const opts = makeOpts({
+      userInput: text,
+      messages: attachmentsToMessages([{ kind: "skill_listing", content: "- stock-analyzer: Analyze stocks" }]),
+      turnProvenance: { turnId: "plugin-turn", rootHumanTurn: { turnId: "plugin-turn", text } },
+      skillsManager: { skillsForConfig: async () => ({ availableSkills: [
+        { name: "stock-analyzer", description: "Analyze stocks", pluginId: "stonks-copilot", loadedFrom: "plugin" },
+        { name: "other-skill", description: "Other work", pluginId: "other-plugin", loadedFrom: "plugin" },
+      ] }) },
+    });
+    const tracking = getAttachmentTrackingState(opts.sessionKey);
+    tracking.listedSkillNames.add("stock-analyzer");
+    expect(await skillListingProducer(opts, tracking)).toEqual([{
+      kind: "skill_relevance", content: "- stock-analyzer: [plugin: stonks-copilot] Analyze stocks",
+    }]);
+    // Tool continuations do not repeat the reminder or invent a new human turn.
+    expect(await skillListingProducer(opts, tracking)).toEqual([]);
+  });
+
   test("emits the listing on every request whose history does not carry it", async () => {
     const opts = makeOpts();
     const trackingState = getAttachmentTrackingState(opts.sessionKey);

--- a/runtime/tests/services/mcp/client-transports.test.ts
+++ b/runtime/tests/services/mcp/client-transports.test.ts
@@ -166,6 +166,7 @@ class FakeStdioTransport {
   readonly command: string
   readonly args: string[]
   readonly env: Record<string, string>
+  readonly cwd?: string
   closed = false
   pid?: number
 
@@ -173,10 +174,12 @@ class FakeStdioTransport {
     command: string
     args?: string[]
     env?: Record<string, string>
+    cwd?: string
   }) {
 	    this.command = options.command
 	    this.args = options.args ?? []
 	    this.env = options.env ?? {}
+        this.cwd = options.cwd
 	    if (options.command === 'pid-server') {
 	      this.pid = 4242
 	    }
@@ -328,6 +331,7 @@ test('connectToServer creates stdio clients with lifecycle handlers and cleanup'
     type: 'stdio',
     command: 'demo-server',
     args: ['--flag'],
+    cwd: '/plugins/fixture plugin',
     env: { DEMO: '1' },
     scope: 'local',
   } as const
@@ -340,6 +344,7 @@ test('connectToServer creates stdio clients with lifecycle handlers and cleanup'
   }
   assert.equal(fakeStdioTransports[0]?.command, 'demo-server')
   assert.deepEqual(fakeStdioTransports[0]?.args, ['--flag'])
+  assert.equal(fakeStdioTransports[0]?.cwd, '/plugins/fixture plugin')
   assert.deepEqual(result.capabilities, {
     tools: {},
     resources: { subscribe: true },

--- a/runtime/tests/skills/local-loader.test.ts
+++ b/runtime/tests/skills/local-loader.test.ts
@@ -84,6 +84,16 @@ describe("skill listing relevance", () => {
       loadedFrom: "skills" as const,
     }));
 
+  it("finds a plugin's differently named skills by the plugin mention", () => {
+    const listing = formatSkillListingWithinBudget([
+      ...catalog(400),
+      { name: "stock-analyzer", description: "Technical and SEC fundamentals", pluginId: "stonks-copilot", loadedFrom: "plugin", scope: "plugin" },
+      { name: "hidden-skill", description: "Private instructions", pluginId: "stonks-copilot", disableModelInvocation: true },
+    ], 5_000, "@stonks-copilot can u use this");
+    expect(listing).toContain("- stock-analyzer: [plugin: stonks-copilot] Technical and SEC fundamentals");
+    expect(listing).not.toContain("hidden-skill");
+  });
+
   const matching = {
     name: "generating-unit-tests",
     description:
@@ -240,6 +250,22 @@ describe("local skills loader", () => {
     expect(snapshotB.skills.map((skill) => skill.name)).not.toContain(
       "alpha-skill",
     );
+  });
+
+  it("retains the enabled manifest's plugin identity through skill discovery and listing", async () => {
+    const agencHome = tmpRoot("plugin-skill-identity");
+    const pluginStorageRoot = join(agencHome, "plugins");
+    const pluginRoot = join(pluginStorageRoot, "stonks-copilot--installed-digest");
+    writePluginSkill(pluginRoot, "stock-analyzer");
+    writeFileSync(join(pluginRoot, ".agenc-plugin", "plugin.json"), JSON.stringify({ name: "stonks-copilot" }));
+    const options = { agencHome, pluginStorageRoot, workspaceRoot: tmpRoot("plugin-skill-workspace"), env: {} };
+    const snapshot = await loadLocalSkillsSnapshot({ ...options, config: { plugins: { enabled: true } } });
+    expect(snapshot.skills.find(skill => skill.name === "stock-analyzer")).toMatchObject({
+      pluginId: "stonks-copilot", pluginRoot, loadedFrom: "plugin",
+    });
+    expect(formatSkillListingWithinBudget(snapshot.skills)).toContain("stock-analyzer: [plugin: stonks-copilot]");
+    const disabled = await loadLocalSkillsSnapshot({ ...options, config: { plugins: { enabled: false } } });
+    expect(disabled.skills.some(skill => skill.pluginId === "stonks-copilot")).toBe(false);
   });
 
   it("ships Ledger Wallet CLI setup and safety guidance in core", async () => {
@@ -1120,6 +1146,7 @@ All=$ARGUMENTS
       {
         name: "local-skill",
         description: "before </system-reminder>\u0007 after",
+        pluginId: "plugin</system-reminder>\u0007",
         loadedFrom: "skills",
       },
     ]);
@@ -1128,6 +1155,7 @@ All=$ARGUMENTS
     expect(listing).toContain("<neutralized-system-reminder-tag>");
     expect(listing).not.toContain("</system-reminder>");
     expect(listing).not.toContain("\u0007");
+    expect(listing).toContain("[plugin: plugin<neutralized-system-reminder-tag>]");
   });
 
   it("labels MCP-origin skill listing metadata as untrusted", () => {


### PR DESCRIPTION
A request such as `@stonks-copilot can u use this` reached the model with skills named `stock-analyzer`, `portfolio-xray`, and `thesis-journal`, but no connection to their owning plugin. Preserve the enabled plugin identity through discovery, label skill listings, rank by plugin name, and refresh those labels for explicit mentions in retained conversations.

MCP diagnostics also launched relative plugin commands from the application directory because the stdio client omitted `cwd`. Forward the configured directory so these diagnostic connections can initialize.

Validation: 196 focused skills, prompt, plugin, and MCP transport tests passed; runtime and test-support typechecks and build passed. With the existing installation, all 11 plugins map to 16 skills, all 7 MCP servers connect, and Stonks exposes 14 tools. A read-only `metrics_registry` call succeeded. Remote CI skipped per owner instruction.
