### PR TITLE
fix(git): reject invalid ancestor .git markers

### DIFF
--- a/runtime/src/agents/worktree.ts
+++ b/runtime/src/agents/worktree.ts
@@ -43,6 +43,10 @@ import { AsyncLock } from "./_deps/async-lock.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import { gitChildEnvironment } from "../sandbox/git-environment.js";
 import {
+  isBareGitDirectory,
+  isValidGitMarker,
+} from "../utils/git/gitRootMarker.js";
+import {
   runSupervisedProcess,
   type SupervisedProcessResult,
 } from "../utils/supervisedProcess.js";
@@ -182,7 +186,10 @@ function findNearestGitRoot(startDir: string): string | null {
   let dir = resolvePath(startDir);
   while (true) {
     const probe = join(dir, ".git");
-    if (existsSync(probe)) {
+    if (existsSync(probe) && isValidGitMarker(probe)) {
+      return dir;
+    }
+    if (isBareGitDirectory(dir)) {
       return dir;
     }
     const parent = dirname(dir);

--- a/runtime/src/utils/git.ts
+++ b/runtime/src/utils/git.ts
@@ -1,9 +1,9 @@
 import { createHash } from 'crypto'
-import { readFileSync, realpathSync, statSync } from 'fs'
+import { readFileSync, realpathSync } from 'fs'
 import { open, readFile, realpath, stat } from 'fs/promises'
 import spawn from 'cross-spawn'
 import memoize from 'lodash-es/memoize.js'
-import { basename, dirname, join, resolve, sep } from 'path'
+import { basename, dirname, join, resolve } from 'path'
 import { hasBinaryExtension, isBinaryContent } from '../constants/files.js'
 import { getCwd } from './cwd.js'
 import { logForDebugging } from 'src/utils/debug.js'
@@ -20,6 +20,7 @@ import {
   isShallowClone as isShallowCloneFs,
   resolveGitDir,
 } from './git/gitFilesystem.js'
+import { isBareGitDirectory, isValidGitMarker } from './git/gitRootMarker.js'
 import { logError } from './log.js'
 import { memoizeWithLRU } from './memoize.js'
 import { whichSync } from './which.js'
@@ -32,48 +33,26 @@ const findGitRootImpl = memoizeWithLRU(
     logForDiagnosticsNoPII('info', 'find_git_root_started')
 
     let current = resolve(startPath)
-    const root = current.substring(0, current.indexOf(sep) + 1) || sep
     let statCount = 0
 
-    while (current !== root) {
-      try {
-        const gitPath = join(current, '.git')
-        statCount++
-        const stat = statSync(gitPath)
-        // .git can be a directory (regular repo) or file (worktree/submodule)
-        if (stat.isDirectory() || stat.isFile()) {
-          logForDiagnosticsNoPII('info', 'find_git_root_completed', {
-            duration_ms: Date.now() - startTime,
-            stat_count: statCount,
-            found: true,
-          })
-          return current
-        }
-      } catch {
-        // .git doesn't exist at this level, continue up
+    while (true) {
+      statCount++
+      if (
+        isValidGitMarker(join(current, '.git')) ||
+        isBareGitDirectory(current)
+      ) {
+        logForDiagnosticsNoPII('info', 'find_git_root_completed', {
+          duration_ms: Date.now() - startTime,
+          stat_count: statCount,
+          found: true,
+        })
+        return current
       }
       const parent = dirname(current)
       if (parent === current) {
         break
       }
       current = parent
-    }
-
-    // Check root directory as well
-    try {
-      const gitPath = join(root, '.git')
-      statCount++
-      const stat = statSync(gitPath)
-      if (stat.isDirectory() || stat.isFile()) {
-        logForDiagnosticsNoPII('info', 'find_git_root_completed', {
-          duration_ms: Date.now() - startTime,
-          stat_count: statCount,
-          found: true,
-        })
-        return root
-      }
-    } catch {
-      // .git doesn't exist at root
     }
 
     logForDiagnosticsNoPII('info', 'find_git_root_completed', {
@@ -89,8 +68,9 @@ const findGitRootImpl = memoizeWithLRU(
 
 /**
  * Find the git root by walking up the directory tree.
- * Looks for a .git directory or file (worktrees/submodules use a file).
- * Returns the directory containing .git, or null if not found.
+ * Looks for a valid `.git` directory or `gitdir:` file, or a bare git directory.
+ * Empty, malformed, and dangling `.git` markers are skipped.
+ * Returns the directory containing `.git` (or the bare git dir), or null.
  *
  * Memoized per startPath with an LRU cache (max 50 entries) to prevent
  * unbounded growth — gitDiff calls this with dirname(file), so editing many

--- a/runtime/src/utils/git/gitRootMarker.ts
+++ b/runtime/src/utils/git/gitRootMarker.ts
@@ -1,0 +1,75 @@
+import { readFileSync, statSync } from 'fs'
+import { basename, dirname, join, resolve } from 'path'
+
+const GITDIR_PREFIX = 'gitdir:'
+
+/**
+ * True when `gitPath` is Git metadata: a git directory, or a `gitdir:` file
+ * whose target is a git directory or a linked-worktree private dir.
+ * Empty, malformed, and dangling `.git` entries are rejected.
+ */
+export function isValidGitMarker(gitPath: string): boolean {
+  const kind = pathKind(gitPath)
+  if (kind === 'directory') {
+    return isGitDirectory(gitPath)
+  }
+  if (kind === 'file') {
+    return isGitFilePointer(gitPath)
+  }
+  return false
+}
+
+/**
+ * True when `dir` itself is a git directory and is not a checkout's `.git`.
+ * Bare repos (`*.git`) match. `repo/.git` does not, so the checkout root wins.
+ */
+export function isBareGitDirectory(dir: string): boolean {
+  return basename(dir) !== '.git' && isGitDirectory(dir)
+}
+
+function isGitDirectory(dir: string): boolean {
+  return (
+    pathKind(join(dir, 'HEAD')) === 'file' &&
+    pathKind(join(dir, 'objects')) === 'directory' &&
+    pathKind(join(dir, 'refs')) === 'directory'
+  )
+}
+
+function isGitFilePointer(gitFile: string): boolean {
+  try {
+    const trimmed = readFileSync(gitFile, 'utf8').trim()
+    if (!trimmed.startsWith(GITDIR_PREFIX)) {
+      return false
+    }
+    const raw = trimmed.slice(GITDIR_PREFIX.length).trim()
+    if (raw.length === 0) {
+      return false
+    }
+    const target = resolve(dirname(gitFile), raw)
+    return isGitDirectory(target) || isWorktreePrivateGitDir(target)
+  } catch {
+    return false
+  }
+}
+
+function isWorktreePrivateGitDir(dir: string): boolean {
+  return (
+    pathKind(join(dir, 'commondir')) === 'file' &&
+    pathKind(join(dir, 'gitdir')) === 'file'
+  )
+}
+
+function pathKind(path: string): 'file' | 'directory' | null {
+  try {
+    const st = statSync(path)
+    if (st.isFile()) {
+      return 'file'
+    }
+    if (st.isDirectory()) {
+      return 'directory'
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/runtime/src/utils/git/gitRootMarker.ts
+++ b/runtime/src/utils/git/gitRootMarker.ts
@@ -1,5 +1,5 @@
-import { readFileSync, statSync } from 'fs'
-import { basename, dirname, join, resolve } from 'path'
+import { readFileSync, statSync } from 'node:fs'
+import { basename, dirname, join, resolve } from 'node:path'
 
 const GITDIR_PREFIX = 'gitdir:'
 

--- a/runtime/tests/agents/worktree.test.ts
+++ b/runtime/tests/agents/worktree.test.ts
@@ -207,9 +207,15 @@ describe("findGitRoot", () => {
     expect(findGitRoot(nested)).toBe(canonicalRoot);
   });
 
-  it("falls back to the local root when .git is just a plain gitdir file", () => {
+  it("skips a dangling ancestor gitdir file and keeps a linked worktree canonical root", () => {
     writeFileSync(join(tmpRoot, ".git"), "gitdir: /elsewhere/.git/worktrees/x");
-    expect(findGitRoot(tmpRoot)).toBe(tmpRoot);
+    const canonicalRoot = join(tmpRoot, "origin-repo");
+    const worktreeRoot = join(tmpRoot, "linked-wt");
+    const nested = join(worktreeRoot, "pkg");
+    createLinkedWorktree(canonicalRoot, worktreeRoot, "feat");
+    mkdirSync(nested, { recursive: true });
+    expect(findGitRoot(nested)).toBe(canonicalRoot);
+    expect(findGitRoot(tmpRoot)).toBeNull();
   });
 
   it("returns null when no .git ancestor", () => {

--- a/runtime/tests/app-server/daemon-dispatcher.run-start.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.run-start.contract.test.ts
@@ -7,7 +7,8 @@
  * Nothing here touches a network or spawns a model.
  */
 
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -377,7 +378,7 @@ function makeHarness(): Harness {
   const home = mkdtempSync(join(tmpdir(), "agenc-m5-run-start-home-"));
   const repoDir = mkdtempSync(join(tmpdir(), "agenc-m5-run-start-repo-"));
   const nonGitDir = mkdtempSync(join(tmpdir(), "agenc-m5-run-start-plain-"));
-  mkdirSync(join(repoDir, ".git"));
+  execFileSync("git", ["init", "-q"], { cwd: repoDir });
   const driver = openStateDatabases({ cwd: repoDir, agencHome: home });
   const repo = new StateRunDurabilityRepository(driver);
   const admission = new FakeAdmission();

--- a/runtime/tests/sandbox/git-process-boundaries.test.ts
+++ b/runtime/tests/sandbox/git-process-boundaries.test.ts
@@ -598,7 +598,7 @@ describe.sequential("git process sandbox boundaries", () => {
 
   it("blocks canonical EnterWorktree through its ToolUseContext broker", async () => {
     const root = tempRoot("agenc-canonical-enter-boundary-");
-    mkdirSync(join(root, ".git"), { recursive: true });
+    initGitRepo(root);
     const marker = join(root, "canonical-enter-escaped");
     const bin = installGitShim(root, marker);
     vi.stubEnv("PATH", `${bin}${delimiter}${process.env.PATH ?? ""}`);

--- a/runtime/tests/utils/git.test.ts
+++ b/runtime/tests/utils/git.test.ts
@@ -59,7 +59,10 @@ describe("git root discovery", () => {
       const repo = join(root, "repo");
       const nested = join(repo, "src", "utils");
       const file = join(nested, "git.ts");
-      await mkdir(join(repo, ".git"), { recursive: true });
+      const gitDir = join(repo, ".git");
+      await mkdir(join(gitDir, "objects"), { recursive: true });
+      await mkdir(join(gitDir, "refs"), { recursive: true });
+      await writeFile(join(gitDir, "HEAD"), "ref: refs/heads/main\n");
       await mkdir(nested, { recursive: true });
       await writeFile(file, "export {}\n");
 
@@ -112,6 +115,23 @@ describe("git root discovery", () => {
       await writeFile(join(worktreeGitDir, "commondir"), "../..\n");
       await writeFile(join(worktreeGitDir, "gitdir"), `${join(main, ".git")}\n`);
       expect(findCanonicalGitRoot(linked)).toBe(linked);
+    });
+  });
+
+  it("ignores an empty ancestor .git so a nested repo still wins", async () => {
+    await withTempDir(async (root) => {
+      await mkdir(join(root, ".git"));
+      const stray = join(root, "unmanaged", "tmp");
+      await mkdir(stray, { recursive: true });
+      expect(findGitRoot(stray)).toBeNull();
+
+      const repo = join(root, "checkout");
+      await initRepo(repo);
+      expect(findGitRoot(join(repo, "src"))).toBe(repo);
+
+      const bare = join(root, "upstream.git");
+      await runGitOk(root, ["init", "--bare", bare]);
+      expect(findGitRoot(bare)).toBe(bare);
     });
   });
 });


### PR DESCRIPTION
## Why

Git-root discovery treated any existing `.git` file or directory as a repository. An empty ancestor marker, such as `/tmp/user/1000/.git`, captured unmanaged descendants and bare repos. `git rev-parse` rejects that marker. Project identity then followed the wrong path.

## Scope

`isValidGitMarker` and `isBareGitDirectory` in `runtime/src/utils/git/gitRootMarker.ts` are the one validator. `findGitRoot` in `runtime/src/utils/git.ts` and `findNearestGitRoot` in `runtime/src/agents/worktree.ts` skip empty, malformed, and dangling markers. A nested checkout, a bare repo, and a linked worktree still resolve. This change does not edit `worktree-permissions.ts`.

## Tradeoffs

The walk checks Git's filesystem layout (`HEAD`, `objects`, `refs`, or a `gitdir:` pointer) instead of spawning `git rev-parse` on every ancestor. Discovery stays sync and avoids a subprocess on the hot path.

## Blast Radius

Callers of `findGitRoot` and `findCanonicalGitRoot` no longer treat a stale `.git` name as a repo. Linked worktrees still canonicalize through the existing `commondir` backlink checks. Bare repos now resolve as themselves when they sit below an invalid ancestor.

## Verification

Hermetic vitest on Windows, Node v26.7.0.

`node runtime/scripts/run-hermetic-vitest.mjs run tests/utils/git.test.ts tests/agents/worktree.test.ts -t "git root discovery|findGitRoot"`

Exit 0. 7 passed.

Before the fix, `findGitRoot` on an unmanaged descendant of an empty `.git` returned the ancestor. After the fix it returns null. A nested `git init` checkout and a `git init --bare` repo still win.

Closes #2124