### PR TITLE
fix(llm): map Anthropic context-window overflow and reject pause_turn

### DIFF
--- a/runtime/src/llm/providers/anthropic/adapter.ts
+++ b/runtime/src/llm/providers/anthropic/adapter.ts
@@ -460,7 +460,7 @@ export class AnthropicProvider implements LLMProvider {
     streamAttempts: while (true) {
       let content = "";
       let model = requestModel;
-      let finishReason: LLMResponse["finishReason"] = "stop";
+      let stopReason = "end_turn";
       let sawMessageStop = false;
       let usage: AnthropicUsageAccumulator = {
         input_tokens: 0,
@@ -718,23 +718,8 @@ export class AnthropicProvider implements LLMProvider {
               ? (event.data.delta as Record<string, unknown>)
               : {};
           usage = mergeAnthropicUsage(usage, event.data.usage);
-          switch (String(delta.stop_reason ?? "")) {
-            case "tool_use":
-              finishReason = "tool_calls";
-              break;
-            case "max_tokens":
-              finishReason = "length";
-              break;
-            case "content_filter":
-            case "refusal":
-              finishReason = "content_filter";
-              break;
-            case "error":
-              finishReason = "error";
-              break;
-            default:
-              finishReason = "stop";
-              break;
+          if (typeof delta.stop_reason === "string") {
+            stopReason = delta.stop_reason;
           }
           continue;
         }
@@ -822,16 +807,7 @@ export class AnthropicProvider implements LLMProvider {
                 }];
               }),
             ],
-            stop_reason:
-              finishReason === "tool_calls"
-                ? "tool_use"
-                : finishReason === "length"
-                  ? "max_tokens"
-                  : finishReason === "content_filter"
-                    ? "content_filter"
-                    : finishReason === "error"
-                      ? "error"
-                      : "end_turn",
+            stop_reason: stopReason,
             usage,
           },
           requestOptions,

--- a/runtime/src/llm/wire/messages-anthropic.ts
+++ b/runtime/src/llm/wire/messages-anthropic.ts
@@ -18,8 +18,8 @@ import {
 import {
   coerceUsage,
   collectRequestMetrics,
-  normalizeFinishReason,
   normalizeToolCalls,
+  requireMappedFinishReason,
   parseAnthropicToolChoice,
   prepareMessagesForWire,
   toAnthropicMessageContent,
@@ -559,7 +559,7 @@ export function parseAnthropicMessagesResponse(
         toolCalls.length === 0 &&
         structuredOutput
         ? "stop"
-        : normalizeFinishReason(response.stop_reason),
+        : requireMappedFinishReason("anthropic", response.stop_reason),
     requestMetrics: withEndpointMarkers(requestMetrics, "/messages", response),
     ...(structuredOutput ? { structuredOutput } : {}),
     ...(thinking.length > 0 ? { thinking } : {}),

--- a/runtime/src/llm/wire/shared.ts
+++ b/runtime/src/llm/wire/shared.ts
@@ -8,11 +8,13 @@ import type {
   LLMChatOptions,
   LLMContentPart,
   LLMMessage,
+  LLMResponse,
   LLMTool,
   LLMToolCall,
   LLMToolChoice,
   LLMUsage,
 } from "../types.js";
+import { LLMInvalidResponseError } from "../errors.js";
 import { normalizeMessagesForAPI } from "../messages.js";
 import { validateToolCall, validateToolCallDetailed } from "../types.js";
 import { encodeMcpToolNameForWire } from "./mcp-tool-naming.js";
@@ -302,27 +304,52 @@ export function coerceUsage(usage: {
   };
 }
 
-export function normalizeFinishReason(
+type LLMFinishReason = LLMResponse["finishReason"];
+
+type ProviderStopOutcome =
+  | { readonly kind: "mapped"; readonly finishReason: LLMFinishReason }
+  | { readonly kind: "unsupported" };
+
+const PROVIDER_STOP_REASON_OUTCOME: {
+  readonly [reason: string]: ProviderStopOutcome;
+} = {
+  tool_calls: { kind: "mapped", finishReason: "tool_calls" },
+  tool_use: { kind: "mapped", finishReason: "tool_calls" },
+  length: { kind: "mapped", finishReason: "length" },
+  max_tokens: { kind: "mapped", finishReason: "length" },
+  model_context_window_exceeded: { kind: "mapped", finishReason: "length" },
+  content_filter: { kind: "mapped", finishReason: "content_filter" },
+  refusal: { kind: "mapped", finishReason: "content_filter" },
+  sensitive: { kind: "mapped", finishReason: "content_filter" },
+  error: { kind: "mapped", finishReason: "error" },
+  network_error: { kind: "mapped", finishReason: "error" },
+  pause_turn: { kind: "unsupported" },
+};
+
+function outcomeForProviderStopReason(reason: unknown): ProviderStopOutcome {
+  return PROVIDER_STOP_REASON_OUTCOME[String(reason ?? "")] ?? {
+    kind: "mapped",
+    finishReason: "stop",
+  };
+}
+
+export function normalizeFinishReason(reason: unknown): LLMFinishReason {
+  const outcome = outcomeForProviderStopReason(reason);
+  return outcome.kind === "mapped" ? outcome.finishReason : "error";
+}
+
+export function requireMappedFinishReason(
+  providerName: string,
   reason: unknown,
-): "stop" | "tool_calls" | "length" | "content_filter" | "error" {
-  switch (String(reason ?? "")) {
-    case "tool_calls":
-    case "tool_use":
-      return "tool_calls";
-    case "length":
-    case "max_tokens":
-    case "model_context_window_exceeded":
-      return "length";
-    case "content_filter":
-    case "refusal":
-    case "sensitive":
-      return "content_filter";
-    case "error":
-    case "network_error":
-      return "error";
-    default:
-      return "stop";
+): LLMFinishReason {
+  const outcome = outcomeForProviderStopReason(reason);
+  if (outcome.kind === "unsupported") {
+    throw new LLMInvalidResponseError(
+      providerName,
+      `Unsupported provider state ${JSON.stringify(String(reason ?? ""))}`,
+    );
   }
+  return outcome.finishReason;
 }
 
 export function messageTextContent(

--- a/runtime/src/llm/wire/shared.ts
+++ b/runtime/src/llm/wire/shared.ts
@@ -326,8 +326,12 @@ const PROVIDER_STOP_REASON_OUTCOME: {
   pause_turn: { kind: "unsupported" },
 };
 
+function providerStopReasonKey(reason: unknown): string {
+  return typeof reason === "string" ? reason : "";
+}
+
 function outcomeForProviderStopReason(reason: unknown): ProviderStopOutcome {
-  return PROVIDER_STOP_REASON_OUTCOME[String(reason ?? "")] ?? {
+  return PROVIDER_STOP_REASON_OUTCOME[providerStopReasonKey(reason)] ?? {
     kind: "mapped",
     finishReason: "stop",
   };
@@ -346,7 +350,7 @@ export function requireMappedFinishReason(
   if (outcome.kind === "unsupported") {
     throw new LLMInvalidResponseError(
       providerName,
-      `Unsupported provider state ${JSON.stringify(String(reason ?? ""))}`,
+      `Unsupported provider state ${JSON.stringify(providerStopReasonKey(reason))}`,
     );
   }
   return outcome.finishReason;

--- a/runtime/tests/llm/providers/anthropic/adapter.test.ts
+++ b/runtime/tests/llm/providers/anthropic/adapter.test.ts
@@ -854,4 +854,84 @@ describe("AnthropicProvider", () => {
     expect(headers.get("x-api-key")).toBe("anthropic-test");
     expect(headers.get("accept")).toBe("text/event-stream");
   });
+
+  test("maps chat model_context_window_exceeded to length", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_window",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4.5",
+          content: [
+            { type: "text", text: "truncated answer" },
+            {
+              type: "tool_use",
+              id: "toolu_cut",
+              name: "system.echo",
+              input: { text: "incomplete" },
+            },
+          ],
+          stop_reason: "model_context_window_exceeded",
+          usage: { input_tokens: 8, output_tokens: 4 },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const provider = new AnthropicProvider({
+      apiKey: "anthropic-test",
+      model: "claude-sonnet-4.5",
+      fetchImpl,
+    });
+
+    const response = await provider.chat(
+      [{ role: "user", content: "fill the window" }],
+    );
+
+    expect(response.finishReason).toBe("length");
+    expect(response.content).toBe("truncated answer");
+  });
+
+  test("rejects chat pause_turn as an unsupported provider state", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_pause",
+          type: "message",
+          role: "assistant",
+          model: "claude-opus-4-7",
+          content: [
+            { type: "text", text: "searching" },
+            {
+              type: "server_tool_use",
+              id: "srvtoolu_1",
+              name: "web_search",
+              input: { query: "latest news" },
+            },
+          ],
+          stop_reason: "pause_turn",
+          usage: { input_tokens: 3, output_tokens: 2 },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const provider = new AnthropicProvider({
+      apiKey: "anthropic-test",
+      model: "claude-opus-4-7",
+      fetchImpl,
+    });
+
+    await expect(
+      provider.chat([{ role: "user", content: "search the web" }]),
+    ).rejects.toMatchObject({
+      name: "LLMInvalidResponseError",
+      message: expect.stringContaining("pause_turn"),
+    });
+  });
 });

--- a/runtime/tests/llm/providers/anthropic/adapter.thinking-stream.test.ts
+++ b/runtime/tests/llm/providers/anthropic/adapter.thinking-stream.test.ts
@@ -158,4 +158,30 @@ describe("messages-API adapter forwards extended-thinking SSE events", () => {
     expect(response.toolCalls.map((c) => c.name)).toEqual(["Read"]);
     expect(response.content).toBe("done");
   });
+
+  test("maps streamed model_context_window_exceeded to length", async () => {
+    const { response } = await runStream([
+      messageStart,
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"cut mid-sentence"}}\n\n',
+      'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"model_context_window_exceeded","stop_sequence":null},"usage":{"output_tokens":7}}\n\n',
+      messageStop,
+    ]);
+    expect(response.finishReason).toBe("length");
+    expect(response.content).toBe("cut mid-sentence");
+  });
+
+  test("rejects streamed pause_turn instead of treating it as a natural stop", async () => {
+    await expect(
+      runStream([
+        messageStart,
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"pause_turn","stop_sequence":null},"usage":{"output_tokens":1}}\n\n',
+        messageStop,
+      ]),
+    ).rejects.toMatchObject({
+      name: "LLMInvalidResponseError",
+      message: expect.stringContaining("pause_turn"),
+    });
+  });
 });


### PR DESCRIPTION
## Why

Anthropic now returns `model_context_window_exceeded` and `pause_turn`. The stream switch and the default `normalizeFinishReason` path treated both as a natural stop. Truncated output looked complete. A paused server-tool turn looked finished.

## Scope

`PROVIDER_STOP_REASON_OUTCOME` in `runtime/src/llm/wire/shared.ts` is the one mapping table.

`parseAnthropicMessagesResponse` calls `requireMappedFinishReason`. `AnthropicProvider.chatStream` keeps the raw `stop_reason` and no longer has a second switch.

`model_context_window_exceeded` maps to `length`. `pause_turn` throws `LLMInvalidResponseError`. Existing `max_tokens`, `refusal`, and `tool_use` mappings stay.

This PR does not change Anthropic thinking budgets (#2398). It does not auto-continue `pause_turn`. AgenC does not ship Anthropic server tools, so a continue loop would live in an adapter that does not own that contract yet.

## Tradeoffs

A typed reject is the smaller fix. Continuation needs the exact assistant content, the same tools array, and an iteration budget. Reject `pause_turn` until that loop exists.

## Blast Radius

Chat and stream Anthropic Messages calls. Other providers still use `normalizeFinishReason`, which maps `pause_turn` to `error` if they ever send it. Phase-layer tool dispatch already drops tools when `finishReason` is `length`.

## Verification

Hermetic vitest on Windows with Node v26.7.0.

- Before the fix, stream `model_context_window_exceeded` finished as `stop`. Chat and stream `pause_turn` finished as `stop`. Chat `model_context_window_exceeded` already mapped to `length`.
- After the fix, `tests/llm/providers/anthropic/adapter.test.ts` and `tests/llm/providers/anthropic/adapter.thinking-stream.test.ts` passed 26 tests. Nearby `messages-anthropic.test.ts` and Z.AI provider tests passed 91 tests.

Closes #2111