### PR TITLE
Support DeepSeek V4.1 in native and managed integrations [skip ci]

### DIFF
--- a/runtime/src/llm/registry/agenc-deepseek.ts
+++ b/runtime/src/llm/registry/agenc-deepseek.ts
@@ -1,5 +1,14 @@
-/** Exact model in the reviewed AgenC promotion, not a public entitlement. */
+/** Exact route identities, never a public entitlement or an automatic migration. */
 export const AGENC_DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash-0731";
+export const AGENC_DEEPSEEK_V41_MODEL = "deepseek/deepseek-v4.1-flash";
+export const AGENC_DEEPSEEK_MODELS = [
+  { model: AGENC_DEEPSEEK_MODEL, label: "DeepSeek V4 Flash 0731" },
+  { model: AGENC_DEEPSEEK_V41_MODEL, label: "DeepSeek V4.1 Flash" },
+] as const;
+
+export function isAgenCDeepSeekModel(model: string | undefined): boolean {
+  return AGENC_DEEPSEEK_MODELS.some(entry => entry.model === model);
+}
 
 // Native levels published for this exact model. Medium is a legacy alias
 // for High, not a distinct reasoning level to offer in the selector.

--- a/runtime/src/llm/registry/deepseek-models.ts
+++ b/runtime/src/llm/registry/deepseek-models.ts
@@ -1,13 +1,14 @@
-/** Native DeepSeek API metadata, verified 2026-09-10.
+/** Native DeepSeek API metadata, verified 2026-09-11.
  * https://api-docs.deepseek.com/quick_start/pricing/
  * https://api-docs.deepseek.com/guides/thinking_mode/
  * The 64k default is AgenC's per-call budget; 384k is the provider ceiling.
  * Managed AgenC and third-party routes have separate contracts.
  */
 export const DEEPSEEK_REASONING_LEVELS = ["low", "high", "max"] as const;
+export const DEEPSEEK_FLASH_MODEL = "deepseek-flash";
 export const DEEPSEEK_MODELS = [
-  { model: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
-  { model: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { model: DEEPSEEK_FLASH_MODEL, label: "DeepSeek V4.1 Flash", vision: true },
+  { model: "deepseek-v4-pro", label: "DeepSeek V4 Pro", vision: false },
 ].map(entry => ({
   ...entry,
   contextWindow: 1_048_576,
@@ -15,9 +16,17 @@ export const DEEPSEEK_MODELS = [
   maxOutputTokensUpperLimit: 384_000,
   efforts: DEEPSEEK_REASONING_LEVELS,
   defaultEffort: "high" as const,
-  vision: false as const,
 }));
 
+// DeepSeek now serves V4.1 for these retired native Flash names. Keep saved
+// sessions readable without presenting aliases as additional selectable models.
+export const DEEPSEEK_MODEL_ALIASES = [
+  "deepseek-v4-flash",
+  "deepseek-v4-flash-vision-exp",
+].map(model => ({ ...DEEPSEEK_MODELS[0]!, model }));
+
 export function isNativeDeepSeekModel(model: string | undefined): boolean {
-  return DEEPSEEK_MODELS.some(entry => entry.model === model?.trim().toLowerCase());
+  return [...DEEPSEEK_MODELS, ...DEEPSEEK_MODEL_ALIASES].some(
+    entry => entry.model === model?.trim().toLowerCase(),
+  );
 }

--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -15,10 +15,10 @@ import {
 import type { ReasoningEffort, ReasoningSummary } from "../../session/turn-context.js";
 import { normalizeProviderIdentity } from "../../provider-identity.js";
 import { OPENAI_REASONING_MODELS } from "./openai-reasoning-models.js";
-import { DEEPSEEK_MODELS } from "./deepseek-models.js";
+import { DEEPSEEK_MODELS, DEEPSEEK_MODEL_ALIASES } from "./deepseek-models.js";
 import { QWEN_FLASH_NEXT_MODEL } from "./qwen-flash-next.js";
 import { QWEN_CODER_30B_MODEL } from "./qwen-coder-30b.js";
-import { AGENC_DEEPSEEK_MODEL, AGENC_DEEPSEEK_REASONING_LEVELS } from "./agenc-deepseek.js";
+import { AGENC_DEEPSEEK_MODELS, AGENC_DEEPSEEK_REASONING_LEVELS } from "./agenc-deepseek.js";
 import {
   GEMINI_THINKING_MODELS,
   resolveGeminiThinkingModel,
@@ -510,7 +510,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       visibility: "list",
     })),
     ...qwenCloudCatalogEntries(),
-    ...DEEPSEEK_MODELS.map((entry, index): RegisteredModelCatalogEntry => ({
+    ...[...DEEPSEEK_MODELS, ...DEEPSEEK_MODEL_ALIASES].map((entry, index): RegisteredModelCatalogEntry => ({
       provider: "deepseek",
       model: entry.model,
       displayName: entry.label,
@@ -518,7 +518,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       maxContextWindow: entry.contextWindow,
       maxOutputTokens: entry.maxOutputTokens,
       maxOutputTokensUpperLimit: entry.maxOutputTokensUpperLimit,
-      inputModalities: TEXT_MODALITIES,
+      inputModalities: entry.vision ? TEXT_IMAGE_MODALITIES : TEXT_MODALITIES,
       supportsToolUse: true,
       supportsParallelToolCalls: false,
       supportsStructuredOutput: true,
@@ -532,14 +532,14 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       defaultReasoningLevel: entry.defaultEffort,
       additionalSpeedTiers: NO_ADDITIONAL_SPEED_TIERS,
       priority: index,
-      visibility: "list",
+      visibility: index < DEEPSEEK_MODELS.length ? "list" : "none",
     })),
-    // Reviewed AgenC route metadata; account discovery still controls access.
-    // Backend: docs/operations/managed-stream-liveness-20260911.md.
-    {
+    // Client wire metadata only. Account discovery and the reviewed backend
+    // policy control which exact route is live; V4 is not an alias of V4.1.
+    ...AGENC_DEEPSEEK_MODELS.map((entry): RegisteredModelCatalogEntry => ({
       provider: "agenc",
-      model: AGENC_DEEPSEEK_MODEL,
-      displayName: "DeepSeek V4 Flash 0731",
+      model: entry.model,
+      displayName: entry.label,
       contextWindow: 1_048_576,
       maxContextWindow: 1_048_576,
       // Reasoning and tool arguments share this budget. An 8k allowance can
@@ -547,6 +547,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       maxOutputTokens: 64_000,
       maxOutputTokensUpperLimit: 384_000,
       maxOutputTokensCappedDefault: true,
+      // Managed image admission needs a separately reviewed backend contract.
       inputModalities: TEXT_MODALITIES,
       supportsToolUse: true,
       supportsParallelToolCalls: false,
@@ -561,7 +562,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       additionalSpeedTiers: NO_ADDITIONAL_SPEED_TIERS,
       priority: 0,
       visibility: "none",
-    },
+    })),
     // Metadata only: exposing this private route requires configured model access.
     // https://huggingface.co/Qwen/Qwen3.8-Flash-Next/tree/de4b8e4d43b917e7706784d8bb445c9af86a3540
     ...["agenc", "qwen"].map((provider): RegisteredModelCatalogEntry => ({

--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -426,7 +426,7 @@ export const BUILT_IN_PROVIDER_DEFINITIONS = Object.freeze({
   }),
   deepseek: providerDefinition({
     name: "DeepSeek",
-    defaultModel: "deepseek-v4-flash",
+    defaultModel: "deepseek-flash",
     baseURL: "https://api.deepseek.com/v1",
     credentials: apiKeyCredentials(["DEEPSEEK_API_KEY"]),
     baseURLEnvVars: ["DEEPSEEK_BASE_URL"],
@@ -690,7 +690,7 @@ export const BUILT_IN_PROVIDER_MODEL_CATALOG: Readonly<
     "llama-3.3-70b-versatile",
     "llama-3.1-8b-instant",
   ]),
-  deepseek: Object.freeze(["deepseek-v4-flash", "deepseek-v4-pro"]),
+  deepseek: Object.freeze(["deepseek-flash", "deepseek-v4-pro"]),
   // `/models` also advertises image generation and voice transcription.
   // Those are not chat-completion LLMs and deliberately stay out of this list.
   meta: mergeDerivedProviderModels("meta"),

--- a/runtime/src/llm/wire/capability-gating.ts
+++ b/runtime/src/llm/wire/capability-gating.ts
@@ -33,7 +33,7 @@ import { supportsXaiReasoningEffortParam } from "../structured-output.js";
 import { isVerifiedOpenAiReasoningModel } from "../registry/openai-reasoning-models.js";
 import { isQwenFlashNextModel } from "../registry/qwen-flash-next.js";
 import { isQwenCoder30BModel } from "../registry/qwen-coder-30b.js";
-import { isAgenCDeepSeekModel, AGENC_DEEPSEEK_REASONING_LEVELS } from "../registry/agenc-deepseek.js";
+import { isAgenCDeepSeekModel, AGENC_DEEPSEEK_V41_MODEL, AGENC_DEEPSEEK_REASONING_LEVELS } from "../registry/agenc-deepseek.js";
 import { DEEPSEEK_REASONING_LEVELS, isNativeDeepSeekModel } from "../registry/deepseek-models.js";
 
 export interface ChatCompletionsCapabilityHints {
@@ -542,6 +542,12 @@ export function chatCompletionsCapabilityHintsForProvider(
       reasoningContentField: "reasoning_content" as const,
     } : {}),
     ...(isManagedDeepSeek ? {
+      // The reviewed V4.1 route supports automatic tool selection, not forced
+      // or named choices. All tools remain available to the agent.
+      ...(model === AGENC_DEEPSEEK_V41_MODEL ? {
+        acceptsToolChoice: false,
+        toolChoicePolicy: "auto_only" as const,
+      } : {}),
       acceptsParallelToolCalls: false,
       acceptsDirectImageInput: false,
       toolResultImagePolicy: "strip" as const,

--- a/runtime/src/llm/wire/capability-gating.ts
+++ b/runtime/src/llm/wire/capability-gating.ts
@@ -33,7 +33,7 @@ import { supportsXaiReasoningEffortParam } from "../structured-output.js";
 import { isVerifiedOpenAiReasoningModel } from "../registry/openai-reasoning-models.js";
 import { isQwenFlashNextModel } from "../registry/qwen-flash-next.js";
 import { isQwenCoder30BModel } from "../registry/qwen-coder-30b.js";
-import { AGENC_DEEPSEEK_MODEL, AGENC_DEEPSEEK_REASONING_LEVELS } from "../registry/agenc-deepseek.js";
+import { isAgenCDeepSeekModel, AGENC_DEEPSEEK_REASONING_LEVELS } from "../registry/agenc-deepseek.js";
 import { DEEPSEEK_REASONING_LEVELS, isNativeDeepSeekModel } from "../registry/deepseek-models.js";
 
 export interface ChatCompletionsCapabilityHints {
@@ -402,7 +402,7 @@ export function chatCompletionsCapabilityHintsForProvider(
 ): ChatCompletionsCapabilityHints {
   const slug = normalizeProviderIdentity(providerName, "capability gate") ?? "";
   const isManagedDeepSeek = options.managedGateway === true &&
-    slug === "openrouter" && model === AGENC_DEEPSEEK_MODEL;
+    slug === "openrouter" && isAgenCDeepSeekModel(model);
   const isNativeDeepSeek = slug === "deepseek" && isNativeDeepSeekModel(model);
   const normalizedModel = model?.trim().toLowerCase() ?? "";
   const reasoningContentProvenance =
@@ -533,8 +533,8 @@ export function chatCompletionsCapabilityHintsForProvider(
     ...(isNativeDeepSeek ? {
       acceptsToolChoice: false,
       acceptsParallelToolCalls: false,
-      acceptsDirectImageInput: false,
-      toolResultImagePolicy: "strip" as const,
+      acceptsDirectImageInput: acceptsToolResultImages,
+      toolResultImagePolicy: acceptsToolResultImages ? "relay_as_user" as const : "strip" as const,
       toolChoicePolicy: "auto_only" as const,
       acceptsTemperature: false,
       thinkingConfig: { type: "enabled" as const },

--- a/runtime/src/session/cost.ts
+++ b/runtime/src/session/cost.ts
@@ -174,6 +174,22 @@ const COST_TIER_DEEPSEEK_V4_PRO: Readonly<ModelCostEntry> = Object.freeze({
   cachedInputIncludedInInputTokens: true,
 });
 
+// Native API estimates use the published peak rates (2026-09-11). Off-peak
+// calls cost half; these estimates are not authoritative managed-credit usage.
+// https://api-docs.deepseek.com/quick_start/pricing/
+const COST_TIER_DEEPSEEK_V41_FLASH_NATIVE: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.0003,
+  outputUsdPer1K: 0.0012,
+  cachedInputUsdPer1K: 0.000006,
+  cachedInputIncludedInInputTokens: true,
+});
+const COST_TIER_DEEPSEEK_V4_PRO_NATIVE: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.00132,
+  outputUsdPer1K: 0.00396,
+  cachedInputUsdPer1K: 0.000044,
+  cachedInputIncludedInInputTokens: true,
+});
+
 // Official Mistral API prices retrieved 2026-08-24:
 // https://docs.mistral.ai/inference/pricing
 const COST_TIER_MISTRAL_MEDIUM_3_5: Readonly<ModelCostEntry> = Object.freeze({
@@ -434,12 +450,16 @@ export const DEFAULT_MODEL_COSTS: Readonly<Record<string, ModelCostEntry>> =
       inputUsdPer1K: 0.00059,
       outputUsdPer1K: 0.00079,
     },
-    "deepseek:deepseek-v4-flash": COST_TIER_DEEPSEEK_V4_FLASH,
-    "deepseek-v4-flash": COST_TIER_DEEPSEEK_V4_FLASH,
+    "deepseek:deepseek-flash": COST_TIER_DEEPSEEK_V41_FLASH_NATIVE,
+    "deepseek-flash": COST_TIER_DEEPSEEK_V41_FLASH_NATIVE,
+    "deepseek:deepseek-v4-flash": COST_TIER_DEEPSEEK_V41_FLASH_NATIVE,
+    "deepseek-v4-flash": COST_TIER_DEEPSEEK_V41_FLASH_NATIVE,
+    "deepseek:deepseek-v4-flash-vision-exp": COST_TIER_DEEPSEEK_V41_FLASH_NATIVE,
+    "deepseek-v4-flash-vision-exp": COST_TIER_DEEPSEEK_V41_FLASH_NATIVE,
     "deepseek/deepseek-v4-flash": COST_TIER_DEEPSEEK_V4_FLASH,
     "openrouter:deepseek/deepseek-v4-flash": COST_TIER_DEEPSEEK_V4_FLASH,
-    "deepseek:deepseek-v4-pro": COST_TIER_DEEPSEEK_V4_PRO,
-    "deepseek-v4-pro": COST_TIER_DEEPSEEK_V4_PRO,
+    "deepseek:deepseek-v4-pro": COST_TIER_DEEPSEEK_V4_PRO_NATIVE,
+    "deepseek-v4-pro": COST_TIER_DEEPSEEK_V4_PRO_NATIVE,
     "deepseek/deepseek-v4-pro": COST_TIER_DEEPSEEK_V4_PRO,
     "openrouter:deepseek/deepseek-v4-pro": COST_TIER_DEEPSEEK_V4_PRO,
     "cerebras:gpt-oss-120b": COST_TIER_CEREBRAS_GPT_OSS_120B,

--- a/runtime/src/utils/model/openaiContextWindows.ts
+++ b/runtime/src/utils/model/openaiContextWindows.ts
@@ -108,6 +108,9 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
 
   // DeepSeek V4 Flash and Pro: 1,048,576 context and 384,000 output ceiling.
   // The native adapter's default response budget is registered separately.
+  'deepseek-flash':         1_048_576,
+  'deepseek-v4.1-flash':     1_048_576,
+  'deepseek-v4-flash-vision-exp': 1_048_576,
   'deepseek-v4-flash':      1_048_576,
   'deepseek-v4-pro':        1_048_576,
   // Groq (fast inference)
@@ -344,6 +347,9 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'o4-mini':                  100_000,
 
   // DeepSeek V4 coding-agent models. See context-window note above.
+  'deepseek-flash':           384_000,
+  'deepseek-v4.1-flash':       384_000,
+  'deepseek-v4-flash-vision-exp': 384_000,
   'deepseek-v4-flash':        384_000,
   'deepseek-v4-pro':          384_000,
   // Compatibility DeepSeek API aliases documented in the public pricing/model pages.

--- a/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
+++ b/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthBackend } from "../../../../src/auth/backend.js";
 import { createProvider } from "../../../../src/llm/provider.js";
-import { AGENC_DEEPSEEK_MODELS } from "../../../../src/llm/registry/agenc-deepseek.js";
+import { AGENC_DEEPSEEK_MODELS, AGENC_DEEPSEEK_V41_MODEL } from "../../../../src/llm/registry/agenc-deepseek.js";
 import { deriveFlatCatalog, resolveRegisteredModelCatalogEntry } from "../../../../src/llm/registry/model-catalog.js";
 import { chatCompletionsCapabilityHintsForProvider } from "../../../../src/llm/wire/capability-gating.js";
 import { buildChatCompletionsRequest } from "../../../../src/llm/wire/chat-completions.js";
@@ -114,6 +114,7 @@ describe.each(AGENC_DEEPSEEK_MODELS)("AgenC $model promotion wire", ({ model }) 
       ], { reasoningEffort: effort, parallelToolCalls: true, maxOutputTokens: 256 });
       expect(final.content).toBe("marker");
       expect(bodies[0]).toMatchObject({ model, max_tokens: 256, reasoning_effort: effort });
+      if (model === AGENC_DEEPSEEK_V41_MODEL) expect(bodies[0].tool_choice).toBeUndefined();
       expect(bodies[1].reasoning_effort).toBe(effort);
       expect(bodies[1].messages.find((row: any) => row.role === "assistant").reasoning).toBe("Read the synthetic marker.");
       expect(bodies[1].messages.find((row: any) => row.role === "tool").tool_call_id).toBe(markerCallId);

--- a/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
+++ b/runtime/tests/llm/providers/agenc/deepseek-promotion.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthBackend } from "../../../../src/auth/backend.js";
 import { createProvider } from "../../../../src/llm/provider.js";
-import { AGENC_DEEPSEEK_MODEL as model } from "../../../../src/llm/registry/agenc-deepseek.js";
+import { AGENC_DEEPSEEK_MODELS } from "../../../../src/llm/registry/agenc-deepseek.js";
 import { deriveFlatCatalog, resolveRegisteredModelCatalogEntry } from "../../../../src/llm/registry/model-catalog.js";
 import { chatCompletionsCapabilityHintsForProvider } from "../../../../src/llm/wire/capability-gating.js";
 import { buildChatCompletionsRequest } from "../../../../src/llm/wire/chat-completions.js";
@@ -10,7 +10,7 @@ import type { LLMMessage } from "../../../../src/llm/types.js";
 import { ModelMetadataResolver } from "../../../../src/llm/model-metadata.js";
 import { defaultConfig } from "../../../../src/config/schema.js";
 
-describe("AgenC DeepSeek promotion wire", () => {
+describe.each(AGENC_DEEPSEEK_MODELS)("AgenC $model promotion wire", ({ model }) => {
   it.each(["low", "high", "max"] as const)("reserves room for reasoning and tools at native %s effort while honoring explicit limits", reasoningEffort => {
     const config = { ...defaultConfig(), model_provider: "agenc", model, reasoning_effort: reasoningEffort };
     const resolver = new ModelMetadataResolver({ env: {} });

--- a/runtime/tests/llm/providers/deepseek/provider.test.ts
+++ b/runtime/tests/llm/providers/deepseek/provider.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import { DeepSeekProvider } from "./index.js";
 import { BUILT_IN_PROVIDER_BASE_URLS } from "../../registry/provider-info.js";
-import { DEEPSEEK_MODELS } from "../../registry/deepseek-models.js";
+import { DEEPSEEK_MODELS, DEEPSEEK_MODEL_ALIASES } from "../../registry/deepseek-models.js";
 import { ModelMetadataResolver } from "../../model-metadata.js";
 import { defaultConfig } from "../../../config/schema.js";
 import { sessionConfigurationFromAgenCConfig } from "../../../session/configuration.js";
@@ -10,7 +10,7 @@ import type { LLMMessage } from "../../types.js";
 import { bodyAt, createSuccessfulChatResponse, ECHO_TOOL, sseResponse } from "../openai-compatible-test-helpers.js";
 
 describe("DeepSeekProvider", () => {
-  test.each(DEEPSEEK_MODELS)("$model preserves native effort and honors explicit output limits", ({ model }) => {
+  test.each([...DEEPSEEK_MODELS, ...DEEPSEEK_MODEL_ALIASES])("$model preserves native effort and honors explicit output limits", ({ model }) => {
     const config = { ...defaultConfig(), model_provider: "deepseek", model, reasoning_effort: "max" as const };
     const resolver = new ModelMetadataResolver({ env: {} });
     const metadata = resolver.resolveSync({ provider: "deepseek", model, config });
@@ -20,8 +20,7 @@ describe("DeepSeekProvider", () => {
     expect(session.collaborationMode.reasoningEffort).toBe("max");
   });
 
-  test.each(["low", "high", "max"] as const)("sends native %s effort and replays reasoning across tool and user turns", async (reasoningEffort) => {
-    const model = "deepseek-v4-pro";
+  test.each(DEEPSEEK_MODELS.flatMap(({ model }) => (["low", "high", "max"] as const).map(reasoningEffort => ({ model, reasoningEffort }))))("$model sends native $reasoningEffort effort and replays reasoning across tool and user turns", async ({ model, reasoningEffort }) => {
     const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => createSuccessfulChatResponse("deepseek-contract")(model));
     const provider = new DeepSeekProvider({ apiKey: "deepseek-test", model, fetchImpl, tools: [ECHO_TOOL] });
     const provenance = { provider: "deepseek", model };
@@ -44,8 +43,7 @@ describe("DeepSeekProvider", () => {
     expect((bodyAt(fetchImpl, 1).messages as Record<string, unknown>[]).filter(row => row.role === "assistant").every(row => row.reasoning_content === undefined)).toBe(true);
   });
 
-  test("streams a complete tool call and carries its reasoning into the next request", async () => {
-    const model = "deepseek-v4-flash";
+  test.each([...DEEPSEEK_MODELS, ...DEEPSEEK_MODEL_ALIASES])("$model streams a complete tool call and carries its reasoning into the next request", async ({ model }) => {
     const frame = (delta: object, finish_reason: string | null = null) => `data: ${JSON.stringify({ id: "deepseek-stream", model, choices: [{ index: 0, delta, finish_reason }] })}\n\n`;
     const fetchImpl = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(sseResponse([
@@ -64,6 +62,29 @@ describe("DeepSeekProvider", () => {
       { role: "tool", toolCallId: "call_echo", toolName: "system.echo", content: "ok" },
     ], { reasoningEffort: "max" });
     expect((bodyAt(fetchImpl, 1).messages as Record<string, unknown>[]).find(row => row.role === "assistant")?.reasoning_content).toBe("check with the tool");
+  });
+
+  test.each([DEEPSEEK_MODELS[0]!, ...DEEPSEEK_MODEL_ALIASES])("$model sends images and relays tool images as user input", async ({ model }) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(createSuccessfulChatResponse("deepseek-image")(model));
+    const provider = new DeepSeekProvider({ apiKey: "deepseek-test", model, fetchImpl, tools: [ECHO_TOOL] });
+    const image = { type: "image_url" as const, image_url: { url: "data:image/png;base64,aW1hZ2U=" } };
+    await provider.chat([
+      { role: "user", content: [{ type: "text", text: "Inspect" }, image] },
+      { role: "assistant", content: "", toolCalls: [{ id: "call_echo", name: "system.echo", arguments: "{}" }] },
+      { role: "tool", toolCallId: "call_echo", toolName: "system.echo", content: [{ type: "text", text: "Screenshot" }, image] },
+    ]);
+    const messages = bodyAt(fetchImpl).messages as Record<string, unknown>[];
+    expect(messages[0]).toMatchObject({ role: "user", content: expect.arrayContaining([image]) });
+    expect(messages[2]).toEqual({ role: "tool", tool_call_id: "call_echo", content: "Screenshot" });
+    expect(messages[3]).toMatchObject({ role: "user", content: expect.arrayContaining([image]) });
+  });
+
+  test("does not claim V4.1 vision support for V4 Pro", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const provider = new DeepSeekProvider({ apiKey: "deepseek-test", model: "deepseek-v4-pro", fetchImpl });
+    await expect(provider.chat([{ role: "user", content: [{ type: "image_url", image_url: { url: "data:image/png;base64,aW1hZ2U=" } }] }]))
+      .rejects.toThrow("does not support image input");
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   test("maps reasoning_content responses through the compat adapter", async () => {

--- a/runtime/tests/llm/registry/model-sot-unification.test.ts
+++ b/runtime/tests/llm/registry/model-sot-unification.test.ts
@@ -144,10 +144,10 @@ describe("model SoT: one catalog entry surfaces everywhere", () => {
 
 describe("retired models remain historical metadata, not live choices", () => {
   it("uses only reachable provider defaults and catalog rows", () => {
-    expect(BUILT_IN_PROVIDER_DEFAULT_MODELS.deepseek).toBe("deepseek-v4-flash");
+    expect(BUILT_IN_PROVIDER_DEFAULT_MODELS.deepseek).toBe("deepseek-flash");
     expect(BUILT_IN_PROVIDER_DEFAULT_MODELS.mistral).toBe("mistral-medium-latest");
     expect(BUILT_IN_PROVIDER_MODEL_CATALOG.deepseek).toEqual([
-      "deepseek-v4-flash",
+      "deepseek-flash",
       "deepseek-v4-pro",
     ]);
     expect(BUILT_IN_PROVIDER_MODEL_CATALOG.groq).not.toContain(

--- a/runtime/tests/llm/registry/provider-info.test.ts
+++ b/runtime/tests/llm/registry/provider-info.test.ts
@@ -22,7 +22,7 @@ describe("built-in provider info", () => {
       ["openai-compatible", "OpenAI-compatible", "local-model", "http://localhost:8000/v1", "api-key", ["OPENAI_COMPATIBLE_API_KEY", "OPENAI_API_KEY"], ["OPENAI_COMPATIBLE_BASE_URL", "OPENAI_BASE_URL", "OPENAI_API_BASE"], 60, "local", false],
       ["openrouter", "OpenRouter", "x-ai/grok-4.5", "https://openrouter.ai/api/v1", "api-key", ["OPENROUTER_API_KEY"], ["OPENROUTER_BASE_URL"], 70, "api-key", true],
       ["groq", "Groq", "llama-3.3-70b-versatile", "https://api.groq.com/openai/v1", "api-key", ["GROQ_API_KEY"], ["GROQ_BASE_URL"], 80, "api-key", false],
-      ["deepseek", "DeepSeek", "deepseek-v4-flash", "https://api.deepseek.com/v1", "api-key", ["DEEPSEEK_API_KEY"], ["DEEPSEEK_BASE_URL"], 90, "api-key", false],
+      ["deepseek", "DeepSeek", "deepseek-flash", "https://api.deepseek.com/v1", "api-key", ["DEEPSEEK_API_KEY"], ["DEEPSEEK_BASE_URL"], 90, "api-key", false],
       ["meta", "Meta", "muse-spark-1.3", "https://api.meta.ai/v1", "api-key", ["MODEL_API_KEY"], ["META_BASE_URL"], 95, "api-key", false],
       ["qwen", "QwenCloud Pay-As-You-Go", "qwen3.8-max", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "api-key", ["DASHSCOPE_API_KEY", "QWEN_API_KEY"], ["DASHSCOPE_BASE_URL", "QWEN_BASE_URL"], 97, "api-key", false],
       ["qwen-token-plan", "QwenCloud Token Plan", "qwen3.8-max", "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1", "api-key", ["QWEN_TOKEN_PLAN_API_KEY", "DASHSCOPE_TOKEN_PLAN_API_KEY"], ["QWEN_TOKEN_PLAN_BASE_URL", "DASHSCOPE_TOKEN_PLAN_BASE_URL"], 98, "api-key", false],

--- a/runtime/tests/session/cost.test.ts
+++ b/runtime/tests/session/cost.test.ts
@@ -382,17 +382,20 @@ describe("cost helpers", () => {
 
   test("current DeepSeek and Mistral defaults use their official cached-token tiers", () => {
     expect(DEFAULT_MODEL_COSTS["deepseek:deepseek-v4-flash"]).toMatchObject({
-      inputUsdPer1K: 0.00014,
-      outputUsdPer1K: 0.00028,
-      cachedInputUsdPer1K: 0.0000028,
+      inputUsdPer1K: 0.0003,
+      outputUsdPer1K: 0.0012,
+      cachedInputUsdPer1K: 0.000006,
       cachedInputIncludedInInputTokens: true,
     });
     expect(DEFAULT_MODEL_COSTS["deepseek:deepseek-v4-pro"]).toMatchObject({
-      inputUsdPer1K: 0.000435,
-      outputUsdPer1K: 0.00087,
-      cachedInputUsdPer1K: 0.000003625,
+      inputUsdPer1K: 0.00132,
+      outputUsdPer1K: 0.00396,
+      cachedInputUsdPer1K: 0.000044,
       cachedInputIncludedInInputTokens: true,
     });
+    for (const model of ["deepseek-flash", "deepseek-v4-flash-vision-exp"]) {
+      expect(DEFAULT_MODEL_COSTS[`deepseek:${model}`]).toBe(DEFAULT_MODEL_COSTS["deepseek:deepseek-v4-flash"]);
+    }
     expect(DEFAULT_MODEL_COSTS["mistral:mistral-medium-latest"])
       .toMatchObject({
         inputUsdPer1K: 0.0015,


### PR DESCRIPTION
Native DeepSeek now selects `deepseek-flash` (V4.1 Flash) with Low/High/Max, 1,048,576 context tokens and image input. Saved native Flash aliases keep the new metadata without duplicate menu rows; V4 Pro remains a separate text model. Native cost estimates use published peak rates.

AgenC recognizes V4.1 as a separate, hidden, account-authorized route while retaining the existing V4 route. Its tool wire preserves reasoning, discovery context and callable aliases, and uses automatic tool selection supported by the reviewed V4.1 endpoint. Promotion activation remains a backend operation.

Validation: 190 focused tests passed, followed by 76 passing affected wire tests after the endpoint-specific adjustment; typecheck including test support and runtime build passed. A separate real Electron profile answered a native V4.1 greeting and completed `exec_command` in about 3.8 seconds each. Capped OpenRouter Morph probes completed tool round trips at Low/High/Max with ZDR requested; six independent generation receipts matched published rates. Remote CI is skipped under the owner's local-CI instruction.
