### PR TITLE
fix(openai): give GPT-5 the effort ladder its API accepts

### DIFF
--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -78,6 +78,15 @@ const OPENAI_REASONING_LEVELS = Object.freeze([
   "high",
   "xhigh",
 ] as const satisfies readonly ReasoningEffort[]);
+// GPT-5 predates the xhigh tier: the Responses API answers "'xhigh' is not
+// supported with the 'gpt-5' model. Supported values are: 'minimal', 'low',
+// 'medium', 'high'" (probed 2026-09-11; developers.openai.com/api/docs/models/gpt-5).
+const OPENAI_GPT5_REASONING_LEVELS = Object.freeze([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+] as const satisfies readonly ReasoningEffort[]);
 const TEXT_IMAGE_MODALITIES = Object.freeze([
   "text",
   "image",
@@ -945,7 +954,7 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       webSearchToolType: "text_and_image",
       supportsReasoningSummaries: true,
       defaultReasoningSummary: "none",
-      supportedReasoningLevels: OPENAI_REASONING_LEVELS,
+      supportedReasoningLevels: OPENAI_GPT5_REASONING_LEVELS,
       defaultReasoningLevel: "medium",
       additionalSpeedTiers: FAST_SPEED_TIER,
       priority: -1,

--- a/runtime/tests/llm/model-registry.test.ts
+++ b/runtime/tests/llm/model-registry.test.ts
@@ -33,7 +33,9 @@ describe("ModelRegistry", () => {
     expect(modelRegistryEntryToModelInfo(entry)).toMatchObject({
       slug: "gpt-5",
       contextWindow: 272_000,
-      supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
+      // gpt-5 predates xhigh; the API answers "Supported values are:
+      // 'minimal', 'low', 'medium', 'high'" (probed 2026-09-11).
+      supportedReasoningLevels: ["minimal", "low", "medium", "high"],
       usedFallbackModelMetadata: false,
     });
   });

--- a/runtime/tests/llm/models-manager.test.ts
+++ b/runtime/tests/llm/models-manager.test.ts
@@ -32,11 +32,13 @@ describe("StaticModelsManager", () => {
       truncationPolicy: "off",
       usedFallbackModelMetadata: false,
     });
+    // gpt-5's own ladder: minimal is its floor and xhigh is not accepted
+    // (Responses API, probed 2026-09-11).
     expect(info.supportedReasoningLevels).toEqual([
+      "minimal",
       "low",
       "medium",
       "high",
-      "xhigh",
     ]);
   });
 

--- a/runtime/tests/llm/registry/model-sot-unification.test.ts
+++ b/runtime/tests/llm/registry/model-sot-unification.test.ts
@@ -26,6 +26,7 @@ import {
   deriveFlatCatalog,
   listRegisteredModelCatalogEntries,
   resolveModelCatalogMetadata,
+  resolveRegisteredModelCatalogEntry,
 } from "../../../src/llm/registry/model-catalog.js";
 import {
   BUILT_IN_PROVIDER_DEFAULT_MODELS,
@@ -218,6 +219,23 @@ describe("canonical provider catalogs preserve supported selection rows", () => 
     expect(buildProviderModelCatalog(defaultConfig())["nvidia-nim"]).toEqual(
       models,
     );
+  });
+
+  it("gives GPT-5 the effort ladder its API accepts and keeps xhigh for the later generations", () => {
+    // Probed on the Responses API 2026-09-11: gpt-5 rejects xhigh
+    // ("Supported values are: minimal, low, medium, high"); gpt-5.5 and
+    // gpt-5.4 accept xhigh and reject max; gpt-5.3-codex rejects minimal.
+    expect(
+      resolveRegisteredModelCatalogEntry({ provider: "openai", model: "gpt-5" })
+        ?.supportedReasoningLevels,
+    ).toEqual(["minimal", "low", "medium", "high"]);
+    for (const model of ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2"]) {
+      const levels = resolveRegisteredModelCatalogEntry({ provider: "openai", model })
+        ?.supportedReasoningLevels;
+      expect(levels, model).toContain("xhigh");
+      expect(levels, model).not.toContain("minimal");
+      expect(levels, model).not.toContain("max");
+    }
   });
 
   it("keeps every supported MiniMax generation in one catalog", () => {

--- a/runtime/tests/llm/registry/registry.test.ts
+++ b/runtime/tests/llm/registry/registry.test.ts
@@ -149,13 +149,20 @@ describe("LLM registry", () => {
       ...DONOR_MODEL_IDS,
     ]);
     for (const entry of entries) {
-      expect(entry.supportedReasoningLevels).toEqual([
-        "low",
-        "medium",
-        "high",
-        "xhigh",
-        ...(EXTENDED_REASONING_MODEL_IDS.includes(entry.model) ? ["max"] : []),
-      ]);
+      // gpt-5 predates the xhigh tier and keeps minimal as its floor
+      // (Responses API, probed 2026-09-11); every later generation runs
+      // low..xhigh, the 5.6 line and Astra add max.
+      expect(entry.supportedReasoningLevels).toEqual(
+        entry.model === "gpt-5"
+          ? ["minimal", "low", "medium", "high"]
+          : [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              ...(EXTENDED_REASONING_MODEL_IDS.includes(entry.model) ? ["max"] : []),
+            ],
+      );
       expect(entry.supportsVerbosity).toBe(true);
       expect(entry.supportsParallelToolCalls).toBe(true);
       expect(entry.supportsReasoningSummaries).toBe(true);


### PR DESCRIPTION
## Why

The `gpt-5` registry entry shared the `low, medium, high, xhigh` ladder of the later GPT-5.x generations. GPT-5's page (developers.openai.com/api/docs/models/gpt-5) lists `minimal, low, medium, high`, and the Responses API confirms it (probed 2026-09-11):

```
gpt-5        reasoning.effort=minimal -> 200 completed
gpt-5        reasoning.effort=xhigh   -> 400 "'xhigh' is not supported with the 'gpt-5' model. Supported values are: 'minimal', 'low', 'medium', 'high'"
gpt-5.5      none -> 200, xhigh -> 200, max -> 400 (supported: none, low, medium, high, xhigh)
gpt-5.4      none -> 200, max -> 400
gpt-5.3-codex minimal -> 400, xhigh -> 200
```

So a session on `gpt-5` set to xhigh died on its first request, and `minimal`, which the model does accept, was not offered.

## What, per file

`runtime/src/llm/registry/model-catalog.ts`
- New `OPENAI_GPT5_REASONING_LEVELS` (`minimal, low, medium, high`) used by the `gpt-5` entry only. Every other OpenAI entry keeps `OPENAI_REASONING_LEVELS`; the 5.6 line and Astra keep `max`.

Tests
- `tests/llm/registry/model-sot-unification.test.ts`: new case pinning gpt-5's ladder and that 5.5, 5.4, 5.3-codex and 5.2 keep xhigh, exclude minimal and max.
- `tests/llm/model-registry.test.ts`, `tests/llm/models-manager.test.ts`, `tests/llm/registry/registry.test.ts`: the gpt-5 expectations follow.

## Evidence

The probe above (direct Responses API calls with the test key). `none` is not added anywhere: the turn pipeline treats it as an omitted field, as `openai-reasoning-models.ts` documents.

## Tests

- `npm run typecheck`: exit 0.
- `npx vitest run tests/llm/registry tests/utils/effort tests/llm/model-registry.test.ts tests/llm/models-manager.test.ts tests/config/model-catalog-drift.test.ts tests/llm/providers/openai tests/commands/model.test.ts`: 15 files, 238 passed.

## Not changed

- Context windows in the OpenAI registry rows (`272_000`) are untouched; compaction reads `openaiContextWindows.ts`, which already carries 1,050,000 for 5.5 and 5.4.
- The desktop's `gpt-5` row already lists `minimal, low, medium, high`; no counterpart needed.
- `codex-auto-review` (hidden, Guardian's reviewer id) and `o3` are untouched.

## Counterpart PRs

None.
