### PR TITLE
fix(trust): recognise a trusted project under every spelling of its path

### DIFF
--- a/runtime/src/permissions/trust/project-trust.ts
+++ b/runtime/src/permissions/trust/project-trust.ts
@@ -92,7 +92,17 @@ export function trustedProjectsPath(options: ProjectTrustPathOptions = {}): stri
 function canonicalizePathSync(path: string): string {
   const absolute = resolve(path);
   try {
-    return realpathSync(absolute);
+    // The native realpath, not Node's JS one. On a case-insensitive volume
+    // (every default macOS disk, most Windows ones) the JS implementation
+    // hands back whatever case it was given, so "/Users/x/agenc" and
+    // "/Users/x/AgenC" canonicalize to two different strings for one
+    // directory, and a project trusted under the spelling the app stored is
+    // refused when a shell, which reports the on-disk case, opens the same
+    // folder: "project is not trusted: /Users/x/AgenC". libc's realpath
+    // returns the on-disk spelling for every input, which is the identity
+    // this comparison is meant to capture. Measured on this machine: three
+    // spellings, one inode, three JS results, one native result.
+    return realpathSync.native(absolute);
   } catch {
     return absolute;
   }

--- a/runtime/tests/permissions/trust/project-trust.test.ts
+++ b/runtime/tests/permissions/trust/project-trust.test.ts
@@ -3,12 +3,14 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
+import { readFileSync as readFileSyncNode } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { isPathTrusted } from "../../../src/utils/config.js";
 
@@ -28,6 +30,9 @@ import {
   trustedProjectsPath,
 } from "./project-trust.js";
 
+function readFileSyncUtf8(path: string): string {
+  return readFileSyncNode(path, "utf8");
+}
 function mkTmp(): string {
   return mkdtempSync(join(tmpdir(), "agenc-project-trust-"));
 }
@@ -35,6 +40,21 @@ function mkTmp(): string {
 function deadPid(): number {
   return 2_147_483_647;
 }
+
+/**
+ * Whether the temp volume treats two spellings of a name as one directory.
+ * Decided once, at load, from a real probe rather than from the platform
+ * name: a case-sensitive APFS volume exists, and so does case-insensitive
+ * ext4 with casefold.
+ */
+const caseProbe = mkdtempSync(join(tmpdir(), "agenc-case-probe-"));
+mkdirSync(join(caseProbe, "MixedCase"));
+const volumeIgnoresCase =
+  existsSync(join(caseProbe, "mixedcase")) &&
+  statSync(join(caseProbe, "mixedcase")).ino === statSync(join(caseProbe, "MixedCase")).ino;
+afterAll(() => {
+  rmSync(caseProbe, { recursive: true, force: true });
+});
 
 describe("project trust store", () => {
   let home = "";
@@ -53,6 +73,36 @@ describe("project trust store", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test.skipIf(!volumeIgnoresCase)(
+    "a project trusted under one spelling is trusted under every spelling of the same directory",
+    () => {
+      // Observed on a default macOS disk: the app trusted /Users/x/agenc,
+      // the spelling it had stored, and a shell opening the same folder
+      // reported the on-disk /Users/x/AgenC, which the store then refused
+      // with "project is not trusted". Node's JS realpath keeps the case it
+      // is handed; three spellings of one inode canonicalized to three
+      // different strings. The store now uses the native realpath, which
+      // returns the on-disk spelling for all of them.
+      const stored = join(repo, "MixedCase");
+      mkdirSync(stored);
+      mkdirSync(join(stored, ".git"));
+      const spelledDifferently = join(repo, "mixedcase");
+      const upperCased = join(repo, "MIXEDCASE");
+      expect(statSync(spelledDifferently).ino).toBe(statSync(stored).ino);
+
+      trustProjectSync({ agencHome: home, cwd: stored });
+
+      expect(isProjectTrustedSync({ agencHome: home, cwd: spelledDifferently })).toBe(true);
+      expect(isProjectTrustedSync({ agencHome: home, projectRoot: upperCased })).toBe(true);
+      // And trusting it again under another spelling records nothing new:
+      // one directory is one entry, whatever it was called.
+      trustProjectSync({ agencHome: home, cwd: upperCased });
+      expect(
+        JSON.parse(readFileSyncUtf8(trustedProjectsPath({ agencHome: home }))).trustedProjects,
+      ).toHaveLength(1);
+    },
+  );
 
   test("missing trust file means untrusted", async () => {
     expect(await readTrustedProjects({ agencHome: home })).toEqual({


### PR DESCRIPTION
## Why

On a case-insensitive volume, which is every default macOS disk, the app trusted `/Users/x/agenc`, the spelling it had stored, and a shell opening the same folder reported the on-disk `/Users/x/AgenC`. The trust store refused it:

```
agenc: project is not trusted: /Users/x/AgenC
```

Both sides were already canonicalized, but with Node's JS `realpathSync`, which resolves symlinks and keeps whatever case it is handed. Measured on this machine:

```
/Users/tetsuoarena/agenc | realpathSync: /Users/tetsuoarena/agenc | native: /Users/tetsuoarena/AgenC | ino 132036720
/Users/tetsuoarena/AgenC | realpathSync: /Users/tetsuoarena/AgenC | native: /Users/tetsuoarena/AgenC | ino 132036720
/Users/tetsuoarena/AGENC | realpathSync: /Users/tetsuoarena/AGENC | native: /Users/tetsuoarena/AgenC | ino 132036720
```

One inode, three JS results, one native result. libc's realpath returns the on-disk spelling for every input, which is the identity this comparison was always meant to capture. On a case-sensitive volume the two calls agree, so nothing changes there.

## What, per file

- **`runtime/src/permissions/trust/project-trust.ts`** — `canonicalizePathSync` uses `realpathSync.native`. The fallback to the resolved path for a directory that does not exist is unchanged.
- **`runtime/tests/permissions/trust/project-trust.test.ts`** — trusts a project under one spelling and expects it trusted under two others, and expects trusting it again under another spelling to record nothing new. The test probes the temp volume once at load and skips, with the reason, where two spellings are two directories. Verified red without the fix, green with it.

## Evidence

The measurement above, plus the failing test without the fix. An end-to-end CLI run of the exact command that was refused follows in a comment once the runtime is rebuilt.

## Tests

`tests/permissions/trust/project-trust.test.ts`: 13 passed. Typecheck clean against the TS2883 baseline.

## Not changed

The trust file format, the MCP server approval store, and `config/home.ts`, which resolves an existing ancestor with the JS realpath for a different purpose. The desktop's own session cwd equality in `remotePair` is internally consistent (both sides come from the app's stored path) and is not touched.

## Counterpart PRs

None.
