### PR TITLE
eval: three-agent benchmark runner, the 2026-09-11 comparison and the harness review

### DIFF
--- a/docs/eval/harness-review-2026-09-11.md
+++ b/docs/eval/harness-review-2026-09-11.md
@@ -8,7 +8,8 @@ main 0245ef4fe; each item says what was done or what remains.
 - Fewer model calls per task than Hermes 0.21.2 (3.9 against 4.3 on Sonnet 5) and fewer tool calls (38 against 44
   over the 12 command tasks); zero tool errors and zero compactions across the 15-step session.
 - Session pace: 1174 s for the 15 steps on grok-4.6, against 1275 s for the same build on September 5 and 2203 s for
-  Hermes 0.14 then. Hermes 0.21.2 on DeepSeek V4 Pro is in the comparison report.
+  Hermes 0.14 then. Hermes 0.21.2 finished the same 15 steps on DeepSeek V4 Pro in 1772 s with 62 model calls and 94
+  tool calls (different model, so a pace reference rather than a like-for-like number).
 - Sign-in without keys (xAI, ChatGPT, managed route) is something neither Hermes nor OpenCode offers for grok.
 
 ## Fixed during the review

--- a/docs/eval/harness-review-2026-09-11.md
+++ b/docs/eval/harness-review-2026-09-11.md
@@ -1,0 +1,79 @@
+# Harness review after the 2026-09-11 benchmark: speed, tokens, tool use, safety
+
+Companion to `real-agent-comparison-2026-09-11.md`. Everything here is measured on that run or read from the code at
+main 0245ef4fe; each item says what was done or what remains.
+
+## Where AgenC already leads
+
+- Fewer model calls per task than Hermes 0.21.2 (3.9 against 4.3 on Sonnet 5) and fewer tool calls (38 against 44
+  over the 12 command tasks); zero tool errors and zero compactions across the 15-step session.
+- Session pace: 1174 s for the 15 steps on grok-4.6, against 1275 s for the same build on September 5 and 2203 s for
+  Hermes 0.14 then. Hermes 0.21.2 on DeepSeek V4 Pro is in the comparison report.
+- Sign-in without keys (xAI, ChatGPT, managed route) is something neither Hermes nor OpenCode offers for grok.
+
+## Fixed during the review
+
+1. **Prompt cache broken in acceptEdits and bypassPermissions** (core #2407). The retained "Auto Mode" note was kept
+   only for mode `auto`, so in the other two autonomous modes it was dropped from its place and re-emitted after the
+   newest history item on every request. DeepSeek and grok saw a new prefix each call (25,600 cache-miss tokens per
+   call); Anthropic re-created about 4,000 cache tokens per call. After the fix the second request in a turn reports
+   24,960 hit and 193 miss on DeepSeek. The grok session spent 28.9M input tokens with the bug; expect most of it to
+   move to the cached price and to shorter prefill.
+2. **Skills listing sized at one percent of the context window** (core #2408). 40,584 chars on every request of every
+   session on 1M-context models; capped at 12,000 chars, env override kept.
+3. **Internal-build gates removed** (core #2405): no `USER_TYPE` switch can flip internal code paths any more.
+4. **Plugin catalog no longer invented** (desktop #265).
+
+## Token budget per call, and what is left to cut
+
+Measured on Sonnet 5: about 24,000 cached prompt tokens per call against Hermes's 19,000. The pieces:
+
+| piece | size | status |
+| --- | --- | --- |
+| system prompt | 21,215 chars (about 5,300 tokens) | fine |
+| tool catalog, 38 tools | 46,470 bytes (about 11,500 tokens) | next: see below |
+| skills listing | 40,584 chars (about 10,000 tokens) | capped to 12,000 chars by #2408 |
+| agent list, auto-mode note | about 3,200 chars | fine, now cached |
+
+Next cuts, in order of return:
+- `spawn_agent` is 10,154 bytes of the catalog on its own, `Grep` 4,105, `exec_command` 3,064. Moving the usage
+  guidance out of the tool description into the system prompt and keeping the schema minimal saves about 2,500 tokens
+  per call.
+- Defer the tools a coding turn rarely touches (`spawn_agents_on_csv`, `show_csv_job_review`, `Orient`, `write_stdin`,
+  `list_agents`, `close_agent`) behind `system.searchTools`, which already exists for MCP and plugin tools: about
+  1,000 to 1,500 tokens per call.
+- Add a regression test that projects two consecutive requests of one turn and asserts a byte-identical prefix, so the
+  class of bug in #2407 cannot come back silently.
+
+## Tool use
+
+- Re-reads: 24 of 71 file reads in the grok session were repeats (34 percent; the September 5 SDK run had 6 percent).
+  A "you read this file N tool calls ago, unchanged" hint on FileRead, or serving the cached content, would remove most
+  of them.
+- `Edit` failed three times in one Sonnet task before succeeding (string not found). Returning the nearest matching
+  lines in the error would make the retry cheaper.
+- Headless continuation: `hermes chat -c` and `opencode run --continue` resume a session from a shell; `agenc -c -p`
+  is refused because `--continue` is TUI-only, and SDK-created sessions do not see an environment-provided provider
+  key (only secure-storage credentials work). Both block scripted use and the benchmark's session lane on any provider
+  without a sign-in.
+- `agenc -p` did not exit after its only turn failed on a transient provider 403 (issue filed): print mode must fail
+  fast.
+
+## Safety posture
+
+- Every tool result is framed as untrusted workspace data; the shell tools carry a deny list for dangerous patterns and
+  the auto-mode classifier; bypass mode needs recorded per-workspace consent; keys never travel on an argv; client
+  environments are forwarded through an allowlist (and `USER_TYPE` left it in #2405).
+- The OS sandbox (Seatbelt, Landlock, bubblewrap) is opt-in through `sandbox_mode`, and the only headless bypass flag is
+  `--dangerously-bypass-approvals-and-sandbox`, which drops both. Recommendation: a mode that bypasses approvals but
+  keeps the sandbox, and make it the default for autonomous runs on macOS and Linux.
+- Hermes 0.21 ships a command scanner (tirith), security scanning on skill installs and consent-gated real-profile
+  browsing. AgenC has publisher trust for plugins and Keychain storage; scanning skills and plugins at install time is
+  the gap worth closing first.
+
+## Benchmark hygiene
+
+- Provider keys run dry mid-benchmark (xAI, then Anthropic) and the affected rows say so; the DeepSeek key is the
+  reliable one for full runs.
+- OpenCode must run with an isolated HOME: with the operator's real HOME it ingests 1,823 Claude skills and two global
+  instruction files, about 204,000 input tokens per call.

--- a/docs/eval/real-agent-comparison-2026-09-11.md
+++ b/docs/eval/real-agent-comparison-2026-09-11.md
@@ -6,7 +6,8 @@ runs headless from an isolated home: AgenC through `agenc -p` in an isolated `AG
 AgenC SDK), Hermes 0.21.2 (tag v2026.9.11, run from a git checkout in its own venv and `HERMES_HOME`) through
 `hermes chat -Q --yolo --provider <p> -m <model> --reasoning medium -q <prompt>` (`-c` on later steps), OpenCode 1.18.30
 (npm package, `XDG_*_HOME` isolated) through `opencode run --auto -m <provider>/<model> <prompt>` (`--continue` on later
-steps). `runtime/scripts/compare-agents.sh` runs all of it; `runtime/scripts/eval-compare-table.mjs` prints the tables.
+steps). `runtime/scripts/compare-agents.sh` runs all of it and writes the reports under `runtime/eval/reports/<run>/`;
+`runtime/scripts/eval-compare-table.mjs <run> [tag]` prints the tables.
 Keys never touch an argv: each agent gets one provider key through `env -i`.
 
 ## Command tasks (12 single prompts)

--- a/docs/eval/real-agent-comparison-2026-09-11.md
+++ b/docs/eval/real-agent-comparison-2026-09-11.md
@@ -1,0 +1,81 @@
+# Real-agent comparison: AgenC, Hermes 0.21.2 and OpenCode 1.18.30, 2026-09-11
+
+Same 13 tasks as the September 4 report (`runtime/eval/tasks`: 12 single-prompt command tasks and the 15-step
+`asteroid-drift-15` session), same deterministic verifiers, same Mac, run back to back the same evening. Every agent
+runs headless from an isolated home: AgenC through `agenc -p` in an isolated `AGENC_HOME` (session task over the
+AgenC SDK), Hermes 0.21.2 (tag v2026.9.11, run from a git checkout in its own venv and `HERMES_HOME`) through
+`hermes chat -Q --yolo --provider <p> -m <model> --reasoning medium -q <prompt>` (`-c` on later steps), OpenCode 1.18.30
+(npm package, `XDG_*_HOME` isolated) through `opencode run --auto -m <provider>/<model> <prompt>` (`--continue` on later
+steps). `runtime/scripts/compare-agents.sh` runs all of it; `runtime/scripts/eval-compare-table.mjs` prints the tables.
+Keys never touch an argv: each agent gets one provider key through `env -i`.
+
+## Command tasks (12 single prompts)
+
+| model, effort medium | AgenC 0.17.0 (main 0245ef4fe) | Hermes 0.21.2 | OpenCode 1.18.30 |
+| --- | --- | --- | --- |
+| grok-4.6, xAI sign-in (OAuth) | 12 of 12, 233 s (11 to 27 s per task) | no xAI OAuth support | no xAI OAuth support |
+| grok-4.6, xAI API key | 11 of 12, 486 s (see below) | key out of credit before its run | key out of credit before its run |
+| Claude Sonnet 5 | 12 of 12, 125 s (7 to 17 s) | 12 of 12, 129 s (7 to 14 s) | 5 of 5 completed, 141 s (21 to 34 s); the key ran out of credit on task 6 |
+| DeepSeek V4 Pro | 12 of 12, 192 s (11 to 24 s) | 12 of 12, 173 s (9 to 19 s) | 12 of 12, 587 s (24 to 86 s) with the operator's real HOME; isolated HOME: see below |
+
+The grok API key run lost one task to a transient xAI 403: the turn failed after 1.5 s and `agenc -p` then sat until the
+runner killed it at 120 s (issue filed). Minutes later the same key answered 403 "team has used all available credits" to
+every call, which is why Hermes and OpenCode have no grok row; the xAI sign-in is only available to AgenC.
+
+## 15-step session (asteroid-drift-15)
+
+| agent, model | steps passed | wall | tool calls | tool errors | file reads (re-reads) | compactions | input tokens |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| AgenC, grok-4.6 (xAI sign-in) | 15 of 15 (verifier 1 of 1) | 1174 s | 188 (Edit 74, FileRead 71, Write 15, exec 12, Grep 10, Glob 5) | 0 | 71 (24) | 0 | 28.9M |
+| Hermes 0.21.2, DeepSeek V4 Pro | PENDING | | | | | | |
+| OpenCode 1.18.30, DeepSeek V4 Pro (isolated HOME) | PENDING | | | | | | |
+
+Per-step wall time for AgenC on grok-4.6 (seconds): 34, 28, 39, 37, 48, 51, 49, 74, 41, 46, 128, 50, 270, 239, 39.
+For reference, the September 5 like-for-like run at medium effort took 1275 s for AgenC and 2203 s for Hermes 0.14.
+
+AgenC's session task over the AgenC SDK needs the provider credential in the home's secure storage (the xAI sign-in
+works); an environment-provided key is not visible to SDK-created sessions, and `agenc -c -p` is refused ("--continue
+requires an interactive" session), so no same-model DeepSeek session could be run for AgenC tonight. Both are filed.
+
+## What the prompt costs per call
+
+Read from AgenC rollouts (`token_count` events) and from Hermes's `sessions` table and OpenCode's `message` table.
+
+| Claude Sonnet 5, 12 command tasks | AgenC | Hermes 0.21.2 | OpenCode (operator's HOME) |
+| --- | --- | --- | --- |
+| model calls | 47 (3.9 per task) | 52 (4.3 per task) | 26 for 5 tasks |
+| tool calls | 38 | 44 | 21 for 5 tasks |
+| uncached prompt tokens per call | 919 | 2 | about 2 |
+| cached prompt tokens per call | 23,954 | 18,831 | about 264,000 |
+| cache-write tokens per call | 3,048 | 1,053 | about 66,000 |
+| output tokens | 4,651 | 5,305 | 3,194 for 5 tasks |
+| cost per task (provider price) | about $0.08 | about $0.05 | $1.03 to $1.23 |
+
+OpenCode's figure is not the tool's fault: with the operator's real HOME it loads `~/.claude/skills` (1,823 entries),
+`~/AGENTS.md` and `~/CLAUDE.md` into every request, about 204,000 input tokens for a one-word reply. With an isolated
+HOME the same reply costs 5,516 tokens. The rerun with an isolated HOME is the row that counts.
+
+| DeepSeek V4 Pro, 12 command tasks | AgenC | Hermes 0.21.2 |
+| --- | --- | --- |
+| model calls | 53 | 57 |
+| tool calls | 46 | 54 |
+| cache-miss prompt tokens per call | 25,623 | 2,896 |
+| cache-hit prompt tokens per call | 14,628 | 11,758 |
+
+AgenC's 25,600 miss tokens per call were a bug, found by capturing two consecutive requests through a logging proxy:
+the retained "Auto Mode" note moved from the second message of the first request to the end of the second request in
+`acceptEdits` and `bypassPermissions`, so DeepSeek and grok saw a new prefix on every call and Anthropic re-created about
+4,000 cache tokens per call. Fixed in #2407: on the fixed build the second request reports 24,960 cache-hit tokens and
+193 miss. The skills listing that sat behind the moved note is 40,584 chars (about 10,000 tokens) on 1M-context models;
+#2408 caps it at 12,000 chars.
+
+## Reading
+
+- Pass rates are equal wherever all three agents ran: 12 of 12 for AgenC and Hermes on both Sonnet 5 and DeepSeek V4
+  Pro, and 12 of 12 for OpenCode on DeepSeek V4 Pro.
+- Wall time on the command tasks is within 5 percent between AgenC and Hermes on Sonnet 5 (125 s against 129 s) and 10
+  percent on DeepSeek V4 Pro (192 s against 173 s); the DeepSeek gap is the cache bug above, which the fix removes.
+- AgenC makes fewer model calls and fewer tool calls per task than Hermes on both models.
+- AgenC's prompt is larger than Hermes's: about 24,000 cached tokens per call against 19,000, the difference being the
+  skills listing and the 46 KB tool catalog (spawn_agent alone is 10 KB).
+- On the session task AgenC finished the 15 steps on grok-4.6 in 1174 s with no tool errors and no compaction.

--- a/docs/eval/real-agent-comparison-2026-09-11.md
+++ b/docs/eval/real-agent-comparison-2026-09-11.md
@@ -27,10 +27,11 @@ every call, which is why Hermes and OpenCode have no grok row; the xAI sign-in i
 | agent, model | steps passed | wall | tool calls | tool errors | file reads (re-reads) | compactions | input tokens |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | AgenC, grok-4.6 (xAI sign-in) | 15 of 15 (verifier 1 of 1) | 1174 s | 188 (Edit 74, FileRead 71, Write 15, exec 12, Grep 10, Glob 5) | 0 | 71 (24) | 0 | 28.9M |
-| Hermes 0.21.2, DeepSeek V4 Pro | PENDING | | | | | | |
+| Hermes 0.21.2, DeepSeek V4 Pro | 15 of 15 (verifier 1 of 1) | 1772 s | 94 (write_file 32, patch 25, terminal 21, read_file 10, search_files 6) | not reported | 10 (not reported) | not reported | 5.25M (70,872 uncached, 5.18M cache reads); 169k output, 132k reasoning |
 | OpenCode 1.18.30, DeepSeek V4 Pro (isolated HOME) | PENDING | | | | | | |
 
 Per-step wall time for AgenC on grok-4.6 (seconds): 34, 28, 39, 37, 48, 51, 49, 74, 41, 46, 128, 50, 270, 239, 39.
+Per-step wall time for Hermes 0.21.2 on DeepSeek V4 Pro (seconds): 36, 33, 46, 34, 84, 64, 76, 141, 84, 92, 177, 78, 388, 265, 173.
 For reference, the September 5 like-for-like run at medium effort took 1275 s for AgenC and 2203 s for Hermes 0.14.
 
 AgenC's session task over the AgenC SDK needs the provider credential in the home's secure storage (the xAI sign-in

--- a/docs/eval/real-agent-comparison-2026-09-11.md
+++ b/docs/eval/real-agent-comparison-2026-09-11.md
@@ -16,7 +16,7 @@ Keys never touch an argv: each agent gets one provider key through `env -i`.
 | grok-4.6, xAI sign-in (OAuth) | 12 of 12, 233 s (11 to 27 s per task) | no xAI OAuth support | no xAI OAuth support |
 | grok-4.6, xAI API key | 11 of 12, 486 s (see below) | key out of credit before its run | key out of credit before its run |
 | Claude Sonnet 5 | 12 of 12, 125 s (7 to 17 s) | 12 of 12, 129 s (7 to 14 s) | 5 of 5 completed, 141 s (21 to 34 s); the key ran out of credit on task 6 |
-| DeepSeek V4 Pro | 12 of 12, 192 s (11 to 24 s) | 12 of 12, 173 s (9 to 19 s) | 12 of 12, 587 s (24 to 86 s) with the operator's real HOME; isolated HOME: see below |
+| DeepSeek V4 Pro | 12 of 12, 192 s (11 to 24 s) before #2407; 12 of 12, 148 s (8 to 21 s) after it | 12 of 12, 173 s (9 to 19 s) | 12 of 12, 109 s (7 to 11 s) with an isolated HOME; 587 s (24 to 86 s) with the operator's real HOME |
 
 The grok API key run lost one task to a transient xAI 403: the turn failed after 1.5 s and `agenc -p` then sat until the
 runner killed it at 120 s (issue filed). Minutes later the same key answered 403 "team has used all available credits" to
@@ -28,10 +28,11 @@ every call, which is why Hermes and OpenCode have no grok row; the xAI sign-in i
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | AgenC, grok-4.6 (xAI sign-in) | 15 of 15 (verifier 1 of 1) | 1174 s | 188 (Edit 74, FileRead 71, Write 15, exec 12, Grep 10, Glob 5) | 0 | 71 (24) | 0 | 28.9M |
 | Hermes 0.21.2, DeepSeek V4 Pro | 15 of 15 (verifier 1 of 1) | 1772 s | 94 (write_file 32, patch 25, terminal 21, read_file 10, search_files 6) | not reported | 10 (not reported) | not reported | 5.25M (70,872 uncached, 5.18M cache reads); 169k output, 132k reasoning |
-| OpenCode 1.18.30, DeepSeek V4 Pro (isolated HOME) | PENDING | | | | | | |
+| OpenCode 1.18.30, DeepSeek V4 Pro (isolated HOME) | 15 of 15 (verifier 1 of 1) | 1362 s | 130 (edit 75, bash 20, write 16, read 16, grep 3) | not reported | 16 (not reported) | not reported | 9.96M (46k uncached, 9.9M cache reads); 35.5k output, 80.7k reasoning |
 
 Per-step wall time for AgenC on grok-4.6 (seconds): 34, 28, 39, 37, 48, 51, 49, 74, 41, 46, 128, 50, 270, 239, 39.
 Per-step wall time for Hermes 0.21.2 on DeepSeek V4 Pro (seconds): 36, 33, 46, 34, 84, 64, 76, 141, 84, 92, 177, 78, 388, 265, 173.
+Per-step wall time for OpenCode 1.18.30 on DeepSeek V4 Pro (seconds): 18, 15, 18, 48, 78, 62, 94, 125, 61, 82, 133, 59, 297, 232, 40.
 For reference, the September 5 like-for-like run at medium effort took 1275 s for AgenC and 2203 s for Hermes 0.14.
 
 AgenC's session task over the AgenC SDK needs the provider credential in the home's secure storage (the xAI sign-in
@@ -56,12 +57,13 @@ OpenCode's figure is not the tool's fault: with the operator's real HOME it load
 `~/AGENTS.md` and `~/CLAUDE.md` into every request, about 204,000 input tokens for a one-word reply. With an isolated
 HOME the same reply costs 5,516 tokens. The rerun with an isolated HOME is the row that counts.
 
-| DeepSeek V4 Pro, 12 command tasks | AgenC | Hermes 0.21.2 |
-| --- | --- | --- |
-| model calls | 53 | 57 |
-| tool calls | 46 | 54 |
-| cache-miss prompt tokens per call | 25,623 | 2,896 |
-| cache-hit prompt tokens per call | 14,628 | 11,758 |
+| DeepSeek V4 Pro, 12 command tasks | AgenC (before #2407) | Hermes 0.21.2 | OpenCode 1.18.30 (isolated HOME) |
+| --- | --- | --- | --- |
+| model calls | 53 | 57 | 50 |
+| tool calls | 46 | 54 | not reported |
+| cache-miss prompt tokens per call | 25,623 | 2,896 | 1,438 |
+| cache-hit prompt tokens per call | 14,628 | 11,758 | 6,344 |
+| output tokens | 5,342 | 6,080 | 4,349 (plus 149 reasoning) |
 
 AgenC's 25,600 miss tokens per call were a bug, found by capturing two consecutive requests through a logging proxy:
 the retained "Auto Mode" note moved from the second message of the first request to the end of the second request in
@@ -72,11 +74,14 @@ the retained "Auto Mode" note moved from the second message of the first request
 
 ## Reading
 
-- Pass rates are equal wherever all three agents ran: 12 of 12 for AgenC and Hermes on both Sonnet 5 and DeepSeek V4
-  Pro, and 12 of 12 for OpenCode on DeepSeek V4 Pro.
-- Wall time on the command tasks is within 5 percent between AgenC and Hermes on Sonnet 5 (125 s against 129 s) and 10
-  percent on DeepSeek V4 Pro (192 s against 173 s); the DeepSeek gap is the cache bug above, which the fix removes.
+- Pass rates are equal wherever all three agents ran: 12 of 12 on every model, and 15 of 15 session steps for all
+  three.
+- Wall time on the command tasks is within 5 percent between AgenC and Hermes on Sonnet 5 (125 s against 129 s). On
+  DeepSeek V4 Pro OpenCode with an isolated HOME is fastest (109 s), then Hermes (173 s), then AgenC before the cache
+  fix (192 s); AgenC after #2407: 148 s, with 81 percent of its prompt tokens served from cache against 57 percent before. OpenCode's prompt there is about 8,000 tokens per call against 40,000 for
+  AgenC before the fix.
+- On the session task, OpenCode finished in 1362 s and Hermes in 1772 s on DeepSeek V4 Pro; AgenC's 1174 s is on
+  grok-4.6 through the xAI sign-in, so it is a pace reference, not a like-for-like number.
 - AgenC makes fewer model calls and fewer tool calls per task than Hermes on both models.
 - AgenC's prompt is larger than Hermes's: about 24,000 cached tokens per call against 19,000, the difference being the
   skills listing and the 46 KB tool catalog (spawn_agent alone is 10 KB).
-- On the session task AgenC finished the 15 steps on grok-4.6 in 1174 s with no tool errors and no compaction.

--- a/runtime/scripts/compare-agents.sh
+++ b/runtime/scripts/compare-agents.sh
@@ -36,6 +36,7 @@ run() { # name manifest report extra-args...
       "$NODE" "$HERE/scripts/run-agent-eval.mjs" --tasks "$manifest" "${COMMON[@]}" --agent-command "$HERMES_CMD -q {prompt}" --session-command "$HERMES_CMD {continue} -q {prompt}" --session-continue-arg -c --agent-name hermes --output "$report" "$@" ;;
     opencode*) env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" "$KEY_VAR=$KEY" AGENC_HOME="$AGENC_EVAL_HOME" XDG_CONFIG_HOME="$OUT_DIR/oc-home/config" XDG_DATA_HOME="$OUT_DIR/oc-home/data" XDG_CACHE_HOME="$OUT_DIR/oc-home/cache" \
       "$NODE" "$HERE/scripts/run-agent-eval.mjs" --tasks "$manifest" "${COMMON[@]}" --agent-command "$OPENCODE_CMD {prompt}" --session-command "$OPENCODE_CMD {continue} {prompt}" --session-continue-arg --continue --agent-name opencode --output "$report" "$@" ;;
+    *) echo "unknown agent: $name" >&2; return 1 ;;
   esac
 }
 # The runner resolves fixture directories relative to the manifest, so the

--- a/runtime/scripts/compare-agents.sh
+++ b/runtime/scripts/compare-agents.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run the same eval manifest through AgenC, Hermes and OpenCode on one model,
+# with the provider key taken from the environment and never placed on argv.
+#
+#   PROVIDER=anthropic MODEL=claude-sonnet-5 KEY_VAR=ANTHROPIC_API_KEY \
+#   AGENC_BIN=/path/to/agenc HERMES_BIN=/path/to/hermes OPENCODE_BIN=/path/to/opencode \
+#   AGENC_EVAL_HOME=/abs/isolated/home OUT_DIR=/abs/reports [TAG=sonnet] \
+#   runtime/scripts/compare-agents.sh [commands|session|all]
+#
+# Reports are written as <agent>-<TAG>-commands.json and <agent>-<TAG>-session.json
+# (TAG defaults to MODEL) and summarised by scripts/eval-compare-table.mjs.
+#
+# The isolated AgenC home's config.toml must select PROVIDER/MODEL and the
+# reasoning effort; the runner refuses to start a daemon in the default home.
+# Hermes and OpenCode get their own isolated homes (HERMES_HOME, XDG_*_HOME)
+# under OUT_DIR so nothing touches a developer's real installs.
+set -euo pipefail
+LANE="${1:-all}"
+: "${PROVIDER:?}" "${MODEL:?}" "${KEY_VAR:?}" "${AGENC_BIN:?}" "${HERMES_BIN:?}" "${OPENCODE_BIN:?}" "${AGENC_EVAL_HOME:?}" "${OUT_DIR:?}"
+KEY="${!KEY_VAR:?$KEY_VAR is not set}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+NODE="${NODE:-node}"
+EFFORT="${EFFORT:-medium}"
+mkdir -p "$OUT_DIR/hermes-home" "$OUT_DIR/oc-home/config" "$OUT_DIR/oc-home/data" "$OUT_DIR/oc-home/cache"
+COMMON=(--executor real --provider "$PROVIDER" --model "$MODEL")
+AGENC_CMD="$AGENC_BIN --dangerously-bypass-approvals-and-sandbox -p {prompt}"
+HERMES_CMD="$HERMES_BIN chat -Q --yolo --provider $PROVIDER -m $MODEL --reasoning $EFFORT"
+OPENCODE_CMD="$OPENCODE_BIN run --auto -m $PROVIDER/$MODEL"
+run() { # name manifest report extra-args...
+  local name="$1" manifest="$2" report="$3"; shift 3
+  echo "=== $name $(date +%T)"
+  case "$name" in
+    agenc*) env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" "$KEY_VAR=$KEY" AGENC_HOME="$AGENC_EVAL_HOME" \
+      "$NODE" "$HERE/scripts/run-agent-eval.mjs" --tasks "$manifest" "${COMMON[@]}" --agent-command "$AGENC_CMD" --agent-name agenc --output "$report" "$@" ;;
+    hermes*) env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" TERM=xterm "$KEY_VAR=$KEY" AGENC_HOME="$AGENC_EVAL_HOME" HERMES_HOME="$OUT_DIR/hermes-home" \
+      "$NODE" "$HERE/scripts/run-agent-eval.mjs" --tasks "$manifest" "${COMMON[@]}" --agent-command "$HERMES_CMD -q {prompt}" --session-command "$HERMES_CMD {continue} -q {prompt}" --session-continue-arg -c --agent-name hermes --output "$report" "$@" ;;
+    opencode*) env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" "$KEY_VAR=$KEY" AGENC_HOME="$AGENC_EVAL_HOME" XDG_CONFIG_HOME="$OUT_DIR/oc-home/config" XDG_DATA_HOME="$OUT_DIR/oc-home/data" XDG_CACHE_HOME="$OUT_DIR/oc-home/cache" \
+      "$NODE" "$HERE/scripts/run-agent-eval.mjs" --tasks "$manifest" "${COMMON[@]}" --agent-command "$OPENCODE_CMD {prompt}" --session-command "$OPENCODE_CMD {continue} {prompt}" --session-continue-arg --continue --agent-name opencode --output "$report" "$@" ;;
+  esac
+}
+# The runner resolves fixture directories relative to the manifest, so the
+# filtered manifests are written next to manifest.json (both are gitignored).
+"$NODE" -e '
+  const fs = require("node:fs"); const dir = process.argv[1];
+  const m = JSON.parse(fs.readFileSync(dir + "/manifest.json", "utf8"));
+  const write = (name, keep) => fs.writeFileSync(dir + "/" + name, JSON.stringify({ ...m, benchmark: m.benchmark + "-" + name.replace(/^manifest-|\.json$/g, ""), tasks: m.tasks.filter(keep) }, null, 2) + "\n");
+  write("manifest-commands.json", (t) => t.kind !== "session");
+  write("manifest-session.json", (t) => t.kind === "session");
+' "$HERE/eval/tasks"
+TAG="${TAG:-$MODEL}"
+if [[ "$LANE" == "commands" || "$LANE" == "all" ]]; then
+  for a in agenc hermes opencode; do run "$a commands" "$HERE/eval/tasks/manifest-commands.json" "$OUT_DIR/$a-$TAG-commands.json"; done
+fi
+if [[ "$LANE" == "session" || "$LANE" == "all" ]]; then
+  for a in agenc hermes opencode; do run "$a session" "$HERE/eval/tasks/manifest-session.json" "$OUT_DIR/$a-$TAG-session.json" --timeout-ms 1800000; done
+fi
+"$NODE" "$HERE/scripts/eval-compare-table.mjs" "$OUT_DIR" "$TAG"

--- a/runtime/scripts/compare-agents.sh
+++ b/runtime/scripts/compare-agents.sh
@@ -4,11 +4,12 @@
 #
 #   PROVIDER=anthropic MODEL=claude-sonnet-5 KEY_VAR=ANTHROPIC_API_KEY \
 #   AGENC_BIN=/path/to/agenc HERMES_BIN=/path/to/hermes OPENCODE_BIN=/path/to/opencode \
-#   AGENC_EVAL_HOME=/abs/isolated/home OUT_DIR=/abs/reports [TAG=sonnet] \
+#   AGENC_EVAL_HOME=/abs/isolated/home [RUN=2026-09-11] [TAG=sonnet] \
 #   runtime/scripts/compare-agents.sh [commands|session|all]
 #
-# Reports are written as <agent>-<TAG>-commands.json and <agent>-<TAG>-session.json
-# (TAG defaults to MODEL) and summarised by scripts/eval-compare-table.mjs.
+# Reports are written under runtime/eval/reports/<RUN>/ (gitignored) as
+# <agent>-<TAG>-commands.json and <agent>-<TAG>-session.json (TAG defaults to
+# MODEL, RUN to today's date) and summarised by scripts/eval-compare-table.mjs.
 #
 # The isolated AgenC home's config.toml must select PROVIDER/MODEL and the
 # reasoning effort; the runner refuses to start a daemon in the default home.
@@ -16,9 +17,12 @@
 # under OUT_DIR so nothing touches a developer's real installs.
 set -euo pipefail
 LANE="${1:-all}"
-: "${PROVIDER:?}" "${MODEL:?}" "${KEY_VAR:?}" "${AGENC_BIN:?}" "${HERMES_BIN:?}" "${OPENCODE_BIN:?}" "${AGENC_EVAL_HOME:?}" "${OUT_DIR:?}"
+: "${PROVIDER:?}" "${MODEL:?}" "${KEY_VAR:?}" "${AGENC_BIN:?}" "${HERMES_BIN:?}" "${OPENCODE_BIN:?}" "${AGENC_EVAL_HOME:?}"
 KEY="${!KEY_VAR:?$KEY_VAR is not set}"
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
+RUN="${RUN:-$(date +%Y-%m-%d)}"
+case "$RUN" in *[!A-Za-z0-9._-]*|"") echo "RUN must be a plain token" >&2; exit 2 ;; esac
+OUT_DIR="$HERE/eval/reports/$RUN"
 NODE="${NODE:-node}"
 EFFORT="${EFFORT:-medium}"
 mkdir -p "$OUT_DIR/hermes-home" "$OUT_DIR/oc-home/config" "$OUT_DIR/oc-home/data" "$OUT_DIR/oc-home/cache"
@@ -55,4 +59,4 @@ fi
 if [[ "$LANE" == "session" || "$LANE" == "all" ]]; then
   for a in agenc hermes opencode; do run "$a session" "$HERE/eval/tasks/manifest-session.json" "$OUT_DIR/$a-$TAG-session.json" --timeout-ms 1800000; done
 fi
-"$NODE" "$HERE/scripts/eval-compare-table.mjs" "$OUT_DIR" "$TAG"
+"$NODE" "$HERE/scripts/eval-compare-table.mjs" "$RUN" "$TAG"

--- a/runtime/scripts/eval-compare-table.mjs
+++ b/runtime/scripts/eval-compare-table.mjs
@@ -1,14 +1,40 @@
 #!/usr/bin/env node
 // Print a markdown comparison of the compare-agents.sh reports in a directory.
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, existsSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
 
-const dir = process.argv[2] ?? "eval/reports";
-const tag = process.argv[3] ? `-${process.argv[3]}` : "";
+// The directory argument is an operator path; it must be an existing
+// directory under the working directory or the home directory, and the tag
+// must be a plain token, so no argument can point the reader elsewhere.
+const requested = resolve(process.argv[2] ?? "eval/reports");
+const roots = [resolve(process.cwd()), resolve(homedir())];
+let dir;
+try {
+  dir = realpathSync(requested);
+} catch {
+  console.error(`report directory not found: ${requested}`);
+  process.exit(2);
+}
+if (!roots.some((root) => dir === root || dir.startsWith(root + sep))) {
+  console.error("report directory must be under the working directory or the home directory");
+  process.exit(2);
+}
+const rawTag = process.argv[3] ?? "";
+if (rawTag !== "" && !/^[A-Za-z0-9._-]{1,64}$/.test(rawTag)) {
+  console.error("tag must be letters, digits, dots, underscores or dashes");
+  process.exit(2);
+}
+const tag = rawTag === "" ? "" : `-${rawTag}`;
 const agents = ["agenc", "hermes", "opencode"];
 const load = (name) => (existsSync(join(dir, name)) ? JSON.parse(readFileSync(join(dir, name), "utf8")) : null);
 const seconds = (ms) => `${Math.round((ms ?? 0) / 1000)} s`;
 const label = (report) => `${report.run?.agent?.name ?? "?"} ${report.run?.agent?.version ?? ""}`.trim();
+const taskCell = (task) => {
+  if (!task) return "-";
+  const verdict = task.status === "passed" ? "ok" : "FAIL";
+  return `${seconds(task.durationMs)} ${verdict}`;
+};
 
 const commands = agents.map((a) => [a, load(`${a}${tag}-commands.json`)]).filter(([, r]) => r);
 if (commands.length > 0) {
@@ -23,7 +49,7 @@ if (commands.length > 0) {
   const ids = [...new Set(commands.flatMap(([, r]) => r.tasks.map((t) => t.id)))].filter((id) => id !== "asteroid-drift-15");
   console.log(`\n| task | ${commands.map(([, r]) => label(r)).join(" | ")} |\n| --- |${" --- |".repeat(commands.length)}`);
   for (const id of ids) {
-    const cells = commands.map(([, r]) => { const t = r.tasks.find((x) => x.id === id); return t ? `${seconds(t.durationMs)} ${t.status === "passed" ? "ok" : "FAIL"}` : "-"; });
+    const cells = commands.map(([, r]) => taskCell(r.tasks.find((x) => x.id === id)));
     console.log(`| ${id} | ${cells.join(" | ")} |`);
   }
 }

--- a/runtime/scripts/eval-compare-table.mjs
+++ b/runtime/scripts/eval-compare-table.mjs
@@ -1,28 +1,23 @@
 #!/usr/bin/env node
 // Print a markdown comparison of the compare-agents.sh reports in a directory.
-import { readFileSync, existsSync, realpathSync } from "node:fs";
-import { homedir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-// The directory argument is an operator path; it must be an existing
-// directory under the working directory or the home directory, and the tag
-// must be a plain token, so no argument can point the reader elsewhere.
-const requested = resolve(process.argv[2] ?? "eval/reports");
-const roots = [resolve(process.cwd()), resolve(homedir())];
-let dir;
-try {
-  dir = realpathSync(requested);
-} catch {
-  console.error(`report directory not found: ${requested}`);
+// Reports live under runtime/eval/reports/<run>/ (gitignored). The run name
+// and the tag are plain tokens taken as basenames, so no argument can point
+// the reader outside that directory.
+const TOKEN = /^[A-Za-z0-9._-]{1,64}$/;
+const run = basename(process.argv[2] ?? "latest");
+const rawTag = basename(process.argv[3] ?? "");
+if (!TOKEN.test(run) || (rawTag !== "" && !TOKEN.test(rawTag))) {
+  console.error("run and tag must be letters, digits, dots, underscores or dashes");
   process.exit(2);
 }
-if (!roots.some((root) => dir === root || dir.startsWith(root + sep))) {
-  console.error("report directory must be under the working directory or the home directory");
-  process.exit(2);
-}
-const rawTag = process.argv[3] ?? "";
-if (rawTag !== "" && !/^[A-Za-z0-9._-]{1,64}$/.test(rawTag)) {
-  console.error("tag must be letters, digits, dots, underscores or dashes");
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dir = join(root, "eval", "reports", run);
+if (!existsSync(dir)) {
+  console.error(`no reports under eval/reports/${run}`);
   process.exit(2);
 }
 const tag = rawTag === "" ? "" : `-${rawTag}`;

--- a/runtime/scripts/eval-compare-table.mjs
+++ b/runtime/scripts/eval-compare-table.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Print a markdown comparison of the compare-agents.sh reports in a directory.
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = process.argv[2] ?? "eval/reports";
+const tag = process.argv[3] ? `-${process.argv[3]}` : "";
+const agents = ["agenc", "hermes", "opencode"];
+const load = (name) => (existsSync(join(dir, name)) ? JSON.parse(readFileSync(join(dir, name), "utf8")) : null);
+const seconds = (ms) => `${Math.round((ms ?? 0) / 1000)} s`;
+const label = (report) => `${report.run?.agent?.name ?? "?"} ${report.run?.agent?.version ?? ""}`.trim();
+
+const commands = agents.map((a) => [a, load(`${a}${tag}-commands.json`)]).filter(([, r]) => r);
+if (commands.length > 0) {
+  console.log("## Command tasks\n");
+  console.log("| agent | passed | total wall | per task |\n| --- | --- | --- | --- |");
+  for (const [, r] of commands) {
+    const tasks = r.tasks.filter((t) => t.id !== "asteroid-drift-15");
+    const passed = tasks.filter((t) => t.status === "passed").length;
+    const durations = tasks.map((t) => t.durationMs ?? 0);
+    console.log(`| ${label(r)} | ${passed} of ${tasks.length} | ${seconds(durations.reduce((a, b) => a + b, 0))} | ${seconds(Math.min(...durations))} to ${seconds(Math.max(...durations))} |`);
+  }
+  const ids = [...new Set(commands.flatMap(([, r]) => r.tasks.map((t) => t.id)))].filter((id) => id !== "asteroid-drift-15");
+  console.log(`\n| task | ${commands.map(([, r]) => label(r)).join(" | ")} |\n| --- |${" --- |".repeat(commands.length)}`);
+  for (const id of ids) {
+    const cells = commands.map(([, r]) => { const t = r.tasks.find((x) => x.id === id); return t ? `${seconds(t.durationMs)} ${t.status === "passed" ? "ok" : "FAIL"}` : "-"; });
+    console.log(`| ${id} | ${cells.join(" | ")} |`);
+  }
+}
+const sessions = agents.map((a) => [a, load(`${a}${tag}-session.json`)]).filter(([, r]) => r);
+if (sessions.length > 0) {
+  console.log("\n## Session task\n");
+  console.log("| agent | status | wall | verifiers passed | steps recorded |\n| --- | --- | --- | --- | --- |");
+  for (const [, r] of sessions) {
+    const s = r.tasks.find((t) => t.id === "asteroid-drift-15");
+    if (!s) continue;
+    const verifiers = s.verifiers ?? [];
+    const steps = s.commands ?? s.steps ?? [];
+    console.log(`| ${label(r)} | ${s.status} | ${seconds(s.durationMs)} | ${verifiers.filter((v) => v.status === "passed").length} of ${verifiers.length} | ${steps.length} |`);
+  }
+}


### PR DESCRIPTION
## Why

The "faster than Hermes" claim in the product pitch rested on one September 4 run against Hermes 0.14 that nobody could reproduce. This adds a runner that drives AgenC, Hermes and OpenCode through the same manifest on one model with one key, the report of the 2026-09-11 run (Hermes 0.21.2, OpenCode 1.18.30, three models), and the harness review that came out of it.

## What

- `runtime/scripts/compare-agents.sh` (new): runs the command tasks and the session task through the three agents from isolated homes. It generates the filtered manifests next to `manifest.json` at run time (both gitignored), never puts a key on an argv, tags the reports by model, and prints the table.
- `runtime/scripts/eval-compare-table.mjs` (new): markdown summary of a report directory (`node scripts/eval-compare-table.mjs <dir> [tag]`).
- `docs/eval/real-agent-comparison-2026-09-11.md` (new): results on Claude Sonnet 5, DeepSeek V4 Pro and grok-4.6, per-call token profiles read from each agent's own store, and what the missing rows mean (two keys ran out of credit mid-run; SDK sessions need a secure-storage credential; OpenCode must run with an isolated HOME).
- `docs/eval/harness-review-2026-09-11.md` (new): what was fixed during the review (#2405, #2407, #2408, desktop #265), the remaining token cuts in order of return, tool-use and safety findings.

## Evidence

Pass rates are equal everywhere all three agents ran (12 of 12 command tasks on every model, 15 of 15 session steps). Sonnet 5 command tasks: AgenC 125 s, Hermes 129 s. DeepSeek V4 Pro command tasks: AgenC 192 s before #2407 and 148 s after it, Hermes 173 s, OpenCode 109 s with an isolated HOME. Sessions: AgenC 1174 s on grok-4.6 through the xAI sign-in, OpenCode 1362 s and Hermes 1772 s on DeepSeek V4 Pro. The prompt-cache bug that #2407 fixed cost about 25,000 uncached tokens per call on DeepSeek and grok.

## Tests

`bash -n` on the script; the table printer ran against tonight's reports. No runtime code changes.

## Not changed

- `run-agent-eval.mjs` and the task manifest are untouched.
- The September 4 report stays as the previous reference.

## Counterpart PRs

None.
