### PR TITLE
fix(llm): keep Anthropic thinking budgets below max_tokens

### DIFF
--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -36,6 +36,7 @@ import {
   anthropicAcceptsEffort,
   anthropicAcceptsSamplingParameters,
   anthropicEffort,
+  anthropicManualBudgetTokens,
   anthropicThinkingControl,
 } from "../../utils/model/anthropicThinkingControl.js";
 
@@ -232,6 +233,7 @@ export function buildAnthropicMessagesRequest(
   const systemMessageHasCacheControl = systemMessages.some((message) =>
     hasEphemeralCacheControl(message)
   );
+  const maxTokens = input.maxTokens ?? 4096;
 
   const body: Record<string, unknown> = {
     model: input.model,
@@ -306,7 +308,7 @@ export function buildAnthropicMessagesRequest(
           content: normalizeAnthropicMessageContent(message),
         };
       }),
-    max_tokens: input.maxTokens ?? 4096,
+    max_tokens: maxTokens,
   };
 
   const wireMessages = body.messages as Array<Record<string, unknown>>;
@@ -429,11 +431,10 @@ export function buildAnthropicMessagesRequest(
       ? { type: "adaptive" }
       : {
           type: "enabled",
-          budget_tokens:
-            input.options?.reasoningEffort === "high" ||
-              input.options?.reasoningEffort === "xhigh"
-              ? 4096
-              : 2048,
+          budget_tokens: anthropicManualBudgetTokens(
+            input.options?.reasoningEffort,
+            maxTokens,
+          ),
         };
   }
   // The effort dial only means something on the wire as output_config.effort;

--- a/runtime/src/utils/model/anthropicThinkingControl.ts
+++ b/runtime/src/utils/model/anthropicThinkingControl.ts
@@ -82,3 +82,19 @@ export function anthropicEffort(
       return undefined;
   }
 }
+
+const ANTHROPIC_MIN_MANUAL_BUDGET_TOKENS = 1024;
+
+export function anthropicManualBudgetTokens(
+  effort: string | undefined,
+  maxTokens: number,
+): number {
+  const requested = effort === "high" || effort === "xhigh" ? 4096 : 2048;
+  const budget = Math.min(requested, maxTokens - 1);
+  if (budget < ANTHROPIC_MIN_MANUAL_BUDGET_TOKENS) {
+    throw new Error(
+      `Anthropic manual thinking requires budget_tokens >= ${ANTHROPIC_MIN_MANUAL_BUDGET_TOKENS} and below max_tokens (${maxTokens})`,
+    );
+  }
+  return budget;
+}

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -911,7 +911,7 @@ describe("buildAnthropicMessagesRequest — fable/mythos 5 family", () => {
     expect(request("us.anthropic.agenc-opus-5-v1", "low").thinking).toEqual({ type: "adaptive" });
 
     // Budgeted generations keep their config; effort only where the API takes it.
-    expect(request("claude-opus-4-5-20251101", "high").thinking).toEqual({ type: "enabled", budget_tokens: 4096 });
+    expect(request("claude-opus-4-5-20251101", "high").thinking).toEqual({ type: "enabled", budget_tokens: 4095 });
     expect(request("claude-opus-4-5-20251101", "high").output_config).toEqual({ effort: "high" });
     for (const model of ["claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001"]) {
       expect(request(model, "low").thinking, model).toEqual({ type: "enabled", budget_tokens: 2048 });

--- a/runtime/tests/llm/wire/messages-anthropic.test.ts
+++ b/runtime/tests/llm/wire/messages-anthropic.test.ts
@@ -1043,3 +1043,84 @@ describe("buildAnthropicMessagesRequest — fable/mythos 5 family", () => {
     expect(response.content).toBe("");
   });
 });
+
+describe("buildAnthropicMessagesRequest — thinking capability matrix", () => {
+  const turns = [{ role: "user" as const, content: "hello" }];
+
+  test("adaptive, always-on, and manual families emit valid request bodies", () => {
+    const rows = [
+      {
+        label: "opus-4-7 medium at a 1024 cap",
+        model: "claude-opus-4-7",
+        maxTokens: 1024,
+        effort: "medium" as const,
+        thinking: { type: "adaptive" },
+        output_config: { effort: "medium" },
+      },
+      {
+        label: "opus-4-8 medium",
+        model: "claude-opus-4-8",
+        maxTokens: 4096,
+        effort: "medium" as const,
+        thinking: { type: "adaptive" },
+        output_config: { effort: "medium" },
+      },
+      {
+        label: "fable-5 medium omits thinking",
+        model: "claude-fable-5",
+        maxTokens: 4096,
+        effort: "medium" as const,
+        thinking: undefined,
+        output_config: { effort: "medium" },
+      },
+      {
+        label: "opus-4-5 high on the default cap",
+        model: "claude-opus-4-5-20251101",
+        maxTokens: undefined,
+        effort: "high" as const,
+        thinking: { type: "enabled", budget_tokens: 4095 },
+        output_config: { effort: "high" },
+      },
+      {
+        label: "sonnet-4-5 high under a 2048 cap",
+        model: "claude-sonnet-4-5-20250929",
+        maxTokens: 2048,
+        effort: "high" as const,
+        thinking: { type: "enabled", budget_tokens: 2047 },
+        output_config: undefined,
+      },
+      {
+        label: "unknown future model medium under a 1500 cap",
+        model: "claude-future-unknown",
+        maxTokens: 1500,
+        effort: "medium" as const,
+        thinking: { type: "enabled", budget_tokens: 1499 },
+        output_config: undefined,
+      },
+    ];
+
+    for (const row of rows) {
+      const request = buildAnthropicMessagesRequest({
+        model: row.model,
+        messages: turns,
+        tools: [],
+        ...(row.maxTokens === undefined ? {} : { maxTokens: row.maxTokens }),
+        options: { reasoningEffort: row.effort },
+      });
+      expect(request.thinking, row.label).toEqual(row.thinking);
+      expect(request.output_config, row.label).toEqual(row.output_config);
+    }
+  });
+
+  test("a 1024 output cap cannot carry a manual thinking budget", () => {
+    expect(() =>
+      buildAnthropicMessagesRequest({
+        model: "claude-haiku-4-5-20251001",
+        messages: turns,
+        tools: [],
+        maxTokens: 1024,
+        options: { reasoningEffort: "high" },
+      }),
+    ).toThrow("budget_tokens >= 1024 and below max_tokens (1024)");
+  });
+});

--- a/runtime/tests/utils/model/anthropicThinkingControl.test.ts
+++ b/runtime/tests/utils/model/anthropicThinkingControl.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   anthropicAcceptsEffort,
   anthropicEffort,
+  anthropicManualBudgetTokens,
   anthropicThinkingControl,
 } from "../../../src/utils/model/anthropicThinkingControl.js";
 
@@ -48,5 +49,14 @@ describe("anthropicThinkingControl", () => {
     expect(anthropicEffort("max")).toBe("max");
     expect(anthropicEffort("none")).toBeUndefined();
     expect(anthropicEffort(undefined)).toBeUndefined();
+  });
+
+  test("manual budgets clamp below max_tokens and reject caps under 1025", () => {
+    expect(anthropicManualBudgetTokens("xhigh", 5000)).toBe(4096);
+    expect(anthropicManualBudgetTokens("low", 3000)).toBe(2048);
+    expect(anthropicManualBudgetTokens("high", 4096)).toBe(4095);
+    expect(() => anthropicManualBudgetTokens("high", 1024)).toThrow(
+      "budget_tokens >= 1024 and below max_tokens (1024)",
+    );
   });
 });


### PR DESCRIPTION
## Why

#2392 already sends adaptive thinking and `output_config.effort` for Opus 4.7 and 4.8. Manual models still sent `budget_tokens` equal to the default 4096 `max_tokens`, and they kept 4096 when the caller chose a smaller cap. Anthropic rejects those bodies.

## Scope

`anthropicManualBudgetTokens` in `runtime/src/utils/model/anthropicThinkingControl.ts` clamps the existing 2048/4096 ladder to `max_tokens - 1` and throws when that value would fall below 1024.

`buildAnthropicMessagesRequest` in `runtime/src/llm/wire/messages-anthropic.ts` uses that helper for the budget family only. Adaptive and always-on paths stay as #2392 left them.

Out of scope: Gemini and Ollama adapters, stream-watchdog, MCP SSE, and the catalog lineup from #2392.

## Tradeoffs

A 1024 `max_tokens` cap with manual thinking now fails in the builder instead of as an Anthropic 400. This PR does not raise `max_tokens` to make room for the budget.

## Blast Radius

Callers that send reasoning effort to Opus 4.5, Sonnet 4.5, Haiku 4.5, or an unknown Anthropic id with a small output cap now get a local error or a smaller budget. Default high-effort turns change `budget_tokens` from 4096 to 4095 so the budget stays below `max_tokens`. Adaptive models are unaffected.

## Verification

Hermetic vitest on Windows with `.tools/node-v26.7.0` (v26.7.0).

Before the fix, `thinking capability matrix` failed. Default high effort on Opus 4.5 sent `budget_tokens: 4096`. A 1024 cap did not throw.

After the fix, `tests/llm/wire/messages-anthropic.test.ts`, `tests/utils/model/anthropicThinkingControl.test.ts`, and `tests/gaphunt3/llm-wire-messages-anthropic.test.ts` passed. 46 tests. Exit 0.

Closes #2101
