### PR TITLE
fix(session): drop failed compaction payload chunks on open

### DIFF
--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -241,7 +241,7 @@ interface MutableAttemptScan {
 }
 
 export interface CanonicalCompactionAttemptScan {
-  readonly intent: CompactionIntentV1;
+  readonly intent?: CompactionIntentV1;
   readonly records: readonly StrictCanonicalJournalRecord[];
   readonly admissionValid: boolean;
   readonly hasLaterCanonicalWork: boolean;
@@ -570,7 +570,9 @@ function scanCanonicalRolloutUntimed(
           [...state.attempts].map(([attemptId, attempt]) => [
             attemptId,
             {
-              intent: attempt.intent!,
+              ...(attempt.intent !== undefined
+                ? { intent: attempt.intent }
+                : {}),
               records: Object.freeze(attempt.records.slice()),
               admissionValid: validAdmission(attempt),
               hasLaterCanonicalWork:
@@ -943,7 +945,11 @@ function observeCanonicalRecord(
       attempt.intent === undefined &&
       !attempt.terminal,
   );
-  if (incompleteAttempt !== undefined) {
+  if (
+    incompleteAttempt !== undefined &&
+    (item.type === "compaction_committed" ||
+      item.type === "compaction_rollback_committed")
+  ) {
     throw new Error(
       "canonical compaction intent is missing its required source payload bundle",
     );
@@ -1341,6 +1347,7 @@ function assertAttemptsReconstructed(
   attempts: ReadonlyMap<string, MutableAttemptScan>,
 ): void {
   for (const attempt of attempts.values()) {
+    if (failedAttemptDroppedPayloads(attempt)) continue;
     if (attempt.intent === undefined) {
       throw new Error(
         "canonical compaction intent did not reconstruct its source manifests",
@@ -1360,6 +1367,13 @@ function assertAttemptsReconstructed(
   }
 }
 
+function failedAttemptDroppedPayloads(attempt: MutableAttemptScan): boolean {
+  return (
+    attempt.intent === undefined &&
+    attempt.records.some((record) => record.item.type === "compaction_failed")
+  );
+}
+
 /**
  * Line numbers the digest-anchored second pass must re-read: the caller's
  * additional lines, every attempt's active-history refs, and the live active
@@ -1372,7 +1386,8 @@ function collectSourceLines(
 ): Set<number> {
   const sourceLines = new Set(options.additionalSourceLines ?? []);
   for (const attempt of attempts.values()) {
-    for (const ref of attempt.intent!.source.active_history_refs) {
+    if (attempt.intent === undefined) continue;
+    for (const ref of attempt.intent.source.active_history_refs) {
       sourceLines.add(ref.first_sequence);
     }
   }

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -864,6 +864,9 @@ export class RolloutStore {
       }
 
       this.store.open(meta);
+      this.store.rewriteFailedCompactionPayloadChunksAtomically(
+        COMPACTION_SOURCE_DIGEST_DOMAIN,
+      );
       this.promoteDurableCheckpointSchema(meta);
       this.rebuildLiveToolPairProjection();
       // Re-check under the canonical rollout lease. Retention can retire the
@@ -2563,6 +2566,7 @@ export class RolloutStore {
     );
     for (const attempt of orderedAttempts) {
       const intent = attempt.intent;
+      if (intent === undefined) continue;
       if (this.compactionRetentionRepo.get(intent.attempt_id) !== undefined) {
         continue;
       }

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -140,6 +140,131 @@ type RolloutPhysicalLineExclusion = {
     }
 );
 
+function isCompactionPayloadKind(
+  value: string | undefined,
+): value is CompactionPayloadKind {
+  return (
+    value === "active_history_refs" ||
+    value === "source_history" ||
+    value === "final_summary" ||
+    value === "summary_dag" ||
+    value === "replacement_history"
+  );
+}
+
+function rolloutPhysicalIdentity(decoded: string): {
+  readonly type: string;
+  readonly attemptId?: string;
+  readonly payloadKind?: string;
+} | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(decoded);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== "object" || value === null) return undefined;
+  const type = (value as { readonly type?: unknown }).type;
+  if (typeof type !== "string") return undefined;
+  const payload = (value as { readonly payload?: unknown }).payload;
+  if (typeof payload !== "object" || payload === null) return { type };
+  const attemptId = (payload as { readonly attempt_id?: unknown }).attempt_id;
+  const payloadKind = (payload as { readonly payload_kind?: unknown })
+    .payload_kind;
+  return {
+    type,
+    ...(typeof attemptId === "string" ? { attemptId } : {}),
+    ...(typeof payloadKind === "string" ? { payloadKind } : {}),
+  };
+}
+
+function assertPhysicalExclusionMatch(
+  exclusion: RolloutPhysicalLineExclusion,
+  physical: Buffer,
+  decoded: string,
+  digestDomain: string,
+): void {
+  const identity = rolloutPhysicalIdentity(decoded);
+  const digest = createHash("sha256")
+    .update(digestDomain, "utf8")
+    .update(physical)
+    .digest("hex");
+  if (
+    physical.byteLength !== exclusion.encodedBytes ||
+    digest !== exclusion.sha256 ||
+    identity?.type !== exclusion.itemType ||
+    (exclusion.itemType === "compaction_payload_chunk" &&
+      (identity.attemptId !== exclusion.attemptId ||
+        identity.payloadKind !== exclusion.payloadKind))
+  ) {
+    throw new Error(
+      "physical-row exclusion no longer matches canonical source",
+    );
+  }
+}
+
+function failedCompactionPayloadExclusions(
+  bytes: Buffer,
+  digestDomain: string,
+): RolloutPhysicalLineExclusion[] {
+  const failedAttemptIds = new Set<string>();
+  const chunks: Array<{
+    readonly lineNumber: number;
+    readonly physical: Buffer;
+    readonly attemptId: string;
+    readonly payloadKind: CompactionPayloadKind;
+  }> = [];
+  let lineNumber = 0;
+  let start = 0;
+  for (let offset = 0; offset < bytes.byteLength; offset += 1) {
+    if (bytes[offset] !== 0x0a) continue;
+    lineNumber += 1;
+    const physical = bytes.subarray(start, offset + 1);
+    start = offset + 1;
+    const identity = rolloutPhysicalIdentity(
+      new TextDecoder("utf-8", { fatal: true }).decode(
+        physical.subarray(0, physical.byteLength - 1),
+      ),
+    );
+    if (identity === undefined) continue;
+    if (
+      identity.type === "compaction_failed" &&
+      identity.attemptId !== undefined
+    ) {
+      failedAttemptIds.add(identity.attemptId);
+    }
+    if (
+      identity.type === "compaction_payload_chunk" &&
+      identity.attemptId !== undefined &&
+      isCompactionPayloadKind(identity.payloadKind)
+    ) {
+      chunks.push({
+        lineNumber,
+        physical,
+        attemptId: identity.attemptId,
+        payloadKind: identity.payloadKind,
+      });
+    }
+  }
+  return chunks.flatMap((chunk) =>
+    failedAttemptIds.has(chunk.attemptId)
+      ? [
+          {
+            lineNumber: chunk.lineNumber,
+            encodedBytes: chunk.physical.byteLength,
+            sha256: createHash("sha256")
+              .update(digestDomain, "utf8")
+              .update(chunk.physical)
+              .digest("hex"),
+            itemType: "compaction_payload_chunk" as const,
+            attemptId: chunk.attemptId,
+            payloadKind: chunk.payloadKind,
+          },
+        ]
+      : [],
+  );
+}
+
 // OOM: bound the per-session monotonic indices (`toolResultBytesByTurn`,
 // `tokenEstimateByTurn`, `toolCallTurnIds`, `offsetsBySeq`). These are advisory
 // accumulators — the rollout JSONL is the source of truth (I-25), the live
@@ -974,6 +1099,11 @@ function hydrateManifestCompactionItems(
         : [],
     ),
   );
+  const failedAttemptIds = new Set(
+    items.flatMap((item) =>
+      item.type === "compaction_failed" ? [item.payload.attempt_id] : [],
+    ),
+  );
   const payloadChunks = (
     manifest: Parameters<typeof reconstructCompactionPayloadV1>[0],
   ): readonly CompactionPayloadChunkV1[] =>
@@ -998,6 +1128,9 @@ function hydrateManifestCompactionItems(
         return item;
       }
       const persisted = readCompactionPersistedIntentV1(raw);
+      if (failedAttemptIds.has(persisted.attempt_id)) {
+        return item;
+      }
       const entries = reconstruct(
         persisted.source.active_history_refs_manifest,
       );
@@ -2890,6 +3023,25 @@ export class SessionStore {
   }
 
   /**
+   * Drop payload chunks whose attempt already recorded compaction_failed.
+   * Schema-invalid chunks still match by physical digest and type fields.
+   */
+  rewriteFailedCompactionPayloadChunksAtomically(digestDomain: string): void {
+    const bytes =
+      this.resumeSourceFd !== undefined
+        ? this.readBoundResumeSourceBytes()
+        : existsSync(this.rolloutPath)
+          ? readFileSync(this.rolloutPath)
+          : Buffer.alloc(0);
+    const exclusions = failedCompactionPayloadExclusions(bytes, digestDomain);
+    if (exclusions.length === 0) return;
+    this.rewriteRolloutExcludingPhysicalLinesAtomically(
+      exclusions,
+      digestDomain,
+    );
+  }
+
+  /**
    * Stream an exact physical-row deletion into a durable inode replacement.
    * This keeps compaction retention bounded by one canonical line instead of
    * loading the complete rollout into memory.
@@ -2909,7 +3061,7 @@ export class SessionStore {
     if (this.pending.length > 0) {
       throw new Error("cannot stream-rewrite rollout with pending appends");
     }
-    const byLine = new Map<number, (typeof exclusions)[number]>();
+    const byLine = new Map<number, RolloutPhysicalLineExclusion>();
     for (const exclusion of exclusions) {
       const existing = byLine.get(exclusion.lineNumber);
       if (
@@ -2991,33 +3143,22 @@ export class SessionStore {
     const writePhysical = (physical: Buffer): void => {
       lineNumber += 1;
       const exclusion = byLine.get(lineNumber);
-      const content = physical.subarray(0, physical.byteLength - 1);
-      const item = parseRolloutLine(
-        new TextDecoder("utf-8", { fatal: true }).decode(content),
+      const decoded = new TextDecoder("utf-8", { fatal: true }).decode(
+        physical.subarray(0, physical.byteLength - 1),
       );
-      if (item === null)
-        throw new Error("canonical rollout rewrite found a blank row");
       if (exclusion !== undefined) {
-        const digest = createHash("sha256")
-          .update(digestDomain, "utf8")
-          .update(physical)
-          .digest("hex");
-        if (
-          physical.byteLength !== exclusion.encodedBytes ||
-          digest !== exclusion.sha256 ||
-          item.type !== exclusion.itemType ||
-          (exclusion.itemType === "compaction_payload_chunk" &&
-            (item.type !== "compaction_payload_chunk" ||
-              item.payload.attempt_id !== exclusion.attemptId ||
-              item.payload.payload_kind !== exclusion.payloadKind))
-        ) {
-          throw new Error(
-            "physical-row exclusion no longer matches canonical source",
-          );
-        }
+        assertPhysicalExclusionMatch(
+          exclusion,
+          physical,
+          decoded,
+          digestDomain,
+        );
         matched.add(lineNumber);
         return;
       }
+      const item = parseRolloutLine(decoded);
+      if (item === null)
+        throw new Error("canonical rollout rewrite found a blank row");
       let written = 0;
       while (written < physical.byteLength) {
         const count = writeSync(

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -3027,12 +3027,7 @@ export class SessionStore {
    * Schema-invalid chunks still match by physical digest and type fields.
    */
   rewriteFailedCompactionPayloadChunksAtomically(digestDomain: string): void {
-    const bytes =
-      this.resumeSourceFd !== undefined
-        ? this.readBoundResumeSourceBytes()
-        : existsSync(this.rolloutPath)
-          ? readFileSync(this.rolloutPath)
-          : Buffer.alloc(0);
+    const bytes = this.readCurrentRolloutBytes();
     const exclusions = failedCompactionPayloadExclusions(bytes, digestDomain);
     if (exclusions.length === 0) return;
     this.rewriteRolloutExcludingPhysicalLinesAtomically(
@@ -3555,12 +3550,7 @@ export class SessionStore {
         "resumed rollout writer authority was revoked after replacement failure",
       );
     }
-    const content =
-      this.resumeSourceFd !== undefined
-        ? this.readBoundResumeSourceUtf8()
-        : existsSync(this.rolloutPath)
-          ? readFileSync(this.rolloutPath, "utf8")
-          : "";
+    const content = this.readCurrentRolloutBytes().toString("utf8");
     const items: RolloutItem[] = [];
     let malformed = 0;
     for (const line of content.split("\n")) {
@@ -3578,8 +3568,14 @@ export class SessionStore {
     return hydrateManifestCompactionItems(items);
   }
 
-  private readBoundResumeSourceUtf8(): string {
-    return this.readBoundResumeSourceBytes().toString("utf8");
+  private readCurrentRolloutBytes(): Buffer {
+    if (this.resumeSourceFd !== undefined) {
+      return this.readBoundResumeSourceBytes();
+    }
+    if (existsSync(this.rolloutPath)) {
+      return readFileSync(this.rolloutPath);
+    }
+    return Buffer.alloc(0);
   }
 
   private readBoundResumeSourceBytes(): Buffer {

--- a/runtime/src/state/recovery-journal-contract.ts
+++ b/runtime/src/state/recovery-journal-contract.ts
@@ -368,6 +368,7 @@ export class StrictCanonicalJournalValidator {
       if (!isPlainRecord(sourceHistoryManifest)) continue;
       const sourceHistory = attempt.payloadChunks?.get("source_history");
       if (sourceHistory !== undefined) continue;
+      if (attempt.terminal === "failed") continue;
       if (attempt.terminal !== "committed" || attempt.release !== true) {
         this.#fail(
           "identity_conflict",

--- a/runtime/tests/session/rollout-store.compaction-transaction.test.ts
+++ b/runtime/tests/session/rollout-store.compaction-transaction.test.ts
@@ -971,6 +971,89 @@ describe("RolloutStore transactional compaction", () => {
     );
   });
 
+  it("repairs failed-attempt payload chunks that fail strict validation", () => {
+    const cwd = createTestWorkspace();
+    temporaryWorkspaces.push(cwd);
+    const sessionId = "failed-chunk-repair";
+    const attemptId = "failed-chunk-repair-attempt";
+    const store = openStore(sessionId, {}, cwd);
+    const rolloutPath = store.rolloutPath;
+    try {
+      store.appendRollout(
+        {
+          type: "response_item",
+          payload: { role: "user", content: "keep-me" },
+        },
+        { durable: true },
+      );
+      const prepared = store.prepareSource(attemptId, []);
+      const intent: CompactionIntentV1 = {
+        format_version: COMPACTION_EVENT_FORMAT_VERSION,
+        minimum_reader_runtime: COMPACTION_MINIMUM_READER_RUNTIME,
+        attempt_id: attemptId,
+        recorded_at_ms: Date.now(),
+        source: prepared.source,
+        policy_digest: "ab".repeat(32),
+        configuration_digest: "cd".repeat(32),
+        accounting_ref: "ef".repeat(32),
+        automatic: false,
+        selected_history_indexes: [0],
+        admission_required: true,
+        planned_provider_calls: 1,
+      };
+      store.pinAndRecordIntent(intent, sourcePayloadBundles(prepared, intent));
+      store.recordFailure({
+        format_version: COMPACTION_EVENT_FORMAT_VERSION,
+        minimum_reader_runtime: COMPACTION_MINIMUM_READER_RUNTIME,
+        attempt_id: attemptId,
+        recorded_at_ms: Date.now(),
+        source_sha256: prepared.source.source_sha256,
+        history_digest: prepared.source.history_digest,
+        reason: "commit_failed",
+        detail_digest: "4".repeat(64),
+      });
+    } finally {
+      store.close();
+    }
+
+    mutatePayloadChunk(rolloutPath, "source_history", (fragment) =>
+      fragment.replace("keep-me", "[REDACTED_SECRET]"),
+    );
+    expect(() =>
+      validateCanonicalJournalBytes(readFileSync(rolloutPath)),
+    ).toThrow(/compaction_payload_chunk payload does not match the runtime schema/);
+
+    const repaired = openStore(sessionId, { resume: true }, cwd);
+    try {
+      const rows = readTestRolloutRows(repaired.rolloutPath);
+      expect(
+        rows.some(
+          (row) =>
+            row.type === "compaction_failed" &&
+            (row.payload as { readonly attempt_id: string }).attempt_id ===
+              attemptId,
+        ),
+      ).toBe(true);
+      expect(
+        rows.some(
+          (row) =>
+            row.type === "compaction_payload_chunk" &&
+            (row.payload as CompactionPayloadChunkV1).attempt_id === attemptId,
+        ),
+      ).toBe(false);
+      expect(
+        reconstructFromRollout(repaired.readAll()).history.map(
+          (message) => message.content,
+        ),
+      ).toEqual(["keep-me"]);
+      expect(() =>
+        validateCanonicalJournalBytes(readFileSync(repaired.rolloutPath)),
+      ).not.toThrow();
+    } finally {
+      repaired.close();
+    }
+  });
+
   it("binds a persisted rollback to the hydrated canonical commit digest", () => {
     const cwd = createTestWorkspace();
     temporaryWorkspaces.push(cwd);


### PR DESCRIPTION
## Why

#2162. Before #2160, a compaction whose source history held a secret-like string wrote `compaction_payload_chunk` rows whose byte count and digest were taken before redaction. Strict resume then rejects the chunk (`canonical compaction_payload_chunk payload does not match the runtime schema`). `readAll` skips the invalid line and then throws `payload chunk count does not match its manifest`. The attempt is already `compaction_failed` with `reason: commit_failed`, so those payload rows are not needed. #2160 stops new writes. This repairs rollouts that already have them.

## Scope

- `SessionStore.rewriteFailedCompactionPayloadChunksAtomically` collects physical `compaction_payload_chunk` rows whose `attempt_id` has a `compaction_failed` record and drops them through `rewriteRolloutExcludingPhysicalLinesAtomically`.
- Exclusion matching uses the physical digest plus JSON `type` / `attempt_id` / `payload_kind`, so a schema-invalid chunk can still be dropped. Kept rows still go through `parseRolloutLine`.
- `RolloutStore.open` runs that rewrite after the store opens and before compaction reconciliation.
- `hydrateManifestCompactionItems` does not reconstruct payload manifests for an attempt that already failed.
- The canonical scanner allows a failed attempt without reconstructed source payloads. `#seal` does the same when `terminal === "failed"`.
- One unique test mutates a `source_history` fragment after `compaction_failed`, asserts the schema error, then resumes and checks that the chunks are gone, the failure record remains, and `keep-me` history reconstructs.

Not changed: MCP SSE, Anthropic wire, plugin loaders, committed-chunk tamper rejection, the strict per-line chunk schema.

## Tradeoffs

The reader still does not treat an invalid chunk as inert. The chunk has to leave the file. That keeps the per-line validator contract and means a failed attempt without chunks is now a valid sealed journal.

## Blast Radius

Resume and startup of sessions that already recorded `compaction_failed` with leftover payload rows. Committed or rollback payload tampering still fails closed, as the existing restart tests require. Physical rewrite stays on the existing atomic path.

## Verification

Hermetic vitest with Node v26.7.0 from `.tools/node-v26.7.0`.

- Before the fix, `repairs failed-attempt payload chunks that fail strict validation` failed on resume (`payload chunk count does not match its manifest`, then `compaction source_history manifest has no chunk chain or durable release`).
- After the fix, `node scripts/run-hermetic-vitest.mjs run tests/session/rollout-store.compaction-transaction.test.ts tests/services/compact/payload-manifest.test.ts` exit 0, 58 passed.
- `tests/session/canonical-rollout-scanner.test.ts`, `tests/state/recovery-journal-contract.test.ts`, `tests/session/rollout-store.canonical-scan-reuse.test.ts` exit 0, 65 passed.
- Descriptor-bound streaming rewrite tests exit 0, 2 passed.
- `rolls back a partial append before degraded requeue` fails on this Windows host against `main` as well (7-byte tail not rolled back). Not introduced here.

Closes #2162