### PR TITLE
feat(minimax): current model lineup, M3 thinking switch, split reasoning replay, H3 video

### DIFF
--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -203,6 +203,100 @@ const ZAI_CHAT_MODELS = Object.freeze([
   },
 ] as const satisfies readonly ZaiChatModelSpec[]);
 
+interface MinimaxChatModelSpec {
+  readonly model: string;
+  readonly displayName: string;
+  readonly contextWindow: number;
+  readonly vision: boolean;
+  /** Only MiniMax-M3 exposes the `thinking` switch; M2.x always think. */
+  readonly thinkingSwitch: boolean;
+  readonly priority: number;
+}
+
+/**
+ * MiniMax-M3's `thinking` control on the OpenAI-compatible route has two
+ * positions, `disabled` and `adaptive` (adaptive when the field is omitted).
+ * The effort dial spells them `low` and `high`; there is no depth between.
+ */
+const MINIMAX_M3_REASONING_LEVELS = Object.freeze([
+  "low",
+  "high",
+] as const satisfies readonly ReasoningEffort[]);
+
+const MINIMAX_MAX_OUTPUT_TOKENS = 131_072;
+
+/**
+ * The chat models MiniMax documents for its OpenAI-compatible route
+ * (platform.minimax.io, 2026-09-11). M3 takes image input and has the
+ * thinking switch; the M2 generations are text-only and always think.
+ */
+const MINIMAX_CHAT_MODELS = Object.freeze([
+  {
+    model: "MiniMax-M3",
+    displayName: "MiniMax M3",
+    contextWindow: 1_000_000,
+    vision: true,
+    thinkingSwitch: true,
+    priority: 0,
+  },
+  {
+    model: "MiniMax-M2.7",
+    displayName: "MiniMax M2.7",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 1,
+  },
+  {
+    model: "MiniMax-M2.7-highspeed",
+    displayName: "MiniMax M2.7 Highspeed",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 2,
+  },
+  {
+    model: "MiniMax-M2.5",
+    displayName: "MiniMax M2.5",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 3,
+  },
+  {
+    model: "MiniMax-M2.5-highspeed",
+    displayName: "MiniMax M2.5 Highspeed",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 4,
+  },
+  {
+    model: "MiniMax-M2.1",
+    displayName: "MiniMax M2.1",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 5,
+  },
+  {
+    model: "MiniMax-M2.1-highspeed",
+    displayName: "MiniMax M2.1 Highspeed",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 6,
+  },
+  {
+    model: "MiniMax-M2",
+    displayName: "MiniMax M2",
+    contextWindow: 204_800,
+    vision: false,
+    thinkingSwitch: false,
+    priority: 7,
+  },
+] as const satisfies readonly MinimaxChatModelSpec[]);
+
 const QWEN_CLOUD_PROVIDER_IDS = Object.freeze([
   "qwen",
   "qwen-token-plan",
@@ -379,6 +473,36 @@ function zaiCatalogEntries(): readonly RegisteredModelCatalogEntry[] {
       visibility: "list" as const,
     })),
   );
+}
+
+function minimaxCatalogEntries(): readonly RegisteredModelCatalogEntry[] {
+  return MINIMAX_CHAT_MODELS.map((model) => Object.freeze({
+    provider: "minimax",
+    model: model.model,
+    displayName: model.displayName,
+    contextWindow: model.contextWindow,
+    maxContextWindow: model.contextWindow,
+    maxOutputTokens: MINIMAX_MAX_OUTPUT_TOKENS,
+    inputModalities: model.vision ? TEXT_IMAGE_MODALITIES : TEXT_MODALITIES,
+    supportsToolUse: true,
+    supportsParallelToolCalls: false,
+    // MiniMax documents no response_format contract on this route.
+    supportsStructuredOutput: false,
+    supportsSearchTool: false,
+    supportsVerbosity: false,
+    webSearchToolType: "none" as const,
+    supportsReasoningSummaries: false,
+    defaultReasoningSummary: "none" as const,
+    supportedReasoningLevels: model.thinkingSwitch
+      ? MINIMAX_M3_REASONING_LEVELS
+      : NO_REASONING_LEVELS,
+    ...(model.thinkingSwitch
+      ? { defaultReasoningLevel: "high" as const }
+      : {}),
+    additionalSpeedTiers: NO_ADDITIONAL_SPEED_TIERS,
+    priority: model.priority,
+    visibility: "list" as const,
+  }));
 }
 
 function kimiCatalogEntries(): readonly RegisteredModelCatalogEntry[] {
@@ -637,6 +761,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
     },
     ...zaiCatalogEntries(),
     ...kimiCatalogEntries(),
+    ...minimaxCatalogEntries(),
     {
       provider: "cerebras",
       model: "qwen-3.8-27b",

--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -167,18 +167,6 @@ const NVIDIA_PROVIDER_MODEL_IDS = Object.freeze([
   "moonshotai/kimi-k2-instruct-0905",
 ] as const);
 
-const MINIMAX_MODEL_IDS = Object.freeze([
-  "MiniMax-M3",
-  "MiniMax-M2.7",
-  "MiniMax-M2",
-  "MiniMax-M2.1",
-  "MiniMax-M2.5",
-  "MiniMax-Text-01",
-  "MiniMax-Text-01-Preview",
-  "MiniMax-Vision-01",
-  "MiniMax-Vision-01-Fast",
-] as const);
-
 // Single source of truth: model lists for providers that have entries in
 // REGISTERED_MODEL_CATALOG are computed from it. model-catalog.ts does not
 // import this module, so this one-directional import introduces no cycle.
@@ -527,7 +515,7 @@ export const BUILT_IN_PROVIDER_DEFINITIONS = Object.freeze({
   }),
   minimax: providerDefinition({
     name: "MiniMax",
-    defaultModel: "MiniMax-M2.5",
+    defaultModel: "MiniMax-M3",
     baseURL: "https://api.minimax.io/v1",
     credentials: apiKeyCredentials(["MINIMAX_API_KEY"]),
     baseURLEnvVars: ["MINIMAX_BASE_URL"],
@@ -708,7 +696,7 @@ export const BUILT_IN_PROVIDER_MODEL_CATALOG: Readonly<
   ]),
   mistral: Object.freeze(["mistral-medium-latest"]),
   "nvidia-nim": NVIDIA_PROVIDER_MODEL_IDS,
-  minimax: MINIMAX_MODEL_IDS,
+  minimax: mergeDerivedProviderModels("minimax"),
   // Copilot proxies models owned by several providers. Keep those entries
   // qualified here so bare slugs such as gpt-5.4 retain one global owner.
   github: GITHUB_COPILOT_CATALOG_MODELS,

--- a/runtime/src/llm/wire/capability-gating.ts
+++ b/runtime/src/llm/wire/capability-gating.ts
@@ -96,6 +96,12 @@ export interface ChatCompletionsCapabilityHints {
   readonly reasoningContentField?: "reasoning_content" | "reasoning";
   /** Older compatible runtimes may emit the legacy name while replay uses canonical. */
   readonly reasoningContentFallbackField?: "reasoning_content" | "reasoning";
+  /**
+   * MiniMax inlines thinking in `content` behind think markers unless
+   * `reasoning_split` is set; with it the thinking arrives in
+   * `reasoning_content`, where the tool turn can replay it.
+   */
+  readonly reasoningSplit?: boolean;
   /** vLLM receives Jinja thinking controls inside chat_template_kwargs. */
   readonly usesVllmThinkingTemplate?: boolean;
   /**
@@ -109,9 +115,13 @@ export interface ChatCompletionsCapabilityHints {
   readonly replaysReasoningContentOnlyForIntactHistory?: boolean;
   /** Canonical destination required for opaque reasoning replay. */
   readonly reasoningContentProvenance?: ProviderReasoningProvenance;
-  /** Provider-native nested thinking configuration for always-on reasoning. */
+  /**
+   * Provider-native nested thinking configuration. `enabled` is the always-on
+   * form (DeepSeek, Z.AI, Kimi). `adaptive` is MiniMax-M3's two-position
+   * switch: the wire sends `disabled` for a `low` effort, `adaptive` otherwise.
+   */
   readonly thinkingConfig?: {
-    readonly type: "enabled";
+    readonly type: "enabled" | "adaptive";
     readonly clearThinking?: boolean;
     readonly keep?: "all";
   };
@@ -414,6 +424,9 @@ export function chatCompletionsCapabilityHintsForProvider(
       ?.supportsImageInput === true;
   const isZai = slug === "zai" || slug === "zai-coding-plan";
   const isKimi = slug === "kimi";
+  const isMinimax = slug === "minimax";
+  const isMinimaxM3 =
+    isMinimax && /(?:^|[/:])minimax-m3(?:$|[-_.:])/i.test(model ?? "");
   const isKimiK3 = isKimi && normalizedModel === "kimi-k3";
   const isKimiK27 =
     isKimi && /^kimi-k2\.7-code(?:-highspeed)?$/u.test(normalizedModel);
@@ -617,7 +630,8 @@ export function chatCompletionsCapabilityHintsForProvider(
     slug === "qwen" ||
     slug === "qwen-token-plan" ||
     slug === "cerebras" ||
-    isZai
+    isZai ||
+    isMinimax
       ? {
           toolResultImagePolicy: acceptsToolResultImages
             ? ("relay_as_user" as const)
@@ -669,6 +683,23 @@ export function chatCompletionsCapabilityHintsForProvider(
           structuredOutputContract: "zai_json_object" as const,
           ...(acceptsToolResultImages
             ? { imageInputContract: "zai_flash" as const }
+            : {}),
+        }
+      : {}),
+    ...(isMinimax
+      ? {
+          // MiniMax inlines thinking in `content` behind think markers by
+          // default. reasoning_split moves it to reasoning_content, and the
+          // docs want thinking preserved unchanged in later turns, above all
+          // in tool-use conversations, so every same-route turn replays it
+          // (the Qwen and Kimi shape, not Z.AI's adjacent-only rule: a
+          // runtime reminder after a tool result must not drop the chain).
+          reasoningSplit: true,
+          replaysReasoningContent: true,
+          reasoningContentField: "reasoning_content" as const,
+          // Only M3 has the thinking switch; M2.x always think.
+          ...(isMinimaxM3
+            ? { thinkingConfig: { type: "adaptive" as const } }
             : {}),
         }
       : {}),

--- a/runtime/src/llm/wire/chat-completions.ts
+++ b/runtime/src/llm/wire/chat-completions.ts
@@ -256,6 +256,12 @@ function reasoningHistoryFingerprint(
   return JSON.stringify(comparable);
 }
 
+/** Efforts that turn MiniMax-M3's two-position thinking switch off. */
+const MINIMAX_THINKING_OFF_EFFORTS: ReadonlySet<string> = new Set([
+  "minimal",
+  "low",
+]);
+
 function toChatCompletionsMessages(
   messages: readonly LLMMessage[],
   options: LLMChatOptions | undefined,
@@ -641,22 +647,32 @@ export function buildChatCompletionsRequest(
     body.preserve_thinking = true;
   }
   if (input.providerCapabilityHints?.thinkingConfig !== undefined) {
+    const thinkingConfig = input.providerCapabilityHints.thinkingConfig;
     const keepsAdjacentToolReasoning = reasoningContinuation !== undefined;
     body.thinking = {
-      type: input.providerCapabilityHints.thinkingConfig.type,
-      ...(input.providerCapabilityHints.thinkingConfig.keep !== undefined
-        ? { keep: input.providerCapabilityHints.thinkingConfig.keep }
+      // MiniMax-M3's switch has two positions: a low effort answers without
+      // thinking, every other effort keeps the provider's adaptive default.
+      type:
+        thinkingConfig.type === "adaptive"
+          ? MINIMAX_THINKING_OFF_EFFORTS.has(input.options?.reasoningEffort ?? "")
+            ? "disabled"
+            : "adaptive"
+          : thinkingConfig.type,
+      ...(thinkingConfig.keep !== undefined
+        ? { keep: thinkingConfig.keep }
         : {}),
-      ...(input.providerCapabilityHints.thinkingConfig.clearThinking !==
-          undefined
+      ...(thinkingConfig.clearThinking !== undefined
         ? {
             clear_thinking:
               keepsAdjacentToolReasoning
                 ? false
-                : input.providerCapabilityHints.thinkingConfig.clearThinking,
+                : thinkingConfig.clearThinking,
           }
         : {}),
     };
+  }
+  if (input.providerCapabilityHints?.reasoningSplit === true) {
+    body.reasoning_split = true;
   }
   if (
     input.options?.parallelToolCalls !== undefined &&

--- a/runtime/src/llm/wire/think-tags.ts
+++ b/runtime/src/llm/wire/think-tags.ts
@@ -14,6 +14,12 @@
  * ends it. That is where every known chat template puts the block, and
  * it keeps a literal "<think>" later in an answer — likely when the
  * subject of the conversation is this very bug — visible text.
+ *
+ * One more shape is marker residue rather than a block: a provider that
+ * has already split the reasoning out of `content` (MiniMax with
+ * `reasoning_split`) can leave the bare closer behind, so `content`
+ * starts with `</think>` and nothing was ever opened. A closer with
+ * nothing open before it is never visible text; it is dropped.
  */
 
 interface ThinkMarkerPair {
@@ -42,6 +48,12 @@ export interface ThinkSplit {
 export function splitLeadingThinkBlock(content: string): ThinkSplit {
   const trimmed = content.trimStart();
   for (const marker of THINK_MARKERS) {
+    if (trimmed.startsWith(marker.close)) {
+      return {
+        text: trimmed.slice(marker.close.length).trimStart(),
+        reasoning: "",
+      };
+    }
     if (!trimmed.startsWith(marker.open)) continue;
     const body = trimmed.slice(marker.open.length);
     const closeAt = body.indexOf(marker.close);
@@ -71,6 +83,12 @@ export class ThinkTagStreamFilter {
   private state: "detect" | "inside" | "pass" = "detect";
   private buffer = "";
   private marker: ThinkMarkerPair | null = null;
+  /**
+   * After a marker resolves, the whitespace that separates it from the
+   * answer may arrive in a later chunk. Keep dropping it until the first
+   * visible character, the way the whole-message split does.
+   */
+  private trimLeading = false;
 
   push(input: string): ThinkSplit {
     if (input.length === 0) return { text: "", reasoning: "" };
@@ -83,15 +101,28 @@ export class ThinkTagStreamFilter {
       const opened = THINK_MARKERS.find((candidate) =>
         trimmed.startsWith(candidate.open),
       );
+      const residue = THINK_MARKERS.find((candidate) =>
+        trimmed.startsWith(candidate.close),
+      );
       if (opened !== undefined) {
         this.state = "inside";
         this.marker = opened;
         this.buffer = trimmed.slice(opened.open.length);
+      } else if (residue !== undefined) {
+        // A bare closer with nothing open: the provider split the block
+        // out already and left its marker behind. Drop it.
+        this.state = "pass";
+        this.trimLeading = true;
+        this.buffer = trimmed.slice(residue.close.length);
       } else if (
         trimmed.length === 0 ||
-        THINK_MARKERS.some((candidate) => candidate.open.startsWith(trimmed))
+        THINK_MARKERS.some(
+          (candidate) =>
+            candidate.open.startsWith(trimmed) ||
+            candidate.close.startsWith(trimmed),
+        )
       ) {
-        // Still ambiguous — could grow into an opener. Keep buffering.
+        // Still ambiguous — could grow into a marker. Keep buffering.
         return { text: "", reasoning: "" };
       } else {
         this.state = "pass";
@@ -106,11 +137,10 @@ export class ThinkTagStreamFilter {
       if (closeAt !== -1) {
         reasoning = this.buffer.slice(0, closeAt);
         this.state = "pass";
-        text = this.buffer
-          .slice(closeAt + this.marker.close.length)
-          .trimStart();
-        this.buffer = "";
+        this.trimLeading = true;
+        this.buffer = this.buffer.slice(closeAt + this.marker.close.length);
         this.marker = null;
+        text = this.takeText();
         return { text, reasoning };
       }
       // Hold back a possible partial closer; everything before it is
@@ -124,23 +154,32 @@ export class ThinkTagStreamFilter {
       return { text, reasoning };
     }
 
-    text = this.buffer;
-    this.buffer = "";
+    text = this.takeText();
     return { text, reasoning };
   }
 
   /** Drain whatever is still buffered when the stream ends. */
   flush(): ThinkSplit {
-    const remainder = this.buffer;
-    this.buffer = "";
-    if (remainder.length === 0) return { text: "", reasoning: "" };
     if (this.state === "inside") {
+      const remainder = this.buffer;
+      this.buffer = "";
       this.state = "pass";
       this.marker = null;
       return { text: "", reasoning: remainder };
     }
     this.state = "pass";
-    return { text: remainder, reasoning: "" };
+    return { text: this.takeText(), reasoning: "" };
+  }
+
+  /** Emit the buffer as visible text, minus the whitespace after a marker. */
+  private takeText(): string {
+    let text = this.buffer;
+    this.buffer = "";
+    if (this.trimLeading) {
+      text = text.trimStart();
+      if (text.length > 0) this.trimLeading = false;
+    }
+    return text;
   }
 
   /** Longest tail of the buffer that is a proper prefix of the closer. */

--- a/runtime/src/tools/system/imagine-video.ts
+++ b/runtime/src/tools/system/imagine-video.ts
@@ -10,6 +10,10 @@
  *   MiniMax  POST /video_generation → task_id;
  *            GET /query/video_generation until "Success" → file_id;
  *            GET /files/retrieve → download_url on MiniMax's CDN.
+ *   MiniMax H3 (v2 task API, sibling of /v1 on the same host)
+ *            POST /v2/video_generation → task_id;
+ *            GET /v2/query/video_generation/{task_id} until "succeeded" →
+ *            task.content.url on MiniMax's CDN.
  *
  * Auth follows the same rule as ImagineImage: a session generates with its
  * own provider's native route, authorized only by that provider's canonical
@@ -116,6 +120,8 @@ const OPENAI_VIDEO_RESOLUTIONS = Object.freeze(new Set(["720p", "1080p"]));
 
 const MINIMAX_VIDEO_MODELS = Object.freeze(
   new Set([
+    "MiniMax-H3",
+    "MiniMax-H3-Max",
     "MiniMax-Hailuo-02",
     "MiniMax-Hailuo-2.3",
     "MiniMax-Hailuo-2.3-fast",
@@ -136,6 +142,31 @@ const MINIMAX_VIDEO_RESOLUTIONS = Object.freeze(
  * 512P is only supported when param 'first_frame_image' provided".
  */
 const MINIMAX_FIRST_FRAME_ONLY_RESOLUTION = "512P";
+/**
+ * The H3 generation lives on MiniMax's v2 task API (platform.minimax.io,
+ * 2026-09-11). H3 renders 768P or 2K for 4 to 15 seconds; H3-Max renders
+ * 480P or 768P for 5 to 15 seconds. Hailuo stays on the v1 route above.
+ */
+const MINIMAX_V2_VIDEO_MODELS = Object.freeze(
+  new Set(["MiniMax-H3", "MiniMax-H3-Max"]),
+);
+const MINIMAX_V2_VIDEO_RESOLUTIONS: Readonly<
+  Record<string, readonly string[]>
+> = Object.freeze({
+  "MiniMax-H3": Object.freeze(["768P", "2K"]),
+  "MiniMax-H3-Max": Object.freeze(["480P", "768P"]),
+});
+const MINIMAX_V2_VIDEO_DURATIONS: Readonly<
+  Record<string, readonly [number, number]>
+> = Object.freeze({
+  "MiniMax-H3": [4, 15],
+  "MiniMax-H3-Max": [5, 15],
+});
+/** Text-to-video on v2 requires a concrete ratio; a first frame fixes it. */
+const MINIMAX_V2_VIDEO_RATIOS = Object.freeze(
+  new Set(["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]),
+);
+const MINIMAX_V2_DEFAULT_RATIO = "16:9";
 
 const MAX_VIDEO_DOWNLOAD_BYTES = 256 * 1024 * 1024;
 const MAX_VIDEO_DOWNLOAD_REDIRECTS = 5;
@@ -812,17 +843,18 @@ async function runMinimaxVideo(ctx: VideoRunContext): Promise<ToolResult> {
         "MiniMax takes a single first frame; use image_url rather than reference_image_urls",
     });
   }
-  // MiniMax sizes a video by resolution and model, so an aspect_ratio from
-  // the universal schema is dropped and named rather than refused.
-  const ignoredControls: string[] = [];
-  if (stringValue(args.aspect_ratio) !== undefined) {
-    ignoredControls.push("aspect_ratio");
-  }
   const model = stringValue(args.model) ?? MINIMAX_TEXT_TO_VIDEO_MODEL;
   if (!MINIMAX_VIDEO_MODELS.has(model)) {
     return refusal({
       error: `MiniMax video model must be one of ${[...MINIMAX_VIDEO_MODELS].join(", ")}`,
     });
+  }
+  if (MINIMAX_V2_VIDEO_MODELS.has(model)) return runMinimaxV2Video(ctx, model);
+  // MiniMax sizes a Hailuo video by resolution and model, so an aspect_ratio
+  // from the universal schema is dropped and named rather than refused.
+  const ignoredControls: string[] = [];
+  if (stringValue(args.aspect_ratio) !== undefined) {
+    ignoredControls.push("aspect_ratio");
   }
   const requestedResolution = stringValue(args.resolution);
   const resolutionSupported =
@@ -966,6 +998,158 @@ async function runMinimaxVideo(ctx: VideoRunContext): Promise<ToolResult> {
   });
 }
 
+// ── MiniMax H3 (v2 task API) ──────────────────────────────────────────
+
+/** v2 answers a real HTTP status with an OpenAI-style error body. */
+interface MinimaxV2ErrorEnvelope {
+  readonly type?: string;
+  readonly error?: { readonly type?: string; readonly message?: string };
+}
+
+function minimaxV2Failure(payload: MinimaxV2ErrorEnvelope): string | undefined {
+  if (payload.type !== "error") return undefined;
+  return payload.error?.message ?? "MiniMax request failed";
+}
+
+/** Hailuo lives under /v1; the H3 task API is the sibling /v2 on the host. */
+function minimaxV2BaseURL(baseURL: string): string {
+  return /\/v1$/.test(baseURL) ? baseURL.replace(/\/v1$/, "/v2") : `${baseURL}/v2`;
+}
+
+async function runMinimaxV2Video(
+  ctx: VideoRunContext,
+  model: string,
+): Promise<ToolResult> {
+  const { args, backend, fetchImpl, signal } = ctx;
+  const ignoredControls: string[] = [];
+  const resolutions = MINIMAX_V2_VIDEO_RESOLUTIONS[model] ?? [];
+  const requestedResolution = stringValue(args.resolution)?.toUpperCase();
+  const resolutionSupported =
+    requestedResolution !== undefined &&
+    resolutions.includes(requestedResolution);
+  if (requestedResolution !== undefined && !resolutionSupported) {
+    ignoredControls.push("resolution");
+  }
+  const resolution = resolutionSupported ? requestedResolution : "768P";
+  const [minDuration, maxDuration] = MINIMAX_V2_VIDEO_DURATIONS[model] ?? [4, 15];
+  const duration = Math.min(
+    maxDuration,
+    Math.max(minDuration, requestedDuration(args) ?? 6),
+  );
+  // Text-to-video must name a ratio; with a first frame the image decides
+  // and the API treats anything else as adaptive anyway.
+  const requestedRatio = stringValue(args.aspect_ratio);
+  const ratioSupported =
+    requestedRatio !== undefined && MINIMAX_V2_VIDEO_RATIOS.has(requestedRatio);
+  if (requestedRatio !== undefined && !ratioSupported) {
+    ignoredControls.push("aspect_ratio");
+  }
+  const ratio =
+    ctx.imageUrl !== undefined
+      ? "adaptive"
+      : ratioSupported
+        ? requestedRatio
+        : MINIMAX_V2_DEFAULT_RATIO;
+  const v2 = minimaxV2BaseURL(backend.baseURL);
+
+  const submitRes = await fetchImpl(`${v2}/video_generation`, {
+    method: "POST",
+    headers: authHeaders(backend),
+    body: JSON.stringify({
+      model,
+      content: [
+        { type: "text", text: ctx.prompt },
+        ...(ctx.imageUrl === undefined
+          ? []
+          : [{
+              type: "image_url",
+              image_url: { url: ctx.imageUrl },
+              role: "first_frame",
+            }]),
+      ],
+      resolution,
+      duration,
+      ratio,
+    }),
+    ...signalInit(signal),
+  });
+  const submitJson = (await submitRes.json()) as MinimaxV2ErrorEnvelope & {
+    task_id?: string;
+  };
+  if (!submitRes.ok) {
+    return json(
+      {
+        error:
+          minimaxV2Failure(submitJson) ??
+          `MiniMax video submit HTTP ${submitRes.status}`,
+      },
+      true,
+    );
+  }
+  const taskId = submitJson.task_id;
+  if (!taskId) {
+    return json({ error: "MiniMax response did not include a task_id" }, true);
+  }
+
+  const polled = await pollForVideo(ctx.opts, signal, async () => {
+    const pollRes = await fetchImpl(
+      `${v2}/query/video_generation/${encodeURIComponent(taskId)}`,
+      { method: "GET", headers: authHeaders(backend), ...signalInit(signal) },
+    );
+    const pollJson = (await pollRes.json()) as MinimaxV2ErrorEnvelope & {
+      task?: {
+        status?: string;
+        content?: { url?: string };
+        error?: { message?: string };
+      };
+    };
+    if (!pollRes.ok) {
+      return {
+        state: "failed",
+        error:
+          minimaxV2Failure(pollJson) ??
+          `MiniMax video poll HTTP ${pollRes.status}`,
+      };
+    }
+    // Documented: queued → running → succeeded | failed | cancelled.
+    const status = String(pollJson.task?.status ?? "").toLowerCase();
+    if (status === "succeeded") {
+      const url = pollJson.task?.content?.url;
+      if (!url) {
+        return {
+          state: "failed",
+          error: "MiniMax reported success without a video URL",
+        };
+      }
+      return { state: "done", value: url };
+    }
+    if (status === "failed" || status === "cancelled") {
+      return {
+        state: "failed",
+        error:
+          pollJson.task?.error?.message ?? `MiniMax video generation ${status}`,
+      };
+    }
+    return { state: "pending", status: status || "queued" };
+  });
+  if ("error" in polled) {
+    return json({ error: polled.error, request_id: taskId }, true);
+  }
+  const bytes = await downloadVideo(fetchImpl, polled.value, "minimax", signal);
+  const path = await saveVideoBytes(ctx.opts.workspaceRoot, bytes, signal);
+  return json({
+    model,
+    path,
+    url: polled.value,
+    request_id: taskId,
+    duration,
+    resolution,
+    ratio,
+    modality: ctx.imageUrl === undefined ? "text" : "image",
+    ...(ignoredControls.length > 0 ? { ignoredControls } : {}),
+  });
+}
+
 // ── Tool surface ──────────────────────────────────────────────────────
 
 function imagineVideoDescription(kind: VideoBackendKind | undefined): string {
@@ -977,9 +1161,10 @@ function imagineVideoDescription(kind: VideoBackendKind | undefined): string {
       );
     case "minimax":
       return (
-        "Generate a video with MiniMax Hailuo and save the MP4 under the workspace. " +
+        "Generate a video with MiniMax and save the MP4 under the workspace. " +
         "Text-to-video, or image-to-video by passing image_url as the first frame. " +
-        "Duration is 6 or 10 seconds."
+        "Hailuo (default) takes 6 or 10 seconds; model MiniMax-H3 takes 4 to 15 " +
+        "seconds at 768P or 2K, MiniMax-H3-Max 5 to 15 seconds at 480P or 768P."
       );
     case "xai":
       return (
@@ -1028,12 +1213,22 @@ function imagineVideoInputSchema(
         },
         duration: {
           type: "number",
-          description: "Seconds: 6 or 10; anything else snaps to the nearest (default 6)",
+          description:
+            "Seconds. Hailuo: 6 or 10, anything else snaps to the nearest. " +
+            "MiniMax-H3: 4 to 15; MiniMax-H3-Max: 5 to 15 (default 6)",
         },
         resolution: {
           type: "string",
-          enum: [...MINIMAX_VIDEO_RESOLUTIONS],
-          description: "512P requires image_url; text-to-video uses 768P or 1080P",
+          enum: [...MINIMAX_VIDEO_RESOLUTIONS, "480P", "2K"],
+          description:
+            "Hailuo: 512P (requires image_url), 768P or 1080P. " +
+            "MiniMax-H3: 768P or 2K. MiniMax-H3-Max: 480P or 768P",
+        },
+        aspect_ratio: {
+          type: "string",
+          enum: [...MINIMAX_V2_VIDEO_RATIOS],
+          description:
+            "MiniMax-H3 text-to-video only (default 16:9); Hailuo sizes by resolution",
         },
       },
       required: ["prompt"],

--- a/runtime/src/utils/context.ts
+++ b/runtime/src/utils/context.ts
@@ -246,7 +246,8 @@ function resolveCatalogContextWindow(
     normalizedProvider !== 'grok' &&
     normalizedProvider !== 'zai' &&
     normalizedProvider !== 'zai-coding-plan' &&
-    normalizedProvider !== 'kimi'
+    normalizedProvider !== 'kimi' &&
+    normalizedProvider !== 'minimax'
   ) {
     return undefined
   }
@@ -320,7 +321,8 @@ export function getModelMaxOutputTokensForContext(
   if (
     normalizedProvider === 'zai' ||
     normalizedProvider === 'zai-coding-plan' ||
-    normalizedProvider === 'kimi'
+    normalizedProvider === 'kimi' ||
+    normalizedProvider === 'minimax'
   ) {
     const catalog = resolveModelCatalogMetadata({ provider: normalizedProvider, model })
     if (catalog?.maxOutputTokens !== undefined) {

--- a/runtime/src/utils/model/openaiContextWindows.ts
+++ b/runtime/src/utils/model/openaiContextWindows.ts
@@ -174,7 +174,9 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   // Yi via NVIDIA NIM
   '01-ai/yi-large': 32_768,
 
-  // MiniMax (all M2.x variants share 204,800 context, 131,072 max output)
+  // MiniMax (M3 has a 1,000,000 window; all M2.x variants share 204,800)
+  'MiniMax-M3':               1_000_000,
+  'minimax-m3':               1_000_000,
   'MiniMax-M2.7':             204_800,
   'MiniMax-M2.7-highspeed':   204_800,
   'MiniMax-M2.5':             204_800,
@@ -188,11 +190,8 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'minimax-m2.1':             204_800,
   'minimax-m2.1-highspeed':   204_800,
 
-  // MiniMax new models
+  // MiniMax ids no longer in the documented lineup that still answer
   'MiniMax-Text-01':          524_288,
-  'MiniMax-Text-01-Preview':  262_144,
-  'MiniMax-Vision-01':        32_768,
-  'MiniMax-Vision-01-Fast':   16_384,
   'MiniMax-M2':               204_800,
 
   // Google (via OpenRouter)
@@ -363,7 +362,9 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'mistral-large-latest':     32_768,
   'mistral-small-latest':     32_768,
 
-  // MiniMax (all M2.x variants share 131,072 max output)
+  // MiniMax (M3 and all M2.x variants share 131,072 max output)
+  'MiniMax-M3':              131_072,
+  'minimax-m3':              131_072,
   'MiniMax-M2.7':            131_072,
   'MiniMax-M2.7-highspeed':  131_072,
   'MiniMax-M2.5':            131_072,

--- a/runtime/tests/live/imagine-video-backends.live.test.ts
+++ b/runtime/tests/live/imagine-video-backends.live.test.ts
@@ -1,5 +1,5 @@
 /**
- * LIVE: the Sora and MiniMax Hailuo video backends against the real APIs.
+ * LIVE: the Sora, MiniMax Hailuo and MiniMax H3 video backends against the real APIs.
  *
  * Run:
  *   OPENAI_API_KEY=… MINIMAX_API_KEY=… \
@@ -77,6 +77,45 @@ describe.skipIf(!process.env.OPENAI_API_KEY)("Sora video, live", () => {
       duration: 4,
       size: "720x1280",
     });
+    const bytes = await readFile(parsed.path);
+    expect(bytes.length).toBeGreaterThan(10_000);
+    expect(bytes.subarray(4, 8).toString("hex")).toBe(MP4_FTYP);
+  }, 660_000);
+});
+
+describe.skipIf(!process.env.MINIMAX_API_KEY)("MiniMax H3 video (v2 task API), live", () => {
+  it("submits to /v2, polls the task and saves a real MP4", async () => {
+    // H3-Max at 480P for 5 seconds is the cheapest clip the v2 route sells.
+    const { result } = await generate({
+      provider: "minimax",
+      model: "MiniMax-M3",
+      credential: "MINIMAX_API_KEY",
+      args: {
+        model: "MiniMax-H3-Max",
+        duration: 5,
+        resolution: "480P",
+        aspect_ratio: "16:9",
+      },
+    });
+
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      model: string;
+      duration: number;
+      resolution: string;
+      ratio: string;
+      request_id: string;
+      url: string;
+      path: string;
+    };
+    expect(parsed).toMatchObject({
+      model: "MiniMax-H3-Max",
+      duration: 5,
+      resolution: "480P",
+      ratio: "16:9",
+    });
+    expect(parsed.request_id.length).toBeGreaterThan(0);
+    expect(new URL(parsed.url).hostname.endsWith(".minimax.io")).toBe(true);
     const bytes = await readFile(parsed.path);
     expect(bytes.length).toBeGreaterThan(10_000);
     expect(bytes.subarray(4, 8).toString("hex")).toBe(MP4_FTYP);

--- a/runtime/tests/llm/providers/minimax/provider.test.ts
+++ b/runtime/tests/llm/providers/minimax/provider.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { resolveProviderCapabilityEntry } from "../../capabilities.js";
+import {
+  resolveModelCatalogMetadata,
+  resolveRegisteredModelCatalogEntry,
+} from "../../registry/model-catalog.js";
+import {
+  BUILT_IN_PROVIDER_DEFAULT_MODELS,
+  BUILT_IN_PROVIDER_MODEL_CATALOG,
+} from "../../registry/provider-info.js";
+import type { LLMMessage } from "../../types.js";
+import { chatCompletionsCapabilityHintsForProvider } from "../../wire/capability-gating.js";
+import {
+  bodyAt,
+  createSuccessfulChatResponse,
+  ECHO_TOOL,
+} from "../openai-compatible-test-helpers.js";
+import { MiniMaxProvider } from "./index.js";
+
+const successfulChat = createSuccessfulChatResponse("chatcmpl_minimax");
+
+function createSuccessfulMinimaxProvider(model = "MiniMax-M3") {
+  // A fresh Response per call: one test drives two turns through one provider.
+  const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
+    successfulChat(model),
+  );
+  const provider = new MiniMaxProvider({
+    apiKey: "minimax-test",
+    model,
+    tools: [ECHO_TOOL],
+    fetchImpl,
+  });
+  return { fetchImpl, provider };
+}
+
+function echoReasoningRound(options: {
+  readonly id: string;
+  readonly text: string;
+  readonly reasoning: string;
+  readonly model?: string;
+}): readonly [LLMMessage, LLMMessage] {
+  return [{
+    role: "assistant",
+    content: "",
+    toolCalls: [{
+      id: options.id,
+      name: "system.echo",
+      arguments: JSON.stringify({ text: options.text }),
+    }],
+    providerReasoningContent: options.reasoning,
+    providerReasoningProvenance: {
+      provider: "minimax",
+      model: options.model ?? "MiniMax-M3",
+    },
+  }, {
+    role: "tool",
+    toolCallId: options.id,
+    toolName: "system.echo",
+    content: options.text,
+  }];
+}
+
+describe("MiniMax catalog", () => {
+  test("lists the documented lineup with M3 as the default", () => {
+    expect(BUILT_IN_PROVIDER_DEFAULT_MODELS.minimax).toBe("MiniMax-M3");
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.minimax[0]).toBe("MiniMax-M3");
+    expect(BUILT_IN_PROVIDER_MODEL_CATALOG.minimax).not.toContain(
+      "MiniMax-Vision-01",
+    );
+    expect(
+      resolveModelCatalogMetadata({ provider: "minimax", model: "MiniMax-M3" }),
+    ).toMatchObject({ contextWindow: 1_000_000, maxOutputTokens: 131_072 });
+    expect(
+      resolveModelCatalogMetadata({ provider: "minimax", model: "MiniMax-M2.7-highspeed" }),
+    ).toMatchObject({ contextWindow: 204_800, maxOutputTokens: 131_072 });
+  });
+
+  test("M3 alone carries the two-position thinking switch and image input", () => {
+    const m3 = resolveRegisteredModelCatalogEntry({
+      provider: "minimax",
+      model: "MiniMax-M3",
+    });
+    expect(m3?.supportedReasoningLevels).toEqual(["low", "high"]);
+    expect(m3?.defaultReasoningLevel).toBe("high");
+    expect(
+      resolveProviderCapabilityEntry({ provider: "minimax", model: "MiniMax-M3" })
+        .supportsImageInput,
+    ).toBe(true);
+
+    for (const model of ["MiniMax-M2.7", "MiniMax-M2.5-highspeed", "MiniMax-M2"]) {
+      const entry = resolveRegisteredModelCatalogEntry({ provider: "minimax", model });
+      expect(entry?.supportedReasoningLevels, model).toEqual([]);
+      expect(entry?.defaultReasoningLevel, model).toBeUndefined();
+      expect(
+        resolveProviderCapabilityEntry({ provider: "minimax", model })
+          .supportsImageInput,
+        model,
+      ).toBe(false);
+    }
+  });
+
+  test("the wire never forwards reasoning_effort; M3 maps it onto the switch", () => {
+    const m3 = chatCompletionsCapabilityHintsForProvider("minimax", "MiniMax-M3");
+    expect(m3.acceptsReasoningEffort).toBe(false);
+    expect(m3.thinkingConfig).toEqual({ type: "adaptive" });
+    expect(m3.reasoningSplit).toBe(true);
+    expect(m3.replaysReasoningContent).toBe(true);
+    expect(m3.replaysReasoningContentOnlyForAdjacentToolContinuation).toBeUndefined();
+    expect(m3.reasoningContentField).toBe("reasoning_content");
+
+    const m27 = chatCompletionsCapabilityHintsForProvider("minimax", "MiniMax-M2.7");
+    expect(m27.thinkingConfig).toBeUndefined();
+    expect(m27.reasoningSplit).toBe(true);
+    expect(m27.replaysReasoningContent).toBe(true);
+  });
+});
+
+describe("MiniMaxProvider wire", () => {
+  test("asks for split reasoning and adaptive thinking on M3 by default", async () => {
+    const { fetchImpl, provider } = createSuccessfulMinimaxProvider();
+    await provider.chat([{ role: "user", content: "hello" }], {
+      reasoningEffort: "high",
+      tools: [ECHO_TOOL],
+    });
+    const body = bodyAt(fetchImpl);
+    expect(body).toMatchObject({
+      model: "MiniMax-M3",
+      reasoning_split: true,
+      thinking: { type: "adaptive" },
+    });
+    expect(body).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("a low effort turns M3 thinking off", async () => {
+    const { fetchImpl, provider } = createSuccessfulMinimaxProvider();
+    await provider.chat([{ role: "user", content: "hello" }], {
+      reasoningEffort: "low",
+    });
+    expect(bodyAt(fetchImpl).thinking).toEqual({ type: "disabled" });
+    expect(bodyAt(fetchImpl)).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("M2.7 gets split reasoning but no thinking switch", async () => {
+    const { fetchImpl, provider } = createSuccessfulMinimaxProvider("MiniMax-M2.7");
+    await provider.chat([{ role: "user", content: "hello" }], {
+      reasoningEffort: "high",
+    });
+    const body = bodyAt(fetchImpl);
+    expect(body.reasoning_split).toBe(true);
+    expect(body).not.toHaveProperty("thinking");
+    expect(body).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("moves reasoning_content to the thinking channel and keeps it for replay", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      successfulChat("MiniMax-M3", "The answer.", {
+        reasoning_content: "opaque MiniMax reasoning",
+      }),
+    );
+    const provider = new MiniMaxProvider({
+      apiKey: "minimax-test",
+      model: "MiniMax-M3",
+      fetchImpl,
+    });
+    const response = await provider.chat([{ role: "user", content: "hello" }]);
+    expect(response.content).toBe("The answer.");
+    expect(response.thinking?.[0]?.text).toBe("opaque MiniMax reasoning");
+    expect(response.providerReasoningContent).toBe("opaque MiniMax reasoning");
+    expect(response.providerReasoningProvenance).toEqual({
+      provider: "minimax",
+      model: "minimax-m3",
+    });
+  });
+
+  test("echoes reasoning_content back on every earlier MiniMax turn", async () => {
+    const { fetchImpl, provider } = createSuccessfulMinimaxProvider();
+    await provider.chat([
+      { role: "user", content: "call echo" },
+      ...echoReasoningRound({
+        id: "call_echo",
+        text: "hi",
+        reasoning: "reasoning for the echo call",
+      }),
+    ]);
+    const replay = bodyAt(fetchImpl) as { messages: Array<Record<string, unknown>> };
+    expect(replay.messages[1]).toMatchObject({
+      role: "assistant",
+      reasoning_content: "reasoning for the echo call",
+    });
+
+    // A runtime reminder after the tool result, or a later user turn, keeps
+    // the chain: MiniMax asks for thinking preserved in later turns.
+    await provider.chat([
+      { role: "user", content: "call echo" },
+      ...echoReasoningRound({
+        id: "call_old",
+        text: "old",
+        reasoning: "earlier turn reasoning",
+      }),
+      { role: "user", content: "now a new question" },
+    ]);
+    const later = bodyAt(fetchImpl, 1) as { messages: Array<Record<string, unknown>> };
+    expect(later.messages[1]).toMatchObject({
+      role: "assistant",
+      reasoning_content: "earlier turn reasoning",
+    });
+  });
+
+  test("never replays reasoning that came from another provider or model", async () => {
+    const { fetchImpl, provider } = createSuccessfulMinimaxProvider();
+    await provider.chat([
+      { role: "user", content: "call echo" },
+      ...echoReasoningRound({
+        id: "call_other",
+        text: "x",
+        reasoning: "foreign reasoning",
+        model: "MiniMax-M2.7",
+      }),
+    ]);
+    expect(JSON.stringify(bodyAt(fetchImpl).messages)).not.toContain(
+      "foreign reasoning",
+    );
+  });
+});

--- a/runtime/tests/llm/registry/model-sot-unification.test.ts
+++ b/runtime/tests/llm/registry/model-sot-unification.test.ts
@@ -222,16 +222,17 @@ describe("canonical provider catalogs preserve supported selection rows", () => 
 
   it("keeps every supported MiniMax generation in one catalog", () => {
     const models = BUILT_IN_PROVIDER_MODEL_CATALOG.minimax;
+    // The lineup MiniMax documents for its OpenAI-compatible route
+    // (platform.minimax.io, 2026-09-11), newest first.
     expect(models).toEqual([
       "MiniMax-M3",
       "MiniMax-M2.7",
-      "MiniMax-M2",
-      "MiniMax-M2.1",
+      "MiniMax-M2.7-highspeed",
       "MiniMax-M2.5",
-      "MiniMax-Text-01",
-      "MiniMax-Text-01-Preview",
-      "MiniMax-Vision-01",
-      "MiniMax-Vision-01-Fast",
+      "MiniMax-M2.5-highspeed",
+      "MiniMax-M2.1",
+      "MiniMax-M2.1-highspeed",
+      "MiniMax-M2",
     ]);
     expect(new Set(models)).toHaveLength(models.length);
     expect(buildProviderModelCatalog(defaultConfig()).minimax).toEqual(models);

--- a/runtime/tests/llm/registry/provider-info.test.ts
+++ b/runtime/tests/llm/registry/provider-info.test.ts
@@ -33,7 +33,7 @@ describe("built-in provider info", () => {
       ["kimi", "Kimi (Moonshot)", "kimi-k3", "https://api.moonshot.ai/v1", "api-key", ["MOONSHOT_API_KEY"], [], 101, "api-key", false],
       ["mistral", "Mistral", "mistral-medium-latest", "https://api.mistral.ai/v1", "api-key", ["MISTRAL_API_KEY"], ["MISTRAL_BASE_URL"], 110, "api-key", false],
       ["nvidia-nim", "NVIDIA NIM", "nvidia/llama-3.1-nemotron-70b-instruct", "https://integrate.api.nvidia.com/v1", "api-key", ["NVIDIA_API_KEY"], ["NVIDIA_BASE_URL"], 120, "api-key", false],
-      ["minimax", "MiniMax", "MiniMax-M2.5", "https://api.minimax.io/v1", "api-key", ["MINIMAX_API_KEY"], ["MINIMAX_BASE_URL"], 130, "api-key", false],
+      ["minimax", "MiniMax", "MiniMax-M3", "https://api.minimax.io/v1", "api-key", ["MINIMAX_API_KEY"], ["MINIMAX_BASE_URL"], 130, "api-key", false],
       ["github", "GitHub Copilot", "gpt-5.3-codex", "https://api.githubcopilot.com", "api-key", ["GITHUB_TOKEN", "GH_TOKEN"], ["GITHUB_BASE_URL"], 140, "api-key", false],
       ["amazon-bedrock", "Amazon Bedrock", "amazon.nova-pro-v1:0", "https://bedrock-runtime.us-east-1.amazonaws.com", "aws-sigv4", [], ["AWS_BEDROCK_BASE_URL"], 150, "environment", false],
       ["agenc", "AgenC", "agenc", "https://id.agenc.ag/v1", "none", [], ["AGENC_BASE_URL"], 160, "managed", false],

--- a/runtime/tests/llm/wire/think-tags.test.ts
+++ b/runtime/tests/llm/wire/think-tags.test.ts
@@ -74,6 +74,27 @@ describe("splitLeadingThinkBlock", () => {
       reasoning: "never stopped",
     });
   });
+
+  test("drops a bare leading closer a provider left behind after splitting the block out", () => {
+    // MiniMax with reasoning_split streams the thinking on reasoning_content
+    // and still emits the closer in content.
+    expect(splitLeadingThinkBlock("</think>\n\n# Lighthouse Notes")).toEqual({
+      text: "# Lighthouse Notes",
+      reasoning: "",
+    });
+    expect(splitLeadingThinkBlock(" ◁/think▷Answer.")).toEqual({
+      text: "Answer.",
+      reasoning: "",
+    });
+  });
+
+  test("a closer later in the message stays visible", () => {
+    const content = "Close it with </think> at the end of the block.";
+    expect(splitLeadingThinkBlock(content)).toEqual({
+      text: content,
+      reasoning: "",
+    });
+  });
 });
 
 describe("ThinkTagStreamFilter", () => {
@@ -134,6 +155,25 @@ describe("ThinkTagStreamFilter", () => {
     });
   });
 
+  test("drops a bare leading closer, whole or split across chunks", () => {
+    expect(runFilter(["</think>", "\n\n# Lighthouse", " Notes"])).toEqual({
+      text: "# Lighthouse Notes",
+      reasoning: "",
+    });
+    expect(runFilter(["</th", "ink>", "answer"])).toEqual({
+      text: "answer",
+      reasoning: "",
+    });
+    expect(runFilter(["◁/thi", "nk▷ok"])).toEqual({ text: "ok", reasoning: "" });
+  });
+
+  test("a closer lookalike at the start is emitted once resolvable", () => {
+    expect(runFilter(["</them>", "notatag"])).toEqual({
+      text: "</them>notatag",
+      reasoning: "",
+    });
+  });
+
   test("an unresolved marker prefix at stream end is text", () => {
     expect(runFilter(["<thi"])).toEqual({ text: "<thi", reasoning: "" });
   });
@@ -166,6 +206,28 @@ describe("parseChatCompletionsResponse think extraction", () => {
         kind: "reasoning_summary",
       },
     ]);
+  });
+
+  test("keeps split reasoning and drops the closer MiniMax leaves in content", () => {
+    const parsed = parseChatCompletionsResponse(
+      "MiniMax-M3",
+      {
+        model: "MiniMax-M3",
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "</think>\n\n# Lighthouse Notes",
+              reasoning_content: "The user wants the first line.",
+            },
+            finish_reason: "stop",
+          },
+        ],
+      },
+      { model: "MiniMax-M3", messages: [], tools: [] },
+    );
+    expect(parsed.content).toBe("# Lighthouse Notes");
+    expect(parsed.thinking?.[0]?.text).toBe("The user wants the first line.");
   });
 
   test("clean content grows no thinking blocks", () => {

--- a/runtime/tests/tools/system/imagine-video.test.ts
+++ b/runtime/tests/tools/system/imagine-video.test.ts
@@ -564,6 +564,173 @@ describe("ImagineVideo execute", () => {
     });
   });
 
+  it("generates with MiniMax H3 on the v2 task API and downloads from its CDN", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-h3-"));
+    let polls = 0;
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u === "https://api.minimax.io/v2/video_generation" && init?.method === "POST") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ task_id: "h3-task-1" }),
+        };
+      }
+      if (u === "https://api.minimax.io/v2/query/video_generation/h3-task-1") {
+        polls += 1;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            task: polls < 2
+              ? { model: "MiniMax-H3", status: "running" }
+              : {
+                  model: "MiniMax-H3",
+                  status: "succeeded",
+                  content: { url: "https://video-product.cdn.minimax.io/h3.mp4" },
+                  resolution: "768P",
+                  duration: 4,
+                  ratio: "16:9",
+                },
+          }),
+        };
+      }
+      if (u === "https://video-product.cdn.minimax.io/h3.mp4") {
+        return new Response(
+          Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () =>
+        ({
+          services: {
+            provider: createProvider("minimax", {
+              apiKey: "minimax-session-key",
+              model: "MiniMax-M3",
+            }),
+          },
+        }) as unknown as Session,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    const result = await tool.execute({
+      prompt: "a lighthouse at dusk",
+      model: "MiniMax-H3",
+      duration: 4,
+      aspect_ratio: "16:9",
+    });
+
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      model: "MiniMax-H3",
+      request_id: "h3-task-1",
+      duration: 4,
+      resolution: "768P",
+      ratio: "16:9",
+      modality: "text",
+    });
+    expect((await readFile(parsed.path as string)).length).toBeGreaterThan(0);
+    const submit = (fetchImpl as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]!;
+    const init = submit[1] as RequestInit;
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      "Bearer isolated-minimax-key",
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      model: "MiniMax-H3",
+      content: [{ type: "text", text: "a lighthouse at dusk" }],
+      resolution: "768P",
+      duration: 4,
+      ratio: "16:9",
+    });
+  });
+
+  it("clamps H3-Max controls to what the model renders and names the drops", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.endsWith("/v2/video_generation")) {
+        return { ok: true, status: 200, json: async () => ({ task_id: "t" }) };
+      }
+      if (u.includes("/v2/query/video_generation/")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            task: {
+              status: "succeeded",
+              content: { url: "https://video-product.cdn.minimax.io/max.mp4" },
+            },
+          }),
+        };
+      }
+      return new Response(Uint8Array.from([0x00, 0x01]), { status: 200 });
+    }) as unknown as typeof fetch;
+    const root = await mkdtemp(join(tmpdir(), "imagine-h3-max-"));
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () => null,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    // 2K and a 4 second clip exist on H3 only; 4:3 is fine, "wide" is not.
+    const result = await tool.execute({
+      prompt: "x",
+      model: "MiniMax-H3-Max",
+      resolution: "2K",
+      duration: 2,
+      aspect_ratio: "wide",
+    });
+
+    expect(result.isError, String(result.content)).toBeUndefined();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      model: "MiniMax-H3-Max",
+      resolution: "768P",
+      duration: 5,
+      ratio: "16:9",
+      ignoredControls: ["resolution", "aspect_ratio"],
+    });
+  });
+
+  it("surfaces the v2 error body when MiniMax rejects an H3 request", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 402,
+      json: async () => ({
+        type: "error",
+        error: {
+          type: "insufficient_balance_error",
+          message: "insufficient balance (1008)",
+        },
+      }),
+    })) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: process.cwd(),
+      home: testHome(process.cwd()),
+      getSession: () => null,
+      env: { MINIMAX_API_KEY: "isolated-minimax-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "x", model: "MiniMax-H3" });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("insufficient balance (1008)");
+  });
+
   it("refuses a MiniMax download that leaves MiniMax's hosts", async () => {
     const root = await mkdtemp(join(tmpdir(), "imagine-hailuo-host-"));
     const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {

--- a/runtime/tests/utils/context.test.ts
+++ b/runtime/tests/utils/context.test.ts
@@ -94,6 +94,18 @@ providerTest('gpt-5.4 family uses provider-specific context and output caps', ()
   })
 })
 
+providerTest('MiniMax-M3 carries its 1M window on the openai-compatible table', () => {
+  process.env.AGENC_PROVIDER = 'openai'
+  delete process.env.AGENC_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  expect(getContextWindowForModel('MiniMax-M3')).toBe(1_000_000)
+  expect(getModelMaxOutputTokens('MiniMax-M3')).toEqual({
+    default: 131_072,
+    upperLimit: 131_072,
+  })
+})
+
 providerTest('MiniMax-M2.7 uses explicit provider-specific context and output caps', () => {
   process.env.AGENC_PROVIDER = 'openai'
   delete process.env.AGENC_MAX_OUTPUT_TOKENS


### PR DESCRIPTION
## Why

The MiniMax provider was out of date on every axis the desktop shows:

- `MINIMAX_MODEL_IDS` listed `MiniMax-Text-01-Preview`, `MiniMax-Vision-01` and `MiniMax-Vision-01-Fast`, which the API now rejects (unknown model, code 2013), and the default was `MiniMax-M2.5` while M3 has been the flagship since its launch. The highspeed variants were absent.
- `MiniMax-M3` had no row in `openaiContextWindows.ts`, so a 1,000,000-token model ran on the 128k fallback window.
- No MiniMax model carried an effort control. On the OpenAI-compatible route M3 has a two-position `thinking` switch (`disabled` | `adaptive`, adaptive when omitted); M2.x always think and cannot be turned off (probed: `thinking.disabled` is accepted by M2.7 and ignored).
- Thinking arrived inline in `content` behind `<think>` markers. The adapter strips them into the thinking channel but nothing was replayed on tool turns, which MiniMax asks for ("preserve thinking unchanged in later turns, especially in tool-use conversations").
- ImagineVideo only knew the v1 Hailuo route; the H3 generation lives on the v2 task API.

Verified against platform.minimax.io on 2026-09-11 (OpenAI-compatible chat OpenAPI: `thinking.type` enum `disabled | adaptive`, `reasoning_split`, `reasoning_content` / `reasoning_details`; v2 video OpenAPI: `POST /v2/video_generation`, `GET /v2/query/video_generation/{task_id}`) and against the live API with the test key. Music generation is closed to new users (HTTP 410), so it stays absent; speech (T2A) is not modelled here.

## What, per file

`runtime/src/llm/registry/model-catalog.ts`
- `MINIMAX_CHAT_MODELS` and `minimaxCatalogEntries()`: `MiniMax-M3` (1,000,000 window, 131,072 output, image input, `supportedReasoningLevels: ["low", "high"]`, `defaultReasoningLevel: "high"`), then `M2.7`, `M2.7-highspeed`, `M2.5`, `M2.5-highspeed`, `M2.1`, `M2.1-highspeed`, `M2` (204,800 window, 131,072 output, text only, no levels). `supportsStructuredOutput: false` (no documented `response_format` contract), `supportsParallelToolCalls: false`.
- Entries appended to `REGISTERED_MODEL_CATALOG` after Kimi's.

`runtime/src/llm/registry/provider-info.ts`
- `minimax` model list now derives from the registry (`mergeDerivedProviderModels("minimax")`); the hand-written `MINIMAX_MODEL_IDS` with the dead ids is gone. Default model `MiniMax-M3`.

`runtime/src/utils/model/openaiContextWindows.ts`
- `MiniMax-M3` / `minimax-m3` rows: 1,000,000 context, 131,072 output. Dead `Text-01-Preview`, `Vision-01`, `Vision-01-Fast` rows removed; `MiniMax-Text-01` and `MiniMax-M2` rows kept (both still answer).

`runtime/src/utils/context.ts`
- `minimax` joins `grok`, `zai`, `zai-coding-plan`, `kimi` in the registry-first window and output-cap lookups.

`runtime/src/llm/wire/capability-gating.ts`
- `thinkingConfig.type` widened to `"enabled" | "adaptive"`; new `reasoningSplit` hint.
- MiniMax branch: `reasoningSplit: true`, `replaysReasoningContent: true`, `reasoningContentField: "reasoning_content"`, `toolResultImagePolicy` (relay as user for M3, strip for text-only models, the same rule as meta/qwen/cerebras/zai), and for M3 only `thinkingConfig: { type: "adaptive" }`. `acceptsReasoningEffort` stays `false`: `reasoning_effort` is never sent to MiniMax.

`runtime/src/llm/wire/chat-completions.ts`
- `thinking.type === "adaptive"` becomes `disabled` when the turn effort is `low` or `minimal`, `adaptive` otherwise. `reasoning_split: true` is written when the hint is set.

`runtime/src/tools/system/imagine-video.ts`
- `MiniMax-H3` and `MiniMax-H3-Max` accepted as `model`; they run on `runMinimaxV2Video`: `POST {v2}/video_generation` with `content: [{type: "text", text}]` (plus a `first_frame` `image_url` when `image_url` is given), `resolution`, `duration`, `ratio`; `GET {v2}/query/video_generation/{task_id}` until `task.status` is `succeeded`, `failed` or `cancelled`; download from `task.content.url` through the existing MiniMax host allowlist. v2 answers real HTTP statuses with an OpenAI-style error body, surfaced as the tool error. Per-model limits: H3 768P or 2K, 4 to 15 s; H3-Max 480P or 768P, 5 to 15 s; unsupported controls are clamped and named in `ignoredControls`. Text-to-video needs a concrete ratio (default 16:9). Hailuo stays on v1 and stays the default.
- Tool description and schema mention H3; `aspect_ratio` added to the MiniMax schema.

`runtime/src/llm/wire/think-tags.ts`
- A bare closer at the start of `content` (`</think>` or `◁/think▷` with nothing opened before it) is dropped by both the whole-message split and the stream filter, and the whitespace after a resolved marker is trimmed across chunk boundaries. Found in the desktop app: with `reasoning_split`, M3 streams its thinking on `reasoning_content` and still emits a `"</think>"` content delta before the tool call, which the transcript showed as a literal `</think>` line. Raw stream captured through the proxy:

```
delta: {"content": "", "reasoning_content": "The user wants me to read README.md ..."}
delta: {"content": "</think>"}
delta: {"tool_calls": ["FileRead"]}
```

Tests
- New `runtime/tests/llm/providers/minimax/provider.test.ts` (9): catalog lineup and default, M3 switch and image input vs M2.x, hints, wire body (`reasoning_split`, `thinking` adaptive / disabled / absent on M2.7, no `reasoning_effort`), `reasoning_content` into the thinking channel with provenance, replay on later turns, no replay across models.
- `imagine-video.test.ts` (+3): H3 v2 happy path with the exact submit body, H3-Max clamping with named drops, v2 error body.
- `imagine-video-backends.live.test.ts` (+1): H3-Max at 480P for 5 s, the cheapest v2 clip.
- `model-sot-unification.test.ts` id list, `provider-info.test.ts` default row, `context.test.ts` M3 row.
- `think-tags.test.ts` (+5): bare leading closer dropped in the whole-message split (both marker styles), a closer later in a message stays visible, the stream filter drops a bare closer whole or split across chunks, a closer lookalike still passes, and `parseChatCompletionsResponse` keeps split `reasoning_content` while dropping the leftover closer.

## Evidence

Live through core itself (fresh `runtime/dist` of this branch, `agenc -p --provider minimax`, a logging proxy in front of `api.minimax.io` that records the wire shape and never the key):

```
MiniMax-M3   thinking={'type': 'disabled'} reasoning_split=True reasoning_effort=None tools=41
             RESP finish=tool_calls tools=['FileRead'] think_tag_in_content=False
             RESP finish=stop content='# Lighthouse Notes'
MiniMax-M2.7 thinking=None reasoning_split=True reasoning_effort=None tools=41
             RESP finish=tool_calls tools=['FileRead'] reasoning_content_len=99
             replayed assistant: keys=['content','reasoning_content','role','tool_calls'] reasoning_content_len=99
             RESP finish=stop content='# Lighthouse Notes'
```

The test home has `reasoning_effort = "low"`, which is why M3 sent `disabled` (the mapping under test). Both models called FileRead, the call executed, and the final answer was exactly the file's first line with no `<think>` markers.

After the think-closer fix, the same M3 turn with thinking on (`thinking: {"type":"adaptive"}`, stored effort `high`): MiniMax still sends `"</think>"` as the first content delta, core's event stream carries 0 think markers, the final message is exactly `# Lighthouse Notes`, and the tool turn replayed the 94-character `reasoning_content` (`replayed assistant: keys=['content','reasoning_content','role','tool_calls']`).

Live H3-Max video: `npx vitest run --config vitest.live.config.ts tests/live/imagine-video-backends.live.test.ts -t H3` passed in 8.6 s; a 534,591-byte MP4 (`ftypisom`) downloaded from a `.minimax.io` host.

## Tests

- `npm run typecheck`: exit 0.
- `npx vitest run tests/llm/wire/think-tags.test.ts tests/llm/providers/{minimax,openai,kimi,qwen,ollama,zai,deepseek}`: 23 files, 498 passed.
- Targeted run over 26 files (`tests/llm/providers/minimax`, `tests/tools/system`, `tests/llm/registry`, `tests/llm/wire`, `tests/llm/capabilities`, `tests/llm/provider-parity`, `tests/llm/provider`, `tests/config/model-catalog-drift`, `tests/llm/model-registry`, `tests/llm/models-manager`, `tests/commands/model`, `tests/commands/provider`, `tests/utils/model/model.provider-defaults`, `tests/utils/context`, `tests/llm/providers/{zai,deepseek,kimi}`, `tests/llm/structured-output`): 906 passed, 1 failed.
- The one failure is pre-existing on `main`: `tests/llm/capabilities.test.ts > keeps routed compatible providers fail-closed where the matrix says varies` expects `acceptsImageHistory: false` for `deepseek-v4-flash`; commit 9b4cb0c2d (`feat(deepseek): adopt native V4.1`, pushed directly to `main` today) made that model image-capable without updating the test. This PR does not touch DeepSeek.
- Wider run (`tests/llm`, `tests/utils/model`, `tests/tools/system`, `tests/config`, the two command tests): the same DeepSeek failure plus `tests/config/session-home-authority.test.ts` (6, expects `/tmp/...` while this machine resolves `TMPDIR` to `/private/tmp/...`), `tests/tools/system/bash-workspace-fence.test.ts` (1) and `tests/tools/system/exec-command.test.ts` (1, live PTY); all three fail the same way in isolation and none reads a file this PR changes.

## Not changed

- Video input for M3 (`video_url`) is not wired: the runtime has no video attachment modality.
- `max_tokens` is still the request field (MiniMax accepts it; `max_completion_tokens` is the documented preference).
- `service_tier` is not forwarded to MiniMax.
- Hailuo-02 remains the default video model; H3 is opt-in through `model`.
- Speech (T2A) endpoints are not modelled; music generation is closed to new users (410) and stays absent.
- DeepSeek, AgenC managed routes and every other provider are untouched.

## Counterpart PRs

Desktop: tetsuo-ai/agenc-desktop#256 (catalog rows, windows and the M3 Low/High dial that mirror this registry).
