### PR TITLE
fix(mcp): close SSE sessions before http.Server.close

### DIFF
--- a/runtime/src/mcp-server/http-sse.ts
+++ b/runtime/src/mcp-server/http-sse.ts
@@ -103,6 +103,7 @@ export class McpHttpSseServerTransport {
   };
   #serverFactory: () => McpServerFramework;
   readonly #sessions = new Map<string, McpHttpSseSession>();
+  #closed = false;
 
   constructor(options: McpHttpSseServerTransportOptions) {
     this.#serverFactory = options.serverFactory;
@@ -135,12 +136,14 @@ export class McpHttpSseServerTransport {
    * under which they were admitted.
    */
   replaceServerFactory(serverFactory: () => McpServerFramework): number {
-    const sessionIds = [...this.#sessions.keys()];
     this.#serverFactory = serverFactory;
-    for (const sessionId of sessionIds) {
-      this.closeSession(sessionId);
-    }
-    return sessionIds.length;
+    return this.#revokeSessions();
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#revokeSessions();
   }
 
   createNodeServer(): Server {
@@ -159,6 +162,9 @@ export class McpHttpSseServerTransport {
   ): Promise<boolean> {
     const url = requestUrl(request);
     try {
+      if (this.#closed) {
+        throw new HttpError(503, "MCP HTTP/SSE server is shutting down");
+      }
       this.#validateOrigin(request);
       if (request.method === "POST" && url.pathname === this.#options.httpPath) {
         await this.#handleHttpPost(request, response);
@@ -271,6 +277,14 @@ export class McpHttpSseServerTransport {
     }
     this.#sessions.delete(sessionId);
     return true;
+  }
+
+  #revokeSessions(): number {
+    const sessionIds = [...this.#sessions.keys()];
+    for (const sessionId of sessionIds) {
+      this.closeSession(sessionId);
+    }
+    return sessionIds.length;
   }
 
   #validateOrigin(request: IncomingMessage): void {

--- a/runtime/src/mcp/server/start.ts
+++ b/runtime/src/mcp/server/start.ts
@@ -230,20 +230,32 @@ export async function startMcpSseServe(
       });
       return () => transport.replaceServerFactory(replacementFactory);
     },
-    close: () =>
-      new Promise((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      }),
+    close: closeMcpSseHttpServer(server, transport),
     waitUntilClosed: () =>
       new Promise((resolve) => {
         server.once("close", resolve);
       }),
+  };
+}
+
+function closeMcpSseHttpServer(
+  server: Server,
+  transport: McpHttpSseServerTransport,
+): () => Promise<void> {
+  let closing: Promise<void> | undefined;
+  return () => {
+    closing ??= new Promise((resolve, reject) => {
+      transport.close();
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+      server.closeAllConnections();
+    });
+    return closing;
   };
 }
 

--- a/runtime/tests/mcp-server/http-sse.test.ts
+++ b/runtime/tests/mcp-server/http-sse.test.ts
@@ -882,4 +882,48 @@ describe("MCP HTTP/SSE server transport", () => {
       await server.close();
     }
   });
+
+  test("close ends live streams, is idempotent, and refuses later connects", async () => {
+    const transport = new McpHttpSseServerTransport({
+      serverFactory: () => new McpServerFramework(),
+      streamableIdleMs: 60_000,
+    });
+    const server = await startServer(transport);
+    const legacy = await openSse(`${server.baseUrl}/sse`);
+    await withTimeout(legacy.nextEvent());
+    const initialize = await fetch(`${server.baseUrl}/mcp`, {
+      method: "POST",
+      headers: streamablePostHeaders(),
+      body: JSON.stringify(request(1, "initialize")),
+    });
+    const sessionId = initialize.headers.get("mcp-session-id");
+    expect(sessionId).toEqual(expect.any(String));
+    const streamable = await openSse(
+      `${server.baseUrl}/mcp?sessionId=${sessionId}`,
+    );
+    try {
+      expect(legacy.response.statusCode).toBe(200);
+      expect(streamable.response.statusCode).toBe(200);
+      expect(transport.snapshots()).toHaveLength(2);
+
+      transport.close();
+      transport.close();
+      expect(transport.snapshots()).toHaveLength(0);
+
+      const refusedLegacy = await fetch(`${server.baseUrl}/sse`);
+      expect(refusedLegacy.status).toBe(503);
+      await expect(refusedLegacy.text()).resolves.toContain("shutting down");
+
+      const refusedInit = await fetch(`${server.baseUrl}/mcp`, {
+        method: "POST",
+        headers: streamablePostHeaders(),
+        body: JSON.stringify(request(2, "initialize")),
+      });
+      expect(refusedInit.status).toBe(503);
+    } finally {
+      legacy.close();
+      streamable.close();
+      await server.close();
+    }
+  });
 });

--- a/runtime/tests/mcp/server/start.test.ts
+++ b/runtime/tests/mcp/server/start.test.ts
@@ -1,3 +1,4 @@
+import { request as httpRequest } from "node:http";
 import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -570,4 +571,43 @@ describe("mcp server start config", () => {
       "only binds to loopback hosts",
     );
   });
+
+  test("close settles with a live SSE client and ignores a second close", async () => {
+    const started = await startMcpSseServe({
+      transport: "sse",
+      host: "127.0.0.1",
+      port: 0,
+    });
+    const sseUrl = new URL("/sse", started.url).href;
+    const live = await new Promise<{
+      readonly statusCode: number;
+      readonly ended: Promise<void>;
+    }>((resolve, reject) => {
+      const req = httpRequest(
+        sseUrl,
+        { headers: { accept: "text/event-stream" } },
+        (response) => {
+          response.resume();
+          resolve({
+            statusCode: response.statusCode ?? 0,
+            ended: new Promise((done) => {
+              response.once("end", () => done());
+              response.once("close", () => done());
+            }),
+          });
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+    expect(live.statusCode).toBe(200);
+    const first = started.close();
+    const second = started.close();
+    await expect(first).resolves.toBeUndefined();
+    await expect(second).resolves.toBeUndefined();
+    await live.ended;
+    await expect(
+      fetch(sseUrl, { headers: { accept: "text/event-stream" } }),
+    ).rejects.toThrow();
+  }, 2000);
 });


### PR DESCRIPTION
## Why

Daemon stop calls `StartedMcpSseServer.close()`, which only ran `http.Server.close()`. An open SSE response keeps the socket in keep-alive, so the close callback never fires and process teardown can wait forever. Shutdown must end every MCP session first, then close the listener.

## Scope

- `McpHttpSseServerTransport.close()` latches `#closed` and runs `#revokeSessions()`.
- `replaceServerFactory` uses the same revoke helper.
- New HTTP requests after the latch get 503.
- `closeMcpSseHttpServer` calls `transport.close()`, `server.close()`, and `server.closeAllConnections()`. A second close returns the same promise.
- Tests in `runtime/tests/mcp-server/http-sse.test.ts` and `runtime/tests/mcp/server/start.test.ts`.

Out of scope: `services/mcp/client.ts` env_vars.

## Tradeoffs

`closeAllConnections()` is immediate instead of a timed fallback. A hang on leftover sockets is worse than dropping a keep-alive that already received `response.end()`.

## Blast Radius

Daemon MCP autostart stop, `agenc mcp serve` shutdown, and tests that used to destroy the client before `close()`. Idle timers are cancelled with the sessions. In-flight requests on other sockets are cut when remaining connections drop.

## Verification

Hermetic vitest on Windows, Node v26.7.0.

Before the fix, `close settles with a live SSE client` timed out at 2000ms and `transport.close` was not a function.

After:

- `node runtime/scripts/run-hermetic-vitest.mjs run tests/mcp-server/http-sse.test.ts`. 14 passed.
- `node runtime/scripts/run-hermetic-vitest.mjs run tests/mcp/server/start.test.ts -t "close settles with a live SSE"`. 1 passed.
- `node runtime/scripts/run-hermetic-vitest.mjs run tests/gaphunt3/mcp-server-http-sse.test.ts`. 3 passed.

Closes #2097