### PR TITLE
fix(mcp): honor stdio env_vars via createStdioMCPEnvironment

### DIFF
--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -91,10 +91,7 @@ import {
 } from '../../utils/proxy.js'
 import { recursivelySanitizeUnicode } from '../../utils/sanitization.js'
 import { getSessionIngressAuthToken } from '../../utils/sessionIngressAuth.js'
-import {
-  subprocessEnv,
-  withChildTempAuthority,
-} from '../../utils/subprocessEnv.js'
+import { withChildTempAuthority } from '../../utils/subprocessEnv.js'
 import {
   isPersistError,
   persistToolResult,
@@ -121,6 +118,7 @@ import {
   sanitizeOptionalMcpModelFacingText,
 } from '../../mcp-client/model-facing-sanitization.js'
 import { normalizeMcpToolOutput } from '../../mcp-client/tool-output.js'
+import { createStdioMCPEnvironment } from '../../mcp-client/transports/stdio.js'
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
@@ -978,10 +976,11 @@ export const connectToServer = memoize(
           args: finalArgs,
           ...(serverRef.cwd !== undefined ? { cwd: serverRef.cwd } : {}),
           env: withChildTempAuthority(
-            {
-              ...subprocessEnv({ ...environment }),
-              ...serverRef.env,
-            },
+            createStdioMCPEnvironment(
+              serverRef.env,
+              serverRef.env_vars,
+              environment,
+            ),
             mcpSessionTempRoot(options),
           ),
           stderr: 'pipe', // prevents error output from the MCP server from printing to the UI

--- a/runtime/tests/services/mcp/client-transports.test.ts
+++ b/runtime/tests/services/mcp/client-transports.test.ts
@@ -607,6 +607,59 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
   if (second.type === 'connected') await second.cleanup()
 })
 
+test('connectToServer honors PATH-only plugin env_vars on stdio spawn', async () => {
+  vi.resetModules()
+  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
+    Client: FakeClient,
+  }))
+  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+    StdioClientTransport: FakeStdioTransport,
+  }))
+
+  const { connectToServer } = await import('./client.js')
+  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
+    { VERSION: 'test' }
+
+  const result = await connectToServer(
+    'plugin-path-stdio',
+    {
+      type: 'stdio',
+      command: 'node',
+      args: ['./server/main.mjs'],
+      env: {
+        AGENC_PLUGIN_ROOT: '/plugins/fixture',
+        AGENC_PLUGIN_DATA: '/plugins/fixture-data',
+        AGENC_PLUGIN_NAME: 'fixture',
+        AGENC_PLUGIN_MCP_SERVER: 'x',
+        AGENC_PLUGIN_SANDBOX: 'stdio-child-process',
+      },
+      env_vars: ['PATH'],
+      cwd: '/plugins/fixture',
+      scope: 'dynamic',
+      pluginServer: { pluginName: 'fixture', serverName: 'x' },
+    },
+    undefined,
+    {
+      environment: Object.freeze({
+        PATH: '/only/bin',
+        LEAK: 'must-not-copy',
+        MCP_TIMEOUT: '1000',
+      }),
+    },
+  )
+
+  assert.equal(result.type, 'connected')
+  assert.equal(fakeStdioTransports[0]?.command, 'node')
+  assert.equal(fakeStdioTransports[0]?.env.PATH, '/only/bin')
+  assert.equal(fakeStdioTransports[0]?.env.LEAK, undefined)
+  assert.equal(fakeStdioTransports[0]?.env.AGENC_PLUGIN_NAME, 'fixture')
+  assert.equal(fakeStdioTransports[0]?.env.AGENC_PLUGIN_SANDBOX, 'stdio-child-process')
+
+  if (result.type === 'connected') {
+    await result.cleanup()
+  }
+})
+
 test('connectToServer logs successful stdio startup stderr before cleanup', async () => {
   vi.resetModules()
   vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({

--- a/runtime/tests/services/mcp/client-transports.test.ts
+++ b/runtime/tests/services/mcp/client-transports.test.ts
@@ -556,10 +556,12 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
       TEMP: 'C:\\declared\\temp',
       TMP: 'C:\\declared\\tmp',
     },
+    env_vars: ['PATH'],
     scope: 'local',
   } as const
   const environment = Object.freeze({
     PATH: '/usr/bin',
+    LEAK: 'must-not-copy',
     AGENC_TMPDIR: '/ambient/agenc',
     TMPDIR: '/ambient/posix',
     TEMP: 'C:\\ambient\\temp',
@@ -586,7 +588,16 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
   assert.equal(first.type, 'connected')
   assert.equal(second.type, 'connected')
   assert.equal(fakeStdioTransports.length, 2)
-  assert.deepEqual(fakeStdioTransports[0]?.env, {
+  const posixEnv = (env: Record<string, string> | undefined) =>
+    Object.fromEntries(
+      Object.entries(env ?? {}).map(([key, value]) => [
+        key,
+        value.replaceAll('\\', '/'),
+      ]),
+    )
+  assert.equal(posixEnv(fakeStdioTransports[0]?.env).LEAK, undefined)
+  assert.equal(posixEnv(fakeStdioTransports[1]?.env).LEAK, undefined)
+  assert.deepEqual(posixEnv(fakeStdioTransports[0]?.env), {
     PATH: '/usr/bin',
     AGENC_TMPDIR: '/tmp/agenc-mcp-session-a',
     TMPDIR: '/tmp/agenc-mcp-session-a',
@@ -594,7 +605,7 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
     TMP: '/tmp/agenc-mcp-session-a',
     TMPPREFIX: '/tmp/agenc-mcp-session-a/zsh',
   })
-  assert.deepEqual(fakeStdioTransports[1]?.env, {
+  assert.deepEqual(posixEnv(fakeStdioTransports[1]?.env), {
     PATH: '/usr/bin',
     AGENC_TMPDIR: '/tmp/agenc-mcp-session-b',
     TMPDIR: '/tmp/agenc-mcp-session-b',
@@ -605,59 +616,6 @@ test('connectToServer isolates stdio temp authority in env and cache identity', 
 
   if (first.type === 'connected') await first.cleanup()
   if (second.type === 'connected') await second.cleanup()
-})
-
-test('connectToServer honors PATH-only plugin env_vars on stdio spawn', async () => {
-  vi.resetModules()
-  vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
-    Client: FakeClient,
-  }))
-  vi.doMock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
-    StdioClientTransport: FakeStdioTransport,
-  }))
-
-  const { connectToServer } = await import('./client.js')
-  ;(globalThis as typeof globalThis & { MACRO?: { VERSION: string } }).MACRO ??=
-    { VERSION: 'test' }
-
-  const result = await connectToServer(
-    'plugin-path-stdio',
-    {
-      type: 'stdio',
-      command: 'node',
-      args: ['./server/main.mjs'],
-      env: {
-        AGENC_PLUGIN_ROOT: '/plugins/fixture',
-        AGENC_PLUGIN_DATA: '/plugins/fixture-data',
-        AGENC_PLUGIN_NAME: 'fixture',
-        AGENC_PLUGIN_MCP_SERVER: 'x',
-        AGENC_PLUGIN_SANDBOX: 'stdio-child-process',
-      },
-      env_vars: ['PATH'],
-      cwd: '/plugins/fixture',
-      scope: 'dynamic',
-      pluginServer: { pluginName: 'fixture', serverName: 'x' },
-    },
-    undefined,
-    {
-      environment: Object.freeze({
-        PATH: '/only/bin',
-        LEAK: 'must-not-copy',
-        MCP_TIMEOUT: '1000',
-      }),
-    },
-  )
-
-  assert.equal(result.type, 'connected')
-  assert.equal(fakeStdioTransports[0]?.command, 'node')
-  assert.equal(fakeStdioTransports[0]?.env.PATH, '/only/bin')
-  assert.equal(fakeStdioTransports[0]?.env.LEAK, undefined)
-  assert.equal(fakeStdioTransports[0]?.env.AGENC_PLUGIN_NAME, 'fixture')
-  assert.equal(fakeStdioTransports[0]?.env.AGENC_PLUGIN_SANDBOX, 'stdio-child-process')
-
-  if (result.type === 'connected') {
-    await result.cleanup()
-  }
 })
 
 test('connectToServer logs successful stdio startup stderr before cleanup', async () => {


### PR DESCRIPTION
## Why

Plugin-declared MCP stdio servers spawn through `connectToServer` with a child environment that ignored `env_vars`. The transport path already copies those names through `createStdioMCPEnvironment`. A plugin that declares `command: "node"` and `env_vars: ["PATH"]` therefore launched without PATH on the service-client path, so the child died before it appeared in the process table.

## Scope

`runtime/src/services/mcp/client.ts` now builds the stdio child env with `createStdioMCPEnvironment(serverRef.env, serverRef.env_vars, environment)` and still wraps the result in `withChildTempAuthority`. One regression test in `runtime/tests/services/mcp/client-transports.test.ts` spawns a plugin-like stdio server with a PATH-only parent environment and asserts PATH is copied while undeclared keys are not.

Out of scope: stream-watchdog, ripgrep, and a second env-build helper.

## Tradeoffs

The service-client stdio path no longer copies the entire sanitized parent environment. It copies the same allowlist as the transport path (`DEFAULT_STDIO_ENV_VARS` plus `env_vars`, then `server.env` overrides). Servers that relied on undeclared parent keys must list them in `env_vars`. That is the transport contract.

## Blast Radius

CLI `agenc mcp list` / `mcp doctor`, AgentTool MCP connects, and any other `connectToServer` stdio caller. Session `MCPManager` already used the helper. Temp-directory keys still come only from `withChildTempAuthority`.

## Verification

From `runtime` with portable Node `.tools/node-v26.7.0`:

- `node scripts/run-hermetic-vitest.mjs run tests/services/mcp/client-transports.test.ts -t "honors PATH-only plugin env_vars"` exit 0 (1 passed, 37 skipped). Failed before the fix because `LEAK` was copied. Passed after because only PATH and plugin reserved keys remain.
- `node scripts/run-hermetic-vitest.mjs run tests/services/mcp/client-authority.architecture.test.ts` exit 0 (3 passed).
- Nearby `client-transports` stdio tests still connect. Windows path-separator mismatches in pre-existing env deepEquals were not changed.

Closes #2078
