### PR TITLE
fix(runtime): confine plugin and skill reads to verified roots

### DIFF
--- a/runtime/src/fs/root-contained-read.ts
+++ b/runtime/src/fs/root-contained-read.ts
@@ -1,0 +1,285 @@
+import { type BigIntStats, type Dirent } from "node:fs";
+import { lstat, open, readdir, realpath, type FileHandle } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import {
+  identityFromStats,
+  isContained,
+  sameStats,
+  verifiedFileOpenFlags,
+  type FileIdentity,
+} from "./verified-read.js";
+
+export type ContainedKind = "file" | "directory";
+
+export type ContainedRejectCode =
+  | "not-found"
+  | "symlink"
+  | "outside-root"
+  | "not-file"
+  | "not-directory"
+  | "changed";
+
+export interface ContainedRoot {
+  readonly declaredPath: string;
+  readonly canonicalPath: string;
+}
+
+export interface ContainedReject {
+  readonly ok: false;
+  readonly code: ContainedRejectCode;
+  readonly declaredPath: string;
+}
+
+export interface ContainedInspectOk {
+  readonly ok: true;
+  readonly kind: ContainedKind;
+  readonly declaredPath: string;
+  readonly canonicalPath: string;
+  readonly identity: FileIdentity;
+}
+
+export type ContainedInspect = ContainedInspectOk | ContainedReject;
+
+export interface ContainedReadOk {
+  readonly ok: true;
+  readonly declaredPath: string;
+  readonly text: string;
+}
+
+export type ContainedRead = ContainedReadOk | ContainedReject;
+
+export interface ContainedWalkOptions {
+  readonly maxDepth: number;
+  readonly maxFiles: number;
+  readonly collectFile: (name: string) => boolean;
+  readonly skipDir?: (name: string) => boolean;
+  readonly includeStartFiles?: boolean;
+}
+
+export interface ContainedWalkResult {
+  readonly files: readonly string[];
+  readonly droppedCount: number;
+  readonly rejections: readonly ContainedReject[];
+}
+
+export interface ContainedRootIo {
+  readonly lstat: (path: string) => Promise<BigIntStats>;
+  readonly realpath: (path: string) => Promise<string>;
+  readonly open: (path: string, flags: number) => Promise<FileHandle>;
+  readonly readdir: (path: string) => Promise<Dirent[]>;
+}
+
+export const defaultContainedRootIo: ContainedRootIo = {
+  lstat: (path) => lstat(path, { bigint: true }),
+  realpath,
+  open,
+  readdir: (path) => readdir(path, { withFileTypes: true }),
+};
+
+export const PLUGIN_MARKDOWN_WALK: ContainedWalkOptions = {
+  maxDepth: 8,
+  maxFiles: 512,
+  collectFile: (name) => name.toLowerCase().endsWith(".md"),
+};
+
+export function containedRejectReason(code: ContainedRejectCode): string {
+  switch (code) {
+    case "not-found":
+      return "path not found";
+    case "symlink":
+      return "symbolic link rejected before read";
+    case "outside-root":
+      return "path resolves outside the verified root";
+    case "not-file":
+      return "path is not a regular file";
+    case "not-directory":
+      return "path is not a directory";
+    case "changed":
+      return "path changed during read";
+  }
+}
+
+export async function bindContainedRoot(
+  path: string,
+  io: ContainedRootIo = defaultContainedRootIo,
+): Promise<ContainedRoot | null> {
+  const declaredPath = resolve(path);
+  try {
+    await io.lstat(declaredPath);
+  } catch {
+    return null;
+  }
+  try {
+    const canonicalPath = await io.realpath(declaredPath);
+    const canonicalStats = await io.lstat(canonicalPath);
+    if (canonicalStats.isSymbolicLink() || !canonicalStats.isDirectory()) {
+      return null;
+    }
+    return { declaredPath, canonicalPath };
+  } catch {
+    return null;
+  }
+}
+
+export async function inspectContainedPath(
+  root: ContainedRoot,
+  candidatePath: string,
+  io: ContainedRootIo = defaultContainedRootIo,
+): Promise<ContainedInspect> {
+  const declaredPath = resolve(candidatePath);
+  if (
+    declaredPath !== root.declaredPath &&
+    !isContained(root.declaredPath, declaredPath)
+  ) {
+    return { ok: false, code: "outside-root", declaredPath };
+  }
+  let stats: BigIntStats;
+  try {
+    stats = await io.lstat(declaredPath);
+  } catch {
+    return { ok: false, code: "not-found", declaredPath };
+  }
+  if (stats.isSymbolicLink()) {
+    return { ok: false, code: "symlink", declaredPath };
+  }
+  let canonicalPath: string;
+  try {
+    canonicalPath = await io.realpath(declaredPath);
+  } catch {
+    return { ok: false, code: "not-found", declaredPath };
+  }
+  if (!isInsideContainedRoot(root, canonicalPath)) {
+    return { ok: false, code: "outside-root", declaredPath };
+  }
+  if (stats.isDirectory()) {
+    return {
+      ok: true,
+      kind: "directory",
+      declaredPath,
+      canonicalPath,
+      identity: identityFromStats(stats),
+    };
+  }
+  if (stats.isFile()) {
+    return {
+      ok: true,
+      kind: "file",
+      declaredPath,
+      canonicalPath,
+      identity: identityFromStats(stats),
+    };
+  }
+  return { ok: false, code: "not-file", declaredPath };
+}
+
+export async function readContainedUtf8(
+  root: ContainedRoot,
+  candidatePath: string,
+  io: ContainedRootIo = defaultContainedRootIo,
+): Promise<ContainedRead> {
+  const inspected = await inspectContainedPath(root, candidatePath, io);
+  if (!inspected.ok) return inspected;
+  if (inspected.kind !== "file") {
+    return { ok: false, code: "not-file", declaredPath: inspected.declaredPath };
+  }
+  let handle: FileHandle;
+  try {
+    handle = await io.open(inspected.declaredPath, verifiedFileOpenFlags());
+  } catch {
+    return { ok: false, code: "not-found", declaredPath: inspected.declaredPath };
+  }
+  try {
+    const opened = await handle.stat({ bigint: true });
+    if (!opened.isFile() || !sameStats(inspected.identity, opened)) {
+      return { ok: false, code: "changed", declaredPath: inspected.declaredPath };
+    }
+    const canonicalPath = await io.realpath(inspected.declaredPath);
+    if (!isInsideContainedRoot(root, canonicalPath)) {
+      return {
+        ok: false,
+        code: "outside-root",
+        declaredPath: inspected.declaredPath,
+      };
+    }
+    return {
+      ok: true,
+      declaredPath: inspected.declaredPath,
+      text: await handle.readFile("utf8"),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function walkContainedFiles(
+  root: ContainedRoot,
+  startPath: string,
+  options: ContainedWalkOptions,
+  io: ContainedRootIo = defaultContainedRootIo,
+): Promise<ContainedWalkResult> {
+  const start = await inspectContainedPath(root, startPath, io);
+  if (!start.ok) {
+    return { files: [], droppedCount: 0, rejections: [start] };
+  }
+  if (start.kind !== "directory") {
+    return {
+      files: [],
+      droppedCount: 0,
+      rejections: [{
+        ok: false,
+        code: "not-directory",
+        declaredPath: start.declaredPath,
+      }],
+    };
+  }
+  const files: string[] = [];
+  const rejections: ContainedReject[] = [];
+  let droppedCount = 0;
+  const visited = new Set<string>([start.canonicalPath]);
+  const queue: Array<{ readonly path: string; readonly depth: number }> = [
+    { path: start.declaredPath, depth: 0 },
+  ];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current.depth > options.maxDepth) continue;
+    let entries: Dirent[];
+    try {
+      entries = await io.readdir(current.path);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (options.skipDir?.(entry.name) === true) continue;
+      const childPath = join(current.path, entry.name);
+      const inspected = await inspectContainedPath(root, childPath, io);
+      if (!inspected.ok) {
+        rejections.push(inspected);
+        continue;
+      }
+      if (inspected.kind === "directory") {
+        if (
+          current.depth < options.maxDepth &&
+          !visited.has(inspected.canonicalPath)
+        ) {
+          visited.add(inspected.canonicalPath);
+          queue.push({ path: inspected.declaredPath, depth: current.depth + 1 });
+        }
+        continue;
+      }
+      if (current.depth === 0 && options.includeStartFiles === false) continue;
+      if (!options.collectFile(entry.name)) continue;
+      if (files.length >= options.maxFiles) droppedCount += 1;
+      else files.push(inspected.declaredPath);
+    }
+  }
+  files.sort((left, right) => left.localeCompare(right));
+  return { files, droppedCount, rejections };
+}
+
+function isInsideContainedRoot(root: ContainedRoot, canonicalPath: string): boolean {
+  return (
+    canonicalPath === root.canonicalPath ||
+    isContained(root.canonicalPath, canonicalPath)
+  );
+}

--- a/runtime/src/fs/root-contained-read.ts
+++ b/runtime/src/fs/root-contained-read.ts
@@ -212,6 +212,19 @@ export async function readContainedUtf8(
   }
 }
 
+type ContainedWalkFrame = {
+  readonly path: string;
+  readonly depth: number;
+};
+
+type ContainedWalkState = {
+  readonly files: string[];
+  readonly rejections: ContainedReject[];
+  droppedCount: number;
+  readonly visited: Set<string>;
+  readonly queue: ContainedWalkFrame[];
+};
+
 export async function walkContainedFiles(
   root: ContainedRoot,
   startPath: string,
@@ -233,48 +246,81 @@ export async function walkContainedFiles(
       }],
     };
   }
-  const files: string[] = [];
-  const rejections: ContainedReject[] = [];
-  let droppedCount = 0;
-  const visited = new Set<string>([start.canonicalPath]);
-  const queue: Array<{ readonly path: string; readonly depth: number }> = [
-    { path: start.declaredPath, depth: 0 },
-  ];
-  while (queue.length > 0) {
-    const current = queue.shift()!;
+  const state: ContainedWalkState = {
+    files: [],
+    rejections: [],
+    droppedCount: 0,
+    visited: new Set([start.canonicalPath]),
+    queue: [{ path: start.declaredPath, depth: 0 }],
+  };
+  while (state.queue.length > 0) {
+    const current = state.queue.shift()!;
     if (current.depth > options.maxDepth) continue;
-    let entries: Dirent[];
-    try {
-      entries = await io.readdir(current.path);
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (options.skipDir?.(entry.name) === true) continue;
-      const childPath = join(current.path, entry.name);
-      const inspected = await inspectContainedPath(root, childPath, io);
-      if (!inspected.ok) {
-        rejections.push(inspected);
-        continue;
-      }
-      if (inspected.kind === "directory") {
-        if (
-          current.depth < options.maxDepth &&
-          !visited.has(inspected.canonicalPath)
-        ) {
-          visited.add(inspected.canonicalPath);
-          queue.push({ path: inspected.declaredPath, depth: current.depth + 1 });
-        }
-        continue;
-      }
-      if (current.depth === 0 && options.includeStartFiles === false) continue;
-      if (!options.collectFile(entry.name)) continue;
-      if (files.length >= options.maxFiles) droppedCount += 1;
-      else files.push(inspected.declaredPath);
-    }
+    await visitContainedDirectory(root, current, options, io, state);
   }
-  files.sort((left, right) => left.localeCompare(right));
-  return { files, droppedCount, rejections };
+  state.files.sort((left, right) => left.localeCompare(right));
+  return {
+    files: state.files,
+    droppedCount: state.droppedCount,
+    rejections: state.rejections,
+  };
+}
+
+async function visitContainedDirectory(
+  root: ContainedRoot,
+  current: ContainedWalkFrame,
+  options: ContainedWalkOptions,
+  io: ContainedRootIo,
+  state: ContainedWalkState,
+): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await io.readdir(current.path);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    await visitContainedChild(root, current, entry, options, io, state);
+  }
+}
+
+async function visitContainedChild(
+  root: ContainedRoot,
+  current: ContainedWalkFrame,
+  entry: Dirent,
+  options: ContainedWalkOptions,
+  io: ContainedRootIo,
+  state: ContainedWalkState,
+): Promise<void> {
+  if (options.skipDir?.(entry.name) === true) return;
+  const inspected = await inspectContainedPath(
+    root,
+    join(current.path, entry.name),
+    io,
+  );
+  if (!inspected.ok) {
+    state.rejections.push(inspected);
+    return;
+  }
+  if (inspected.kind === "directory") {
+    enqueueContainedDirectory(inspected, current.depth, options.maxDepth, state);
+    return;
+  }
+  if (current.depth === 0 && options.includeStartFiles === false) return;
+  if (!options.collectFile(entry.name)) return;
+  if (state.files.length >= options.maxFiles) state.droppedCount += 1;
+  else state.files.push(inspected.declaredPath);
+}
+
+function enqueueContainedDirectory(
+  inspected: ContainedInspectOk,
+  depth: number,
+  maxDepth: number,
+  state: ContainedWalkState,
+): void {
+  if (depth >= maxDepth || state.visited.has(inspected.canonicalPath)) return;
+  state.visited.add(inspected.canonicalPath);
+  state.queue.push({ path: inspected.declaredPath, depth: depth + 1 });
 }
 
 function isInsideContainedRoot(root: ContainedRoot, canonicalPath: string): boolean {

--- a/runtime/src/plugins/loader.ts
+++ b/runtime/src/plugins/loader.ts
@@ -1,5 +1,14 @@
 import { readFile, readdir, realpath, stat } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import {
+  PLUGIN_MARKDOWN_WALK,
+  bindContainedRoot,
+  containedRejectReason,
+  inspectContainedPath,
+  readContainedUtf8,
+  walkContainedFiles,
+  type ContainedReject,
+} from "../fs/root-contained-read.js";
 import { isValidPermissionDefaultMode, validateHooksConfig, validateMcpServersConfig } from "../config/schema.js";
 import type {
   AgenCConfig,
@@ -46,8 +55,6 @@ import {
 } from "./package-authority.js";
 
 const INSTALL_METADATA_FILE = "agenc-install.json";
-const MAX_PLUGIN_MARKDOWN_FILES = 512;
-const MAX_PLUGIN_SCAN_DEPTH = 8;
 const LSP_SERVER_KEYS = new Set([
   "command",
   "args",
@@ -980,15 +987,35 @@ async function loadCommands(
   errors: PluginLoadIssue[],
 ): Promise<LoadedPluginCommand[]> {
   const commands: LoadedPluginCommand[] = [];
+  const bound = await bindContainedRoot(pluginRoot);
   const defaultCommandsDir = join(pluginRoot, DEFAULT_COMPONENT_DIRS.commands);
-  if (manifest.commands === undefined && await pathIsDirectory(defaultCommandsDir)) {
-    commands.push(
-      ...(await collectMarkdownFiles(defaultCommandsDir)).map((path) => ({
-        name: basename(path).replace(/\.md$/iu, ""),
-        path,
-        metadata: { source: path },
-      })),
-    );
+  if (manifest.commands === undefined && bound !== null) {
+    const inspected = await inspectContainedPath(bound, defaultCommandsDir);
+    if (inspected.ok && inspected.kind === "directory") {
+      const walked = await walkContainedFiles(
+        bound,
+        defaultCommandsDir,
+        PLUGIN_MARKDOWN_WALK,
+      );
+      pushContainedRejections(
+        errors,
+        walked.rejections,
+        source,
+        manifest.name,
+        "commands",
+      );
+      commands.push(
+        ...walked.files.map((path) => ({
+          name: basename(path).replace(/\.md$/iu, ""),
+          path,
+          metadata: { source: path },
+        })),
+      );
+    } else if (!inspected.ok && inspected.code !== "not-found") {
+      errors.push(
+        containedPathIssue(inspected, source, manifest.name, "commands"),
+      );
+    }
   }
   if (manifest.commands !== undefined) {
     commands.push(
@@ -1067,9 +1094,25 @@ async function loadComponentPaths(
   pluginName: string,
 ): Promise<readonly string[]> {
   const defaultDir = defaultDirForComponent(pluginRoot, component);
-  const paths = declaration === undefined && defaultDir !== null && await pathIsDirectory(defaultDir)
-    ? [defaultDir]
-    : await resolveExistingPaths(pluginRoot, component, declaration, source, pluginName, errors);
+  const bound = await bindContainedRoot(pluginRoot);
+  if (declaration === undefined && defaultDir !== null && bound !== null) {
+    const inspected = await inspectContainedPath(bound, defaultDir);
+    if (inspected.ok && inspected.kind === "directory") {
+      return [defaultDir];
+    }
+    if (!inspected.ok && inspected.code !== "not-found") {
+      errors.push(containedPathIssue(inspected, source, pluginName, component));
+    }
+    return [];
+  }
+  const paths = await resolveExistingPaths(
+    pluginRoot,
+    component,
+    declaration,
+    source,
+    pluginName,
+    errors,
+  );
   return [...new Set(paths)].sort((a, b) => a.localeCompare(b));
 }
 
@@ -1100,14 +1143,17 @@ async function resolveExistingPaths(
   errors: PluginLoadIssue[],
 ): Promise<string[]> {
   if (declaration === undefined) return [];
+  const bound = await bindContainedRoot(pluginRoot);
+  if (bound === null) return [];
   const declarations = Array.isArray(declaration) ? declaration : [declaration];
   const out: string[] = [];
   for (const entry of declarations) {
     try {
       const resolved = resolveManifestRelativePath(pluginRoot, field, entry);
-      if (await pathIsFile(resolved) || await pathIsDirectory(resolved)) {
+      const inspected = await inspectContainedPath(bound, resolved);
+      if (inspected.ok) {
         out.push(resolved);
-      } else {
+      } else if (inspected.code === "not-found") {
         errors.push({
           type: "path-not-found",
           source,
@@ -1116,6 +1162,15 @@ async function resolveExistingPaths(
           component: componentFromField(field),
           message: `Plugin component path not found: ${entry}`,
         });
+      } else {
+        errors.push(
+          containedPathIssue(
+            inspected,
+            source,
+            pluginName,
+            componentFromField(field),
+          ),
+        );
       }
     } catch (error) {
       errors.push({
@@ -1142,36 +1197,32 @@ function componentFromField(field: string): PluginComponentKind | undefined {
   return undefined;
 }
 
-async function collectMarkdownFiles(root: string): Promise<string[]> {
-  const out: string[] = [];
-  const queue: Array<{ readonly path: string; readonly depth: number }> = [
-    { path: root, depth: 0 },
-  ];
-  const visitedDirs = new Set<string>();
-  while (queue.length > 0) {
-    if (out.length >= MAX_PLUGIN_MARKDOWN_FILES) break;
-    const current = queue.shift()!;
-    if (current.depth > MAX_PLUGIN_SCAN_DEPTH) continue;
-    const identity = await maybeRealpath(current.path);
-    if (visitedDirs.has(identity)) continue;
-    visitedDirs.add(identity);
-    let entries;
-    try {
-      entries = await readdir(current.path, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (out.length >= MAX_PLUGIN_MARKDOWN_FILES) break;
-      const path = join(current.path, entry.name);
-      if (entry.isDirectory()) {
-        queue.push({ path, depth: current.depth + 1 });
-      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
-        out.push(path);
-      }
-    }
+function containedPathIssue(
+  reject: ContainedReject,
+  source: string,
+  pluginName: string,
+  component: PluginComponentKind | undefined,
+): PluginLoadIssue {
+  return {
+    type: "path-not-found",
+    source,
+    plugin: pluginName,
+    path: reject.declaredPath,
+    ...(component === undefined ? {} : { component }),
+    message: containedRejectReason(reject.code),
+  };
+}
+
+function pushContainedRejections(
+  errors: PluginLoadIssue[],
+  rejections: readonly ContainedReject[],
+  source: string,
+  pluginName: string,
+  component: PluginComponentKind | undefined,
+): void {
+  for (const reject of rejections) {
+    errors.push(containedPathIssue(reject, source, pluginName, component));
   }
-  return out.sort((a, b) => a.localeCompare(b));
 }
 
 async function loadHooks(
@@ -1243,8 +1294,32 @@ async function appendHookFile(
   sources: PluginHookSource[],
   errors: PluginLoadIssue[],
 ): Promise<void> {
+  const bound = await bindContainedRoot(pluginRoot);
+  if (bound === null) {
+    errors.push({
+      type: "hooks",
+      source,
+      plugin: pluginName,
+      path,
+      component: "hooks",
+      message: "plugin root is not a verified directory",
+    });
+    return;
+  }
+  const read = await readContainedUtf8(bound, path);
+  if (!read.ok) {
+    errors.push({
+      type: "hooks",
+      source,
+      plugin: pluginName,
+      path: read.declaredPath,
+      component: "hooks",
+      message: containedRejectReason(read.code),
+    });
+    return;
+  }
   try {
-    const parsed = JSON.parse(await readJsonText(path));
+    const parsed = JSON.parse(read.text);
     const hooks = normalizeHooksMap(parsed);
     if (hooks === null) {
       errors.push({

--- a/runtime/src/plugins/registration/common.ts
+++ b/runtime/src/plugins/registration/common.ts
@@ -7,9 +7,15 @@
  * records and never imports from the compatibility scaffolding tree.
  */
 
-import { readdir, readFile, realpath, stat } from "node:fs/promises";
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { stat } from "node:fs/promises";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { load as loadYaml } from "js-yaml";
+import {
+  PLUGIN_MARKDOWN_WALK,
+  bindContainedRoot,
+  readContainedUtf8,
+  walkContainedFiles,
+} from "../../fs/root-contained-read.js";
 
 import { parseArguments } from "../../tui/slash/argument-substitution.js";
 import {
@@ -42,9 +48,6 @@ import type {
 type PluginRuntimeOptionSchema = Readonly<
   Record<string, PluginUserConfigOption>
 >;
-
-const MAX_PLUGIN_REGISTRATION_MARKDOWN_FILES = 512;
-const MAX_PLUGIN_REGISTRATION_SCAN_DEPTH = 8;
 
 export interface PluginRuntimeLoadOptions {
   readonly readOnly?: boolean;
@@ -154,59 +157,29 @@ export function splitFrontmatter(raw: string): {
 export async function readMarkdownFile(
   filePath: string,
   baseDir: string,
+  pluginRoot: string,
 ): Promise<ParsedMarkdownFile | null> {
-  try {
-    const raw = await readFile(filePath, "utf8");
-    const parsed = splitFrontmatter(raw);
-    return {
-      filePath,
-      baseDir,
-      frontmatter: parsed.frontmatter,
-      markdown: parsed.markdown,
-    };
-  } catch {
-    return null;
-  }
+  const root = await bindContainedRoot(pluginRoot);
+  if (root === null) return null;
+  const read = await readContainedUtf8(root, filePath);
+  if (!read.ok) return null;
+  const parsed = splitFrontmatter(read.text);
+  return {
+    filePath,
+    baseDir,
+    frontmatter: parsed.frontmatter,
+    markdown: parsed.markdown,
+  };
 }
 
-export async function collectMarkdownFiles(root: string): Promise<readonly string[]> {
-  const out: string[] = [];
-  const queue: Array<{ readonly path: string; readonly depth: number }> = [
-    { path: root, depth: 0 },
-  ];
-  const visited = new Set<string>();
-  while (queue.length > 0) {
-    if (out.length >= MAX_PLUGIN_REGISTRATION_MARKDOWN_FILES) break;
-    const current = queue.shift()!;
-    if (current.depth > MAX_PLUGIN_REGISTRATION_SCAN_DEPTH) continue;
-    const identity = await maybeRealpath(current.path);
-    if (visited.has(identity)) continue;
-    visited.add(identity);
-    let entries;
-    try {
-      entries = await readdir(current.path, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (out.length >= MAX_PLUGIN_REGISTRATION_MARKDOWN_FILES) break;
-      const path = join(current.path, entry.name);
-      if (entry.isDirectory()) {
-        queue.push({ path, depth: current.depth + 1 });
-      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
-        out.push(path);
-      }
-    }
-  }
-  return out.sort((a, b) => a.localeCompare(b));
-}
-
-async function maybeRealpath(path: string): Promise<string> {
-  try {
-    return await realpath(path);
-  } catch {
-    return path;
-  }
+export async function collectMarkdownFiles(
+  pluginRoot: string,
+  start: string,
+): Promise<readonly string[]> {
+  const root = await bindContainedRoot(pluginRoot);
+  if (root === null) return [];
+  const walked = await walkContainedFiles(root, start, PLUGIN_MARKDOWN_WALK);
+  return walked.files;
 }
 
 export async function pathIsDirectory(path: string): Promise<boolean> {

--- a/runtime/src/plugins/registration/load-plugin-agents.ts
+++ b/runtime/src/plugins/registration/load-plugin-agents.ts
@@ -232,7 +232,7 @@ async function loadAgentFile(
 ): Promise<PluginAgentDefinition | null> {
   if (loadedPaths.has(path)) return null;
   loadedPaths.add(path);
-  const file = await readMarkdownFile(path, baseDir);
+  const file = await readMarkdownFile(path, baseDir, plugin.root);
   return file
     ? createPluginAgent(plugin, file, roleCwd, pluginStorageRoot)
     : null;
@@ -246,7 +246,7 @@ async function loadAgentsFromPath(
   pluginStorageRoot: string | undefined,
 ): Promise<readonly PluginAgentDefinition[]> {
   if (await pathIsDirectory(path)) {
-    const files = await collectMarkdownFiles(path);
+    const files = await collectMarkdownFiles(plugin.root, path);
     const agents = await Promise.all(
       files.map((filePath) =>
         loadAgentFile(

--- a/runtime/src/plugins/registration/load-plugin-commands.ts
+++ b/runtime/src/plugins/registration/load-plugin-commands.ts
@@ -345,7 +345,7 @@ async function readCommandPath(
   if (command.path === undefined) return [];
   if (await pathIsDirectory(command.path)) {
     const commandPath = command.path;
-    const files = await collectCommandMarkdownFiles(command.path);
+    const files = await collectCommandMarkdownFiles(plugin.root, command.path);
     return Promise.all(
       files.map(async (filePath) =>
         readFileAsCommand(plugin, filePath, commandPath, loadedPaths, command.metadata),
@@ -372,8 +372,11 @@ async function readCommandPath(
   ].filter((entry): entry is PluginMarkdownCommand => entry !== null);
 }
 
-async function collectCommandMarkdownFiles(root: string): Promise<readonly string[]> {
-  const files = await collectMarkdownFiles(root);
+async function collectCommandMarkdownFiles(
+  pluginRoot: string,
+  root: string,
+): Promise<readonly string[]> {
+  const files = await collectMarkdownFiles(pluginRoot, root);
   const skillDirs = new Set(
     files
       .filter((filePath) => isSkillFile(filePath))
@@ -398,7 +401,7 @@ async function readFileAsCommand(
 ): Promise<PluginMarkdownCommand | null> {
   if (loadedPaths.has(filePath)) return null;
   loadedPaths.add(filePath);
-  const file = await readMarkdownFile(filePath, baseDir);
+  const file = await readMarkdownFile(filePath, baseDir, plugin.root);
   if (!file) return null;
   return {
     plugin,
@@ -448,7 +451,7 @@ async function loadSkillEntriesFromPath(
 ): Promise<readonly PluginMarkdownCommand[]> {
   const paths = skillsPath.toLowerCase().endsWith(".md")
     ? [skillsPath]
-    : await collectMarkdownFiles(skillsPath);
+    : await collectMarkdownFiles(plugin.root, skillsPath);
   const entries = await Promise.all(
     paths
       .filter((filePath) => isSkillFile(filePath))
@@ -458,7 +461,7 @@ async function loadSkillEntriesFromPath(
         const baseDir = skillsPath.toLowerCase().endsWith(".md")
           ? dirname(skillsPath)
           : skillsPath;
-        const file = await readMarkdownFile(filePath, baseDir);
+        const file = await readMarkdownFile(filePath, baseDir, plugin.root);
         return file
           ? {
               plugin,

--- a/runtime/src/plugins/registration/load-plugin-output-styles.ts
+++ b/runtime/src/plugins/registration/load-plugin-output-styles.ts
@@ -41,7 +41,7 @@ async function loadStyleFile(
 ): Promise<PluginOutputStyle | null> {
   if (loadedPaths.has(filePath)) return null;
   loadedPaths.add(filePath);
-  const file = await readMarkdownFile(filePath, baseDir);
+  const file = await readMarkdownFile(filePath, baseDir, plugin.root);
   if (!file) return null;
   const baseName = coerceString(file.frontmatter.name) ?? markdownStem(filePath);
   const name = pluginScopedIdentifier(
@@ -72,7 +72,7 @@ async function loadStylesFromPath(
   loadedPaths: Set<string>,
 ): Promise<readonly PluginOutputStyle[]> {
   if (await pathIsDirectory(path)) {
-    const files = await collectMarkdownFiles(path);
+    const files = await collectMarkdownFiles(plugin.root, path);
     const styles = await Promise.all(
       files.map((filePath) => loadStyleFile(plugin, filePath, path, loadedPaths)),
     );

--- a/runtime/src/plugins/validation.ts
+++ b/runtime/src/plugins/validation.ts
@@ -1,5 +1,11 @@
-import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  PLUGIN_MARKDOWN_WALK,
+  bindContainedRoot,
+  readContainedUtf8,
+  walkContainedFiles,
+} from "../fs/root-contained-read.js";
 import { load as loadYaml } from "js-yaml";
 import {
   findPluginManifestPath,
@@ -62,8 +68,6 @@ const MARKETPLACE_ONLY_MANIFEST_FIELDS = new Set([
   "tags",
   "id",
 ]);
-const MAX_VALIDATION_MARKDOWN_FILES = 512;
-const MAX_VALIDATION_SCAN_DEPTH = 8;
 
 function errno(error: unknown): string | undefined {
   return typeof error === "object" && error !== null && "code" in error
@@ -429,59 +433,34 @@ export async function validatePluginContents(
 ): Promise<readonly ValidationResult[]> {
   const parsed = await loadPluginManifest(pluginDir).catch(() => null);
   if (!parsed) return [];
+  const bound = await bindContainedRoot(pluginDir);
+  if (bound === null) return [];
   const results: ValidationResult[] = [];
   for (const [fileType, dir] of [
     ["skill", "skills"],
     ["agent", "agents"],
     ["command", "commands"],
   ] as const) {
-    for (const filePath of await collectMarkdown(join(pluginDir, dir), fileType === "skill")) {
-      const raw = await readFile(filePath, "utf8").catch(() => null);
-      if (raw === null) continue;
-      const result = validateMarkdownComponent(filePath, raw, fileType);
+    const walked = await walkContainedFiles(
+      bound,
+      join(pluginDir, dir),
+      fileType === "skill"
+        ? {
+            ...PLUGIN_MARKDOWN_WALK,
+            collectFile: (name) => name === "SKILL.md",
+          }
+        : PLUGIN_MARKDOWN_WALK,
+    );
+    for (const filePath of walked.files) {
+      const read = await readContainedUtf8(bound, filePath);
+      if (!read.ok) continue;
+      const result = validateMarkdownComponent(filePath, read.text, fileType);
       if (result.errors.length > 0 || result.warnings.length > 0) {
         results.push(result);
       }
     }
   }
   return results;
-}
-
-async function collectMarkdown(dir: string, skillsDir: boolean): Promise<string[]> {
-  const out: string[] = [];
-  const queue: Array<{ readonly path: string; readonly depth: number }> = [
-    { path: dir, depth: 0 },
-  ];
-  const visited = new Set<string>();
-  while (queue.length > 0) {
-    if (out.length >= MAX_VALIDATION_MARKDOWN_FILES) break;
-    const current = queue.shift()!;
-    if (current.depth > MAX_VALIDATION_SCAN_DEPTH) continue;
-    let identity = current.path;
-    try {
-      identity = await realpath(current.path);
-    } catch {
-      // Keep walking best-effort if a path disappears during validation.
-    }
-    if (visited.has(identity)) continue;
-    visited.add(identity);
-    const currentEntries = await readdir(current.path, { withFileTypes: true }).catch(() => []);
-    for (const entry of currentEntries) {
-      if (out.length >= MAX_VALIDATION_MARKDOWN_FILES) break;
-      const fullPath = join(current.path, entry.name);
-      if (entry.isDirectory()) {
-        queue.push({ path: fullPath, depth: current.depth + 1 });
-      } else if (
-        entry.isFile() &&
-        (skillsDir
-          ? entry.name === "SKILL.md"
-          : entry.name.toLowerCase().endsWith(".md"))
-      ) {
-        out.push(fullPath);
-      }
-    }
-  }
-  return out;
 }
 
 function validateMarkdownComponent(

--- a/runtime/src/skills/local-loader.ts
+++ b/runtime/src/skills/local-loader.ts
@@ -1,6 +1,4 @@
 import {
-  readdir,
-  readFile,
   realpath,
   stat,
 } from "node:fs/promises";
@@ -18,6 +16,14 @@ import {
 import { load as loadYaml } from "js-yaml";
 
 import type { AgenCConfig } from "../config/schema.js";
+import {
+  bindContainedRoot,
+  containedRejectReason,
+  inspectContainedPath,
+  readContainedUtf8,
+  walkContainedFiles,
+  type ContainedRoot,
+} from "../fs/root-contained-read.js";
 import { FileWatcher } from "../file-watcher/index.js";
 import { discoverPluginSkillRootsWithProvenance } from "../plugins/loader.js";
 import type { SessionServices } from "../session/session.js";
@@ -276,14 +282,6 @@ async function pathIsDirectory(path: string): Promise<boolean> {
   }
 }
 
-async function pathIsFile(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isFile();
-  } catch {
-    return false;
-  }
-}
-
 async function getFileIdentity(filePath: string): Promise<string | null> {
   try {
     return await realpath(filePath);
@@ -438,113 +436,6 @@ export async function discoverSkillWatchRoots(
   );
 }
 
-async function readDirEntries(path: string) {
-  try {
-    return await readdir(path, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-}
-
-async function isDirectoryEntry(path: string, isSymlink: boolean): Promise<boolean> {
-  if (!isSymlink) return true;
-  try {
-    return (await stat(path)).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-interface SkillFileScan {
-  readonly files: readonly string[];
-  readonly droppedCount: number;
-}
-
-interface MutableSkillFileScan {
-  readonly files: string[];
-  droppedCount: number;
-  readonly maxFiles: number;
-}
-
-interface ScanFrame {
-  readonly path: string;
-  readonly depth: number;
-}
-
-type DirEntry = Awaited<ReturnType<typeof readDirEntries>>[number];
-
-async function isScannableDir(entry: DirEntry, path: string): Promise<boolean> {
-  if (!entry.isDirectory() && !entry.isSymbolicLink()) return false;
-  if (SKIP_DIRS.has(entry.name)) return false;
-  return isDirectoryEntry(path, entry.isSymbolicLink());
-}
-
-async function topLevelScanFrames(root: string): Promise<ScanFrame[]> {
-  const frames: ScanFrame[] = [];
-  for (const entry of await readDirEntries(root)) {
-    const next = join(root, entry.name);
-    if (await isScannableDir(entry, next)) frames.push({ path: next, depth: 1 });
-  }
-  return frames;
-}
-
-/** Returns false when the directory (by real path) was already scanned. */
-async function markVisited(path: string, visited: Set<string>): Promise<boolean> {
-  const dirId = await getFileIdentity(path);
-  if (dirId === null) return true;
-  if (visited.has(dirId)) return false;
-  visited.add(dirId);
-  return true;
-}
-
-function recordSkillFile(scan: MutableSkillFileScan, file: string): void {
-  // Past the cap the walk keeps going but only counts, so the snapshot can
-  // say how many skills this root holds that were never loaded.
-  if (scan.files.length >= scan.maxFiles) scan.droppedCount += 1;
-  else scan.files.push(file);
-}
-
-async function scanSkillDir(
-  frame: ScanFrame,
-  scan: MutableSkillFileScan,
-  queue: ScanFrame[],
-): Promise<void> {
-  for (const entry of await readDirEntries(frame.path)) {
-    const next = join(frame.path, entry.name);
-    if (entry.isFile()) {
-      if (isSkillFile(next)) recordSkillFile(scan, next);
-      continue;
-    }
-    if (frame.depth < MAX_SCAN_DEPTH && (await isScannableDir(entry, next))) {
-      queue.push({ path: next, depth: frame.depth + 1 });
-    }
-  }
-}
-
-async function findSkillFiles(root: string): Promise<SkillFileScan> {
-  const scan: MutableSkillFileScan = {
-    files: [],
-    droppedCount: 0,
-    maxFiles: maxSkillFilesPerRoot(),
-  };
-  const queue = await topLevelScanFrames(root);
-  const visitedDirs = new Set<string>();
-  while (queue.length > 0) {
-    const frame = queue.shift()!;
-    if (await markVisited(frame.path, visitedDirs)) {
-      await scanSkillDir(frame, scan, queue);
-    }
-  }
-  return {
-    files: scan.files.toSorted((a, b) => a.localeCompare(b)),
-    droppedCount: scan.droppedCount,
-  };
-}
-
-function isSkillFile(filePath: string): boolean {
-  return basename(filePath).toLowerCase() === "skill.md";
-}
-
 function buildNamespace(targetDir: string, baseDir: string): string {
   const rel = relative(baseDir, targetDir);
   if (!rel || rel === ".") return "";
@@ -644,19 +535,18 @@ function escapeRegExp(value: string): string {
 async function loadSkillFile(
   filePath: string,
   root: SkillRoot,
+  bound: ContainedRoot,
   warnings: SkillLoadWarning[],
 ): Promise<SkillWithContent | null> {
-  if (!(await pathIsFile(filePath))) return null;
-  let raw: string;
-  try {
-    raw = await readFile(filePath, "utf8");
-  } catch (error) {
+  const read = await readContainedUtf8(bound, filePath);
+  if (!read.ok) {
     warnings.push({
-      path: filePath,
-      reason: `unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      path: read.declaredPath,
+      reason: containedRejectReason(read.code),
     });
     return null;
   }
+  const raw = read.text;
 
   const { frontmatter, markdown, warning } = splitFrontmatter(raw);
   if (warning !== undefined) warnings.push({ path: filePath, reason: warning });
@@ -729,27 +619,39 @@ interface LoadedSkillRoot {
 }
 
 async function loadSkillsFromRoot(root: SkillRoot): Promise<LoadedSkillRoot> {
-  const scan = await findSkillFiles(root.path);
-  const files = [...scan.files];
-  // A root can BE one skill: plugin manifests may declare each skill
-  // dir individually (skills: ["./skills/flash-board"]), so the root
-  // itself carries the SKILL.md instead of holding child skill dirs.
+  const bound = await bindContainedRoot(root.path);
+  if (bound === null) {
+    return { skills: [], droppedCount: 0, warnings: [] };
+  }
+  const walked = await walkContainedFiles(bound, root.path, {
+    maxDepth: MAX_SCAN_DEPTH,
+    maxFiles: maxSkillFilesPerRoot(),
+    collectFile: (name) => name.toLowerCase() === SKILL_FILE_NAME.toLowerCase(),
+    skipDir: (name) => SKIP_DIRS.has(name),
+    includeStartFiles: false,
+  });
+  const files = [...walked.files];
+  const warnings: SkillLoadWarning[] = walked.rejections.map((reject) => ({
+    path: reject.declaredPath,
+    reason: containedRejectReason(reject.code),
+  }));
   if (files.length === 0) {
-    const leaf = join(root.path, SKILL_FILE_NAME);
-    try {
-      const stats = await stat(leaf);
-      if (stats.isFile()) files.push(leaf);
-    } catch {
-      // Genuinely empty root.
+    const leaf = await inspectContainedPath(bound, join(root.path, SKILL_FILE_NAME));
+    if (leaf.ok && leaf.kind === "file") {
+      files.push(leaf.declaredPath);
+    } else if (!leaf.ok && leaf.code !== "not-found") {
+      warnings.push({
+        path: leaf.declaredPath,
+        reason: containedRejectReason(leaf.code),
+      });
     }
   }
-  const warnings: SkillLoadWarning[] = [];
   const loaded = await Promise.all(
-    files.map((file) => loadSkillFile(file, root, warnings)),
+    files.map((file) => loadSkillFile(file, root, bound, warnings)),
   );
   return {
     skills: loaded.filter((entry): entry is SkillWithContent => entry !== null),
-    droppedCount: scan.droppedCount,
+    droppedCount: walked.droppedCount,
     warnings,
   };
 }
@@ -946,13 +848,11 @@ async function loadSkillContent(
   if (skill.loadedFrom === "bundled") {
     return renderBundledSkill(skill, args);
   }
-  let raw: string;
-  try {
-    raw = await readFile(skill.path, "utf8");
-  } catch {
-    return null;
-  }
-  const { markdown } = splitFrontmatter(raw);
+  const bound = await bindContainedRoot(skill.root);
+  if (bound === null) return null;
+  const read = await readContainedUtf8(bound, skill.path);
+  if (!read.ok) return null;
+  const { markdown } = splitFrontmatter(read.text);
   const baseDir = dirname(skill.path);
   let content = `Base directory for this skill: ${baseDir}\n\n${markdown}`;
   content = substituteArguments(content, args, true, skill.argNames ?? []);

--- a/runtime/tests/fs/root-contained-read.test.ts
+++ b/runtime/tests/fs/root-contained-read.test.ts
@@ -1,0 +1,92 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  bindContainedRoot,
+  defaultContainedRootIo,
+  inspectContainedPath,
+  readContainedUtf8,
+  type ContainedRootIo,
+} from "../../src/fs/root-contained-read.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("root-contained-read", () => {
+  test("reads a regular file below the bound root", async () => {
+    const rootDir = await tempRoot();
+    const filePath = join(rootDir, "inside.md");
+    await writeFile(filePath, "inside-bytes\n", "utf8");
+    const root = await bindContainedRoot(rootDir);
+    expect(root).not.toBeNull();
+    const read = await readContainedUtf8(root!, filePath);
+    expect(read).toEqual({
+      ok: true,
+      declaredPath: resolve(filePath),
+      text: "inside-bytes\n",
+    });
+  });
+
+  test("rejects a mock symlink from lstat without opening the path", async () => {
+    const rootDir = await tempRoot();
+    const filePath = join(rootDir, "linked.md");
+    await writeFile(filePath, "must-not-be-read\n", "utf8");
+    const root = await bindContainedRoot(rootDir);
+    expect(root).not.toBeNull();
+    const opened: string[] = [];
+    const io = symlinkLstatIo(filePath, opened);
+    const read = await readContainedUtf8(root!, filePath, io);
+    expect(read).toEqual({
+      ok: false,
+      code: "symlink",
+      declaredPath: resolve(filePath),
+    });
+    expect(opened).toEqual([]);
+  });
+
+  test("rejects a path that is lexically outside the bound root", async () => {
+    const rootDir = await tempRoot();
+    const outside = join(rootDir, "..", "outside.md");
+    const root = await bindContainedRoot(rootDir);
+    expect(root).not.toBeNull();
+    const inspected = await inspectContainedPath(root!, outside);
+    expect(inspected.ok).toBe(false);
+    if (inspected.ok) return;
+    expect(inspected.code).toBe("outside-root");
+    expect(inspected.declaredPath).not.toContain("must-not-be-read");
+  });
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "agenc-contained-root-"));
+  roots.push(root);
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+function symlinkLstatIo(linkedPath: string, opened: string[]): ContainedRootIo {
+  const target = resolve(linkedPath);
+  return {
+    lstat: async (path) => {
+      const stats = await defaultContainedRootIo.lstat(path);
+      if (resolve(path) !== target) return stats;
+      return Object.create(stats, {
+        isSymbolicLink: { value: () => true },
+        isFile: { value: () => false },
+        isDirectory: { value: () => false },
+      }) as typeof stats;
+    },
+    realpath: defaultContainedRootIo.realpath,
+    open: async (path, flags) => {
+      opened.push(path);
+      return defaultContainedRootIo.open(path, flags);
+    },
+    readdir: defaultContainedRootIo.readdir,
+  };
+}

--- a/runtime/tests/helpers/directory-link.ts
+++ b/runtime/tests/helpers/directory-link.ts
@@ -1,0 +1,12 @@
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export async function writeUtf8(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf8");
+}
+
+export async function linkDirectory(target: string, path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await symlink(target, path, process.platform === "win32" ? "junction" : "dir");
+}

--- a/runtime/tests/plugins/plugin-root-containment.test.ts
+++ b/runtime/tests/plugins/plugin-root-containment.test.ts
@@ -1,0 +1,98 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { linkDirectory, writeUtf8 } from "../helpers/directory-link.js";
+import { loadPlugins } from "../../src/plugins/loader.js";
+import { PLUGIN_MANIFEST_RELATIVE_PATH } from "../../src/plugins/manifest.js";
+import { loadPluginCommands } from "../../src/plugins/registration/load-plugin-commands.js";
+
+const roots: string[] = [];
+const SECRET = "OUTSIDE_PLUGIN_SECRET_BYTES";
+const INSIDE = "INSIDE_PLUGIN_COMMAND_BODY";
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("plugin root containment", () => {
+  test("loads a regular command file below the plugin root", async () => {
+    const { pluginStorageRoot, workspaceRoot, pluginRoot } = await workspace();
+    await writePlugin(pluginRoot, "safe-plugin");
+    await writeUtf8(join(pluginRoot, "commands", "ok.md"), `# ok\n${INSIDE}\n`);
+
+    const loaded = await loadPlugins({
+      pluginStorageRoot,
+      workspaceRoot,
+      config: { plugins: { enabled: true } },
+    });
+    const plugin = loaded.enabled.find((entry) => entry.name === "safe-plugin");
+    expect(plugin).toBeDefined();
+    const commands = await loadPluginCommands({
+      plugins: loaded.enabled,
+      pluginStorageRoot,
+      workspaceRoot,
+    });
+    const ok = commands.find((command) => command.name === "safe-plugin:ok");
+    expect(ok).toBeDefined();
+    const prompt = await ok?.getPromptForCommand?.("", {});
+    expect(JSON.stringify(prompt)).toContain(INSIDE);
+    expect(JSON.stringify(prompt)).not.toContain(SECRET);
+  });
+
+  test("rejects an outbound commands directory link before the outside file is read", async () => {
+    const { pluginStorageRoot, workspaceRoot, pluginRoot, root } = await workspace();
+    await writePlugin(pluginRoot, "escape-plugin");
+    const outsideDir = join(root, "outside-commands");
+    const leaked = join(outsideDir, "leak.md");
+    await writeUtf8(leaked, `# leak\n${SECRET}\n`);
+    await linkDirectory(outsideDir, join(pluginRoot, "commands"));
+
+    const loaded = await loadPlugins({
+      pluginStorageRoot,
+      workspaceRoot,
+      config: { plugins: { enabled: true } },
+    });
+    const plugin = loaded.enabled.find((entry) => entry.name === "escape-plugin");
+    expect(plugin).toBeDefined();
+    expect(plugin?.commands.map((command) => command.name)).not.toContain("leak");
+
+    const issues = [...loaded.errors, ...(plugin?.errors ?? [])];
+    expect(issues.some((issue) => issue.path?.includes("commands") === true)).toBe(true);
+    expect(JSON.stringify(issues)).not.toContain(SECRET);
+
+    const commands = await loadPluginCommands({
+      plugins: loaded.enabled,
+      pluginStorageRoot,
+      workspaceRoot,
+    });
+    const prompts = await Promise.all(
+      commands.map((command) => command.getPromptForCommand?.("", {}) ?? []),
+    );
+    expect(JSON.stringify(prompts)).not.toContain(SECRET);
+  });
+});
+
+async function workspace(): Promise<{
+  readonly root: string;
+  readonly pluginStorageRoot: string;
+  readonly workspaceRoot: string;
+  readonly pluginRoot: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "agenc-plugin-root-containment-"));
+  roots.push(root);
+  const workspaceRoot = join(root, "workspace");
+  const pluginStorageRoot = join(root, "home", "plugins");
+  const pluginRoot = join(workspaceRoot, ".agents", "plugins", "sample");
+  await mkdir(pluginStorageRoot, { recursive: true });
+  return { root, pluginStorageRoot, workspaceRoot, pluginRoot };
+}
+
+async function writePlugin(pluginRoot: string, name: string): Promise<void> {
+  await writeUtf8(
+    join(pluginRoot, PLUGIN_MANIFEST_RELATIVE_PATH),
+    `${JSON.stringify({ name }, null, 2)}\n`,
+  );
+}

--- a/runtime/tests/skills/skill-root-containment.test.ts
+++ b/runtime/tests/skills/skill-root-containment.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { linkDirectory, writeUtf8 } from "../helpers/directory-link.js";
+import { loadLocalSkillsSnapshot } from "../../src/skills/local-loader.js";
+
+const roots: string[] = [];
+const SECRET = "OUTSIDE_SKILL_SECRET_BYTES";
+const INSIDE = "INSIDE_SKILL_BODY";
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("local-skill root containment", () => {
+  it("loads a regular SKILL.md below the project skill root", async () => {
+    const { agencHome, pluginStorageRoot, workspaceRoot } = await workspace();
+    await writeSkill(join(workspaceRoot, ".agents", "skills", "ok-skill"), "ok-skill", INSIDE);
+
+    const snapshot = await loadLocalSkillsSnapshot({
+      agencHome,
+      pluginStorageRoot,
+      workspaceRoot,
+      env: {},
+    });
+
+    expect(snapshot.skills.map((skill) => skill.name)).toContain("ok-skill");
+    expect(JSON.stringify(snapshot.warnings)).not.toContain(SECRET);
+  });
+
+  it("rejects an outbound skill directory link before the outside SKILL.md is read", async () => {
+    const { agencHome, pluginStorageRoot, workspaceRoot, root } = await workspace();
+    const skillRoot = join(workspaceRoot, ".agents", "skills");
+    await writeSkill(join(skillRoot, "ok-skill"), "ok-skill", INSIDE);
+    const outsideSkill = join(root, "outside-skill");
+    await writeSkill(outsideSkill, "leaked-skill", SECRET);
+    await linkDirectory(outsideSkill, join(skillRoot, "leaked-skill"));
+
+    const snapshot = await loadLocalSkillsSnapshot({
+      agencHome,
+      pluginStorageRoot,
+      workspaceRoot,
+      env: {},
+    });
+
+    expect(snapshot.skills.map((skill) => skill.name)).toContain("ok-skill");
+    expect(snapshot.skills.map((skill) => skill.name)).not.toContain("leaked-skill");
+    expect(snapshot.warnings.some((warning) => warning.path.includes("leaked-skill"))).toBe(true);
+    expect(JSON.stringify(snapshot)).not.toContain(SECRET);
+  });
+});
+
+async function workspace(): Promise<{
+  readonly root: string;
+  readonly agencHome: string;
+  readonly pluginStorageRoot: string;
+  readonly workspaceRoot: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "agenc-skill-root-containment-"));
+  roots.push(root);
+  const workspaceRoot = join(root, "workspace");
+  const agencHome = join(root, "home");
+  const pluginStorageRoot = join(agencHome, "plugins");
+  await mkdir(pluginStorageRoot, { recursive: true });
+  return { root, agencHome, pluginStorageRoot, workspaceRoot };
+}
+
+async function writeSkill(dir: string, name: string, body: string): Promise<void> {
+  await writeUtf8(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${name} description\n---\n# ${name}\n${body}\n`,
+  );
+}


### PR DESCRIPTION
## Why

Repository plugin and local-skill loaders checked containment on path strings, then followed directory links during walk and read. A plugin `commands` directory or a project skill folder that was a link to an outside tree loaded that outside Markdown into AgenC. Issue #2094.

## Scope

`runtime/src/fs/root-contained-read.ts` is the shared helper. It binds the plugin or skill root, lstats each candidate, and refuses a symbolic link before `open`. Regular files below the root still load. Call sites are `resolveExistingPaths`, default component directories, plugin markdown collection, registration `readMarkdownFile`, hook file reads, plugin content validation, and the local-skill scanner.

MCP stdio env and stream-watchdog are untouched.

## Tradeoffs

Windows has no descriptor-path proof, so the helper uses lstat, realpath containment, then an identity check on the opened file. That is weaker than the Linux MCP verified-read path and still rejects outbound links before content is read. In-root regular files keep working. Skill walk still ignores a root-level `SKILL.md` when nested skill dirs exist.

## Blast Radius

Plugin command, agent, skill, output-style, and hook loads. Local project skill discovery and later skill body reads. `validatePluginContents` markdown scans. A planted outbound link now yields a warning or load issue that names the declared path, not bytes from the target.

## Verification

Hermetic vitest on Windows with Node 26.7.0.

`node scripts/run-hermetic-vitest.mjs run tests/fs/root-contained-read.test.ts tests/plugins/plugin-root-containment.test.ts tests/skills/skill-root-containment.test.ts`

7 passed, including the failing-before outbound-link cases. Mock lstat on the helper never opens the path. Adjacent `keeps invalid plugin paths non-fatal`, `bounds default command discovery`, nested skill names, leaf skill roots, and per-root cap tests passed.

Closes #2094
