### PR TITLE
session: keep the auto-mode note retained in every autonomous mode

### DIFF
--- a/runtime/src/prompts/attachments/auto-mode.ts
+++ b/runtime/src/prompts/attachments/auto-mode.ts
@@ -59,7 +59,13 @@ const AUTO_FAMILY_MODES: ReadonlySet<PermissionMode> = new Set<PermissionMode>([
   "bypassPermissions",
 ]);
 
-function isAutoFamilyMode(mode: PermissionMode): boolean {
+/**
+ * True for every mode that carries the auto-mode reminder. The retention
+ * ledger keeps the retained note under the same rule, so the note stays
+ * where the provider first saw it instead of being dropped and re-emitted
+ * at the end of the prompt (which moved the cached prefix on every call).
+ */
+export function isAutoFamilyMode(mode: PermissionMode): boolean {
   return AUTO_FAMILY_MODES.has(mode);
 }
 

--- a/runtime/src/session/attachment-retention.ts
+++ b/runtime/src/session/attachment-retention.ts
@@ -26,6 +26,7 @@ import { createHash } from "node:crypto";
 
 import type { LLMMessage } from "../llm/types.js";
 import type { PermissionMode } from "../permissions/types.js";
+import { isAutoFamilyMode } from "../prompts/attachments/auto-mode.js";
 
 export type RetainedPlacement = "before" | "after";
 
@@ -124,8 +125,12 @@ export function projectRetainedAttachments(
       switch (message.runtimeOnly?.permissionModeReminder) {
         case "plan": return permissionMode === "plan";
         case "plan_exit": return permissionMode !== "plan";
-        case "auto": return permissionMode === "auto";
-        case "auto_exit": return permissionMode !== "auto";
+        // The producer emits the note for the whole autonomous family
+        // (auto, acceptEdits, bypassPermissions); keep it under the same
+        // rule or the note is dropped here and re-emitted after the newest
+        // history item, moving the provider's cached prefix on every call.
+        case "auto": return isAutoFamilyMode(permissionMode);
+        case "auto_exit": return !isAutoFamilyMode(permissionMode);
         default: return true;
       }
     });

--- a/runtime/tests/session/attachment-retention.test.ts
+++ b/runtime/tests/session/attachment-retention.test.ts
@@ -28,6 +28,46 @@ const toolResult = (id: string, body: string): LLMMessage => ({
 });
 
 describe("attachment retention", () => {
+  it("keeps the auto-mode note in every autonomous mode, not only in auto", () => {
+    const note: LLMMessage = {
+      role: "user",
+      content: "<system-reminder>\nAuto mode is active\n</system-reminder>",
+      runtimeOnly: { mergeBoundary: "user_context", permissionModeReminder: "auto" },
+    };
+    const exitNote: LLMMessage = {
+      role: "user",
+      content: "<system-reminder>\nexited auto mode\n</system-reminder>",
+      runtimeOnly: { mergeBoundary: "user_context", permissionModeReminder: "auto_exit" },
+    };
+    for (const mode of ["auto", "acceptEdits", "bypassPermissions"] as const) {
+      const ledger = createAttachmentRetentionLedger();
+      const first = [{ role: "system", content: "sys" } as LLMMessage, user("build it")];
+      recordRetainedAttachments(ledger, first, 1, "before", [note, exitNote]);
+      const second = [...first, assistantCall("c1"), toolResult("c1", "ok")];
+      const projected = projectRetainedAttachments(second, ledger, mode);
+      expect(projected.dropped, mode).toBe(0);
+      // The note stays where the provider first saw it; the exit note waits.
+      expect(projected.messages.map((m) => m.content), mode).toEqual([
+        "sys",
+        "<system-reminder>\nAuto mode is active\n</system-reminder>",
+        "build it",
+        "",
+        "ok",
+      ]);
+    }
+    for (const mode of ["default", "plan"] as const) {
+      const ledger = createAttachmentRetentionLedger();
+      const first = [{ role: "system", content: "sys" } as LLMMessage, user("build it")];
+      recordRetainedAttachments(ledger, first, 1, "before", [note, exitNote]);
+      const projected = projectRetainedAttachments(first, ledger, mode);
+      expect(projected.messages.map((m) => m.content), mode).toEqual([
+        "sys",
+        "<system-reminder>\nexited auto mode\n</system-reminder>",
+        "build it",
+      ]);
+    }
+  });
+
   it("keeps the first request's block before the prompt on later projections", () => {
     const ledger = createAttachmentRetentionLedger();
     const first = [{ role: "system", content: "sys" } as LLMMessage, user("build it")];


### PR DESCRIPTION
## Why

Every request after the first one in a turn re-sent the whole prompt uncached on OpenAI-compatible providers, and re-created about 4,000 cache tokens per call on Anthropic. Captured through a logging proxy on DeepSeek V4 Pro (`agenc -p`, bypassPermissions, one FileRead turn): request 1 carried `[system, auto-mode note, agent list, skills list (40,584 chars), prompt]`; request 2 carried `[system, agent list, skills list, prompt, assistant, tool, tool, auto-mode note]`. The note had moved from position 1 to the end, so the prefix differed from the second message on and DeepSeek reported 20,929 cache-miss tokens of a 24,897-token prompt on every call. Measured on the three-agent benchmark tonight: AgenC's grok-4.6 session spent 1.63M uncached prompt tokens against 0.87M cached; Hermes on the same tasks keeps 80 to 95 percent of its prompt cached.

Cause: `projectRetainedAttachments` keeps a retained auto-mode note only when the permission mode is literally `auto`, but the producer in `prompts/attachments/auto-mode.ts` emits the note for the whole autonomous family (`auto`, `acceptEdits`, `bypassPermissions`). In `acceptEdits` and `bypassPermissions` (the desktop's bypass mode) the ledger dropped the note from its anchored place, the producer saw no marker and emitted a fresh full note after the newest history item.

## What

- `runtime/src/prompts/attachments/auto-mode.ts`: `isAutoFamilyMode` is exported; it is the one rule for which modes carry the note.
- `runtime/src/session/attachment-retention.ts`: the `auto` and `auto_exit` reminder filters use that rule instead of `=== "auto"`.
- `runtime/tests/session/attachment-retention.test.ts`: the note stays anchored before the prompt in `auto`, `acceptEdits` and `bypassPermissions`, and the exit note shows only outside the family.

## Evidence

Same proxy probe on the fixed build (DeepSeek V4 Pro, bypassPermissions):

| request | messages | prompt tokens | cache hit | cache miss |
| --- | --- | --- | --- | --- |
| 1 | system, note, agent list, skills, prompt | 24,897 | 3,968 | 20,929 |
| 2 | the same five, then assistant, tool, tool | 25,153 | 24,960 | 193 |

Before the fix request 2 had the note at the end and about 25,000 miss tokens. The first five messages are byte-identical across the two requests.

## Tests

`npm run typecheck` clean. `vitest run tests/session/attachment-retention.test.ts tests/session/attachment-state.test.ts tests/prompts/attachments`: 22 files, 250 tests pass. The authoritative `npm test` needs a Linux Docker host and runs in CI.

## Not changed

- Plan-mode reminders keep their exact-mode rule (`plan` is a single mode).
- The producer's throttle (a pulse every 5 human turns) is unchanged; only retention of what was already shown changes.
- No change to what the model is told, only to where the already-sent note stays.

## Counterpart PRs

None. The desktop does not touch attachment placement.
