### PR TITLE
fix(llm): drop failed model-metadata lookups from cache

### DIFF
--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -92,13 +92,18 @@ interface FetchJsonOptions {
   readonly jsonBody?: Readonly<Record<string, unknown>>;
 }
 
+type MetadataJson = object | string | number | boolean | null;
+
 export class ModelMetadataResolver {
   private readonly fetchImpl?: typeof fetch;
   private readonly env: Readonly<Record<string, string | undefined>>;
   private readonly timeoutMs: number;
   private readonly onWarn?: (msg: string) => void;
-  private readonly inFlightJson = new Map<string, Promise<unknown>>();
-  private readonly jsonCache = new Map<string, unknown>();
+  private readonly inFlightJson = new Map<
+    string,
+    Promise<MetadataJson | undefined>
+  >();
+  private readonly jsonCache = new Map<string, MetadataJson | undefined>();
   private readonly warnedInvalidEnv = new Set<string>();
 
   constructor(options: ModelMetadataResolverOptions = {}) {
@@ -287,7 +292,7 @@ export class ModelMetadataResolver {
   private async fetchJson(
     url: string,
     options: FetchJsonOptions = {},
-  ): Promise<unknown | undefined> {
+  ): Promise<MetadataJson | undefined> {
     if (!this.fetchImpl) return undefined;
     const cacheKey = `${url}\n${JSON.stringify(options.headers ?? {})}\n${
       JSON.stringify(options.jsonBody ?? null)
@@ -303,7 +308,7 @@ export class ModelMetadataResolver {
   private async fetchJsonUncached(
     url: string,
     options: FetchJsonOptions,
-  ): Promise<unknown | undefined> {
+  ): Promise<MetadataJson | undefined> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {

--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -97,8 +97,8 @@ export class ModelMetadataResolver {
   private readonly env: Readonly<Record<string, string | undefined>>;
   private readonly timeoutMs: number;
   private readonly onWarn?: (msg: string) => void;
-  private readonly inFlightJson = new Map<string, Promise<unknown | undefined>>();
-  private readonly jsonCache = new Map<string, unknown | undefined>();
+  private readonly inFlightJson = new Map<string, Promise<unknown>>();
+  private readonly jsonCache = new Map<string, unknown>();
   private readonly warnedInvalidEnv = new Set<string>();
 
   constructor(options: ModelMetadataResolverOptions = {}) {

--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -3,6 +3,7 @@ import {
 } from "../config/resolve-provider.js";
 import type { AgenCConfig } from "../config/schema.js";
 import { resolveModelCatalogMetadata } from "./registry/model-catalog.js";
+import { rememberSuccessfulLookup } from "./remember-successful-lookup.js";
 import { normalizeProviderMetadataIdentity } from "../provider-identity.js";
 import {
   resolveProviderApiKeyEnvironment,
@@ -96,7 +97,8 @@ export class ModelMetadataResolver {
   private readonly env: Readonly<Record<string, string | undefined>>;
   private readonly timeoutMs: number;
   private readonly onWarn?: (msg: string) => void;
-  private readonly jsonCache = new Map<string, Promise<unknown | undefined>>();
+  private readonly inFlightJson = new Map<string, Promise<unknown | undefined>>();
+  private readonly jsonCache = new Map<string, unknown | undefined>();
   private readonly warnedInvalidEnv = new Set<string>();
 
   constructor(options: ModelMetadataResolverOptions = {}) {
@@ -290,11 +292,12 @@ export class ModelMetadataResolver {
     const cacheKey = `${url}\n${JSON.stringify(options.headers ?? {})}\n${
       JSON.stringify(options.jsonBody ?? null)
     }`;
-    const cached = this.jsonCache.get(cacheKey);
-    if (cached) return await cached;
-    const request = this.fetchJsonUncached(url, options);
-    this.jsonCache.set(cacheKey, request);
-    return await request;
+    return await rememberSuccessfulLookup(
+      { inFlight: this.inFlightJson, success: this.jsonCache },
+      cacheKey,
+      () => this.fetchJsonUncached(url, options),
+      (value) => value !== undefined,
+    );
   }
 
   private async fetchJsonUncached(

--- a/runtime/src/llm/models-manager.ts
+++ b/runtime/src/llm/models-manager.ts
@@ -7,6 +7,7 @@ import {
   modelRegistryEntryToModelInfo,
   type ModelMetadataResolverOptions,
 } from "./model-registry.js";
+import { rememberSuccessfulLookup } from "./remember-successful-lookup.js";
 import type { ModelsManager } from "../session/session.js";
 import type { ModelInfo } from "../session/turn-context.js";
 
@@ -16,7 +17,8 @@ export class StaticModelsManager implements ModelsManager {
   private readonly allModels: readonly ModelInfo[];
   private readonly availableModels: readonly ModelInfo[];
   private readonly modelRegistry: ModelRegistry;
-  private readonly modelInfoCache = new Map<string, Promise<ModelInfo>>();
+  private readonly inFlightModelInfo = new Map<string, Promise<ModelInfo>>();
+  private readonly modelInfoCache = new Map<string, ModelInfo>();
 
   constructor(params: {
     readonly config: AgenCConfig;
@@ -64,11 +66,12 @@ export class StaticModelsManager implements ModelsManager {
     readonly model: string;
   }): Promise<ModelInfo> {
     const key = `${params.provider}:${params.model}`;
-    const cached = this.modelInfoCache.get(key);
-    if (cached) return await cached;
-    const resolved = this.buildResolvedModelInfo(params);
-    this.modelInfoCache.set(key, resolved);
-    return await resolved;
+    return await rememberSuccessfulLookup(
+      { inFlight: this.inFlightModelInfo, success: this.modelInfoCache },
+      key,
+      () => this.buildResolvedModelInfo(params),
+      (info) => !info.usedFallbackModelMetadata,
+    );
   }
 
   private async buildResolvedModelInfo(params: {

--- a/runtime/src/llm/remember-successful-lookup.ts
+++ b/runtime/src/llm/remember-successful-lookup.ts
@@ -1,0 +1,23 @@
+export async function rememberSuccessfulLookup<T>(
+  tables: {
+    readonly inFlight: Map<string, Promise<T>>;
+    readonly success: Map<string, T>;
+  },
+  key: string,
+  load: () => Promise<T>,
+  isSuccess: (value: T) => boolean,
+): Promise<T> {
+  const hit = tables.success.get(key);
+  if (hit !== undefined) return hit;
+  const pending = tables.inFlight.get(key);
+  if (pending !== undefined) return await pending;
+  const request = load();
+  tables.inFlight.set(key, request);
+  try {
+    const value = await request;
+    if (isSuccess(value)) tables.success.set(key, value);
+    return value;
+  } finally {
+    tables.inFlight.delete(key);
+  }
+}

--- a/runtime/tests/llm/model-metadata.local-providers.test.ts
+++ b/runtime/tests/llm/model-metadata.local-providers.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "vitest";
 
+import { defaultConfig } from "../../src/config/schema.js";
 import {
+  CONSERVATIVE_CONTEXT_WINDOW_TOKENS,
   ModelMetadataResolver,
   ollamaShowUrlFromBaseUrl,
 } from "../../src/llm/model-metadata.js";
+import { StaticModelsManager } from "../../src/llm/models-manager.js";
 import type { AgenCConfig } from "../../src/utils/config.js";
 
 const EMPTY_CONFIG = {} as unknown as AgenCConfig;
@@ -348,5 +351,82 @@ describe("local providers resolve the real context window", () => {
       });
       expect(resolved.source, String(value)).not.toBe("live_endpoint");
     }
+  });
+});
+
+const OLLAMA_SHOW_URL = "http://127.0.0.1:11434/api/show";
+const OLLAMA_ENV = { OLLAMA_BASE_URL: "http://127.0.0.1:11434" } as const;
+
+function ollamaShowScriptFetch(
+  script: (showCall: number) => Promise<Response> | Response,
+): { readonly impl: typeof fetch; readonly showCalls: () => number } {
+  let showCalls = 0;
+  const impl = (async (input: RequestInfo | URL) => {
+    if (String(input) !== OLLAMA_SHOW_URL) {
+      return new Response("not found", { status: 404 });
+    }
+    showCalls += 1;
+    return await script(showCalls);
+  }) as unknown as typeof fetch;
+  return { impl, showCalls: () => showCalls };
+}
+
+describe("transient metadata failures do not stick", () => {
+  test("a 503 then a valid 32768 window refetches instead of caching undefined", async () => {
+    const { impl, showCalls } = ollamaShowScriptFetch((showCall) => {
+      if (showCall === 1) return new Response("unavailable", { status: 503 });
+      return new Response(JSON.stringify(OLLAMA_SHOW), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const manager = new StaticModelsManager({
+      config: defaultConfig(),
+      fallbackProvider: "ollama",
+      metadata: { fetchImpl: impl, env: OLLAMA_ENV },
+    });
+
+    const first = await manager.getModelInfo("qwen2.5-coder:1.5b");
+    expect(first.usedFallbackModelMetadata).toBe(true);
+    expect(first.contextWindow).toBe(CONSERVATIVE_CONTEXT_WINDOW_TOKENS);
+    expect(showCalls()).toBe(1);
+
+    const second = await manager.getModelInfo("qwen2.5-coder:1.5b");
+    expect(second.contextWindow).toBe(32768);
+    expect(second.usedFallbackModelMetadata).toBe(false);
+    expect(showCalls()).toBe(2);
+  });
+
+  test("concurrent ollama lookups share one in-flight /api/show request", async () => {
+    let releaseFirst!: () => void;
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const { impl, showCalls } = ollamaShowScriptFetch(async (showCall) => {
+      if (showCall === 1) await holdFirst;
+      return new Response(JSON.stringify(OLLAMA_SHOW), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const resolver = new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: OLLAMA_ENV,
+    });
+    const lookup = {
+      provider: "ollama",
+      model: "qwen2.5-coder:1.5b",
+      config: EMPTY_CONFIG,
+    };
+
+    const pending = [resolver.resolve(lookup), resolver.resolve(lookup)];
+    expect(showCalls()).toBe(1);
+    releaseFirst();
+    const [left, right] = await Promise.all(pending);
+    expect(left.source).toBe("live_endpoint");
+    expect(right.source).toBe("live_endpoint");
+    expect(left.contextWindow).toBe(32768);
+    expect(right.contextWindow).toBe(32768);
+    expect(showCalls()).toBe(1);
   });
 });


### PR DESCRIPTION
## Why

A 503 from a local metadata endpoint was stored as a successful `undefined` lookup. `StaticModelsManager` then kept the conservative fallback model record for the process lifetime. One overloaded Ollama `/api/show`, or a server that started late, left the runtime on a 128k window until restart. Truncation, compaction, and budget checks all used the wrong limits.

## Scope

- `rememberSuccessfulLookup` keeps an in-flight map and a success map.
- `ModelMetadataResolver.fetchJson` retains only defined JSON.
- `StaticModelsManager.resolveModelInfo` retains only records that did not use fallback metadata.
- Tests in `runtime/tests/llm/model-metadata.local-providers.test.ts` cover 503 then 32768, and concurrent in-flight sharing.

Out of scope: Anthropic wire format, git discovery, TTL for successful live metadata.

## Tradeoffs

Failed, aborted, invalid, and missing HTTP results drop when they settle. The next lookup retries. Successful JSON stays until the resolver is replaced. There is no TTL. A late local server is more important than caching a miss forever.

## Blast Radius

Ollama, LM Studio, and openai-compatible metadata lookups retry after HTTP errors, timeouts, abort, and invalid JSON. Concurrent callers still share one in-flight request. Built-in and live successes still cache. `getModelInfo` for an unknown model may probe live endpoints again instead of reusing a fallback record.

## Verification

Hermetic vitest on Windows, Node v26.7.0.

Before the fix, `a 503 then a valid 32768 window refetches instead of caching undefined` received contextWindow 128000 on the second lookup.

After:

- `node runtime/scripts/run-hermetic-vitest.mjs run tests/llm/model-metadata.local-providers.test.ts tests/llm/models-manager.test.ts`. 50 passed.

Closes #2108