### PR TITLE
fix(daemon): isolate runtime generations and submission ownership [skip ci]

### DIFF
--- a/docs/design/daemon-session-generation-audit.md
+++ b/docs/design/daemon-session-generation-audit.md
@@ -1,0 +1,78 @@
+# Daemon/session generation audit
+
+Date: 2026-09-11. Baseline: `59256ba756e3`.
+
+## Scope
+
+Three parallel investigations followed transport lifecycle, runner/session
+authority, and SDK submission handling. Integration review traced those findings
+through the dispatcher, multiplexer, persistence callbacks, and connected client
+flows. This extends the [previous audit](daemon-session-control-plane-followup-audit.md).
+
+## Confirmed defects and repairs
+
+| Boundary | Reproduction | Repair |
+| --- | --- | --- |
+| Listener startup → shutdown | Close completes while Unix path preparation or WebSocket address publication is pending; the listener can appear afterwards. Competing Unix startups can both acquire ownership. | Startup reserves ownership synchronously. Close fences admission, joins the pending startup, and releases its listener before completing. |
+| Concurrent close → restart | A second close returns while the first still drains handlers; restart can overlap that cleanup. In-process close can hide a pending cleanup failure. | Concurrent closes share completion. Network transports reject restart during cleanup; in-process close retains its terminal cleanup result, including rejection. |
+| Retired runner → replacement | A terminal callback outlives the runner's notification deadline or a failed restore, then stops a replacement with the same canonical agent ID. Early callbacks can also overwrite another generation's pending terminal. | Concrete runners attach an internal runtime generation to starts, restores, snapshots, and terminal callbacks. Lifecycle state and pending terminals match that generation before applying observations. |
+| Terminal persistence → cold resume | An old terminal finalizer waits on persistence while the canonical agent is resumed, then writes stopped status over the replacement. | Finalizers retain the originating lifecycle object and recheck ownership before starting subsequent status writes. Awaited callbacks run outside the lifecycle lock; captured old sessions still receive cleanup. |
+| Request cancellation → runner failure | A cancelled or disconnected legacy message request launches an interruption that later rejects without an observer. | The dispatcher observes this best-effort interruption separately from the already-settled request, containing failures to that operation. |
+| Delayed replay → SDK result | Replayed events arrive after submission dispatch. Conflicting content can trigger stale approvals, or a terminal can settle successfully before the submission RPC rejects. | The SDK checks available durable message content against the submitted JSON value and holds terminal completion until RPC validation. Rejection and connection close still settle pending handles; live approvals remain available before RPC completion. |
+
+## Ownership rules
+
+A canonical agent ID and durable run epoch do not identify a live runtime
+incarnation. A fresh start receives a random generation; a restore uses its
+attempt identity, retained independently after the publication rollback token is
+cleared. These fields stay internal and do not change the daemon wire protocol.
+Injected legacy runners may omit them for compatibility; generation protection
+requires an identity-bearing observation.
+
+Transport ownership spans asynchronous startup and cleanup. Clearing a listener
+field alone does not prove that close has finished. Existing handler-drain
+semantics remain: standalone network close waits by default, while foreground
+daemon shutdown uses its configured deadline after actor cleanup.
+
+SDK notification ownership requires submission dispatch and a matching durable
+message marker. JSON comparison must use serialized values because transport can
+change object prototypes and omit undefined properties. Terminal notifications
+remain provisional until the submission response validates admission. After
+validation, a matching live terminal preserves existing result semantics; the
+RPC terminal is the fallback. Deferring all notifications would prevent approval
+responses that the running submission itself needs.
+
+## Verification
+
+Regressions use explicit gates to establish the failing ordering. Coverage
+includes real Unix/WebSocket listeners, dispatcher-backed in-process clients,
+the concrete runner's terminal-notification timeout, and a cold resume verified
+against a real rollout file. Cancellation cases exercise both message methods
+under explicit cancellation and disconnect.
+
+```sh
+npm run validate:runtime
+npm run build --workspace=@tetsuo-ai/agenc-sdk
+node runtime/scripts/run-hermetic-test-boundary.mjs run tests/app-server tests/app-server-client tests/sdk-package tests/tui/daemon-session --maxWorkers=2
+npm run test:required-gates
+git diff --check
+```
+
+Final results on Node 26.5.0. Runtime validation, the SDK build, and the Docker
+boundary were repeated after rebasing onto `6f7cb42d2` before publication:
+
+| Check | Result |
+| --- | --- |
+| Linux Docker control-plane boundary | 139 files, 1,816 tests passed, including 24 new regression cases; no skipped tests. Expected-red boundary probe passed. |
+| Runtime and test-support TypeScript checks | Passed locally and inside the Docker boundary. |
+| Runtime build, package entrypoints, generated protocol checks | Passed. |
+| SDK build, generated types, and TypeScript check | Passed after the final JSON normalization repair. |
+| Built runtime/TUI imports and PTY startup | Passed in normal and bypass modes at 148×40, 120×30, and 80×24. |
+| Local required-gate tests | 162 passed. |
+| Patch whitespace check | `git diff --check` passed. |
+
+The original checkout's status and content hashes for its 57 unrelated modified
+files are unchanged; its existing `AGENTS.md` is preserved. All execution was
+local; GitHub CI was not run. Hermetic runner/provider
+fixtures verify lifecycle behavior, not live provider reliability or untested
+platforms.

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -11,6 +11,7 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { isAbsolute, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import {
   AGENC_SDK_DAEMON_PROTOCOL_VERSION,
   AGENC_SDK_JSON_RPC_VERSION,
@@ -1219,7 +1220,14 @@ export class AgencClient {
     let lastCommittedMessage = "";
     let finishing = false;
     let submissionDispatched = false;
+    let submissionValidated = false;
     let submissionObserved = false;
+    let dispatchedContent: MessageContent | undefined;
+    let provisionalTerminal: {
+      code: number;
+      message?: string;
+      turnId?: string;
+    } | undefined;
     let cancelBeforeDispatchReason: string | undefined;
     let deferredCancellationReason: string | undefined;
     let cancellationPromise: Promise<void> | undefined;
@@ -1228,6 +1236,7 @@ export class AgencClient {
     const flushDeferredCancellation = (): Promise<void> => {
       if (
         finishing ||
+        provisionalTerminal !== undefined ||
         cancellationPromise !== undefined ||
         deferredCancellationReason === undefined ||
         !submissionObserved ||
@@ -1246,7 +1255,7 @@ export class AgencClient {
     };
 
     const requestScopedCancellation = (reason: string): Promise<void> => {
-      if (finishing) return Promise.resolve();
+      if (finishing || provisionalTerminal !== undefined) return Promise.resolve();
       if (!submissionDispatched) {
         cancelBeforeDispatchReason = reason;
         return Promise.resolve();
@@ -1317,7 +1326,7 @@ export class AgencClient {
           };
         }
       }
-      if (finishing) return;
+      if (finishing || provisionalTerminal !== undefined) return;
       try {
         if (decision.behavior === "allow") {
           await this.request("tool.approve", {
@@ -1350,7 +1359,7 @@ export class AgencClient {
       } catch {
         return;
       }
-      if (response === null || finishing) return;
+      if (response === null || finishing || provisionalTerminal !== undefined) return;
       try {
         await this.request("elicitation.respond", {
           sessionId,
@@ -1369,11 +1378,23 @@ export class AgencClient {
     const unsubscribe = this.onSessionNotification(sessionId, (message) => {
       // session.attach replays prior submissions before message.send can
       // validate this one's content and identity. Replay is not its admission.
-      if (finishing || !submissionDispatched) return;
+      if (finishing || provisionalTerminal !== undefined || !submissionDispatched) {
+        return;
+      }
       const observedClientMessageId =
         userMessageClientMessageIdFromNotification(message);
       if (!submissionObserved) {
         if (observedClientMessageId !== clientMessageId) return;
+        // A delayed replay can arrive after dispatch. The durable marker's
+        // original content must agree before its turn can own our callbacks.
+        const marker = nestedSessionEventFromNotification(message);
+        if (
+          isJsonObject(marker?.payload) &&
+          marker.payload.message !== undefined &&
+          !isDeepStrictEqual(marker.payload.message, dispatchedContent)
+        ) {
+          return;
+        }
         submissionObserved = true;
       } else if (
         observedClientMessageId !== null &&
@@ -1429,7 +1450,18 @@ export class AgencClient {
         }
       }
       const terminal = terminalStatusFromNotification(message, reservation.turnId);
-      if (terminal !== null) void finish(terminal);
+      if (terminal !== null) {
+        // message.send validates the submission independently of session
+        // notifications. A replayed terminal cannot override its rejection.
+        if (submissionValidated) {
+          void finish(terminal);
+        } else {
+          provisionalTerminal = {
+            ...terminal,
+            ...(reservation.turnId === undefined ? {} : { turnId: reservation.turnId }),
+          };
+        }
+      }
     });
 
     const fail = (error: unknown): void => {
@@ -1471,16 +1503,20 @@ export class AgencClient {
       }
       await this.#attachSession(sessionId);
       throwIfPromptCancelledBeforeDispatch(cancelBeforeDispatchReason);
+      // Compare against exactly what JSON transports send, independently of
+      // caller object prototypes, omitted undefined fields, or later mutation.
+      dispatchedContent = JSON.parse(JSON.stringify(content)) as MessageContent;
       submissionDispatched = true;
       const sendResult = await this.request("message.send", {
         sessionId,
-        content,
+        content: dispatchedContent,
         clientMessageId,
         ...(options.ifBusy !== undefined ? { ifBusy: options.ifBusy } : {}),
         ...(options.metadata !== undefined
           ? { metadata: options.metadata }
           : {}),
       });
+      submissionValidated = true;
       if (sendResult.turnId !== undefined) {
         reservation.turnId = sendResult.turnId;
         void flushDeferredCancellation().catch(() => {});
@@ -1517,12 +1553,20 @@ export class AgencClient {
               ? { message: lastCommittedMessage }
               : {}),
         });
+      } else if (
+        !finishing &&
+        provisionalTerminal !== undefined &&
+        (sendResult.turnId === undefined ||
+          sendResult.turnId === provisionalTerminal.turnId)
+      ) {
+        void finish(provisionalTerminal);
       } else if (sendResult.terminal !== undefined && !finishing) {
         // The RPC result is the authoritative terminal fallback when a live
         // notification was lost or filtered during reconnect. Legacy daemons
         // omit this field, so their behavior remains notification-driven.
         void finish(sendResult.terminal);
       }
+      provisionalTerminal = undefined;
       return {
         messageId: sendResult.messageId,
         clientMessageId,

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -435,6 +435,7 @@ interface MutableAgent {
   stateProjectDir?: string;
   metadata?: JsonObject;
   restoreAttemptId?: string;
+  runtimeGenerationId?: string;
   sessionIds: string[];
   logSessionIds: string[];
   recovered?: boolean;
@@ -466,6 +467,7 @@ interface PendingCanonicalRunCancellation {
 }
 
 interface RunnerTerminationTarget {
+  readonly owner: MutableAgent;
   readonly sessionIds: readonly string[];
   readonly route: AgenCDaemonSnapshotRoute;
   readonly status: AgentStatus;
@@ -545,7 +547,7 @@ export class AgenCDaemonAgentManager {
   >();
   readonly #pendingRunnerTerminations = new Map<
     string,
-    PendingRunnerTermination
+    Map<string | undefined, PendingRunnerTermination>
   >();
   readonly #pendingCanonicalRunCancellations = new Map<
     string,
@@ -1092,6 +1094,9 @@ export class AgenCDaemonAgentManager {
       };
       const agent: MutableAgent = {
         agentId: started.agentId,
+        ...(started.runtimeGenerationId !== undefined
+          ? { runtimeGenerationId: started.runtimeGenerationId }
+          : {}),
         ...(started.agentPath !== undefined
           ? { agentPath: started.agentPath }
           : retainedAgent?.agentPath !== undefined
@@ -1181,7 +1186,9 @@ export class AgenCDaemonAgentManager {
           (state) => {
             signal.throwIfAborted();
             state.agents.set(agent.agentId, agent);
-            const pending = this.#pendingRunnerTerminations.get(agent.agentId);
+            const pendingByGeneration = this.#pendingRunnerTerminations.get(agent.agentId);
+            const pending = pendingByGeneration?.get(agent.runtimeGenerationId)
+              ?? pendingByGeneration?.get(undefined);
             let pendingTermination: RunnerTerminationTarget | null = null;
             if (pending !== undefined) {
               this.#pendingRunnerTerminations.delete(agent.agentId);
@@ -1406,6 +1413,7 @@ export class AgenCDaemonAgentManager {
       rolloutDev: params.rolloutDev,
       rolloutIno: params.rolloutIno,
       restoreAttemptId: params.restoreAttemptId,
+      runtimeGenerationId: params.restoreAttemptId,
     };
   }
 
@@ -1435,7 +1443,10 @@ export class AgenCDaemonAgentManager {
       recovered: true,
       runtimeAvailable: record.runtimeAvailable === true,
       ...(record.restoreAttemptId !== undefined
-        ? { restoreAttemptId: record.restoreAttemptId }
+        ? {
+            restoreAttemptId: record.restoreAttemptId,
+            runtimeGenerationId: record.restoreAttemptId,
+          }
         : {}),
     };
     if (record.cwd !== undefined) agent.cwd = record.cwd;
@@ -2171,22 +2182,31 @@ export class AgenCDaemonAgentManager {
     snapshot: AgenCBackgroundAgentSnapshot,
   ): Promise<void> {
     const transitionAt = this.#now();
-    const target = await this.#state.with((state) => {
+    const outcome = await this.#state.with((state) => {
+      const agent = state.agents.get(agentId);
+      const matchesGeneration = agent === undefined || matchesRuntimeGeneration(agent, snapshot);
       const target = this.#applyRunnerTerminationLocked(
         state,
         agentId,
         snapshot,
         transitionAt,
       );
-      if (target !== null) return target;
-      if (this.#activeCreates > 0 && !state.agents.has(agentId)) {
-        this.#pendingRunnerTerminations.set(agentId, {
+      if (target !== null) return { target };
+      if (this.#activeCreates > 0 && (agent === undefined || !matchesGeneration)) {
+        let pending = this.#pendingRunnerTerminations.get(agentId);
+        if (pending === undefined) {
+          pending = new Map();
+          this.#pendingRunnerTerminations.set(agentId, pending);
+        }
+        pending.set(snapshot.runtimeGenerationId, {
           snapshot,
           transitionAt,
         });
       }
-      return null;
+      return matchesGeneration ? { target: null } : null;
     });
+    if (outcome === null) return;
+    const { target } = outcome;
     const pendingCancellation =
       this.#pendingCanonicalRunCancellations.get(agentId);
     if (pendingCancellation !== undefined) {
@@ -2209,7 +2229,7 @@ export class AgenCDaemonAgentManager {
     transitionAt: string,
   ): RunnerTerminationTarget | null {
     const agent = state.agents.get(agentId);
-    if (agent === undefined) return null;
+    if (agent === undefined || !matchesRuntimeGeneration(agent, snapshot)) return null;
     // Explicit stop has already revoked ingress by publishing "stopping".
     // Its runner still owns the canonical terminal and must project it before
     // the ordinary stopped status can be persisted.
@@ -2228,6 +2248,7 @@ export class AgenCDaemonAgentManager {
     ]);
     agent.sessionIds = [];
     return {
+      owner: agent,
       sessionIds,
       route,
       status: snapshot.status,
@@ -2250,19 +2271,28 @@ export class AgenCDaemonAgentManager {
       this.#recordRunTerminal !== undefined
     ) {
       try {
-        await this.#recordRunTerminal({
-          agentId,
-          sessionId: agentId,
-          ...target.route,
-          ...target.terminal,
+        const pending = await this.#state.with((state) => {
+          if (state.agents.get(agentId) !== target.owner) return undefined;
+          // Begin the write while its owner is authoritative, but retain the
+          // asynchronous continuation outside the lifecycle lock.
+          return { result: this.#recordRunTerminal!({
+            agentId,
+            sessionId: agentId,
+            ...target.route,
+            ...target.terminal!,
+          }) };
         });
+        await pending?.result;
       } catch (error) {
         // Do not advance the legacy agent row to a terminal status when the
         // durable terminal projection failed. The canonical JSONL event can
         // be replayed on restart/query and remains the recovery authority.
         this.#onSnapshotError(error);
-        const explicitStop = this.#agentStopTasks.get(agentId);
-        if (explicitStop !== undefined) explicitStop.finalizationError = error;
+        await this.#state.with((state) => {
+          if (state.agents.get(agentId) !== target.owner) return;
+          const explicitStop = this.#agentStopTasks.get(agentId);
+          if (explicitStop !== undefined) explicitStop.finalizationError = error;
+        });
         await this.#terminateAgentSessions(target.sessionIds, "runner_terminated");
         return;
       }
@@ -2275,6 +2305,8 @@ export class AgenCDaemonAgentManager {
       "runner_terminated",
       target.route,
       target.metadata,
+      undefined,
+      target.owner,
     );
     await this.#terminateAgentSessions(target.sessionIds, "runner_terminated");
   }
@@ -3879,11 +3911,12 @@ export class AgenCDaemonAgentManager {
     route: AgenCDaemonSnapshotRoute = {},
     metadataPatch?: JsonObject,
     runStatus?: string,
+    owner?: MutableAgent,
   ): Promise<void> {
     if (this.#recordAgentStatusTransition === undefined) return;
     for (const sessionId of sessionIds) {
       try {
-        await this.#recordAgentStatusTransition({
+        const record = () => this.#recordAgentStatusTransition!({
           sessionId,
           agentId,
           ...route,
@@ -3893,6 +3926,13 @@ export class AgenCDaemonAgentManager {
           ...(reason !== undefined ? { reason } : {}),
           ...(metadataPatch !== undefined ? { metadataPatch } : {}),
         });
+        const pending = owner === undefined
+          ? { result: record() }
+          : await this.#state.with((state) => state.agents.get(agentId) === owner
+            ? { result: record() }
+            : undefined);
+        if (pending === undefined) return;
+        await pending.result;
       } catch (error) {
         this.#onSnapshotError(error);
       }
@@ -4230,7 +4270,8 @@ export class AgenCDaemonAgentManager {
       const agent = state.agents.get(agentId);
       // A stop, attachment, or restore can commit while the reads are pending.
       // Apply only to the generation and state that initiated those reads.
-      if (agent !== owner || !isDeepStrictEqual(agent, expected)) return undefined;
+      if (agent !== owner || !isDeepStrictEqual(agent, expected) ||
+        (snapshot != null && !matchesRuntimeGeneration(agent, snapshot))) return undefined;
       const previousStatus = agent.status;
       if (snapshot === null && agent.recovered !== true) {
         // Retain the record through transient runner misses. The reaper needs
@@ -5275,6 +5316,16 @@ function normalizeLimit(limit: number | undefined): number {
     );
   }
   return Math.min(limit, 500);
+}
+
+function matchesRuntimeGeneration(
+  agent: MutableAgent,
+  snapshot: AgenCBackgroundAgentSnapshot,
+): boolean {
+  // Injected legacy runners may omit the token. Concrete runners always bind
+  // observations to one incarnation, even when a resume retains the run epoch.
+  return snapshot.runtimeGenerationId === undefined ||
+    snapshot.runtimeGenerationId === agent.runtimeGenerationId;
 }
 
 function applyAgentSnapshot(

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -657,6 +657,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         thread: managedThread,
         status: "running",
         startedAt,
+        runtimeGenerationId: randomUUID(),
         runEpoch: currentRunEpochFromRollout(bootstrap, managedThread.threadId),
         canonicalEventBridgeInstalled: false,
         durableTerminalFinalizerInstalled: false,
@@ -829,6 +830,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       return {
         agentId: managedThread.threadId,
         agentPath: managedThread.agentPath ?? ("/root" as AgentPath),
+        runtimeGenerationId: active.runtimeGenerationId,
         startedAt,
         status: "running",
         ...(rolloutIdentity !== undefined
@@ -895,6 +897,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       return {
         status: active.status,
         lastActiveAt: active.lastActiveAt,
+        runtimeGenerationId: active.runtimeGenerationId,
         ...(active.runtimeSettings !== undefined
           ? {
               runtimeSettings: cloneFrozenRuntimeSettingsSnapshot(
@@ -1211,6 +1214,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               ? "running"
               : "idle",
           startedAt,
+          runtimeGenerationId: params.restoreAttemptId ?? randomUUID(),
           ...(params.restoreAttemptId !== undefined
             ? { restoreAttemptId: params.restoreAttemptId }
             : {}),
@@ -4875,6 +4879,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     const terminalSnapshot: AgenCBackgroundAgentSnapshot = {
       status: active.status,
       lastActiveAt: active.lastActiveAt,
+      runtimeGenerationId: active.runtimeGenerationId,
       ...(active.terminal !== undefined ? { terminal: active.terminal } : {}),
     };
     try {

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -122,6 +122,8 @@ export interface AgenCBackgroundAgentStartParams {
 export interface AgenCBackgroundAgentStartResult {
   readonly agentId: string;
   readonly agentPath?: string;
+  /** Internal runtime incarnation identity; never serialized to clients. */
+  readonly runtimeGenerationId?: string;
   /** Internal pre-publication rollback token; never serialized to clients. */
   readonly restoreAttemptId?: string;
   readonly startedAt: string;
@@ -201,6 +203,8 @@ export interface AgenCBackgroundAgentReplayToolResult {
 export interface AgenCBackgroundAgentSnapshot {
   readonly status: DaemonAgentStatus;
   readonly lastActiveAt: string;
+  /** Identifies the runtime that observed this snapshot, independently of run epoch. */
+  readonly runtimeGenerationId?: string;
   readonly metadata?: JsonObject;
   /** Live daemon-owned session authority, captured after its durable commit. */
   readonly runtimeSettings?: RunRuntimeSettingsSnapshot;
@@ -674,6 +678,7 @@ interface ActiveBackgroundAgent {
   readonly thread: ManagedThread;
   status: DaemonAgentStatus;
   readonly startedAt: string;
+  readonly runtimeGenerationId: string;
   /** Opaque generation proof retained only until publication succeeds/fails. */
   readonly restoreAttemptId?: string;
   /** Current canonical lifecycle epoch, recovered from run_reopened events. */

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -2225,7 +2225,11 @@ export class AgenCDaemonJsonRpcDispatcher {
       });
     }
     const onAbort = (): void => {
-      void cancelTurn();
+      // The request waiter owns its cancellation result. This legacy runner
+      // interruption may fail after that waiter or its connection has closed
+      // (for example, the session was retired). Observe the best-effort task so
+      // its failure cannot become an unhandled rejection for the whole daemon.
+      void cancelTurn().catch(() => {});
     };
     signal.addEventListener("abort", onAbort, { once: true });
     try {

--- a/runtime/src/app-server/transport/in-process.ts
+++ b/runtime/src/app-server/transport/in-process.ts
@@ -48,6 +48,7 @@ export interface StartAgenCInProcessDaemonTransportOptions
 export class AgenCInProcessDaemonTransport {
   readonly #connection: AgenCDaemonJsonRpcConnection;
   #closed = false;
+  #closing: Promise<void> | null = null;
 
   constructor(options: AgenCInProcessDaemonTransportOptions) {
     this.#connection = options.dispatcher.createConnection({
@@ -85,10 +86,11 @@ export class AgenCInProcessDaemonTransport {
     });
   }
 
-  async close(): Promise<void> {
-    if (this.#closed) return;
+  close(): Promise<void> {
+    if (this.#closing !== null) return this.#closing;
     this.#closed = true;
-    await this.#connection.close();
+    this.#closing = this.#connection.close();
+    return this.#closing;
   }
 
   #assertOpen(): void {

--- a/runtime/src/app-server/transport/unix-socket.ts
+++ b/runtime/src/app-server/transport/unix-socket.ts
@@ -133,6 +133,9 @@ export class AgenCUnixSocketServer {
   #nativePeerCredentialBinding: AgenCNativePeerCredentialBinding | null = null;
   #boundSocketIdentity: AgenCUnixSocketPathIdentity | null = null;
   #nextConnectionId = 1;
+  #listening: Promise<string> | null = null;
+  #closing: Promise<void> | null = null;
+  #closeInProgress = false;
 
   constructor(options: AgenCUnixSocketServerOptions) {
     this.#options = options;
@@ -145,11 +148,21 @@ export class AgenCUnixSocketServer {
     );
   }
 
-  async listen(): Promise<string> {
-    if (this.#server !== null) {
-      throw new Error("AgenC Unix socket transport is already listening");
+  listen(): Promise<string> {
+    if (this.#closeInProgress) {
+      return Promise.reject(new Error("AgenC Unix socket transport is closing"));
     }
+    if (this.#server !== null || this.#listening !== null) {
+      return Promise.reject(new Error("AgenC Unix socket transport is already listening"));
+    }
+    this.#closing = null;
+    this.#listening = this.#listen().finally(() => {
+      this.#listening = null;
+    });
+    return this.#listening;
+  }
 
+  async #listen(): Promise<string> {
     if (
       this.#options.nativePeerCredentialAddonPath !== undefined &&
       this.#options.nativePeerCredentialBinding !== undefined
@@ -250,7 +263,23 @@ export class AgenCUnixSocketServer {
     return socketPath;
   }
 
-  async close(options: AgenCTransportCloseOptions = {}): Promise<void> {
+  close(options: AgenCTransportCloseOptions = {}): Promise<void> {
+    if (this.#closing !== null) return this.#closing;
+    this.#closeInProgress = true;
+    const listening = this.#listening;
+    this.#closing = (async () => {
+      // Startup owns its listener until bind and path identity capture finish.
+      // Keep admission fenced while joining it, then release that generation.
+      if (listening !== null) await listening.catch(() => {});
+      await this.#close(options);
+    })().finally(() => {
+      this.#closeInProgress = false;
+      this.#closing = null;
+    });
+    return this.#closing;
+  }
+
+  async #close(options: AgenCTransportCloseOptions): Promise<void> {
     const server = this.#server;
     const boundSocketIdentity = this.#boundSocketIdentity;
     this.#server = null;
@@ -270,7 +299,7 @@ export class AgenCUnixSocketServer {
     if (server !== null) {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => {
-          if (error) {
+          if (error && (error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") {
             reject(error);
             return;
           }
@@ -287,7 +316,7 @@ export class AgenCUnixSocketServer {
   }
 
   #acceptConnection(socket: Socket): void {
-    if (this.#server === null) {
+    if (this.#server === null || this.#closeInProgress) {
       socket.destroy();
       return;
     }

--- a/runtime/src/app-server/transport/websocket.ts
+++ b/runtime/src/app-server/transport/websocket.ts
@@ -142,6 +142,9 @@ export class AgenCWebSocketServer {
   #webSocketServer: WebSocketServer | null = null;
   #listenAddress: AgenCWebSocketListenAddress | null = null;
   #nextConnectionId = 1;
+  #listening: Promise<AgenCWebSocketListenAddress> | null = null;
+  #closing: Promise<void> | null = null;
+  #closeInProgress = false;
 
   constructor(options: AgenCWebSocketServerOptions) {
     this.#options = options;
@@ -163,11 +166,21 @@ export class AgenCWebSocketServer {
     return this.#listenAddress;
   }
 
-  async listen(): Promise<AgenCWebSocketListenAddress> {
-    if (this.#server !== null || this.#webSocketServer !== null) {
-      throw new Error("AgenC websocket transport is already listening");
+  listen(): Promise<AgenCWebSocketListenAddress> {
+    if (this.#closeInProgress) {
+      return Promise.reject(new Error("AgenC websocket transport is closing"));
     }
+    if (this.#server !== null || this.#webSocketServer !== null || this.#listening !== null) {
+      return Promise.reject(new Error("AgenC websocket transport is already listening"));
+    }
+    this.#closing = null;
+    this.#listening = this.#listen().finally(() => {
+      this.#listening = null;
+    });
+    return this.#listening;
+  }
 
+  async #listen(): Promise<AgenCWebSocketListenAddress> {
     const httpServer = createServer((request, response) => {
       this.#handleHttpRequest(request, response);
     });
@@ -230,7 +243,23 @@ export class AgenCWebSocketServer {
     }
   }
 
-  async close(options: AgenCTransportCloseOptions = {}): Promise<void> {
+  close(options: AgenCTransportCloseOptions = {}): Promise<void> {
+    if (this.#closing !== null) return this.#closing;
+    this.#closeInProgress = true;
+    const listening = this.#listening;
+    this.#closing = (async () => {
+      // A requested startup still owns the server until address publication.
+      // Do not close beneath it or allow a replacement to inherit its cleanup.
+      if (listening !== null) await listening.catch(() => {});
+      await this.#close(options);
+    })().finally(() => {
+      this.#closeInProgress = false;
+      this.#closing = null;
+    });
+    return this.#closing;
+  }
+
+  async #close(options: AgenCTransportCloseOptions): Promise<void> {
     const webSocketServer = this.#webSocketServer;
     const httpServer = this.#server;
     this.#webSocketServer = null;
@@ -274,7 +303,7 @@ export class AgenCWebSocketServer {
       return;
     }
     if (path === AGENC_WEBSOCKET_READY_PATH) {
-      const ready = this.#options.ready?.() ?? true;
+      const ready = !this.#closeInProgress && (this.#options.ready?.() ?? true);
       writePlainResponse(response, ready ? 200 : 503, ready ? "ok\n" : "not ready\n");
       return;
     }
@@ -301,7 +330,7 @@ export class AgenCWebSocketServer {
     }
 
     const webSocketServer = this.#webSocketServer;
-    if (webSocketServer === null) {
+    if (webSocketServer === null || this.#closeInProgress) {
       rejectHttpUpgrade(socket, 503, "not ready\n");
       return;
     }
@@ -311,6 +340,10 @@ export class AgenCWebSocketServer {
   }
 
   #acceptConnection(socket: WebSocket, request: IncomingMessage): void {
+    if (this.#webSocketServer === null || this.#closeInProgress) {
+      socket.terminate();
+      return;
+    }
     const connectionId = this.#nextConnectionId;
     this.#nextConnectionId += 1;
 

--- a/runtime/tests/app-server/agent-terminal-generation.contract.test.ts
+++ b/runtime/tests/app-server/agent-terminal-generation.contract.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+
+const timestamp = "2026-09-11T00:00:00.000Z";
+
+describe("runner terminal generation authority", () => {
+  it.each(["current first", "current last"] as const)(
+    "retains the current terminal while create is unpublished: %s", async (order) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const agents = new AgenCDaemonAgentManager({ runner: {
+        startAgent: async () => {
+          entered.resolve();
+          await release.promise;
+          return { agentId: "agent", runtimeGenerationId: "current", startedAt: timestamp, status: "running" };
+        },
+      } });
+      const creating = agents.createAgent({
+        objective: "new runtime", cwd: process.cwd(), runtimeOptions: resolveAgentRuntimeOptions({}), envOverrides: {},
+      });
+      await entered.promise;
+      const current = { status: "stopped" as const, lastActiveAt: timestamp, runtimeGenerationId: "current" };
+      const old = { status: "error" as const, lastActiveAt: timestamp, runtimeGenerationId: "old" };
+      try {
+        for (const snapshot of order === "current first" ? [current, old] : [old, current]) {
+          await agents.handleRunnerTerminated("agent", snapshot);
+        }
+      } finally {
+        release.resolve();
+      }
+      expect(await creating).toMatchObject({ status: "stopped" });
+      expect(await agents.getAgent("agent")).toMatchObject({ status: "stopped" });
+    },
+  );
+
+  it("does not project an old terminal status after its persistence wait crosses a cold resume", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-terminal-generation-"));
+    const cwd = join(root, "workspace");
+    const home = join(root, "home");
+    mkdirSync(join(cwd, ".git"), { recursive: true });
+    const release = Promise.withResolvers<void>();
+    const entered = Promise.withResolvers<void>();
+    let terminal: Promise<void> | undefined;
+    try {
+      const agentId = "conv-terminal-generation";
+      const rollout = new RolloutStore({ cwd, agencHome: home, sessionId: agentId, agencVersion: "0.2.0", sessionTempRoot: tmpdir() });
+      rollout.open({
+        sessionId: agentId, timestamp, cwd, originator: "agenc-cli", source: "interactive-root",
+        agencVersion: "0.2.0", model: "grok-4", modelProvider: "grok",
+      });
+      rollout.appendRollout({ type: "response_item", payload: { role: "user", content: "continue work" } });
+      const result = {
+        runId: agentId, status: "completed" as const, exitCode: 0, stopReason: "turn_completed",
+        finalMessage: "done", usage: null, lastSequence: 1, finishedAt: timestamp,
+      };
+      const eventId = `run-terminal:${agentId}:1`;
+      rollout.append({
+        id: eventId, eventId, seq: 1, msg: { type: "run_terminal", payload: {
+          ...result, epoch: 1, lastSequenceBeforeTerminal: null,
+        } },
+      }, { durable: true });
+      const rolloutPath = rollout.rolloutPath;
+      rollout.close();
+      const stat = lstatSync(rolloutPath, { bigint: true });
+      const cwdStat = lstatSync(cwd, { bigint: true });
+      const sessions = new AgenCDaemonSessionManager();
+      const oldSession = await sessions.createSession({ agentId, cwd });
+      const recordAgentStatusTransition = vi.fn();
+      const agents = new AgenCDaemonAgentManager({
+        agencHome: home, sessionManager: sessions, recordAgentStatusTransition,
+        runner: { startAgent: vi.fn(), restoreAgent: async () => true },
+        recordRunTerminal: async () => { entered.resolve(); await release.promise; },
+      });
+      await agents.restoreAgent({
+        agentId, objective: "old runtime", runtimeAvailable: true, createdAt: timestamp,
+        sessionIds: [oldSession.sessionId], restoreAttemptId: "old-generation",
+      });
+      terminal = agents.handleRunnerTerminated(agentId, {
+        status: "stopped", lastActiveAt: timestamp, runtimeGenerationId: "old-generation",
+        terminal: { openedAt: timestamp, epoch: 1, eventId, rolloutPath, result },
+      });
+      await entered.promise;
+      const resumed = await agents.createAgent({
+        cwd, resumeSessionId: agentId, resumeRolloutPath: rolloutPath,
+        runtimeOptions: resolveAgentRuntimeOptions({}), envOverrides: {},
+        resumeSourceProof: {
+          dev: stat.dev.toString(), ino: stat.ino.toString(), size: stat.size.toString(),
+          sha256: createHash("sha256").update(readFileSync(rolloutPath)).digest("hex"),
+          cwdDev: cwdStat.dev.toString(), cwdIno: cwdStat.ino.toString(),
+        },
+      });
+      recordAgentStatusTransition.mockClear();
+      release.resolve();
+      await terminal;
+      expect(recordAgentStatusTransition).not.toHaveBeenCalled();
+      expect(await agents.getAgent(agentId)).toMatchObject({
+        status: "running", activeSessionIds: resumed.activeSessionIds,
+      });
+    } finally {
+      release.resolve();
+      await terminal;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores a delayed terminal callback after an unpublished restore is replaced", async () => {
+    const sessions = new AgenCDaemonSessionManager();
+    const firstSession = await sessions.createSession({ agentId: "agent", cwd: process.cwd() });
+    const replacementSession = await sessions.createSession({ agentId: "agent", cwd: process.cwd() });
+    const releaseTerminal = Promise.withResolvers<void>();
+    const recordAgentStatusTransition = vi.fn();
+    let failPublication = true;
+    const agents = new AgenCDaemonAgentManager({
+      sessionManager: sessions,
+      recordAgentStatusTransition,
+      runner: {
+        startAgent: vi.fn(),
+        attachAgentSessionEvents: async () => {
+          if (failPublication) throw new Error("publication failed");
+        },
+      },
+    });
+    await expect(agents.restoreAgent({
+      agentId: "agent", objective: "first", runtimeAvailable: true,
+      sessionIds: [firstSession.sessionId], restoreAttemptId: "first-generation",
+    })).rejects.toThrow("publication failed");
+    const oldSnapshot = {
+      status: "stopped" as const, lastActiveAt: timestamp,
+      runtimeGenerationId: "first-generation",
+    };
+    const delayedTerminal = releaseTerminal.promise.then(() =>
+      agents.handleRunnerTerminated("agent", oldSnapshot));
+    await agents.rollbackRestoredAgentRecord("agent", "first-generation");
+    failPublication = false;
+    await agents.restoreAgent({
+      agentId: "agent", objective: "replacement", runtimeAvailable: true,
+      sessionIds: [replacementSession.sessionId], restoreAttemptId: "replacement-generation",
+    });
+    releaseTerminal.resolve();
+    await delayedTerminal;
+
+    expect(await agents.getAgent("agent")).toMatchObject({
+      objective: "replacement", status: "running",
+      activeSessionIds: [replacementSession.sessionId],
+    });
+    expect(await sessions.getSession(replacementSession.sessionId)).toMatchObject({ status: "idle" });
+    expect(recordAgentStatusTransition).not.toHaveBeenCalled();
+
+    const currentSnapshot = {
+      ...oldSnapshot, runtimeGenerationId: "replacement-generation",
+    };
+    await agents.handleRunnerTerminated("agent", currentSnapshot);
+    expect(await agents.getAgent("agent")).toMatchObject({ status: "stopped" });
+    expect(await sessions.getSession(replacementSession.sessionId)).toMatchObject({ status: "closed" });
+  });
+});

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -2657,6 +2657,69 @@ describe("AgenC delegate background-agent runner", () => {
     ).resolves.not.toBeNull();
   });
 
+  it("keeps a timed-out terminal notification bound to the retired runtime generation", async () => {
+    const agentId = "session-delayed-terminal-generation";
+    const h = makeTopLevelRunner({ conversationId: agentId });
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let notification: Promise<void> | undefined;
+    let failPublication = true;
+    const manager = new AgenCDaemonAgentManager({ runner: {
+      startAgent: vi.fn(),
+      attachAgentSessionEvents: async () => {
+        if (failPublication) throw new Error("publication failed");
+      },
+    } });
+    h.runner.setOnActiveAgentTerminated((id, snapshot) => {
+      notification = (async () => {
+        entered.resolve();
+        await release.promise;
+        await manager.handleRunnerTerminated(id, snapshot);
+      })();
+      return notification;
+    });
+    const started = await h.runner.startAgent({
+      objective: "original runtime", initialContent: [], unattendedAllow: [], unattendedDeny: [],
+    });
+    const firstGeneration = started.runtimeGenerationId ?? "legacy-first-generation";
+    await expect(manager.restoreAgent({
+      agentId, objective: "original runtime", runtimeAvailable: true,
+      restoreAttemptId: firstGeneration, sessionIds: ["unpublished-session"],
+    })).rejects.toThrow("publication failed");
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      h.stub.pushStatus({ status: "completed", turnId: "old-turn", endedAtMs: 2, lastMessage: "done" });
+      await vi.advanceTimersByTimeAsync(0);
+      await entered.promise;
+      await manager.rollbackRestoredAgentRecord(agentId, firstGeneration);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(await h.runner.getAgentSnapshot(agentId)).toBeNull();
+      h.stub.pushStatus({ status: "running", turnId: "replacement-turn", startedAtMs: 3 });
+      expect(await h.runner.restoreAgent({
+        agentId, objective: "replacement runtime", explicitColdResume: true,
+        restoreAttemptId: "replacement-generation",
+      })).toBe(true);
+      failPublication = false;
+      await manager.restoreAgent({
+        agentId, objective: "replacement runtime", runtimeAvailable: true,
+        restoreAttemptId: "replacement-generation", sessionIds: ["replacement-session"],
+      });
+      release.resolve();
+      await notification;
+      expect(await manager.getAgent(agentId)).toMatchObject({
+        objective: "replacement runtime", status: "running", activeSessionIds: ["replacement-session"],
+      });
+      expect(await h.runner.getAgentSnapshot(agentId)).toMatchObject({ runtimeGenerationId: "replacement-generation" });
+      expect(started.runtimeGenerationId).toEqual(expect.any(String));
+      expect(started.runtimeGenerationId).not.toBe("replacement-generation");
+    } finally {
+      release.resolve();
+      await notification;
+      vi.useRealTimers();
+      await h.runner.stopAgent(agentId, "test_cleanup");
+    }
+  });
+
   it("reports a cold-restored agent idle until a turn starts", async () => {
     // A hydrated thread reports pending_init, which maps to "running"; with
     // nothing to resume the restored agent must read idle until its next
@@ -5654,6 +5717,7 @@ describe("AgenC delegate background-agent runner", () => {
     ).resolves.toEqual({
       agentId: "parent-session",
       agentPath: "/root",
+      runtimeGenerationId: expect.any(String),
       startedAt: "2026-05-01T12:00:00.500Z",
       status: "running",
     });

--- a/runtime/tests/app-server/request-cancel-failure-isolation.contract.test.ts
+++ b/runtime/tests/app-server/request-cancel-failure-isolation.contract.test.ts
@@ -1,0 +1,82 @@
+import { setImmediate } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { AgenCInProcessDaemonTransport } from "../../src/app-server/transport/in-process.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+
+describe.each(["message.send", "message.stream"])("%s cancellation failure isolation", (method) => {
+  it.each(["request.cancel", "disconnect"])(
+    "keeps a late legacy interruption failure contained after %s", async (trigger) => {
+      const entered = Promise.withResolvers<void>();
+      const releaseStream = Promise.withResolvers<void>();
+      const releaseCancellation = Promise.withResolvers<void>();
+      const sessions = new AgenCDaemonSessionManager();
+      const session = await sessions.createSession({ cwd: process.cwd() });
+      const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+      const cancelSessionTurn = vi.fn(async () => {
+        await releaseCancellation.promise;
+        throw new Error("runner was retired before legacy interruption completed");
+      });
+      const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+        sessionManager: sessions, clientMultiplexer: multiplexer,
+        agentManager: {
+          streamAgentMessage: async (params: JsonObject) => {
+            entered.resolve();
+            await releaseStream.promise;
+            return { disposition: "started", acceptedAt: params.acceptedAt, terminal: { code: 0 } };
+          },
+          cancelSessionTurn,
+        } as never,
+      });
+      const transport = new AgenCInProcessDaemonTransport({ dispatcher, sendNotification: () => {} });
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown): void => { unhandled.push(reason); };
+      process.on("unhandledRejection", onUnhandled);
+      let sending: ReturnType<typeof transport.dispatch> | undefined;
+      try {
+        await transport.initialize();
+        await transport.dispatch({
+          jsonrpc: "2.0", id: "attach", method: "session.attach",
+          params: { sessionId: session.sessionId, clientId: "legacy-client" },
+        });
+        // Omitting clientMessageId preserves the supported legacy interruption
+        // path even when this peer negotiates the current protocol version.
+        sending = transport.dispatch({
+          jsonrpc: "2.0", id: "sending", method,
+          params: { sessionId: session.sessionId, content: "held submission" },
+        });
+        await entered.promise;
+        if (trigger === "disconnect") {
+          await transport.close();
+        } else {
+          await expect(transport.dispatch({
+            jsonrpc: "2.0", id: "cancel", method: "request.cancel", params: { requestId: "sending" },
+          })).resolves.toMatchObject({ result: { cancelled: true } });
+        }
+        await expect(sending).resolves.toHaveProperty("error");
+        expect(cancelSessionTurn).toHaveBeenCalledOnce();
+        releaseCancellation.resolve();
+        await setImmediate();
+        expect(unhandled).toEqual([]);
+        const peer = new AgenCInProcessDaemonTransport({ dispatcher });
+        try {
+          await expect(peer.initialize()).resolves.toHaveProperty("result");
+          await expect(peer.dispatch({ jsonrpc: "2.0", id: "ping", method: "health.ping", params: {} }))
+            .resolves.toHaveProperty("result");
+        } finally {
+          await peer.close();
+        }
+      } finally {
+        releaseCancellation.resolve();
+        releaseStream.resolve();
+        await sending;
+        await transport.close();
+        await dispatcher.close();
+        await setImmediate();
+        process.off("unhandledRejection", onUnhandled);
+      }
+    },
+  );
+});

--- a/runtime/tests/app-server/sdk-submission-validation.contract.test.ts
+++ b/runtime/tests/app-server/sdk-submission-validation.contract.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAgencClient, type AgencTransport, type MessageContent } from "../../../packages/agenc-sdk/src/index.js";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { AgenCInProcessDaemonTransport } from "../../src/app-server/transport/in-process.js";
+import type { AgenCDaemonSessionNotification, JsonObject } from "../../src/app-server/protocol/index.js";
+import { drainMicrotasks } from "../helpers/controlled-async.js";
+
+const sessionId = "sdk-validation-session";
+const clientMessageId = "reused-message";
+const turnId = "original-turn";
+
+function userMessage(content?: MessageContent): AgenCDaemonSessionNotification {
+  return { jsonrpc: "2.0", method: "event.session_event", params: {
+    sessionId, eventId: "user-marker", event: { id: "user-marker", type: "user_message", payload: {
+      messageId: clientMessageId, ...(content === undefined ? {} : { message: content }),
+    } },
+  } };
+}
+
+function status(terminal = false): AgenCDaemonSessionNotification {
+  return { jsonrpc: "2.0", method: "event.agent_status", params: {
+    sessionId, eventId: terminal ? "terminal-event" : "start-event", turnId,
+    status: terminal ? "idle" : "running", ...(terminal ? { runStatus: "completed", message: "notification result" } : {}),
+  } };
+}
+
+const permission: AgenCDaemonSessionNotification = {
+  jsonrpc: "2.0", method: "event.permission_request", params: {
+    sessionId, eventId: "permission-event", requestId: "permission-1", turnId, permissions: [],
+  },
+};
+
+async function connectedDaemon(stream: (params: JsonObject) => Promise<unknown>) {
+  const sessions = new AgenCDaemonSessionManager();
+  await sessions.restoreSession({ sessionId, agentId: "agent_1", cwd: process.cwd() });
+  const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+  const approved = Promise.withResolvers<void>();
+  const approve = vi.fn(async () => {
+    approved.resolve();
+    return { requestId: "permission-1", decision: "approved" };
+  });
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+    sessionManager: sessions, clientMultiplexer: multiplexer,
+    agentManager: {
+      streamAgentMessage: stream, approveTool: approve,
+      getSessionTranscriptV2: async () => ({
+        schemaVersion: 2, sessionId, runId: "run_1", historyEpoch: "initial", asOfSequence: 0, messages: [],
+      }),
+    } as never,
+  });
+  let deliver: (notification: JsonObject) => void = () => {};
+  let paused = false;
+  const delayed: JsonObject[] = [];
+  const transport = new AgenCInProcessDaemonTransport({
+    dispatcher,
+    sendNotification: (notification) => {
+      const wireNotification = JSON.parse(JSON.stringify(notification)) as JsonObject;
+      if (paused) delayed.push(wireNotification);
+      else deliver(wireNotification);
+    },
+  });
+  const onPermissionRequest = vi.fn(async () => ({ behavior: "allow" as const }));
+  const client = createAgencClient({
+    transport: transport as unknown as AgencTransport,
+    clientId: "sdk-validation-client", onPermissionRequest,
+  });
+  deliver = (notification) => client.dispatchNotification(notification);
+  await client.initialize();
+  const session = await client.resumeSession(sessionId);
+  return {
+    client, session, approve, approved, onPermissionRequest,
+    emit: (notification: AgenCDaemonSessionNotification) => multiplexer.broadcastSessionNotification(sessionId, notification),
+    pause: () => { paused = true; },
+    flush: () => { paused = false; for (const notification of delayed.splice(0)) deliver(notification); },
+    close: async () => { await client.close(); await dispatcher.close(); },
+  };
+}
+
+describe("SDK submission validation against delayed session notifications", () => {
+  it.each(["null prototype", "undefined property", "post-dispatch mutation"] as const)(
+    "preserves live approvals for structured content with %s across JSON framing",
+    async (representation) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      let submittedContent: unknown;
+      const daemon = await connectedDaemon(async (params) => {
+        submittedContent = params.content;
+        entered.resolve();
+        await release.promise;
+        return { disposition: "started", acceptedAt: params.acceptedAt, turnId, terminal: { code: 0 } };
+      });
+      const block: { type: "text"; text: string; optional?: undefined } = representation === "null prototype"
+        ? Object.assign(Object.create(null), { type: "text", text: "hello" })
+        : { type: "text", text: "hello", ...(representation === "undefined property" ? { optional: undefined } : {}) };
+      try {
+        const run = daemon.session.prompt([block], { clientMessageId, includeUsage: false });
+        await entered.promise;
+        if (representation === "post-dispatch mutation") block.text = "changed after sending";
+        await daemon.emit(userMessage([{ type: "text", text: "hello" }]));
+        await daemon.emit(status());
+        await daemon.emit(permission);
+        await drainMicrotasks(20);
+        expect(daemon.onPermissionRequest).toHaveBeenCalledOnce();
+        await daemon.approved.promise;
+        expect(submittedContent).toEqual([{ type: "text", text: "hello" }]);
+        release.resolve();
+        await expect(run.result()).resolves.toMatchObject({ exitCode: 0 });
+        await run.accepted;
+      } finally {
+        release.resolve();
+        await daemon.close();
+      }
+    },
+  );
+
+  it("does not grant a replayed approval for a conflicting reused submission ID", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const daemon = await connectedDaemon(async () => {
+      entered.resolve();
+      await release.promise;
+      throw new Error("submission content conflicts");
+    });
+    try {
+      daemon.pause();
+      await daemon.emit(userMessage("original content"));
+      await daemon.emit(status());
+      await daemon.emit(permission);
+      await daemon.emit(status(true));
+      const run = daemon.session.prompt("different content", { clientMessageId, includeUsage: false });
+      const accepted = run.accepted.catch((error: unknown) => error);
+      const result = run.result().catch((error: unknown) => error);
+      await entered.promise;
+      daemon.flush();
+      await drainMicrotasks(20);
+      expect(daemon.onPermissionRequest).not.toHaveBeenCalled();
+      expect(daemon.approve).not.toHaveBeenCalled();
+      release.resolve();
+      expect(await accepted).toMatchObject({ message: "submission content conflicts" });
+      expect(await result).toMatchObject({ message: "submission content conflicts" });
+    } finally {
+      release.resolve();
+      await daemon.close();
+    }
+  });
+
+  it("keeps an identity-only terminal provisional when the RPC later rejects", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const daemon = await connectedDaemon(async () => {
+      entered.resolve();
+      await release.promise;
+      throw new Error("submission rejected");
+    });
+    try {
+      const run = daemon.session.prompt("content", { clientMessageId, includeUsage: false });
+      const accepted = run.accepted.catch((error: unknown) => error);
+      const result = run.result().catch((error: unknown) => error);
+      let settled = false;
+      void run.result().then(() => { settled = true; }, () => { settled = true; });
+      await entered.promise;
+      await daemon.emit(userMessage());
+      await daemon.emit(status());
+      await daemon.emit(status(true));
+      await drainMicrotasks(20);
+      expect(settled).toBe(false);
+      release.resolve();
+      expect(await accepted).toMatchObject({ message: "submission rejected" });
+      expect(await result).toMatchObject({ message: "submission rejected" });
+    } finally {
+      release.resolve();
+      await daemon.close();
+    }
+  });
+
+  it("answers live approvals before the RPC completes and validates its matching terminal", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const daemon = await connectedDaemon(async (params) => {
+      entered.resolve();
+      await release.promise;
+      return { disposition: "started", acceptedAt: params.acceptedAt, turnId, terminal: { code: 0, message: "RPC fallback result" } };
+    });
+    try {
+      const run = daemon.session.prompt("content", { clientMessageId, includeUsage: false });
+      let settled = false;
+      void run.result().then(() => { settled = true; }, () => { settled = true; });
+      await entered.promise;
+      await daemon.emit(userMessage("content"));
+      await daemon.emit(status());
+      await daemon.emit(permission);
+      await daemon.approved.promise;
+      expect(daemon.approve).toHaveBeenCalledOnce();
+      await daemon.emit(status(true));
+      await drainMicrotasks(20);
+      expect(settled).toBe(false);
+      release.resolve();
+      await expect(run.accepted).resolves.toMatchObject({ clientMessageId, turnId });
+      // Preserve the established event-derived result after validating admission;
+      // the RPC terminal supplies a fallback when the matching event is absent.
+      await expect(run.result()).resolves.toMatchObject({ exitCode: 0, finalMessage: "notification result" });
+    } finally {
+      release.resolve();
+      await daemon.close();
+    }
+  });
+
+  it("suppresses a late approval and settles provisional prompt handles when the client closes", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const decision = Promise.withResolvers<{ behavior: "allow" }>();
+    const daemon = await connectedDaemon(async (params) => {
+      entered.resolve();
+      await release.promise;
+      return { disposition: "started", acceptedAt: params.acceptedAt, turnId, terminal: { code: 0 } };
+    });
+    daemon.onPermissionRequest.mockImplementationOnce(() => decision.promise);
+    try {
+      const run = daemon.session.prompt("content", { clientMessageId, includeUsage: false });
+      const accepted = run.accepted.catch((error: unknown) => error);
+      const result = run.result().catch((error: unknown) => error);
+      await entered.promise;
+      await daemon.emit(userMessage("content"));
+      await daemon.emit(status());
+      await daemon.emit(permission);
+      expect(daemon.onPermissionRequest).toHaveBeenCalledOnce();
+      await daemon.emit(status(true));
+      decision.resolve({ behavior: "allow" });
+      await drainMicrotasks(20);
+      expect(daemon.approve).not.toHaveBeenCalled();
+      await daemon.client.close();
+      expect(await accepted).toMatchObject({ message: "AgenC SDK client is closed" });
+      expect(await result).toMatchObject({ message: "AgenC SDK client is closed" });
+    } finally {
+      decision.resolve({ behavior: "allow" });
+      release.resolve();
+      await daemon.close();
+    }
+  });
+});

--- a/runtime/tests/app-server/transport-lifecycle-generations.contract.test.ts
+++ b/runtime/tests/app-server/transport-lifecycle-generations.contract.test.ts
@@ -1,0 +1,149 @@
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCInProcessDaemonTransport } from "../../src/app-server/transport/in-process.js";
+import { AgenCUnixSocketServer } from "../../src/app-server/transport/unix-socket.js";
+import { AgenCWebSocketServer } from "../../src/app-server/transport/websocket.js";
+
+describe.each(["unix", "websocket"] as const)("%s transport lifecycle ownership", (kind) => {
+  async function fixture(onMessage: () => void | Promise<void> = () => {}) {
+    const directory = await mkdtemp(join(tmpdir(), "agenc-transport-generation-"));
+    const server = kind === "unix"
+      ? new AgenCUnixSocketServer({ socketPath: join(directory, "daemon.sock"), onMessage })
+      : new AgenCWebSocketServer({ port: 0, onMessage });
+    const connect = async () => {
+      const client = server instanceof AgenCUnixSocketServer
+        ? createConnection(server.socketPath)
+        : new WebSocket(server.listenAddress!.url);
+      await once(client, client instanceof WebSocket ? "open" : "connect");
+      return client;
+    };
+    return {
+      server, connect,
+      async cleanup() {
+        await server.close().catch(() => {});
+        await rm(directory, { recursive: true, force: true });
+      },
+    };
+  }
+
+  it("close owns an already requested startup until its listener is released", async () => {
+    const { server, cleanup } = await fixture();
+    const starting = server.listen();
+    const closing = server.close();
+    try {
+      await closing;
+      await starting;
+      if (server instanceof AgenCUnixSocketServer) {
+        const client = createConnection(server.socketPath);
+        const event = await Promise.race([
+          once(client, "error").then(() => "closed"),
+          once(client, "connect").then(() => "listening", () => "closed"),
+        ]);
+        client.destroy();
+        expect(event).toBe("closed");
+      } else {
+        expect(server.listenAddress).toBeNull();
+      }
+      // Completion returns the object to a usable, fully closed generation.
+      await expect(server.listen()).resolves.toBeDefined();
+    } finally {
+      await Promise.allSettled([starting, closing]);
+      await cleanup();
+    }
+  });
+
+  it("rejects competing startups before either can replace listener ownership", async () => {
+    const { server, cleanup } = await fixture();
+    const starting = server.listen();
+    const duplicate = server.listen();
+    try {
+      await expect(duplicate).rejects.toThrow("already");
+      await starting;
+    } finally {
+      await Promise.allSettled([starting, duplicate]);
+      await cleanup();
+    }
+  });
+
+  it("coalesces close and rejects restart until the old request drain settles", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const { server, connect, cleanup } = await fixture(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    let client: Socket | WebSocket | undefined;
+    try {
+      await server.listen();
+      client = await connect();
+      const request = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "health.ping" });
+      if (client instanceof WebSocket) client.send(request);
+      else client.write(`${request}\n`);
+      await entered.promise;
+      const first = server.close();
+      const second = server.close();
+      const completed: string[] = [];
+      void first.then(() => completed.push("first"));
+      void second.then(() => completed.push("second"));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(completed).toEqual([]);
+      await expect(server.listen()).rejects.toThrow("closing");
+      release.resolve();
+      await Promise.all([first, second]);
+      await server.listen();
+      const replacement = await connect();
+      if (replacement instanceof WebSocket) replacement.terminate();
+      else replacement.destroy();
+    } finally {
+      release.resolve();
+      if (client instanceof WebSocket) client.terminate();
+      else client?.destroy();
+      await cleanup();
+    }
+  });
+});
+
+describe("in-process transport close ownership", () => {
+  it.each([false, true])("every close joins pending connection cleanup (failure=%s)", async (fail) => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const failure = new Error("connection cleanup failed");
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+      commandExec: {
+        start: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        write: async () => ({}), resize: async () => ({}), terminate: async () => ({}),
+        closeConnection: async () => {
+          entered.resolve();
+          await release.promise;
+          if (fail) throw failure;
+        },
+      },
+    });
+    const transport = new AgenCInProcessDaemonTransport({ dispatcher });
+    const first = transport.close();
+    await entered.promise;
+    const second = transport.close();
+    const completed: string[] = [];
+    void first.then(() => completed.push("first"), () => completed.push("first"));
+    void second.then(() => completed.push("second"), () => completed.push("second"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    try {
+      expect(completed).toEqual([]);
+    } finally {
+      release.resolve();
+    }
+    const outcomes = await Promise.allSettled([first, second, transport.close()]);
+    expect(outcomes.map((outcome) => outcome.status)).toEqual(
+      Array(3).fill(fail ? "rejected" : "fulfilled"),
+    );
+    await dispatcher.close();
+  });
+});

--- a/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
+++ b/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
@@ -233,7 +233,7 @@ async function initializedClient(
   return client;
 }
 
-function userMessage(clientMessageId: string): JsonObject {
+function userMessage(clientMessageId: string, content: string): JsonObject {
   return {
     jsonrpc: "2.0",
     method: "event.session_event",
@@ -243,7 +243,7 @@ function userMessage(clientMessageId: string): JsonObject {
       event: {
         id: `user_${clientMessageId}`,
         type: "user_message",
-        payload: { message: clientMessageId, messageId: clientMessageId },
+        payload: { message: content, messageId: clientMessageId },
       },
     },
   };
@@ -394,7 +394,7 @@ describe("agenc-sdk prompt race safety", () => {
         onElicitationRequest: respond,
       });
       const send = await waitForSend(transport, 0);
-      transport.emit(userMessage("interactive_message"));
+      transport.emit(userMessage("interactive_message", "interactive"));
       transport.emit(turnStarted("interactive_turn"));
       transport.emit({
         jsonrpc: "2.0",
@@ -766,7 +766,7 @@ describe("agenc-sdk prompt race safety", () => {
     ).toThrow(AgencPromptRunInProgressError);
 
     const sendA = await waitForSend(transport, 0);
-    transport.emit(userMessage("message_A"));
+    transport.emit(userMessage("message_A", "A"));
     transport.emit(turnStarted("turn_A"));
     transport.emit(terminal("turn_A", "answer A"));
     resolveSend(sendA, "turn_A");
@@ -791,7 +791,7 @@ describe("agenc-sdk prompt race safety", () => {
     ]);
     expect(stillPending).toBe(true);
 
-    transport.emit(userMessage("message_B"));
+    transport.emit(userMessage("message_B", "B"));
     transport.emit(turnStarted("turn_B"));
     transport.emit(text("turn_B", "ha"));
     transport.emit(text("turn_B", "ha"));
@@ -821,7 +821,7 @@ describe("agenc-sdk prompt race safety", () => {
     const client = await initializedClient(transport);
     const run = client.runPrompt("session_1", "work", { clientMessageId: "failure-message", includeUsage: false });
     const send = await waitForSend(transport, 0);
-    transport.emit(userMessage("failure-message"));
+    transport.emit(userMessage("failure-message", "work"));
     transport.emit(turnStarted("turn-failure"));
     const emit = (id: string, type: string, payload: JsonObject, turnId = "turn-failure") => transport.emit({
       jsonrpc: "2.0", method: "event.session_event",
@@ -882,7 +882,7 @@ describe("agenc-sdk prompt race safety", () => {
       ),
     ).toEqual([]);
 
-    transport.emit(userMessage("message_cancel"));
+    transport.emit(userMessage("message_cancel", "cancel me"));
     expect(
       transport.requests.filter(
         (request) => request.method === "session.cancelTurn",
@@ -924,7 +924,7 @@ describe("agenc-sdk prompt race safety", () => {
         (request) => request.method === "session.cancelTurn",
       ),
     ).toHaveLength(0);
-    transport.emit(userMessage("message_legacy_cancel"));
+    transport.emit(userMessage("message_legacy_cancel", "legacy cancel"));
     transport.emit(turnStarted("turn_legacy_cancel"));
     await Promise.resolve();
     expect(
@@ -989,7 +989,7 @@ describe("agenc-sdk prompt race safety", () => {
     });
     const send = await waitForSend(transport, 0);
 
-    transport.emit(userMessage("message_terminal_fallback"));
+    transport.emit(userMessage("message_terminal_fallback", "finish from result"));
     transport.emit(turnStarted("turn_terminal_fallback"));
     transport.emit(text("turn_terminal_fallback", "answer"));
     transport.emit(committed("turn_terminal_fallback", "answer"));


### PR DESCRIPTION
Daemon shutdown could finish before listener startup or connection cleanup, and delayed terminal callbacks could stop a replacement runtime sharing the same canonical agent ID. SDK replay could also trigger stale approvals or settle a prompt before its submission RPC rejected.

This change:

- Reserves transport startup and close ownership until their work settles, coalesces concurrent closes, and prevents restart during cleanup.
- Binds runner observations and pending terminals to an internal runtime generation, with lifecycle-owner checks on later persistence steps.
- Contains late legacy interruption failures after a request is cancelled or disconnected.
- Correlates SDK events with an immutable JSON submission snapshot and validates admission before settling terminal results, while preserving live approval handling.

Adds 24 deterministic regressions, including real sockets, connected SDK/dispatcher flows, the runner notification timeout, and cold resume from a verified rollout. The detailed audit is in `docs/design/daemon-session-generation-audit.md`.

Local validation:

- Linux Docker control-plane boundary: 139 files, 1,816 tests passed with no skips.
- Runtime and test-support typechecks, runtime build, entrypoint/generated protocol checks, and SDK build passed.
- Built runtime/TUI imports and startup passed in normal and bypass modes at 148×40, 120×30, and 80×24.
- 162 local required-gate tests passed; `git diff --check` passed.

GitHub CI is intentionally skipped as requested. No workflow settings are changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core daemon lifecycle, transport shutdown ordering, and SDK turn completion semantics; mistakes could stop the wrong agent, leave listeners racy, or settle prompts on stale replay.
> 
> **Overview**
> Hardens the daemon control plane and SDK prompt path against **cross-generation races** and **replay-after-dispatch** bugs, with a design audit in `docs/design/daemon-session-generation-audit.md`.
> 
> **Runtime lifecycle** assigns an internal `runtimeGenerationId` to each runner incarnation (fresh UUID on start, restore attempt id on resume). Agent lifecycle applies runner terminations, pending terminals, and async persistence only when the snapshot generation matches the live agent, and rechecks the originating agent object before status writes so a slow old finalizer cannot stop a cold-resumed replacement.
> 
> **Transports** (Unix, WebSocket, in-process) reserve listen/close ownership across async startup and drain: close joins in-flight listen, fences new connections during shutdown, coalesces concurrent closes, and blocks restart until cleanup finishes. Request cancel/disconnect now **`.catch()`** best-effort legacy turn interruption so late failures do not become unhandled rejections.
> 
> **SDK `runPrompt`** snapshots submitted content via JSON round-trip, requires durable user-message content to match before owning notifications, keeps terminal completion **provisional** until `message.send` succeeds, and still allows live permission/elicitation responses before RPC validation.
> 
> Adds **24** targeted contract tests (real sockets, dispatcher flows, cold resume, notification timeout, submission replay cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7922b03c498dd882845342278e2ec51269a982a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->