### PR TITLE
fix(runtime): inject output style into headless base assembly

### DIFF
--- a/runtime/src/constants/outputStyles.ts
+++ b/runtime/src/constants/outputStyles.ts
@@ -217,10 +217,10 @@ export function clearAllOutputStylesCache(): void {
   clearPluginOutputStyleCache()
 }
 
-export async function getOutputStyleConfig(): Promise<OutputStyleConfig | null> {
-  const allStyles = await getAllOutputStyles(getCwd())
-
-  // Check for forced plugin output styles
+export function selectOutputStyleConfig(
+  allStyles: { readonly [styleName: string]: OutputStyleConfig | null },
+  configuredName: string | undefined,
+): OutputStyleConfig | null {
   const forcedStyles = Object.values(allStyles).filter(
     (style): style is OutputStyleConfig =>
       style !== null &&
@@ -242,11 +242,14 @@ export async function getOutputStyleConfig(): Promise<OutputStyleConfig | null> 
     return firstForcedStyle
   }
 
-  const settings = getExecutionAuthoritySettings()
-  const outputStyle = (settings?.outputStyle ||
-    DEFAULT_OUTPUT_STYLE_NAME) as string
+  return allStyles[configuredName || DEFAULT_OUTPUT_STYLE_NAME] ?? null
+}
 
-  return allStyles[outputStyle] ?? null
+export async function getOutputStyleConfig(): Promise<OutputStyleConfig | null> {
+  return selectOutputStyleConfig(
+    await getAllOutputStyles(getCwd()),
+    getExecutionAuthoritySettings()?.outputStyle,
+  )
 }
 
 export function hasCustomOutputStyle(): boolean {

--- a/runtime/src/prompts/system-prompt.ts
+++ b/runtime/src/prompts/system-prompt.ts
@@ -67,7 +67,12 @@ import { BRIEF_TOOL_NAME } from "../tools/BriefTool/prompt.js";
 import { loadMemoryPrompt } from "../memory/memdir.js";
 import { UNTRUSTED_TOOL_RESULT_BOUNDARY } from "../tools/untrusted-tool-result-framing.js";
 import { logForDebugging } from "../utils/debug.js";
+import { runWithCanonicalSettingsAuthority } from "../utils/settings/canonicalAuthority.js";
 import type { ProviderEnvironment } from "../llm/provider-options.js";
+import {
+  getAllOutputStyles,
+  selectOutputStyleConfig,
+} from "../constants/outputStyles.js";
 import { getClientRenderingSection } from "./client-rendering.js";
 export type { McpServerInstructionsInput } from "./mcp-instructions-framing.js";
 export { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./system-prompt-boundary.js";
@@ -759,7 +764,9 @@ function fixedSystemPromptSnapshot(text: string): AssembledSystemPrompt {
 function compactSystemPromptSnapshot(
   ctx: TurnContext,
   enabledTools: ReadonlySet<string>,
+  outputStyle: OutputStyleInput | null = null,
 ): AssembledSystemPrompt {
+  const style = getOutputStyleSection(outputStyle);
   return fixedSystemPromptSnapshot(
     [
       `You are AgenC, an open-source coding agent. You work inside the user's repository and complete their request by calling tools.`,
@@ -791,6 +798,7 @@ function compactSystemPromptSnapshot(
       ``,
       `CWD: ${ctx.cwd}`,
       `Date: ${ctx.currentDate ?? "unknown"}`,
+      ...(style === null ? [] : ["", style]),
     ].join("\n"),
   );
 }
@@ -825,7 +833,13 @@ export async function assembleSystemPromptSnapshot(
   };
   switch (opts.profile ?? "standard") {
     case "compact":
-      return withClientRendering(compactSystemPromptSnapshot(opts.ctx, opts.enabledToolNames ?? new Set()));
+      return withClientRendering(
+        compactSystemPromptSnapshot(
+          opts.ctx,
+          opts.enabledToolNames ?? new Set(),
+          opts.outputStyle ?? null,
+        ),
+      );
     case "coordinator": {
       const { getLiveCoordinatorSystemPrompt } =
         await import("../coordinator/coordinatorMode.js");
@@ -836,6 +850,24 @@ export async function assembleSystemPromptSnapshot(
     case "standard":
       return assembleSystemPrompt(opts);
   }
+}
+
+async function resolveOutputStyleFromSession(
+  session: SystemPromptSessionSnapshot,
+  cwd: string,
+): Promise<OutputStyleInput | null> {
+  const pluginStorageRoot = session.services?.runtimeOptions?.pluginStorageRoot;
+  const configStore = session.services?.configStore;
+  if (typeof pluginStorageRoot !== "string" || configStore === undefined) {
+    return null;
+  }
+  const config = configStore.current();
+  const allStyles = await runWithCanonicalSettingsAuthority(configStore, () =>
+    getAllOutputStyles(cwd, pluginStorageRoot, config),
+  );
+  const selected = selectOutputStyleConfig(allStyles, config.outputStyle);
+  if (selected === null) return null;
+  return { name: selected.name, prompt: selected.prompt };
 }
 
 export async function assembleBaseInstructionsForModel(params: {
@@ -866,7 +898,10 @@ export async function assembleBaseInstructionsForModel(params: {
     provider: params.provider,
     permissionContext: params.permissionContext,
     autonomousMode: params.ctx.config.autonomousMode === true,
-    outputStyle: null,
+    outputStyle: await resolveOutputStyleFromSession(
+      params.session,
+      params.ctx.cwd,
+    ),
   });
   return snapshot.text;
 }

--- a/runtime/tests/fixtures.ts
+++ b/runtime/tests/fixtures.ts
@@ -47,7 +47,20 @@ export function createTestConfigStore(
 
 afterAll(() => {
   for (const home of generatedConfigHomes) {
-    rmSync(home, { recursive: true, force: true });
+    try {
+      rmSync(home, { recursive: true, force: true });
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        (error.code !== "EPERM" &&
+          error.code !== "EBUSY" &&
+          error.code !== "ENOENT")
+      ) {
+        throw error;
+      }
+    }
   }
   generatedConfigHomes.clear();
 });

--- a/runtime/tests/session/headless-output-style.test.ts
+++ b/runtime/tests/session/headless-output-style.test.ts
@@ -1,0 +1,45 @@
+import { writeFileSync } from "node:fs";
+
+import { describe, expect, test } from "vitest";
+
+import { assembleBaseInstructionsForModel } from "../../src/prompts/system-prompt.js";
+import { runTurn } from "../../src/session/run-turn.js";
+import { drain, mkCtx, mkProvider, mkSession } from "../fixtures.js";
+
+describe("headless compact output style", () => {
+  test("puts Explanatory style on the openai-compatible provider payload", async () => {
+    const provider = mkProvider();
+    let captured = "";
+    provider.chatStream = async (_messages, _onChunk, options) => {
+      captured = options?.systemPrompt ?? "";
+      return {
+        content: "ok",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "test-model",
+        finishReason: "stop",
+      };
+    };
+    const { session } = mkSession({ provider });
+    writeFileSync(
+      session.services.configStore.homeContext.configTomlPath,
+      'config_version = 2\noutputStyle = "Explanatory"\n',
+    );
+    await session.services.configStore.reload();
+    const ctx = { ...mkCtx(), permissionInstructionsDeferred: true };
+    const baseInstructions = await assembleBaseInstructionsForModel({
+      session,
+      ctx,
+      registry: session.services.registry,
+      provider: "openai-compatible",
+      permissionContext: session.permissionModeRegistry.current(),
+      profile: "compact",
+    });
+
+    await drain(runTurn(session, { ...ctx, baseInstructions }, "ping"));
+
+    expect(captured).toContain("# Output Style: Explanatory");
+    expect(captured).toContain("# Explanatory Style Active");
+  });
+});
+

--- a/runtime/tests/session/headless-output-style.test.ts
+++ b/runtime/tests/session/headless-output-style.test.ts
@@ -42,4 +42,3 @@ describe("headless compact output style", () => {
     expect(captured).toContain("# Explanatory Style Active");
   });
 });
-


### PR DESCRIPTION
## Why

Headless `agenc -p` builds the model prompt through `assembleBaseInstructionsForModel`. That helper forced `outputStyle` to null, so a configured built-in like Explanatory never reached the provider request. openai-compatible sessions also use the compact profile, which omitted `getOutputStyleSection` even when a style was present.

## Scope

- `assembleBaseInstructionsForModel` resolves the style from the session `ConfigStore` and captured `pluginStorageRoot`.
- `selectOutputStyleConfig` is the shared picker used by `getOutputStyleConfig` and the headless path. Forced plugin styles still win.
- The compact snapshot appends `getOutputStyleSection`. It does not clone the standard persona.
- One hermetic test writes `outputStyle = "Explanatory"` and asserts the mock provider `systemPrompt` contains `# Output Style: Explanatory`.
- `tests/fixtures.ts` ignores Windows `EPERM` on config-home cleanup so the new `mkSession` test can exit 0.

Out of scope. TUI `runSingleTurn` already injects the style. The coordinator profile is unchanged. openai-compatible keeps the compact persona.

## Tradeoffs

Compact local-model sessions stay compact. The style section is appended. Those providers do not switch onto the full standard assembler.

## Blast Radius

Daemon and print-mode sessions that go through bootstrap or a provider switch now include the configured style in `baseInstructions`. Interactive TUI turns still replace the base prompt through `runSingleTurn`. Default `outputStyle` remains empty, so unchanged configs send the same compact or standard text as before.

## Verification

Windows hermetic vitest:

```
node scripts/run-hermetic-vitest.mjs run tests/session/headless-output-style.test.ts tests/constants/outputStyles.test.ts tests/prompts/system-prompt.test.ts --reporter=dot
```

Exit 0. 73 passed across 3 files.

Before the fix the new test failed with `expected 'You are AgenC, an open-source coding …' to contain '# Output Style: Explanatory'`.

After the fix it passed. `puts Explanatory style on the openai-compatible provider payload`.

Fixes #2290