### PR TITLE
fix(gemini): register the 3.x Flash models the API serves, with their verified thinking levels

### DIFF
--- a/runtime/src/llm/registry/gemini-thinking-models.ts
+++ b/runtime/src/llm/registry/gemini-thinking-models.ts
@@ -15,10 +15,19 @@ const FLASH_LEVELS = Object.freeze(["minimal", ...PRO_LEVELS] as const);
 const ORIGINAL_PRO_LEVELS = Object.freeze(["low", "high"] as const);
 const BUDGET_LEVELS = Object.freeze([] as const);
 
+// Levels per model probed live on generateContent (2026-09-11): 3.8 Flash,
+// 3.7 Flash and 3.1 Pro answer "Thinking level MINIMAL is not supported"
+// while 3.6 Flash, 3.5 Flash, 3.5 Flash Lite and 3.1 Flash Lite take all
+// four. Every 3.x model here thinks by default (thoughtsTokenCount > 0 with
+// no thinkingConfig).
 export const GEMINI_THINKING_MODELS: readonly GeminiThinkingModel[] = Object.freeze(([
   { model: "gemini-3.1-pro-preview", control: "thinkingLevel", levels: PRO_LEVELS, defaultLevel: "high", curated: true },
+  { model: "gemini-3.8-flash", control: "thinkingLevel", levels: PRO_LEVELS, defaultLevel: "medium", curated: true },
   { model: "gemini-3.7-flash", control: "thinkingLevel", levels: PRO_LEVELS, defaultLevel: "medium", curated: true },
+  { model: "gemini-3.6-flash", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "medium", curated: true },
   { model: "gemini-3.5-flash", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "medium", curated: true },
+  { model: "gemini-3.5-flash-lite", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "medium", curated: true },
+  { model: "gemini-3.1-flash-lite", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "medium", curated: true },
   { model: "gemini-2.5-flash", control: "thinkingBudget", levels: BUDGET_LEVELS, curated: true },
   { model: "gemini-3-flash-preview", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "high", curated: false },
   { model: "gemini-3-pro-preview", control: "thinkingLevel", levels: ORIGINAL_PRO_LEVELS, defaultLevel: "high", curated: false },

--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -694,10 +694,16 @@ export const BUILT_IN_PROVIDER_MODEL_CATALOG: Readonly<
   zai: mergeDerivedProviderModels("zai"),
   "zai-coding-plan": mergeDerivedProviderModels("zai-coding-plan"),
   kimi: mergeDerivedProviderModels("kimi"),
+  // Mirrors the curated rows of GEMINI_THINKING_MODELS: every id here has a
+  // verified thinking contract, so an effort never dies at request build.
   gemini: Object.freeze([
     "gemini-3.1-pro-preview",
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
+    "gemini-3.6-flash",
     "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
     "gemini-2.5-flash",
   ]),
   mistral: Object.freeze(["mistral-medium-latest"]),

--- a/runtime/src/session/cost.ts
+++ b/runtime/src/session/cost.ts
@@ -161,6 +161,13 @@ const COST_TIER_GEMINI_3_FLASH_LITE = {
   inputUsdPer1K: 0.0003,
   outputUsdPer1K: 0.0025,
 } as const;
+// 3.1 Flash Lite $0.25/$1.50 per M (openrouter.ai/api/v1/models pass-through
+// of Google's list price, 2026-09-11; ai.google.dev's pricing page needs a
+// sign-in from this host).
+const COST_TIER_GEMINI_3_1_FLASH_LITE = {
+  inputUsdPer1K: 0.00025,
+  outputUsdPer1K: 0.0015,
+} as const;
 const COST_TIER_DEEPSEEK_V4_FLASH: Readonly<ModelCostEntry> = Object.freeze({
   inputUsdPer1K: 0.00014,
   outputUsdPer1K: 0.00028,
@@ -546,12 +553,18 @@ export const DEFAULT_MODEL_COSTS: Readonly<Record<string, ModelCostEntry>> =
     // $0.30/$2.50.
     "gemini:gemini-3.1-pro-preview": COST_TIER_GEMINI_3_1_PRO,
     "gemini-3.1-pro-preview": COST_TIER_GEMINI_3_1_PRO,
+    // 3.8 Flash lists at the same $0.75/$3.75 as 3.7 (openrouter pass-through
+    // of Google's price, 2026-09-11).
+    "gemini:gemini-3.8-flash": COST_TIER_GEMINI_3_FLASH,
+    "gemini-3.8-flash": COST_TIER_GEMINI_3_FLASH,
     "gemini:gemini-3.7-flash": COST_TIER_GEMINI_3_FLASH,
     "gemini-3.7-flash": COST_TIER_GEMINI_3_FLASH,
     "gemini:gemini-3.6-flash": COST_TIER_GEMINI_3_FLASH,
     "gemini-3.6-flash": COST_TIER_GEMINI_3_FLASH,
     "gemini:gemini-3.5-flash": COST_TIER_GEMINI_3_FLASH,
     "gemini-3.5-flash": COST_TIER_GEMINI_3_FLASH,
+    "gemini:gemini-3.1-flash-lite": COST_TIER_GEMINI_3_1_FLASH_LITE,
+    "gemini-3.1-flash-lite": COST_TIER_GEMINI_3_1_FLASH_LITE,
     "gemini:gemini-3.5-flash-lite": COST_TIER_GEMINI_3_FLASH_LITE,
     "gemini-3.5-flash-lite": COST_TIER_GEMINI_3_FLASH_LITE,
     "mistral:mistral-medium-latest": COST_TIER_MISTRAL_MEDIUM_3_5,

--- a/runtime/tests/llm/gemini-reasoning-effort.test.ts
+++ b/runtime/tests/llm/gemini-reasoning-effort.test.ts
@@ -15,8 +15,12 @@ import type { LLMChatOptions } from "../../src/llm/types.js";
 
 const MODEL_LEVELS = [
   ["gemini-3.1-pro-preview", ["low", "medium", "high"]],
+  ["gemini-3.8-flash", ["low", "medium", "high"]],
   ["gemini-3.7-flash", ["low", "medium", "high"]],
+  ["gemini-3.6-flash", ["minimal", "low", "medium", "high"]],
   ["gemini-3.5-flash", ["minimal", "low", "medium", "high"]],
+  ["gemini-3.5-flash-lite", ["minimal", "low", "medium", "high"]],
+  ["gemini-3.1-flash-lite", ["minimal", "low", "medium", "high"]],
   ["gemini-3-flash-preview", ["minimal", "low", "medium", "high"]],
   ["gemini-3-pro-preview", ["low", "high"]],
   ["gemini-2.5-pro", []],


### PR DESCRIPTION
## Why

Core knew four Gemini ids (`gemini-3.1-pro-preview`, `gemini-3.7-flash`, `gemini-3.5-flash`, `gemini-2.5-flash`). Google's `/v1beta/models` serves the whole 3.x line, the desktop already lists `gemini-3.6-flash` and `gemini-3.5-flash-lite`, and `gemini-3.8-flash` is the newest Flash. Any effort on a model outside the table dies before the request is sent:

```
agenc -p --provider gemini --model gemini-3.6-flash ...
gemini error: Reasoning effort 'high' is not supported for model 'gemini-3.6-flash'. Supported reasoning efforts: none verified.
```

The desktop always sets an effort, so those rows could not complete a turn.

Every level was probed live on `generateContent` on 2026-09-11 (`thinkingConfig.thinkingLevel` minimal, low, medium, high, plus a request without `thinkingConfig`):

| model | minimal | low | medium | high | thinks by default |
| --- | --- | --- | --- | --- | --- |
| gemini-3.8-flash | 400 "not supported for this model" | ok | ok | ok | yes |
| gemini-3.7-flash | 400 | ok | ok | ok | yes |
| gemini-3.6-flash | ok | ok | ok | ok | yes |
| gemini-3.5-flash | ok | ok | ok | ok | yes |
| gemini-3.5-flash-lite | ok | ok | ok | ok | yes |
| gemini-3.1-flash-lite | ok | ok | ok | ok | yes |
| gemini-3.1-pro-preview | 400 | ok | ok | ok | yes |

All of them report a 1,048,576-token input limit and 65,536 output.

## What, per file

`runtime/src/llm/registry/gemini-thinking-models.ts`
- Curated rows for `gemini-3.8-flash` (low, medium, high), `gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite` (minimal through high), default level medium like the other Flash rows. The existing rows are unchanged.

`runtime/src/llm/registry/provider-info.ts`
- The gemini catalog list mirrors the curated table: 3.1 Pro (default, unchanged), 3.8, 3.7, 3.6, 3.5 Flash, 3.5 Flash Lite, 3.1 Flash Lite, 2.5 Flash.

`runtime/src/session/cost.ts`
- `gemini-3.8-flash` on the 3.x Flash tier ($0.75 / $3.75 per M, the same figure openrouter.ai's model list passes through for 3.8, 3.7 and 3.6); `gemini-3.1-flash-lite` at $0.25 / $1.50. ai.google.dev's pricing page redirects to a Google sign-in from this host, so the OpenRouter pass-through is the source named in the comment.

`runtime/tests/llm/gemini-reasoning-effort.test.ts`
- The level table gains the four models, so the existing "shares exact levels", "sends exact effort on the wire" (chat, stream, count) and capability cases run for them too.

## Evidence

Through core (fresh `runtime/dist` of this branch, `agenc -p --provider gemini`, a logging proxy on `GEMINI_BASE_URL=.../v1beta`, stored effort `high`, the prompt asks for a FileRead tool call and README.md's first line):

```
gemini-3.8-flash       exit=0  finalMessage '# Lighthouse Notes'   POST /v1beta/models/gemini-3.8-flash:streamGenerateContent -> 200 (tool turn), 200 (answer)
                       generationConfig.thinkingConfig={'thinkingLevel': 'high'} maxOutputTokens=128000
gemini-3.6-flash       exit=0  finalMessage '# Lighthouse Notes'   200, 200
gemini-3.5-flash-lite  exit=0  finalMessage '# Lighthouse Notes'   200, 200
gemini-3.7-flash       exit=0  finalMessage '# Lighthouse Notes'   (already listed; unchanged)
gemini-3.1-pro-preview exit=0  finalMessage '# Lighthouse Notes'   (already listed; unchanged)
```

Before the change the first two failed at request build with the error quoted above.

## Tests

- `npm run typecheck`: exit 0.
- `npx vitest run tests/llm/gemini-reasoning-effort.test.ts tests/llm/registry tests/session/cost tests/llm/providers/gemini tests/llm/github-model-authority.test.ts tests/config/model-catalog-drift.test.ts tests/commands/model.test.ts tests/commands/provider.test.ts`: 15 files, 694 passed.

## Not changed

- `gemini-2.5-flash` keeps its thinkingBudget contract; the non-curated `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-2.5-pro`, `gemini-2.5-flash-lite` rows are untouched.
- The default model stays `gemini-3.1-pro-preview`.
- The 3.5 Flash tier already in the file is untouched (OpenRouter lists $1.50 / $9.00 for it today; the file's comment records the intro pricing; left for a separate check).

## Counterpart PRs

Desktop: DESK_PR_NUMBER (adds the `gemini-3.8-flash` and `gemini-3.1-flash-lite` rows; the 3.6 Flash and 3.5 Flash Lite rows it already lists start working with this PR).
