### PR TITLE
fix(plugins): refresh the official marketplace instead of serving a stale copy forever

### DIFF
--- a/runtime/src/plugins/marketplace/catalog-cli.ts
+++ b/runtime/src/plugins/marketplace/catalog-cli.ts
@@ -51,9 +51,23 @@ export const OFFICIAL_MARKETPLACE_URL =
   "https://agenc.tech/plugins/marketplace.json";
 
 /**
- * Register the official marketplace when the profile has none. Returns
- * true when it was added. Never throws: an offline first run must still
- * produce a catalog (an empty one), not a hard CLI failure.
+ * How long a cached copy of the official marketplace is served before it is
+ * fetched again.
+ *
+ * The marketplace was installed once, on first use, and then read from disk
+ * forever. A home that installed it on Sep 10 had a manifest with 5 plugins
+ * while the live one listed 11, and the desktop's Plugins pane, which is built
+ * from this catalog, showed the 5. Nothing refreshed it: the only way to see a
+ * plugin published after install was to remove and re-add the marketplace by
+ * hand. An hour keeps the pane current without a fetch on every open.
+ */
+export const OFFICIAL_MARKETPLACE_REFRESH_MS = 60 * 60_000;
+
+/**
+ * Register the official marketplace when the profile has none, and fetch it
+ * again once the cached copy is older than the refresh window. Returns true
+ * when it was added or refreshed. Never throws: an offline first run must
+ * still produce a catalog (an empty one), not a hard CLI failure.
  */
 export async function ensureOfficialMarketplace(
   options: MarketplaceOperationOptions,
@@ -65,13 +79,21 @@ export async function ensureOfficialMarketplace(
 ): Promise<boolean> {
   if (options.env?.AGENC_SKIP_OFFICIAL_MARKETPLACE === "1") return false;
   const index = await readMarketplaceIndex(options);
-  if (Object.keys(index.marketplaces).length > 0) return false;
+  const official = index.marketplaces[OFFICIAL_MARKETPLACE_NAME];
+  const hasAny = Object.keys(index.marketplaces).length > 0;
+  // A manifest older than the window is fetched again in place. Failure keeps
+  // the cached copy: a stale catalog is a catalog, an empty one is an outage.
+  const stale =
+    official !== undefined &&
+    (options.now ?? (() => new Date()))().getTime() - Date.parse(official.updatedAt) >
+      OFFICIAL_MARKETPLACE_REFRESH_MS;
+  if (hasAny && !stale) return false;
   try {
     await addMarketplace({
       ...options,
       source: OFFICIAL_MARKETPLACE_URL,
       name: OFFICIAL_MARKETPLACE_NAME,
-      force: false,
+      force: stale,
     });
     return true;
   } catch {

--- a/runtime/tests/plugins/marketplace/catalog-cli.test.ts
+++ b/runtime/tests/plugins/marketplace/catalog-cli.test.ts
@@ -7,6 +7,10 @@ import {
   marketplacePluginSupportsProduct,
   parseQualifiedMarketplacePluginId,
   resolveMarketplaceInstallTarget,
+  ensureOfficialMarketplace,
+  OFFICIAL_MARKETPLACE_NAME,
+  OFFICIAL_MARKETPLACE_REFRESH_MS,
+  OFFICIAL_MARKETPLACE_URL,
 } from "./catalog-cli.js";
 import { addMarketplaceOp } from "./marketplace.js";
 
@@ -233,5 +237,59 @@ describe("marketplace catalog CLI surface", () => {
     await expect(
       resolveMarketplaceInstallTarget(options, "missing@nowhere", "desktop"),
     ).rejects.toThrow(/not configured/);
+  });
+});
+
+describe("the official marketplace stays current", () => {
+  // The marketplace was installed once and then read from disk forever: a
+  // home that installed it on Sep 10 served a 5-plugin manifest while the
+  // live one listed 11, and the Plugins pane showed the 5.
+  const hour = 60 * 60_000;
+  const t0 = Date.parse("2026-09-11T12:00:00.000Z");
+  type Added = { source: string; name: string; force: boolean };
+  async function seededOfficial(ageMs: number) {
+    const { pluginStorageRoot, workspaceRoot } = await tempRuntime();
+    const marketplaceRoot = await writeMarketplace(join(workspaceRoot, "official"));
+    await addMarketplaceOp({
+      pluginStorageRoot, workspaceRoot, source: marketplaceRoot, force: false,
+      name: OFFICIAL_MARKETPLACE_NAME, now: () => new Date(t0 - ageMs),
+    });
+    const added: Added[] = [];
+    const spy = async (input: Added) => { added.push({ source: input.source, name: input.name, force: input.force }); };
+    return { options: { pluginStorageRoot, workspaceRoot, now: () => new Date(t0) }, added, spy };
+  }
+
+  it("installs it into an empty home", async () => {
+    const { pluginStorageRoot, workspaceRoot } = await tempRuntime();
+    const added: Added[] = [];
+    const refreshed = await ensureOfficialMarketplace(
+      { pluginStorageRoot, workspaceRoot, now: () => new Date(t0) },
+      async (input) => { added.push({ source: input.source, name: input.name, force: input.force }); },
+    );
+    expect(refreshed).toBe(true);
+    expect(added).toEqual([{ source: OFFICIAL_MARKETPLACE_URL, name: OFFICIAL_MARKETPLACE_NAME, force: false }]);
+  });
+
+  it("leaves a fresh copy alone", async () => {
+    const { options, added, spy } = await seededOfficial(hour / 2);
+    expect(await ensureOfficialMarketplace(options, spy)).toBe(false);
+    expect(added).toEqual([]);
+  });
+
+  it("fetches it again, in place, once the copy is older than the refresh window", async () => {
+    const { options, added, spy } = await seededOfficial(OFFICIAL_MARKETPLACE_REFRESH_MS + 1);
+    expect(await ensureOfficialMarketplace(options, spy)).toBe(true);
+    // force: the existing install is replaced rather than refused as a duplicate.
+    expect(added).toEqual([{ source: OFFICIAL_MARKETPLACE_URL, name: OFFICIAL_MARKETPLACE_NAME, force: true }]);
+  });
+
+  it("keeps the cached copy when the refresh fails", async () => {
+    // A stale catalog is a catalog. An empty one is an outage.
+    const { options } = await seededOfficial(2 * hour);
+    const refreshed = await ensureOfficialMarketplace(options, async () => { throw new Error("offline"); });
+    expect(refreshed).toBe(false);
+    const catalog = await buildMarketplaceCatalog(options, "desktop");
+    expect(catalog.marketplaces).toHaveLength(1);
+    expect(catalog.marketplaces[0]!.plugins.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Why

The desktop Plugins pane showed 5 plugins while the official marketplace lists 11. The pane is built from `agenc plugin marketplace catalog --product desktop --json`, which reads the cached copy of the official marketplace under `<home>/plugins/marketplaces/agenc-plugins/`. `ensureOfficialMarketplace` registered that marketplace only when the profile had no marketplaces at all, so a home that installed it on Sep 10 (5 plugins) never fetched it again. The only way to see a plugin published after install was to remove and re-add the marketplace by hand.

## What

`runtime/src/plugins/marketplace/catalog-cli.ts`
- New `OFFICIAL_MARKETPLACE_REFRESH_MS` (one hour).
- `ensureOfficialMarketplace` now also runs when the cached official copy's `updatedAt` is older than the window, and calls `addMarketplace` with `force: true` so the copy is refetched in place. A refresh failure keeps the cached copy (a stale catalog is a catalog, an empty one is an outage). Empty-home behaviour is unchanged (`force: false`).

`runtime/tests/plugins/marketplace/catalog-cli.test.ts`
- New `describe("the official marketplace stays current")` with four cases: installs into an empty home, leaves a fresh copy alone, refetches in place once the copy is older than the window, keeps the cached copy when the refresh fails.

## Evidence

End to end on a home whose cached manifest had 5 plugins (updatedAt Sep 10), with a fresh `runtime/dist` build of this branch:

```
=== cached manifest before: 5 plugins
=== catalog --product desktop (fresh dist) ===
plugins: 11 ['forja', 'inbox', 'iot-builder', 'ledger', 'llm-checker', 'motor3d', 'olimpo', 'paper-radar', 'pluma', 'stonks-copilot', 'zeroday-hunter']
errors: []
=== cached manifest after: 11 plugins
```

## Tests

- `npx vitest run tests/plugins/marketplace/catalog-cli.test.ts`: 8 passed (4 existing + 4 new).
- `npm run typecheck` (runtime): clean.

## Not changed

- No change to `addMarketplace`, the index format, or the desktop pane. The desktop reads the CLI JSON and needs no counterpart.
- The refresh window is one hour; no fetch happens on every catalog call.
- `AGENC_SKIP_OFFICIAL_MARKETPLACE=1` still opts out entirely.

## Counterpart PRs

None. Desktop consumes the CLI output unchanged.
