### PR TITLE
fix(llm): warn on quiet streams and abort only dead sockets

### DIFF
--- a/runtime/src/llm/client-session.ts
+++ b/runtime/src/llm/client-session.ts
@@ -1099,7 +1099,7 @@ export class ProviderHttpClientSession {
               if (next.done) return;
               // LLM-09: empty chunks still count as body progress for idle
               // watchdog (providers may send keepalives).
-              watchdog.kick();
+              watchdog.kick("bytes");
               if (!next.value || next.value.length === 0) continue;
               if (prepared.continuation) {
                 const decoded = decoder.decode(next.value, { stream: true });

--- a/runtime/src/llm/stream-watchdog.ts
+++ b/runtime/src/llm/stream-watchdog.ts
@@ -5,25 +5,13 @@
  * `streamWatchdogFiredAt`, `streamIdleAborted`) driven by
  * `stream_idle_timeout_ms` from provider info.
  *
- * The watchdog has no implicit deadline. The canonical config snapshot carries
- * a positive timeout when operators opt in; `0` disables it. This keeps long
- * silent reasoning and tool-argument generation valid for arbitrarily long
- * turns.
+ * Abort is opt-in (`timeoutMs` > 0) and fires only when the socket never
+ * received bytes. Heartbeats (`kick("bytes")`) keep that abort from firing.
+ * Model deltas (`kick("delta")`) reset the quiet-warning window. A zero abort
+ * timeout still warns when `onWarning` is set, so long grok-4.6 xhigh quiet
+ * phases stay alive with a ticker signal instead of a hard kill.
  *
- * Timers use monotonic clock (I-82) via `monotonicMs()` — immune to
- * NTP corrections, `date` set, suspend/resume, container clock skew.
- *
- * ## Usage patterns
- *
- * **Streaming** (T7 `chatStream`): call `kick()` on every received
- * chunk. The watchdog fires abort after `STREAM_IDLE_TIMEOUT_MS` of
- * silence since the last kick.
- *
- * **Total-timeout fallback** (T5 `chat()`): install with no kicks —
- * the watchdog fires after `STREAM_IDLE_TIMEOUT_MS` from install.
- * This is a coarse fallback because we can't observe intra-response
- * progress without a streaming channel; T7 replaces it with real
- * per-chunk kicks once `chatStream` wires in.
+ * Timers use monotonic clock (I-82) via `monotonicMs()`.
  *
  * @module
  */
@@ -82,6 +70,78 @@ export function resolveSessionStreamIdleTimeoutMs(input: {
   return resolveStreamIdleTimeoutMs(preferred);
 }
 
+/** Soft "no model delta" warning when abort is disabled. Matches the session default idle window. */
+export const STREAM_QUIET_WARNING_MS = 600_000;
+
+export type StreamWatchdogKickSource = "bytes" | "delta";
+export type StreamLiveness = "live" | "quiet" | "dead";
+
+export function classifyStreamLiveness(input: {
+  readonly nowMs: number;
+  readonly startedAtMs: number;
+  readonly lastByteMs: number | null;
+  readonly lastDeltaMs: number | null;
+  readonly warningMs: number;
+  readonly deadMs: number;
+}): StreamLiveness {
+  const sinceStart = input.nowMs - input.startedAtMs;
+  if (
+    input.deadMs > 0 &&
+    input.lastByteMs === null &&
+    sinceStart >= input.deadMs
+  ) {
+    return "dead";
+  }
+  const sinceDelta = input.nowMs - (input.lastDeltaMs ?? input.startedAtMs);
+  if (input.warningMs > 0 && sinceDelta >= input.warningMs) {
+    return "quiet";
+  }
+  return "live";
+}
+
+export function resolveStreamIdleWarningMs(input: {
+  readonly timeoutMs: number;
+  readonly warningMs?: number;
+}): number {
+  if (
+    input.warningMs !== undefined &&
+    Number.isFinite(input.warningMs) &&
+    input.warningMs > 0
+  ) {
+    return Math.trunc(input.warningMs);
+  }
+  if (input.timeoutMs > 0) {
+    return Math.trunc(input.timeoutMs / 2);
+  }
+  return STREAM_QUIET_WARNING_MS;
+}
+
+export function formatStreamQuietWarning(elapsedMs: number): string {
+  const minutes = Math.max(1, Math.round(elapsedMs / 60_000));
+  const unit = minutes === 1 ? "minute" : "minutes";
+  return `no output from the model for ${minutes} ${unit}`;
+}
+
+export function streamChunkHasDelta(chunk: {
+  readonly content: string;
+  readonly thinkingDelta?: unknown;
+  readonly reasoningSummaryDelta?: unknown;
+  readonly toolInputDelta?: unknown;
+  readonly thinkingBlockStart?: unknown;
+  readonly toolInputBlockStart?: unknown;
+  readonly toolCalls?: readonly unknown[];
+}): boolean {
+  return (
+    chunk.content.length > 0 ||
+    chunk.thinkingDelta !== undefined ||
+    chunk.reasoningSummaryDelta !== undefined ||
+    chunk.toolInputDelta !== undefined ||
+    chunk.thinkingBlockStart !== undefined ||
+    chunk.toolInputBlockStart !== undefined ||
+    (chunk.toolCalls !== undefined && chunk.toolCalls.length > 0)
+  );
+}
+
 /**
  * Reason string for the abort. Callers observing `signal.reason`
  * check for this exact value.
@@ -90,8 +150,9 @@ export const STREAM_IDLE_ABORT_REASON = "stream_idle";
 export const STREAM_IDLE_WARNING_REASON = "stream_idle_warning";
 
 export interface StreamWatchdogHandle {
-  /** Reset the idle timer on observed activity (per-chunk kick). */
-  kick(): void;
+  /** Heartbeat (`bytes`) keeps a dead-socket abort from firing. A model
+   *  `delta` also resets the quiet-warning window. */
+  kick(source?: StreamWatchdogKickSource): void;
   /** Stop the watchdog without firing (stream completed cleanly). */
   stop(): void;
   /** Whether this watchdog already fired. */
@@ -106,13 +167,15 @@ export interface InstallStreamWatchdogOptions {
    *  in-flight request. */
   readonly abortController: AbortController;
   /** Override for the idle timeout. Defaults to disabled. Pass 0 to
-   *  disable explicitly (returns a no-op handle). */
+   *  disable the dead-socket abort. */
   readonly timeoutMs?: number;
+  /** Override for the no-delta warning. Defaults to half of `timeoutMs`,
+   *  or {@link STREAM_QUIET_WARNING_MS} when abort is disabled. */
+  readonly warningMs?: number;
   /** Callback fired exactly once when the timer expires, before the
    *  `abortController.abort(...)` call. Emit I-8 `stream_error` here. */
   readonly onFired?: (info: { elapsedMs: number; reason: string }) => void;
-  /** Callback fired once per idle window at half the timeout. Use for
-   *  non-fatal diagnostics or typed warnings before the hard abort. */
+  /** Callback fired once per idle window when the stream is quiet or dead. */
   readonly onWarning?: (info: { elapsedMs: number; reason: string }) => void;
 }
 
@@ -123,17 +186,19 @@ export interface InstallStreamWatchdogOptions {
  * The returned handle is safe to use after the stream completes —
  * `stop()` / `kick()` after fire is a no-op.
  *
- * If the canonical timeout is zero, the handle no-ops and never fires. This
- * lets every call site use the
- * same code path without conditional branches.
+ * A zero abort timeout still warns when `onWarning` is set. Abort fires
+ * only for a socket that never received bytes.
  */
 export function installStreamWatchdog(
   options: InstallStreamWatchdogOptions,
 ): StreamWatchdogHandle {
   const timeoutMs = options.timeoutMs ?? resolveStreamIdleTimeoutMs();
+  const warningMs = resolveStreamIdleWarningMs({
+    timeoutMs,
+    ...(options.warningMs !== undefined ? { warningMs: options.warningMs } : {}),
+  });
 
-  if (timeoutMs <= 0) {
-    // Disabled — return a no-op handle.
+  if (timeoutMs <= 0 && (warningMs <= 0 || options.onWarning === undefined)) {
     return {
       kick() {},
       stop() {},
@@ -145,12 +210,13 @@ export function installStreamWatchdog(
   }
 
   const startedAtMs = monotonicMs();
-  let lastKickMs = startedAtMs;
+  let lastByteMs: number | null = null;
+  let lastDeltaMs: number | null = null;
   let warningTimer: ReturnType<typeof setTimeout> | null = null;
   let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
   let firedAtValue: number | null = null;
+  let warned = false;
   let stopped = false;
-  const warningMs = timeoutMs / 2;
 
   const clearTimers = () => {
     if (warningTimer) {
@@ -170,20 +236,21 @@ export function installStreamWatchdog(
   };
 
   const warn = () => {
-    if (stopped || firedAtValue !== null) return;
+    if (stopped || firedAtValue !== null || warned) return;
     warningTimer = null;
-    const warnedAtMs = monotonicMs();
+    warned = true;
+    const nowMs = monotonicMs();
     options.onWarning?.({
-      elapsedMs: warnedAtMs - lastKickMs,
+      elapsedMs: nowMs - (lastDeltaMs ?? startedAtMs),
       reason: STREAM_IDLE_WARNING_REASON,
     });
   };
 
   const fire = () => {
-    if (stopped || firedAtValue !== null) return;
+    if (stopped || firedAtValue !== null || lastByteMs !== null) return;
     timeoutTimer = null;
     firedAtValue = monotonicMs();
-    const elapsedMs = firedAtValue - lastKickMs;
+    const elapsedMs = firedAtValue - startedAtMs;
     try {
       options.onFired?.({ elapsedMs, reason: STREAM_IDLE_ABORT_REASON });
     } finally {
@@ -193,20 +260,32 @@ export function installStreamWatchdog(
 
   const schedule = () => {
     if (stopped || firedAtValue !== null) return;
-    warningTimer = setTimeout(warn, warningMs);
-    timeoutTimer = setTimeout(fire, timeoutMs);
-    // Don't keep the event loop alive solely on the watchdog — the
-    // owning stream promise is what holds the process open.
-    withUnref(warningTimer);
-    withUnref(timeoutTimer);
+    const nowMs = monotonicMs();
+    if (warningMs > 0 && !warned) {
+      const delay = Math.max(
+        0,
+        warningMs - (nowMs - (lastDeltaMs ?? startedAtMs)),
+      );
+      warningTimer = setTimeout(warn, delay);
+      withUnref(warningTimer);
+    }
+    if (timeoutMs > 0 && lastByteMs === null) {
+      timeoutTimer = setTimeout(fire, Math.max(0, timeoutMs - (nowMs - startedAtMs)));
+      withUnref(timeoutTimer);
+    }
   };
 
   schedule();
 
   return {
-    kick() {
+    kick(source: StreamWatchdogKickSource = "delta") {
       if (stopped || firedAtValue !== null) return;
-      lastKickMs = monotonicMs();
+      const nowMs = monotonicMs();
+      lastByteMs = nowMs;
+      if (source === "delta") {
+        lastDeltaMs = nowMs;
+        warned = false;
+      }
       clearTimers();
       schedule();
     },

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -11,10 +11,11 @@
  *
  * Invariants wired here:
  *   I-11 (stream idle watchdog) — installStreamWatchdog wraps the stream;
- *        `kick()` fires on every chunk. The canonical config carries a
- *        ten-minute default idle expiry (`stream_watchdog_timeout_ms`,
- *        `0` disables) that aborts the underlying fetch via the scoped
- *        AbortController; sessions without a config store stay unbounded.
+ *        `kick("delta"|"bytes")` on every chunk. Heartbeats keep a dead-socket
+ *        abort from firing. Quiet reasoning warns instead of aborting. The
+ *        canonical config carries a ten-minute default dead-socket expiry
+ *        (`stream_watchdog_timeout_ms`, `0` disables abort). Sessions without
+ *        a config store still warn after ten minutes of no delta.
  *   I-22 (token budget mid-stream) — per-chunk
  *        `budgetTracker.addEmitted(..., "estimate") + sampleMidStream`
  *        keeps a coarse estimate during streaming, but the actual
@@ -43,9 +44,12 @@ import type {
 } from "../llm/types.js";
 import { cloneLlmMessageSnapshot } from "../llm/content-conversion.js";
 import {
+  formatStreamQuietWarning,
   installStreamWatchdog,
   resolveSessionStreamIdleTimeoutMs,
   STREAM_IDLE_ABORT_REASON,
+  STREAM_IDLE_WARNING_REASON,
+  streamChunkHasDelta,
 } from "../llm/stream-watchdog.js";
 import { DEFAULT_STREAM_WATCHDOG_TIMEOUT_MS } from "../config/schema.js";
 import {
@@ -1109,6 +1113,18 @@ export async function streamModel(
           }
         : {}),
     }),
+    onWarning: (info) => {
+      session.emit({
+        id: session.nextInternalSubId(),
+        msg: {
+          type: "warning",
+          payload: {
+            cause: STREAM_IDLE_WARNING_REASON,
+            message: formatStreamQuietWarning(info.elapsedMs),
+          },
+        },
+      });
+    },
     onFired: (info) => {
       session.emit({
         id: session.nextInternalSubId(),
@@ -1161,8 +1177,7 @@ export async function streamModel(
 
   const onChunk = (chunk: LLMStreamChunk): void => {
     receivedProviderChunk = true;
-    // I-11: any chunk resets the idle timer.
-    watchdog.kick();
+    watchdog.kick(streamChunkHasDelta(chunk) ? "delta" : "bytes");
 
     // I-22: per-chunk token accounting + sampling gate. The sampling
     // result is estimation-only; the continuation decision stays on

--- a/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
+++ b/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
@@ -11,6 +11,10 @@ import { Byline } from '../design-system/Byline.js';
 import FullWidthRow from '../design-system/FullWidthRow.js';
 import { AgenCActivityMark } from './AgenCActivityMark.js';
 import type { SpinnerMode } from './types.js';
+import {
+  formatStreamQuietWarning,
+  STREAM_QUIET_WARNING_MS,
+} from '../../../llm/stream-watchdog.js';
 import { computeSpinnerMessageMaxWidth, truncateSpinnerText } from './utils.js';
 
 const SEP_WIDTH = stringWidth(' · ');
@@ -294,10 +298,16 @@ export function SpinnerAnimationRow({
     loadingStartTimeRef.current,
     !toolsRunning,
   );
-  // Show the heartbeat once the turn has been waiting on a token long enough to
-  // look stuck — but not while "thinking" is already explaining the silence.
-  const stallNoteText =
+  const quietWarningText =
     trackLiveness &&
+    !hasRunningTeammates &&
+    !toolsRunning &&
+    msSinceLastToken >= STREAM_QUIET_WARNING_MS
+      ? formatStreamQuietWarning(msSinceLastToken)
+      : null;
+  const stallNoteText =
+    quietWarningText ??
+    (trackLiveness &&
     !hasRunningTeammates &&
     thinkingStatus !== 'thinking' &&
     elapsedTimeMs > STALL_NOTE_AFTER_MS
@@ -307,7 +317,7 @@ export function SpinnerAnimationRow({
           ratePerSec,
           toolsRunning,
         })
-      : null;
+      : null);
   const showStallNote = stallNoteText !== null;
   const stallNoteWidth = stallNoteText ? stringWidth(stallNoteText) : 0;
   const rateText = ratePerSec > 0 ? formatRate(ratePerSec) : null;

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -322,6 +322,7 @@ const USER_VISIBLE_WARNING_CAUSES: ReadonlySet<string> = new Set([
   "schema_validation_failed",
   "malformed_tool_call",
   "daemon_connection_state",
+  "stream_idle_warning",
 ]);
 
 /**

--- a/runtime/tests/llm/stream-watchdog.test.ts
+++ b/runtime/tests/llm/stream-watchdog.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  classifyStreamLiveness,
+  formatStreamQuietWarning,
   installStreamWatchdog,
   STREAM_IDLE_ABORT_REASON,
   STREAM_IDLE_WARNING_REASON,
+  streamChunkHasDelta,
 } from "./stream-watchdog.js";
 
 describe("stream-watchdog", () => {
@@ -64,7 +67,7 @@ describe("stream-watchdog", () => {
     expect(handle.firedAt).toBe(100);
   });
 
-  test("kick resets both warning and timeout windows", () => {
+  test("a delta kick resets the quiet warning window without aborting", () => {
     const abortController = new AbortController();
     const warnings: Array<{ elapsedMs: number; reason: string }> = [];
     const fired: Array<{ elapsedMs: number; reason: string }> = [];
@@ -92,10 +95,9 @@ describe("stream-watchdog", () => {
 
     nowMs = 140;
     vi.advanceTimersByTime(50);
-    expect(fired).toEqual([
-      { elapsedMs: 100, reason: STREAM_IDLE_ABORT_REASON },
-    ]);
-    expect(handle.firedAt).toBe(140);
+    expect(fired).toEqual([]);
+    expect(abortController.signal.aborted).toBe(false);
+    expect(handle.firedAt).toBeNull();
   });
 
   test("stop cancels pending warning and timeout timers", () => {
@@ -141,5 +143,99 @@ describe("stream-watchdog", () => {
     expect(onFired).not.toHaveBeenCalled();
     expect(abortController.signal.aborted).toBe(false);
     expect(handle.firedAt).toBeNull();
+  });
+
+  test("distinguishes quiet reasoning from a dead socket", () => {
+    expect(
+      classifyStreamLiveness({
+        nowMs: 100,
+        startedAtMs: 0,
+        lastByteMs: null,
+        lastDeltaMs: null,
+        warningMs: 50,
+        deadMs: 100,
+      }),
+    ).toBe("dead");
+    expect(
+      classifyStreamLiveness({
+        nowMs: 100,
+        startedAtMs: 0,
+        lastByteMs: 10,
+        lastDeltaMs: 10,
+        warningMs: 50,
+        deadMs: 100,
+      }),
+    ).toBe("quiet");
+    expect(
+      classifyStreamLiveness({
+        nowMs: 80,
+        startedAtMs: 0,
+        lastByteMs: 40,
+        lastDeltaMs: null,
+        warningMs: 50,
+        deadMs: 100,
+      }),
+    ).toBe("quiet");
+    expect(
+      classifyStreamLiveness({
+        nowMs: 20,
+        startedAtMs: 0,
+        lastByteMs: 10,
+        lastDeltaMs: 10,
+        warningMs: 50,
+        deadMs: 100,
+      }),
+    ).toBe("live");
+    expect(streamChunkHasDelta({ content: "" })).toBe(false);
+    expect(streamChunkHasDelta({ content: "hi" })).toBe(true);
+    expect(formatStreamQuietWarning(600_000)).toBe(
+      "no output from the model for 10 minutes",
+    );
+
+    const deadAbort = new AbortController();
+    const deadWarnings: string[] = [];
+    const deadFired: string[] = [];
+    installStreamWatchdog({
+      abortController: deadAbort,
+      timeoutMs: 100,
+      onWarning: (info) => deadWarnings.push(info.reason),
+      onFired: (info) => deadFired.push(info.reason),
+    });
+    nowMs = 100;
+    vi.advanceTimersByTime(100);
+    expect(deadWarnings).toEqual([STREAM_IDLE_WARNING_REASON]);
+    expect(deadFired).toEqual([STREAM_IDLE_ABORT_REASON]);
+    expect(deadAbort.signal.aborted).toBe(true);
+
+    const quietAbort = new AbortController();
+    const quietWarnings: string[] = [];
+    const quietFired: string[] = [];
+    const quiet = installStreamWatchdog({
+      abortController: quietAbort,
+      timeoutMs: 100,
+      onWarning: (info) => quietWarnings.push(info.reason),
+      onFired: (info) => quietFired.push(info.reason),
+    });
+    nowMs = 110;
+    vi.advanceTimersByTime(10);
+    quiet.kick("bytes");
+    nowMs = 200;
+    vi.advanceTimersByTime(90);
+    expect(quietWarnings).toEqual([STREAM_IDLE_WARNING_REASON]);
+    expect(quietFired).toEqual([]);
+    expect(quietAbort.signal.aborted).toBe(false);
+
+    const disabledAbort = new AbortController();
+    const disabledWarnings: string[] = [];
+    installStreamWatchdog({
+      abortController: disabledAbort,
+      timeoutMs: 0,
+      warningMs: 100,
+      onWarning: (info) => disabledWarnings.push(info.reason),
+    });
+    nowMs = 300;
+    vi.advanceTimersByTime(100);
+    expect(disabledWarnings).toEqual([STREAM_IDLE_WARNING_REASON]);
+    expect(disabledAbort.signal.aborted).toBe(false);
   });
 });

--- a/runtime/tests/phases/stream-model.test.ts
+++ b/runtime/tests/phases/stream-model.test.ts
@@ -26,7 +26,10 @@ import type {
 import type { AdmissionLease } from "../budget/admission-types.js";
 import { WorkflowHandoffSpool } from "../agents/workflow-handoff-spool.js";
 import { defaultConfig } from "../config/schema.js";
-import { STREAM_IDLE_ABORT_REASON } from "../llm/stream-watchdog.js";
+import {
+  STREAM_IDLE_ABORT_REASON,
+  STREAM_IDLE_WARNING_REASON,
+} from "../llm/stream-watchdog.js";
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -614,6 +617,64 @@ describe("streamModel — live assistant text sanitization", () => {
       expect(error).toBeInstanceOf(StreamModelError);
       expect((error as Error).message).toMatch(/^stream_idle: no data for 600000ms/);
       expect(isRetryableStreamError(error)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a stream that produced a chunk warns on quiet idle and does not abort", async () => {
+    vi.useFakeTimers();
+    const external = new AbortController();
+    try {
+      const ctx = mkCtx("chat");
+      let providerSignal: AbortSignal | undefined;
+      const provider = mkProvider(
+        (_messages, onChunk, options) =>
+          new Promise<LLMResponse>((_resolve, reject) => {
+            providerSignal = options?.signal;
+            onChunk({ content: "hi", done: false });
+            options?.signal?.addEventListener(
+              "abort",
+              () => reject(new Error(String(options.signal?.reason))),
+              { once: true },
+            );
+          }),
+      );
+      const { session, events } = mkSession(provider);
+      (session.services as { configStore?: unknown }).configStore = {
+        current: () => ({ stream_watchdog_timeout_ms: 100 }),
+      };
+
+      const outcome = streamModel(
+        mkState(ctx),
+        ctx,
+        session,
+        mkRequest([{ role: "user", content: "hello" }]),
+        external.signal,
+      ).then(
+        () => "resolved" as const,
+        (error: unknown) => error,
+      );
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(
+        events.some(
+          (event) =>
+            event.msg.type === "warning" &&
+            (event.msg.payload as { cause?: string }).cause ===
+              STREAM_IDLE_WARNING_REASON,
+        ),
+      ).toBe(true);
+      expect(providerSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(providerSignal?.aborted).toBe(false);
+      expect(
+        events.some((event) => event.msg.type === "stream_error"),
+      ).toBe(false);
+
+      external.abort();
+      await outcome;
     } finally {
       vi.useRealTimers();
     }

--- a/runtime/tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx
+++ b/runtime/tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx
@@ -92,8 +92,7 @@ describe("SpinnerAnimationRow liveness + token grammar", () => {
     vi.spyOn(Date, "now").mockReturnValue(NOW);
 
     const output = await renderRow({
-      // Turn started ~13 minutes ago and nothing has streamed yet.
-      loadingStartTimeRef: makeRef(NOW - 13 * 60_000),
+      loadingStartTimeRef: makeRef(NOW - 30_000),
       responseLengthRef: makeRef(0),
       mode: "responding",
     });
@@ -101,6 +100,7 @@ describe("SpinnerAnimationRow liveness + token grammar", () => {
     expect(output).toContain("waiting for model");
     expect(output).toContain("no output yet");
     expect(output).not.toContain("slow model");
+    expect(output).not.toContain("no output from the model");
   });
 
   // Operator bug 2026-07-20: "Running tools… (1m 33s · ↓ 208 tokens ·
@@ -161,13 +161,28 @@ describe("SpinnerAnimationRow liveness + token grammar", () => {
     vi.spyOn(Date, "now").mockReturnValue(NOW);
 
     const output = await renderRow({
-      loadingStartTimeRef: makeRef(NOW - 13 * 60_000),
+      loadingStartTimeRef: makeRef(NOW - 60_000),
       responseLengthRef: makeRef(0),
       thinkingStatus: "thinking",
     });
 
     expect(output).not.toContain("slow model");
+    expect(output).not.toContain("no output from the model");
     expect(output).toContain("thinking");
+  });
+
+  test("shows a quiet-stream warning during long thinking", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      loadingStartTimeRef: makeRef(NOW - 13 * 60_000),
+      responseLengthRef: makeRef(0),
+      thinkingStatus: "thinking",
+    });
+
+    expect(output).toContain("no output from the model for 13 minutes");
+    expect(output).toContain("thinking");
+    expect(output).toContain("esc to interrupt");
   });
 
   // The heartbeat must NOT appear for a fresh, fast turn (no false alarm).

--- a/runtime/tests/tui/parity/session-transcript.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.test.ts
@@ -2087,6 +2087,10 @@ describe("AgenC TUI session transcript", () => {
           "editor_proposal_missing",
           "The Editor request returned no valid proposal",
         ],
+        [
+          "stream_idle_warning",
+          "no output from the model for 10 minutes",
+        ],
       ] as const;
       const transcript = adaptTranscriptEvents(
         warnings.map(([cause, message], index) => ({
@@ -2100,6 +2104,7 @@ describe("AgenC TUI session transcript", () => {
       expect(allText).toContain("mid_turn_compact_skipped");
       expect(allText).toContain("Dropped @file/path");
       expect(allText).toContain("returned no valid proposal");
+      expect(allText).toContain("no output from the model for 10 minutes");
     });
   });
 });


### PR DESCRIPTION
## Why

A provider stream that goes quiet holds the turn, and the app cannot tell a stall from long high-effort reasoning. `resolveStreamIdleTimeoutMs` returns 0, so `installStreamWatchdog` was a no-op. A positive `stream_watchdog_timeout_ms` aborted any silence, which would cut grok-4.6 xhigh phases that already produced tokens. The ticker hid its stall note while the status said thinking. Soak finding F52 / #2200.

## Scope

`classifyStreamLiveness` in `runtime/src/llm/stream-watchdog.ts` splits `live`, `quiet` (had bytes, no model delta), and `dead` (no bytes at all).

`kick("bytes")` is a heartbeat. It keeps a dead-socket abort from firing and does not reset the quiet warning. `kick("delta")` resets the warning window. `stream-model` classifies each `LLMStreamChunk`. The HTTP client kicks bytes on every body chunk, including empty keepalives.

A zero abort timeout still warns when `onWarning` is set. `stream-model` emits `warning` with cause `stream_idle_warning`. The TUI ticker shows that copy even while thinking, with the existing stop affordance. Transcript allow-lists the cause.

Out of scope: ripgrep, neovim lifecycle, `turn_failed`, reconnect ladder changes.

## Tradeoffs

A configured idle timeout no longer aborts after the first byte. That is the point. Dead sockets that never receive bytes still abort as retryable `stream_idle`. Quiet reasoning after tokens is a user decision (stop), not a hard kill.

When abort is armed, the warning still fires at half the timeout so existing half-time tests stay true. When abort is disabled, the warning uses `STREAM_QUIET_WARNING_MS` (ten minutes).

## Blast Radius

Session streaming (`stream-model`), provider HTTP streams (`client-session`), and the TUI spinner ticker. Review delegates that opt out of the ambient abort still get the soft warning. No change to turn failure terminals.

## Verification

Reproduced on `installStreamWatchdog({ timeoutMs: 0 })`. `timeoutMs` is 0 and neither warning nor abort fires after 500ms. After the fix, `timeoutMs: 0` with `warningMs: 100` warns and does not abort. A dead socket with timeout 100 still aborts. Heartbeats keep a quiet stream alive.

Focused hermetic vitest, Node v26.7.0 from `.tools\node-v26.7.0`:

- `tests/llm/stream-watchdog.test.ts` 6 passed
- `tests/llm/stream-watchdog.silent-generation.test.ts` 7 passed
- `tests/llm/api/watchdog.test.ts` 1 passed
- `tests/phases/stream-model.test.ts` 38 passed, including quiet-vs-dead
- `tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx` 14 passed
- `tests/llm/client-session.test.ts` 32 passed
- `tests/llm/providers/grok/adapter.stream-liveness.test.ts` 3 passed
- `tests/llm/providers/grok/stream-cancellation.test.ts` 8 passed

Closes #2200