### PR TITLE
fix(anthropic): send the thinking control each Claude generation accepts, and the effort dial

### DIFF
--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -359,7 +359,7 @@ export const BUILT_IN_PROVIDER_DEFINITIONS = Object.freeze({
   }),
   anthropic: providerDefinition({
     name: "Anthropic",
-    defaultModel: "claude-opus-4-7",
+    defaultModel: "claude-opus-5",
     baseURL: "https://api.anthropic.com/v1",
     credentials: apiKeyCredentials(["ANTHROPIC_API_KEY"]),
     baseURLEnvVars: ["ANTHROPIC_BASE_URL"],
@@ -640,7 +640,13 @@ export const BUILT_IN_PROVIDER_MODEL_CATALOG: Readonly<
   openai: mergeDerivedProviderModels("openai", {
     trailingExtras: ["o3"],
   }),
+  // The current lineup platform.claude.com lists (2026-09-11), then the
+  // legacy models it still serves. Haiku 4.5 is not offered: it takes no
+  // effort parameter, and the picker's dial would be a lie there.
   anthropic: Object.freeze([
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",

--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -32,7 +32,12 @@ import {
   decodeMcpToolNameFromWire,
   encodeMcpToolNameForWire,
 } from "./mcp-tool-naming.js";
-import { isAlwaysOnThinkingAnthropicModel } from "../../utils/model/alwaysOnThinking.js";
+import {
+  anthropicAcceptsEffort,
+  anthropicAcceptsSamplingParameters,
+  anthropicEffort,
+  anthropicThinkingControl,
+} from "../../utils/model/anthropicThinkingControl.js";
 
 export interface AnthropicMessagesRequestOptions {
   readonly model: string;
@@ -349,8 +354,15 @@ export function buildAnthropicMessagesRequest(
   // Task 28: the Fable/Mythos 5 family removed sampling parameters —
   // sending `temperature` returns a 400 (provider docs, verified
   // 2026-07-08). Opus-family behavior is unchanged.
-  const alwaysOnThinking = isAlwaysOnThinkingAnthropicModel(input.model);
-  if (input.options?.temperature !== undefined && !alwaysOnThinking) {
+  const thinkingControl = anthropicThinkingControl(input.model);
+  const alwaysOnThinking = thinkingControl === "always_on";
+  // `temperature` is "deprecated for this model" (400) on Opus 5, Sonnet 5,
+  // Opus 4.8 and Opus 4.7 as well (probed 2026-09-11); the 4.6 generation
+  // and older still take it.
+  if (
+    input.options?.temperature !== undefined &&
+    anthropicAcceptsSamplingParameters(input.model)
+  ) {
     body.temperature = input.options.temperature;
   }
   if (
@@ -404,17 +416,31 @@ export function buildAnthropicMessagesRequest(
   // family — thinking is always on and any explicit configuration other
   // than `{type:"adaptive"}` (incl. `disabled` and `enabled`/budget_tokens)
   // returns a 400; omitting the param runs adaptive thinking. Depth is the
-  // effort parameter's job on that family. Opus-family (>= 4.6) behavior
-  // below is unchanged.
+  // effort parameter's job on that family.
+  //
+  // Opus 5, Sonnet 5, Opus 4.8 and Opus 4.7 return the same 400 for
+  // `enabled` + `budget_tokens` ("Use thinking.type.adaptive and
+  // output_config.effort"); they and the 4.6 generation take adaptive
+  // thinking, with depth steered by effort. Only Opus 4.5, Sonnet 4.5,
+  // Haiku 4.5 and older still budget their thinking. Probed live
+  // 2026-09-11; see anthropicThinkingControl.ts.
   if (thinkingEnabled && !alwaysOnThinking) {
-    body.thinking = {
-      type: "enabled",
-      budget_tokens:
-        input.options?.reasoningEffort === "high" ||
-          input.options?.reasoningEffort === "xhigh"
-          ? 4096
-          : 2048,
-    };
+    body.thinking = thinkingControl === "adaptive"
+      ? { type: "adaptive" }
+      : {
+          type: "enabled",
+          budget_tokens:
+            input.options?.reasoningEffort === "high" ||
+              input.options?.reasoningEffort === "xhigh"
+              ? 4096
+              : 2048,
+        };
+  }
+  // The effort dial only means something on the wire as output_config.effort;
+  // Sonnet 4.5 and Haiku 4.5 reject the field, so it stays off for them.
+  const effort = anthropicEffort(input.options?.reasoningEffort);
+  if (effort !== undefined && anthropicAcceptsEffort(input.model)) {
+    body.output_config = { effort };
   }
   if (input.contextManagement) {
     body.context_management = input.contextManagement;

--- a/runtime/src/session/cost.ts
+++ b/runtime/src/session/cost.ts
@@ -283,11 +283,64 @@ const COST_TIER_OPUS_LEGACY: Readonly<ModelCostEntry> = Object.freeze({
 // Current Opus tier ($5/$25 per Mtok) — Opus dropped to $5/$25 with 4.5, so 4.5
 // through 4.8 (and later) bill here. Mirrors utils/modelCost.ts COST_TIER_5_25
 // (the canonical AgenC pricing source of truth), expressed per-1K.
+const COST_TIER_MINIMAX_M3: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.0003,
+  outputUsdPer1K: 0.0012,
+  cachedInputUsdPer1K: 0.00006,
+  cacheCreationUsdPer1K: 0.000375,
+  webSearchUsdPerRequest: 0,
+});
+const COST_TIER_MINIMAX_M2_7_HIGHSPEED: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.0006,
+  outputUsdPer1K: 0.0024,
+  cachedInputUsdPer1K: 0.00006,
+  cacheCreationUsdPer1K: 0.000375,
+  webSearchUsdPerRequest: 0,
+});
+const COST_TIER_MINIMAX_M2: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.0003,
+  outputUsdPer1K: 0.0012,
+  cachedInputUsdPer1K: 0.00003,
+  cacheCreationUsdPer1K: 0.000375,
+  webSearchUsdPerRequest: 0,
+});
+const COST_TIER_MINIMAX_M2_HIGHSPEED: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.0006,
+  outputUsdPer1K: 0.0024,
+  cachedInputUsdPer1K: 0.00003,
+  cacheCreationUsdPer1K: 0.000375,
+  webSearchUsdPerRequest: 0,
+});
+
+function minimaxCostAliases(
+  model: string,
+  entry: Readonly<ModelCostEntry>,
+): Record<string, Readonly<ModelCostEntry>> {
+  return { [`minimax:${model}`]: entry, [model]: entry };
+}
+
 const COST_TIER_OPUS_5_25: Readonly<ModelCostEntry> = Object.freeze({
   inputUsdPer1K: 0.005,
   outputUsdPer1K: 0.025,
   cachedInputUsdPer1K: 0.0005,
   cacheCreationUsdPer1K: 0.00625,
+  webSearchUsdPerRequest: 0.01,
+});
+
+// Claude Fable 5 / 5.1 at $10/$50 and Claude Sonnet 5 at $2/$10
+// (platform.claude.com models overview, 2026-09-11).
+const COST_TIER_FABLE_10_50: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.01,
+  outputUsdPer1K: 0.05,
+  cachedInputUsdPer1K: 0.001,
+  cacheCreationUsdPer1K: 0.0125,
+  webSearchUsdPerRequest: 0.01,
+});
+const COST_TIER_SONNET_2_10: Readonly<ModelCostEntry> = Object.freeze({
+  inputUsdPer1K: 0.002,
+  outputUsdPer1K: 0.01,
+  cachedInputUsdPer1K: 0.0002,
+  cacheCreationUsdPer1K: 0.0025,
   webSearchUsdPerRequest: 0.01,
 });
 
@@ -406,6 +459,14 @@ export const DEFAULT_MODEL_COSTS: Readonly<Record<string, ModelCostEntry>> =
     ...openAiCostAliases("o3", COST_TIER_O3),
     ...openAiCostAliases("o3-mini", COST_TIER_O3_MINI),
     ...openAiCostAliases("o4-mini", COST_TIER_O4_MINI),
+    "anthropic:claude-fable-5-1": COST_TIER_FABLE_10_50,
+    "claude-fable-5-1": COST_TIER_FABLE_10_50,
+    "anthropic:claude-fable-5": COST_TIER_FABLE_10_50,
+    "claude-fable-5": COST_TIER_FABLE_10_50,
+    "anthropic:claude-opus-5": COST_TIER_OPUS_5_25,
+    "claude-opus-5": COST_TIER_OPUS_5_25,
+    "anthropic:claude-sonnet-5": COST_TIER_SONNET_2_10,
+    "claude-sonnet-5": COST_TIER_SONNET_2_10,
     "anthropic:claude-sonnet-4-6": COST_TIER_SONNET,
     "claude-sonnet-4-6": COST_TIER_SONNET,
     "anthropic:claude-sonnet-4-5": COST_TIER_SONNET,
@@ -497,8 +558,19 @@ export const DEFAULT_MODEL_COSTS: Readonly<Record<string, ModelCostEntry>> =
     "mistral-medium-latest": COST_TIER_MISTRAL_MEDIUM_3_5,
     "nvidia-nim:nvidia/llama-3.1-nemotron-70b-instruct": DEFAULT_UNKNOWN_MODEL_COST,
     "nvidia/llama-3.1-nemotron-70b-instruct": DEFAULT_UNKNOWN_MODEL_COST,
-    "minimax:MiniMax-M2.5": DEFAULT_UNKNOWN_MODEL_COST,
-    "MiniMax-M2.5": DEFAULT_UNKNOWN_MODEL_COST,
+    // MiniMax pay-as-you-go (platform.minimax.io/docs/guides/pricing-paygo,
+    // 2026-09-11, standard tier, prompts up to 512k): M3 $0.30/$1.20 per M
+    // with $0.06 cache reads; M2.7 the same; the other M2 generations read
+    // cache at $0.03; every highspeed variant doubles input and output.
+    // Cache writes are $0.375 per M across the line.
+    ...minimaxCostAliases("MiniMax-M3", COST_TIER_MINIMAX_M3),
+    ...minimaxCostAliases("MiniMax-M2.7", COST_TIER_MINIMAX_M3),
+    ...minimaxCostAliases("MiniMax-M2.7-highspeed", COST_TIER_MINIMAX_M2_7_HIGHSPEED),
+    ...minimaxCostAliases("MiniMax-M2.5", COST_TIER_MINIMAX_M2),
+    ...minimaxCostAliases("MiniMax-M2.5-highspeed", COST_TIER_MINIMAX_M2_HIGHSPEED),
+    ...minimaxCostAliases("MiniMax-M2.1", COST_TIER_MINIMAX_M2),
+    ...minimaxCostAliases("MiniMax-M2.1-highspeed", COST_TIER_MINIMAX_M2_HIGHSPEED),
+    ...minimaxCostAliases("MiniMax-M2", COST_TIER_MINIMAX_M2),
     "amazon-bedrock:amazon.nova-pro-v1:0": DEFAULT_UNKNOWN_MODEL_COST,
     "amazon.nova-pro-v1:0": DEFAULT_UNKNOWN_MODEL_COST,
     "agenc:agenc": DEFAULT_UNKNOWN_MODEL_COST,

--- a/runtime/src/utils/effort.ts
+++ b/runtime/src/utils/effort.ts
@@ -109,8 +109,11 @@ function modelSupportsEffortForOptionalContext(
   ) {
     return true
   }
-  // Supported by a subset of AgenC 4 models
+  // Supported by a subset of AgenC 4 models and the current lineup
+  // (platform.claude.com effort doc, 2026-09-11)
   if (
+    m.includes('opus-5') ||
+    m.includes('sonnet-5') ||
     m.includes('opus-4-6') ||
     m.includes('opus-4-7') ||
     m.includes('opus-4-8') ||
@@ -160,8 +163,11 @@ function modelSupportsMaxEffortForOptionalContext(
   }
   const m = model.toLowerCase()
   // Fable 5 supports the full effort range incl. 'max' (provider docs,
-  // verified 2026-07-08).
+  // verified 2026-07-08); Opus 5 and Sonnet 5 accept 'max' too (probed
+  // 2026-09-11).
   if (
+    m.includes('opus-5') ||
+    m.includes('sonnet-5') ||
     m.includes('opus-4-6') ||
     m.includes('opus-4-7') ||
     m.includes('opus-4-8') ||

--- a/runtime/src/utils/model/anthropicThinkingControl.ts
+++ b/runtime/src/utils/model/anthropicThinkingControl.ts
@@ -1,0 +1,84 @@
+/**
+ * Which thinking control each Claude generation accepts on the Messages
+ * API, and which of them take `output_config.effort`. Every row below was
+ * probed live on 2026-09-11 and agrees with platform.claude.com (models
+ * overview, effort, extended thinking):
+ *
+ * - `always_on`: the Fable / Mythos 5 family. `thinking` must be omitted
+ *   (`disabled`, `enabled` + `budget_tokens` return 400); depth is the
+ *   effort parameter's job.
+ * - `adaptive`: Opus 5, Sonnet 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6.
+ *   `thinking: {type: "adaptive"}` turns thinking on and effort steers it.
+ *   Opus 5, Sonnet 5, Opus 4.8 and Opus 4.7 return 400 for `enabled` +
+ *   `budget_tokens`; 4.6 still accepts both.
+ * - `budget`: Opus 4.5, Sonnet 4.5, Haiku 4.5 and everything older.
+ *   `thinking: {type: "enabled", budget_tokens}`; `adaptive` returns 400.
+ *
+ * Effort is accepted on the always-on and adaptive families and on Opus
+ * 4.5; Sonnet 4.5 and Haiku 4.5 answer "This model does not support the
+ * effort parameter". Sampling parameters are gone from the always-on
+ * family and from Opus 5, Sonnet 5, Opus 4.8 and Opus 4.7 (`temperature`
+ * is "deprecated for this model", 400); the 4.6 generation and older still
+ * take them. Kept dependency-free like alwaysOnThinking.ts so the wire
+ * layer can import it.
+ */
+import { isAlwaysOnThinkingAnthropicModel } from "./alwaysOnThinking.js";
+
+export type AnthropicThinkingControl = "always_on" | "adaptive" | "budget";
+
+export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
+function familySpelling(model: string): string {
+  // Bedrock inference profiles brand the segment "anthropic.agenc-<model>".
+  return model.toLowerCase().replaceAll("anthropic.agenc-", "anthropic.claude-");
+}
+
+export function anthropicThinkingControl(
+  model: string,
+): AnthropicThinkingControl {
+  if (isAlwaysOnThinkingAnthropicModel(model)) return "always_on";
+  const spelled = familySpelling(model);
+  if (
+    /(?:opus|sonnet)-5(?!\d)/.test(spelled) ||
+    /opus-4[.-][678](?!\d)/.test(spelled) ||
+    /sonnet-4[.-]6(?!\d)/.test(spelled)
+  ) {
+    return "adaptive";
+  }
+  return "budget";
+}
+
+export function anthropicAcceptsSamplingParameters(model: string): boolean {
+  if (isAlwaysOnThinkingAnthropicModel(model)) return false;
+  const spelled = familySpelling(model);
+  return !(
+    /(?:opus|sonnet)-5(?!\d)/.test(spelled) ||
+    /opus-4[.-][78](?!\d)/.test(spelled)
+  );
+}
+
+export function anthropicAcceptsEffort(model: string): boolean {
+  if (anthropicThinkingControl(model) !== "budget") return true;
+  return /opus-4[.-]5(?!\d)/.test(familySpelling(model));
+}
+
+/** The API's effort ladder; `minimal` rounds up to `low`, `none` sends nothing. */
+export function anthropicEffort(
+  effort: string | undefined,
+): AnthropicEffort | undefined {
+  switch (effort) {
+    case "minimal":
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "xhigh":
+      return "xhigh";
+    case "max":
+      return "max";
+    default:
+      return undefined;
+  }
+}

--- a/runtime/src/utils/model/configs.ts
+++ b/runtime/src/utils/model/configs.ts
@@ -220,6 +220,48 @@ export const AGENC_SONNET_4_6_CONFIG = {
   minimax: 'MiniMax-M2.5',
 } as const satisfies ModelConfig
 
+// The current lineup on platform.claude.com (2026-09-11). Provider ids on
+// Bedrock/Vertex/Foundry follow the documented spellings on the models
+// overview (Bedrock `anthropic.claude-<model>`, the others the API id).
+export const AGENC_FABLE_5_1_CONFIG = {
+  firstParty: 'claude-fable-5-1',
+  bedrock: 'us.anthropic.agenc-fable-5-1-v1',
+  vertex: 'claude-fable-5-1',
+  foundry: 'claude-fable-5-1',
+  openai: 'gpt-4o',
+  gemini: 'gemini-2.5-pro',
+  github: 'github:copilot',
+  agenc: 'gpt-5.5',
+  'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
+  minimax: 'MiniMax-M3',
+} as const satisfies ModelConfig
+
+export const AGENC_OPUS_5_CONFIG = {
+  firstParty: 'claude-opus-5',
+  bedrock: 'us.anthropic.agenc-opus-5-v1',
+  vertex: 'claude-opus-5',
+  foundry: 'claude-opus-5',
+  openai: 'gpt-4o',
+  gemini: 'gemini-2.5-pro',
+  github: 'github:copilot',
+  agenc: 'gpt-5.5',
+  'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
+  minimax: 'MiniMax-M3',
+} as const satisfies ModelConfig
+
+export const AGENC_SONNET_5_CONFIG = {
+  firstParty: 'claude-sonnet-5',
+  bedrock: 'us.anthropic.agenc-sonnet-5-v1',
+  vertex: 'claude-sonnet-5',
+  foundry: 'claude-sonnet-5',
+  openai: 'gpt-4o',
+  gemini: 'gemini-2.0-flash',
+  github: 'github:copilot',
+  agenc: 'gpt-5.5',
+  'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
+  minimax: 'MiniMax-M3',
+} as const satisfies ModelConfig
+
 // @[MODEL LAUNCH]: Register the new config here.
 export const ALL_MODEL_CONFIGS = {
   haiku35: AGENC_3_5_HAIKU_CONFIG,
@@ -235,6 +277,9 @@ export const ALL_MODEL_CONFIGS = {
   opus46: AGENC_OPUS_4_6_CONFIG,
   opus47: AGENC_OPUS_4_7_CONFIG,
   opus48: AGENC_OPUS_4_8_CONFIG,
+  opus5: AGENC_OPUS_5_CONFIG,
+  sonnet5: AGENC_SONNET_5_CONFIG,
+  fable51: AGENC_FABLE_5_1_CONFIG,
   fable5: AGENC_FABLE_5_CONFIG,
 } as const satisfies Record<string, ModelConfig>
 

--- a/runtime/src/utils/model/model.ts
+++ b/runtime/src/utils/model/model.ts
@@ -369,8 +369,17 @@ export function firstPartyNameToCanonical(name: ModelName): ModelShortName {
   name = name.replaceAll('anthropic.agenc-', 'anthropic.claude-')
   // Special cases for AgenC 4+ models to differentiate versions
   // Order matters: check more specific versions first (4-7 before 4-6 before 4-5 before 4)
+  if (name.includes('claude-fable-5-1')) {
+    return 'claude-fable-5-1'
+  }
   if (name.includes('claude-fable-5')) {
     return 'claude-fable-5'
+  }
+  if (name.includes('claude-opus-5')) {
+    return 'claude-opus-5'
+  }
+  if (name.includes('claude-sonnet-5')) {
+    return 'claude-sonnet-5'
   }
   if (name.includes('claude-opus-4-8')) {
     return 'claude-opus-4-8'

--- a/runtime/src/utils/modelCost.ts
+++ b/runtime/src/utils/modelCost.ts
@@ -11,6 +11,9 @@ import {
   AGENC_OPUS_4_6_CONFIG,
   AGENC_OPUS_4_7_CONFIG,
   AGENC_FABLE_5_CONFIG,
+  AGENC_FABLE_5_1_CONFIG,
+  AGENC_OPUS_5_CONFIG,
+  AGENC_SONNET_5_CONFIG,
   AGENC_OPUS_4_8_CONFIG,
   AGENC_OPUS_4_CONFIG,
   AGENC_SONNET_4_5_CONFIG,
@@ -77,6 +80,16 @@ export const COST_TIER_10_50 = {
   webSearchRequests: 0.01,
 } as const satisfies ModelCosts
 
+// Pricing tier for Claude Sonnet 5: $2 input / $10 output per Mtok
+// (platform.claude.com models overview, 2026-09-11). Same cache ratios as
+// the other first-party tiers.
+export const COST_TIER_2_10 = {
+  inputTokens: 2,
+  outputTokens: 10,
+  promptCacheWriteTokens: 2.5,
+  promptCacheReadTokens: 0.2,
+  webSearchRequests: 0.01,
+} as const satisfies ModelCosts
 // Pricing for Haiku 3.5: $0.80 input / $4 output per Mtok
 export const COST_HAIKU_35 = {
   inputTokens: 0.8,
@@ -99,7 +112,10 @@ const DEFAULT_UNKNOWN_MODEL_COST = COST_TIER_5_25
 
 function firstPartyNameToCanonicalForCost(name: string): ModelShortName {
   const normalized = name.toLowerCase()
+  if (normalized.includes('claude-fable-5-1')) return 'claude-fable-5-1'
   if (normalized.includes('claude-fable-5')) return 'claude-fable-5'
+  if (normalized.includes('claude-opus-5')) return 'claude-opus-5'
+  if (normalized.includes('claude-sonnet-5')) return 'claude-sonnet-5'
   if (normalized.includes('claude-opus-4-8')) return 'claude-opus-4-8'
   if (normalized.includes('claude-opus-4-7')) return 'claude-opus-4-7'
   if (normalized.includes('claude-opus-4-6')) return 'claude-opus-4-6'
@@ -166,6 +182,14 @@ export const MODEL_COSTS: Record<ModelShortName, ModelCosts> = {
   // through the fast-aware tier in getModelCosts.
   [firstPartyNameToCanonicalForCost(AGENC_FABLE_5_CONFIG.firstParty)]:
     COST_TIER_10_50,
+  // The current lineup (platform.claude.com, 2026-09-11): Fable 5.1 keeps
+  // Fable's $10/$50, Opus 5 the modern Opus $5/$25, Sonnet 5 is $2/$10.
+  [firstPartyNameToCanonicalForCost(AGENC_FABLE_5_1_CONFIG.firstParty)]:
+    COST_TIER_10_50,
+  [firstPartyNameToCanonicalForCost(AGENC_OPUS_5_CONFIG.firstParty)]:
+    COST_TIER_5_25,
+  [firstPartyNameToCanonicalForCost(AGENC_SONNET_5_CONFIG.firstParty)]:
+    COST_TIER_2_10,
 }
 
 /**

--- a/runtime/src/utils/thinking.ts
+++ b/runtime/src/utils/thinking.ts
@@ -216,7 +216,14 @@ export function modelSupportsAdaptiveThinking(model: string): boolean {
     return true
   }
   // Supported by a subset of AgenC 4 models
-  if (canonical.includes('opus-4-8') || canonical.includes('opus-4-7') || canonical.includes('opus-4-6') || canonical.includes('sonnet-4-6')) {
+  if (
+    canonical.includes('opus-5') ||
+    canonical.includes('sonnet-5') ||
+    canonical.includes('opus-4-8') ||
+    canonical.includes('opus-4-7') ||
+    canonical.includes('opus-4-6') ||
+    canonical.includes('sonnet-4-6')
+  ) {
     return true
   }
   // Exclude any other known compatibility models (allowlist above catches 4-6 variants first)

--- a/runtime/tests/config/provider-model-authority.test.ts
+++ b/runtime/tests/config/provider-model-authority.test.ts
@@ -275,7 +275,7 @@ describe("provider/model configuration authority", () => {
       mergeProviderModelLayer(defaultConfig(), { model_provider: "anthropic" }),
     ).toMatchObject({
       model_provider: "anthropic",
-      model: "claude-opus-4-7",
+      model: "claude-opus-5",
     });
   });
 });

--- a/runtime/tests/llm/provider.test.ts
+++ b/runtime/tests/llm/provider.test.ts
@@ -1579,7 +1579,7 @@ describe("createProvider", () => {
     expect(provider).toBeInstanceOf(AnthropicProvider);
     expect(
       (provider as unknown as { config: { model: string } }).config.model,
-    ).toBe("claude-opus-4-7");
+    ).toBe("claude-opus-5");
   });
 
   test("routes 'ollama' to OllamaProvider and strips a trailing /v1 host suffix", () => {

--- a/runtime/tests/llm/registry/provider-info.test.ts
+++ b/runtime/tests/llm/registry/provider-info.test.ts
@@ -16,7 +16,7 @@ describe("built-in provider info", () => {
     const expected = [
       ["grok", "xAI Grok", "grok-4.6", "https://api.x.ai/v1", "api-key", ["XAI_API_KEY", "GROK_API_KEY"], ["XAI_BASE_URL", "GROK_BASE_URL"], 10, "api-key", false],
       ["openai", "OpenAI", "gpt-5", "https://api.openai.com/v1", "api-key", ["OPENAI_API_KEY"], ["OPENAI_BASE_URL", "OPENAI_API_BASE"], 20, "api-key", false],
-      ["anthropic", "Anthropic", "claude-opus-4-7", "https://api.anthropic.com/v1", "api-key", ["ANTHROPIC_API_KEY"], ["ANTHROPIC_BASE_URL"], 30, "api-key", false],
+      ["anthropic", "Anthropic", "claude-opus-5", "https://api.anthropic.com/v1", "api-key", ["ANTHROPIC_API_KEY"], ["ANTHROPIC_BASE_URL"], 30, "api-key", false],
       ["ollama", "Ollama", "llama3.3", "http://localhost:11434", "none", [], ["OLLAMA_BASE_URL"], 40, "local", false],
       ["lmstudio", "LM Studio", "gpt-4o-mini", "http://localhost:1234/v1", "api-key", ["LMSTUDIO_API_KEY"], ["LMSTUDIO_BASE_URL"], 50, "local", false],
       ["openai-compatible", "OpenAI-compatible", "local-model", "http://localhost:8000/v1", "api-key", ["OPENAI_COMPATIBLE_API_KEY", "OPENAI_API_KEY"], ["OPENAI_COMPATIBLE_BASE_URL", "OPENAI_BASE_URL", "OPENAI_API_BASE"], 60, "local", false],

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -873,24 +873,75 @@ describe("buildAnthropicMessagesRequest — fable/mythos 5 family", () => {
     tools: [],
   };
 
-  test("a fable-5 request carries NO thinking config while opus-4-8 keeps its config", () => {
+  test("a fable-5 request carries NO thinking config while opus-4-8 runs adaptive thinking", () => {
     const fable = buildAnthropicMessagesRequest({
       ...baseInput,
       model: "claude-fable-5",
       options: { reasoningEffort: "high" },
     });
     expect(fable.thinking).toBeUndefined();
+    expect(fable.output_config).toEqual({ effort: "high" });
 
-    // Opus family behavior is unchanged (kept exactly as-is).
+    // Opus 4.8 returns 400 for `enabled` + `budget_tokens` ("Use
+    // thinking.type.adaptive and output_config.effort"), probed 2026-09-11.
     const opus = buildAnthropicMessagesRequest({
       ...baseInput,
       model: "claude-opus-4-8",
       options: { reasoningEffort: "high" },
     });
-    expect(opus.thinking).toEqual({
-      type: "enabled",
-      budget_tokens: 4096,
-    });
+    expect(opus.thinking).toEqual({ type: "adaptive" });
+    expect(opus.output_config).toEqual({ effort: "high" });
+  });
+
+  test("each Claude generation gets the thinking control the API accepts", () => {
+    const request = (model: string, reasoningEffort?: "low" | "medium" | "high" | "xhigh" | "max" | "minimal") =>
+      buildAnthropicMessagesRequest({
+        ...baseInput,
+        model,
+        options: reasoningEffort === undefined ? {} : { reasoningEffort },
+      });
+
+    // Current lineup: Fable 5.1 omits the config, Opus 5 and Sonnet 5 run adaptive.
+    expect(request("claude-fable-5-1", "max").thinking).toBeUndefined();
+    expect(request("claude-fable-5-1", "max").output_config).toEqual({ effort: "max" });
+    for (const model of ["claude-opus-5", "claude-sonnet-5", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"]) {
+      expect(request(model, "medium").thinking, model).toEqual({ type: "adaptive" });
+      expect(request(model, "medium").output_config, model).toEqual({ effort: "medium" });
+    }
+    expect(request("us.anthropic.agenc-opus-5-v1", "low").thinking).toEqual({ type: "adaptive" });
+
+    // Budgeted generations keep their config; effort only where the API takes it.
+    expect(request("claude-opus-4-5-20251101", "high").thinking).toEqual({ type: "enabled", budget_tokens: 4096 });
+    expect(request("claude-opus-4-5-20251101", "high").output_config).toEqual({ effort: "high" });
+    for (const model of ["claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001"]) {
+      expect(request(model, "low").thinking, model).toEqual({ type: "enabled", budget_tokens: 2048 });
+      expect(request(model, "low").output_config, model).toBeUndefined();
+    }
+
+    // No effort, no thinking config and no output_config, as before.
+    expect(request("claude-opus-5").thinking).toBeUndefined();
+    expect(request("claude-opus-5").output_config).toBeUndefined();
+    // `minimal` is not on Claude's ladder; it rounds up to low.
+    expect(request("claude-opus-5", "minimal").output_config).toEqual({ effort: "low" });
+  });
+
+  test("models that answer 400 to temperature never receive it", () => {
+    for (const model of ["claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7"]) {
+      const request = buildAnthropicMessagesRequest({
+        ...baseInput,
+        model,
+        options: { temperature: 0.2 },
+      });
+      expect(request.temperature, model).toBeUndefined();
+    }
+    for (const model of ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"]) {
+      const request = buildAnthropicMessagesRequest({
+        ...baseInput,
+        model,
+        options: { temperature: 0.2 },
+      });
+      expect(request.temperature, model).toBe(0.2);
+    }
   });
 
   test("provider spellings of the family also omit the thinking config", () => {
@@ -955,7 +1006,7 @@ describe("buildAnthropicMessagesRequest — fable/mythos 5 family", () => {
     expect(request.tool_choice).toBeUndefined();
   });
 
-  test("fable-5 omits temperature (sampling params removed) while opus keeps it", () => {
+  test("fable-5 omits temperature (sampling params removed) while opus 4.6 keeps it", () => {
     const fable = buildAnthropicMessagesRequest({
       ...baseInput,
       model: "claude-fable-5",
@@ -963,9 +1014,11 @@ describe("buildAnthropicMessagesRequest — fable/mythos 5 family", () => {
     });
     expect(fable.temperature).toBeUndefined();
 
+    // Opus 4.8 and 4.7 dropped sampling parameters too (400, probed
+    // 2026-09-11); Opus 4.6 is the newest Opus that still takes them.
     const opus = buildAnthropicMessagesRequest({
       ...baseInput,
-      model: "claude-opus-4-8",
+      model: "claude-opus-4-6",
       options: { temperature: 0.4 },
     });
     expect(opus.temperature).toBe(0.4);

--- a/runtime/tests/utils/model/anthropicThinkingControl.test.ts
+++ b/runtime/tests/utils/model/anthropicThinkingControl.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  anthropicAcceptsEffort,
+  anthropicEffort,
+  anthropicThinkingControl,
+} from "../../../src/utils/model/anthropicThinkingControl.js";
+
+describe("anthropicThinkingControl", () => {
+  test("classifies every generation the way the Messages API answered on 2026-09-11", () => {
+    expect(anthropicThinkingControl("claude-fable-5-1")).toBe("always_on");
+    expect(anthropicThinkingControl("claude-fable-5")).toBe("always_on");
+    expect(anthropicThinkingControl("us.anthropic.agenc-fable-5-1-v1")).toBe("always_on");
+    for (const model of [
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "us.anthropic.agenc-opus-4-8-v1",
+      "claude-opus-4.8",
+    ]) {
+      expect(anthropicThinkingControl(model), model).toBe("adaptive");
+    }
+    for (const model of [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001",
+      "claude-3-7-sonnet-20250219",
+    ]) {
+      expect(anthropicThinkingControl(model), model).toBe("budget");
+    }
+  });
+
+  test("effort is accepted on the always-on and adaptive families and on Opus 4.5 only", () => {
+    expect(anthropicAcceptsEffort("claude-fable-5-1")).toBe(true);
+    expect(anthropicAcceptsEffort("claude-sonnet-5")).toBe(true);
+    expect(anthropicAcceptsEffort("claude-opus-4-5-20251101")).toBe(true);
+    expect(anthropicAcceptsEffort("claude-sonnet-4-5-20250929")).toBe(false);
+    expect(anthropicAcceptsEffort("claude-haiku-4-5")).toBe(false);
+  });
+
+  test("maps the runtime ladder onto Claude's", () => {
+    expect(anthropicEffort("minimal")).toBe("low");
+    expect(anthropicEffort("low")).toBe("low");
+    expect(anthropicEffort("xhigh")).toBe("xhigh");
+    expect(anthropicEffort("max")).toBe("max");
+    expect(anthropicEffort("none")).toBeUndefined();
+    expect(anthropicEffort(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

Anthropic BYOK was broken on two of the three models the catalog offered, and stale on the third:

- Every turn on `claude-opus-4-8` or `claude-opus-4-7` that carried an effort failed with `anthropic error: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.` The desktop always sends an effort for Claude, so the app could not complete a single turn on them. Reproduced through core with `agenc -p --provider anthropic --model claude-opus-4-8` (stored `reasoning_effort = "high"`).
- Core never sent `output_config.effort`, so the effort dial changed nothing on any Claude model.
- The lineup was Fable 5, Opus 4.8, Opus 4.7 with `claude-opus-4-7` as the default, while platform.claude.com lists Claude Fable 5.1, Claude Opus 5 and Claude Sonnet 5 as the current models (Fable 5, Opus 4.8 and 4.7 as legacy) and `/v1/models` serves all of them.
- `MiniMax-M3`, the MiniMax default since #2389, had no cost entry, which `tests/session/cost.test.ts` on `main` catches ("minimax:MiniMax-M3 should use a known registry entry").

Every generation was probed live on the Messages API on 2026-09-11 (`thinking` enabled + budget, adaptive, disabled; `output_config.effort` low..max; `temperature`; forced `tool_choice`):

| model | enabled + budget | adaptive | effort | temperature |
| --- | --- | --- | --- | --- |
| claude-fable-5-1, claude-fable-5 | 400 | ok | ok (low..max) | 400 |
| claude-opus-5, claude-sonnet-5, claude-opus-4-8, claude-opus-4-7 | 400 | ok | ok (low..max) | 400 |
| claude-opus-4-6, claude-sonnet-4-6 | ok | ok | ok | ok |
| claude-opus-4-5 | ok | 400 | ok | ok |
| claude-sonnet-4-5, claude-haiku-4-5 | ok | 400 | 400 | ok |

## What, per file

`runtime/src/utils/model/anthropicThinkingControl.ts` (new, dependency-free like `alwaysOnThinking.ts`)
- `anthropicThinkingControl(model)`: `always_on` (Fable / Mythos 5 family), `adaptive` (Opus 5, Sonnet 5, Opus 4.8, 4.7, 4.6, Sonnet 4.6), `budget` (everything older). Handles Bedrock spellings and dotted ids.
- `anthropicAcceptsEffort(model)`: the always-on and adaptive families plus Opus 4.5.
- `anthropicAcceptsSamplingParameters(model)`: false for the always-on family and Opus 5, Sonnet 5, Opus 4.8, 4.7.
- `anthropicEffort(effort)`: the runtime ladder onto Claude's (`minimal` rounds up to `low`, `none` sends nothing).

`runtime/src/llm/wire/messages-anthropic.ts`
- Adaptive family: `thinking: {type: "adaptive"}` when an effort is set (was `enabled` + `budget_tokens`, the 400). Budget family unchanged. Always-on family still omits the config.
- `output_config: {effort}` whenever an effort is set and the model takes it.
- `temperature` omitted where the API answers 400 to it (was: only the always-on family).
- The forced-tool-choice rule while thinking is on is unchanged.

`runtime/src/llm/registry/provider-info.ts`
- Anthropic list: `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5-1`, `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`. Default `claude-opus-5`. Haiku 4.5 is not offered: it takes no effort parameter and the picker's dial would be a lie there.

`runtime/src/utils/model/model.ts`, `runtime/src/utils/modelCost.ts`, `runtime/src/utils/model/configs.ts`
- Canonical names for `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`; `AGENC_FABLE_5_1_CONFIG`, `AGENC_OPUS_5_CONFIG`, `AGENC_SONNET_5_CONFIG` registered in `ALL_MODEL_CONFIGS`; `COST_TIER_2_10` for Sonnet 5 ($2/$10), Opus 5 at $5/$25, Fable 5.1 at $10/$50 (models overview pricing).

`runtime/src/session/cost.ts`
- Sidecar entries for the three new models and Fable 5 (`COST_TIER_FABLE_10_50`, `COST_TIER_SONNET_2_10`).
- MiniMax line priced from platform.minimax.io/docs/guides/pricing-paygo (standard tier, prompts up to 512k): M3 and M2.7 $0.30/$1.20 with $0.06 cache reads, the other M2 generations $0.03 cache reads, highspeed variants double input and output, cache writes $0.375. Replaces the `DEFAULT_UNKNOWN_MODEL_COST` M2.5 entries.

`runtime/src/utils/thinking.ts`, `runtime/src/utils/effort.ts`
- Opus 5 and Sonnet 5 join the adaptive-thinking and effort allowlists (incl. `max`).

Tests
- `tests/llm/wire/messages-anthropic.test.ts`: the Opus 4.8 expectation is now adaptive + `output_config`; a matrix test over every generation (thinking config, `output_config`, `minimal` rounding); the temperature rule per generation.
- New `tests/utils/model/anthropicThinkingControl.test.ts` (3).
- `provider-info.test.ts` row, `provider.test.ts` default, `provider-model-authority.test.ts` merge expectation updated to `claude-opus-5`.

## Evidence

Through core itself (fresh `runtime/dist` of this branch, `agenc -p --provider anthropic`, a logging proxy on `ANTHROPIC_BASE_URL` that records the wire shape and never the key; stored effort `high`; the prompt asks for a FileRead tool call and the first line of README.md):

```
claude-opus-5     thinking={'type': 'adaptive'} output_config={'effort': 'high'} temperature=None tools=41 -> 200 (tool turn), 200 (answer)   finalMessage '# Lighthouse Notes'  costKnown true
claude-sonnet-5   thinking={'type': 'adaptive'} output_config={'effort': 'high'} temperature=None -> 200, 200                                finalMessage '# Lighthouse Notes'  costKnown true
claude-opus-4-8   thinking={'type': 'adaptive'} output_config={'effort': 'high'} temperature=None -> 200, 200                                turn completes (was: 400 on the first request)
claude-fable-5-1  thinking=None                 output_config={'effort': 'high'} temperature=None -> 200, 200                                finalMessage '# Lighthouse Notes'  costKnown true
```

Before the change, the same `claude-opus-4-8` run: `exit=1`, `anthropic error: "thinking.type.enabled" is not supported for this model...`, 0 tokens.

## Tests

- `npm run typecheck`: exit 0.
- Targeted run (32 files: `tests/llm/wire/messages-anthropic`, `tests/utils/model`, `tests/llm/registry`, `tests/llm/providers/{anthropic,minimax}`, `tests/utils/fable5-onboarding`, `tests/utils/effort*`, `tests/utils/thinking*`, `tests/session/cost*`, `tests/utils/modelCost*`, `tests/llm/provider`, `tests/config/provider-model-authority`, `tests/config/canonical-repository`): 540 passed.
- Wide run (`tests/llm`, `tests/utils`, `tests/session`, `tests/config`, the two command tests): 441 files, 6070 passed, 11 failed, 13 skipped. None of the 11 reads a file this PR changes, and each fails the same way on unmodified `main` in this environment: `tests/llm/capabilities.test.ts` (1, the DeepSeek V4.1 `acceptsImageHistory` expectation left behind by 9b4cb0c2d), `tests/config/session-home-authority.test.ts` (6) and `tests/utils/swarm/spawnUtils.test.ts` (1, expects `AGENC_HOME=/tmp/agenc-client-a` and receives the macOS realpath `/private/tmp/agenc-client-a`), `tests/utils/agencPaths.test.ts` (1, the same `/private/tmp` realpath), `tests/utils/supervisedProcess.test.ts` (1, a TERM-resistant process-group leader under this sandbox) and `tests/utils/Shell.workspace-fence.test.ts` (1, detached-writer timing on the Editor fence).

## Not changed

- Haiku 4.5 and the 4.6 / 4.5 generations are not added to the catalog; their wire behaviour is covered by the classification but they stay reachable only by explicit model id.
- The Bedrock / Vertex / Foundry ids for the three new configs follow the documented spellings; only the first-party route was exercised.
- The forced `tool_choice` rule while thinking is enabled is untouched (Fable 5.1 still rejects `any` / `tool`).
- OpenAI, Gemini, Mistral and the other providers are untouched here; their audit findings follow in separate PRs.

## Counterpart PRs

Desktop: tetsuo-ai/agenc-desktop#258 (Claude rows: current lineup, 1M windows).
