### PR TITLE
skills: cap the context-scaled listing at 12,000 chars

### DIFF
--- a/runtime/src/skills/local-loader.ts
+++ b/runtime/src/skills/local-loader.ts
@@ -234,6 +234,14 @@ const MAX_SCAN_DEPTH = 12;
 const MAX_ACTIVE_PATHS = 256;
 const INVOKED_MAIN_AGENT_ID = "__main__";
 const SKILL_LISTING_DEFAULT_CHAR_BUDGET = 8_000;
+/**
+ * Ceiling for the context-scaled listing. One percent of a 1M-token window
+ * is 40,000 chars (about 10,000 tokens) in every request of every session,
+ * measured on 2026-09-11 with 1,801 installed skills; the ranked listing plus
+ * the per-request relevance reminder does the same job in a fraction of that.
+ * `SLASH_COMMAND_TOOL_CHAR_BUDGET` still overrides both the scale and the cap.
+ */
+const SKILL_LISTING_MAX_CHAR_BUDGET = 12_000;
 const SKILL_LISTING_DESC_MAX_CHARS = 250;
 const SKILL_LISTING_CONTEXT_PERCENT = 0.01;
 const CHARS_PER_TOKEN = 4;
@@ -1259,8 +1267,11 @@ function getListingCharBudget(contextWindowTokens?: number): number {
   const envBudget = Number(process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET);
   if (Number.isFinite(envBudget) && envBudget > 0) return envBudget;
   if (contextWindowTokens && Number.isFinite(contextWindowTokens)) {
-    return Math.floor(
-      contextWindowTokens * CHARS_PER_TOKEN * SKILL_LISTING_CONTEXT_PERCENT,
+    return Math.min(
+      SKILL_LISTING_MAX_CHAR_BUDGET,
+      Math.floor(
+        contextWindowTokens * CHARS_PER_TOKEN * SKILL_LISTING_CONTEXT_PERCENT,
+      ),
     );
   }
   return SKILL_LISTING_DEFAULT_CHAR_BUDGET;

--- a/runtime/tests/skills/skill-listing-budget.test.ts
+++ b/runtime/tests/skills/skill-listing-budget.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildSkillListingWithinBudget,
+  type SkillListingEntry,
+} from "../../src/skills/local-loader.js";
+
+const skills: SkillListingEntry[] = Array.from({ length: 400 }, (_, i) => ({
+  name: `skill-${String(i).padStart(3, "0")}`,
+  description: `Does thing number ${i}. `.repeat(8),
+  scope: "user",
+}));
+
+const original = process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET;
+afterEach(() => {
+  if (original === undefined) delete process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET;
+  else process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET = original;
+});
+
+describe("skill listing budget", () => {
+  it("scales with the context window up to a fixed ceiling", () => {
+    delete process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET;
+    const small = buildSkillListingWithinBudget(skills, 200_000);
+    const large = buildSkillListingWithinBudget(skills, 1_000_000);
+    expect(small.stats.budgetChars).toBe(8_000);
+    expect(large.stats.budgetChars).toBe(12_000);
+    expect(large.listing.length).toBeLessThanOrEqual(12_000 + 200);
+    expect(large.stats.listed).toBeGreaterThan(small.stats.listed);
+    expect(large.stats.hidden).toBeGreaterThan(0);
+  });
+
+  it("keeps the default when the window is unknown and honours the env override", () => {
+    delete process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET;
+    expect(buildSkillListingWithinBudget(skills).stats.budgetChars).toBe(8_000);
+    process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET = "30000";
+    expect(buildSkillListingWithinBudget(skills, 1_000_000).stats.budgetChars).toBe(30_000);
+  });
+});


### PR DESCRIPTION
## Why

The skills listing reminder is sized at one percent of the model's context window in characters. On the 1M-context models that are now the defaults (Claude Opus 5 and Sonnet 5, DeepSeek V4, grok-4.6) that is 40,000 chars, about 10,000 tokens, sent in every request of every session. Measured tonight on a real request (DeepSeek V4 Pro, this Mac's 1,801 installed skills): the listing was 40,584 chars and named 156 skills plus "and 1645 more". Hermes 0.21.2 sends about 19,000 prompt tokens per call in total; AgenC sends about 24,000 cached plus the uncached tail, and this listing is the single largest difference.

## What

- `runtime/src/skills/local-loader.ts`: `getListingCharBudget` keeps the one-percent scaling but caps it at `SKILL_LISTING_MAX_CHAR_BUDGET` (12,000 chars). Windows of 300k tokens or less are unchanged (200k already yields 8,000). `SLASH_COMMAND_TOOL_CHAR_BUDGET` still overrides both the scale and the cap, so an operator who wants the full listing can have it.
- `runtime/tests/skills/skill-listing-budget.test.ts` (new): 200k window gives 8,000, 1M gives 12,000 and lists more than the smaller budget while still hiding the rest; unknown window keeps the 8,000 default; the env override wins.

## Evidence

Same request after the change would carry a 12,000-char listing (about 3,000 tokens) instead of 40,584 chars, roughly 7,000 tokens less per call. The ranked listing keeps project and managed scopes first and the per-request `skill_relevance` reminder still names request-matched skills that the listing left out.

## Tests

`npm run typecheck` clean. `vitest run tests/skills/skill-listing-budget.test.ts tests/skills/local-loader.test.ts tests/skills/loadSkillsDir.test.ts`: 3 files, 47 tests pass. The authoritative `npm test` needs a Linux Docker host and runs in CI.

## Not changed

- Ranking, the description length cap (250 chars) and the `[plugin: id]` labels are untouched.
- The `/skills <search>` hint and the relevance reminder are untouched.

## Counterpart PRs

None.
