### PR TITLE
Fix AgenC credit admission errors and local accounting

### DIFF
--- a/runtime/src/llm/errors.ts
+++ b/runtime/src/llm/errors.ts
@@ -138,8 +138,13 @@ export class LLMProviderError extends RuntimeError {
 
 /** An authenticated AgenC response bound to this attempt proves no dispatch. */
 export class LLMManagedAdmissionError extends LLMProviderError {
-  constructor() {
-    super("agenc", "Too many model requests are active. Try again after one finishes. No new model request was started.", 429);
+  constructor(readonly reason: "capacity" | "insufficient_credits" | "credits_unavailable" = "capacity") {
+    const message = reason === "insufficient_credits"
+      ? "Not enough available AgenC model credits for this request. Check your available credits and pending usage in Profile. No new model request was started."
+      : reason === "credits_unavailable"
+        ? "AgenC model credits are unavailable for this account. Check your credit status in Profile. No new model request was started."
+        : "Too many model requests are active. Try again after one finishes. No new model request was started.";
+    super("agenc", message, reason === "capacity" ? 429 : 402);
     this.name = "LLMManagedAdmissionError";
   }
 }

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -1081,6 +1081,10 @@ export class OpenAIProvider implements LLMProvider {
     if (error.status === 429 && usageState === "not_started" && code === "too_many_requests") {
       return new LLMManagedAdmissionError();
     }
+    if (error.status === 402 && usageState === "not_started" &&
+      (code === "insufficient_credits" || code === "credits_unavailable")) {
+      return new LLMManagedAdmissionError(code);
+    }
     if ((error.status === 502 && usageState === "pending" && code === "provider_unavailable") ||
       (error.status === 409 && ["pending", "started", "uncertain"].includes(usageState ?? "") && code === "request_already_recorded")) {
       return new LLMManagedUsagePendingError();

--- a/runtime/tests/budget/admitted-model-call.test.ts
+++ b/runtime/tests/budget/admitted-model-call.test.ts
@@ -866,9 +866,9 @@ describe("runAdmittedModelCall", () => {
     );
   });
 
-  test("settles zero only for a managed gateway no-dispatch receipt", async () => {
+  test.each(["capacity", "insufficient_credits", "credits_unavailable"] as const)("settles zero only for a managed gateway no-dispatch receipt: %s", async (reason) => {
     const state = harness({});
-    const error = new LLMManagedAdmissionError();
+    const error = new LLMManagedAdmissionError(reason);
     await expect(runAdmittedModelCall({session:state.session,provider:state.provider,messages:[],
       options:{maxOutputTokens:200},stepId:"managed-rejected",model:"grok-4.5",providerName:"agenc",
       invoke:async()=>{throw error;},

--- a/runtime/tests/llm/managed-usage-idempotency.test.ts
+++ b/runtime/tests/llm/managed-usage-idempotency.test.ts
@@ -90,6 +90,33 @@ describe("managed paid request identity", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
+  test.each([false,true])("reports a bound credit rejection without retrying or claiming pending usage (stream=%s)",async(streaming)=>{
+    for(const code of ["insufficient_credits","credits_unavailable"] as const){
+      const fetchImpl=vi.fn<typeof fetch>(async(_url,init)=>Response.json({error:{code,message:"untrusted diagnostic"}},{
+        status:402,headers:{"x-agenc-request-id":requestId(init)!,"x-agenc-usage-status":"not_started"},
+      }));
+      const provider=managed(fetchImpl);
+      const error=await(streaming?provider.chatStream(messages,()=>{},{singleWireAttempt:true}):provider.chat(messages,{singleWireAttempt:true})).catch(error=>error);
+      expect(error).toBeInstanceOf(LLMManagedAdmissionError);
+      expect(error).toMatchObject({providerName:"agenc",statusCode:402,reason:code});
+      expect(error.message).toContain("Profile");
+      expect(error.message).toContain("No new model request was started");
+      expect(error.message).not.toContain("untrusted diagnostic");
+      expect(isTransientProviderError(error)).toBe(false);
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    }
+  });
+
+  test.each(["different-request","pending","missing-state","unknown-code"])("does not claim a credit rejection is undispatched without a valid receipt (%s)",async(condition)=>{
+    const fetchImpl=vi.fn<typeof fetch>(async(_url,init)=>Response.json({error:{code:condition==="unknown-code"?"unavailable":"insufficient_credits"}},{
+      status:402,headers:{"x-agenc-request-id":condition==="different-request"?"unrelated":requestId(init)!,
+        ...(condition==="missing-state"?{}:{"x-agenc-usage-status":condition==="pending"?"pending":"not_started"})},
+    }));
+    const error=await managed(fetchImpl).chat(messages,{singleWireAttempt:true}).catch(error=>error);
+    expect(error).not.toBeInstanceOf(LLMManagedAdmissionError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   test.each(["different-request","pending"])("does not infer no usage from an unbound receipt (%s)", async (condition) => {
     const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => Response.json({error:{code:"too_many_requests"}}, {
       status:429, headers:{"x-agenc-request-id":condition==="different-request"?"unrelated":requestId(init)!,"x-agenc-usage-status":condition==="pending"?"pending":"not_started"},


### PR DESCRIPTION
When AgenC rejects a request because model credits are unavailable, Core currently reports a generic OpenRouter failure and leaves its local reservation uncertain. Recognize request-bound HTTP 402 `not_started` receipts, show the credit reason, and reconcile only that undispatched local attempt at zero. Dispatched failures continue to retain their holds.

Validation: 59 focused adapter/accounting tests, runtime typecheck and runtime build passed. Tests cover streamed and non-streamed requests, invalid receipts, no automatic retry and preserved pending holds. Local CI per owner instruction; remote CI skipped.
