### PR TITLE
Skip the file-mention warning for plugin and skill mentions

### DIFF
--- a/runtime/src/hooks/user-prompt-ingress.ts
+++ b/runtime/src/hooks/user-prompt-ingress.ts
@@ -4,7 +4,7 @@ import {
   expandFileMentions,
   extractMentionAllowedRoots,
   formatFileMentionRejection,
-  type FileMentionExpansion,
+  type FileMentionRejection,
 } from "../prompts/file-mentions.js";
 import { renderHookAdditionalContextSection } from "../prompts/hook-context-framing.js";
 import { seedFileMentionSessionReads } from "../session/file-mention-session-reads.js";
@@ -38,11 +38,100 @@ export function userPromptDisplayText(
     .join("\n");
 }
 
+/**
+ * A mention with no path separator and no extension: the shape of a plugin
+ * id or skill name (`@motor3d`), never of a file path (`@src/app.ts`,
+ * `@README.md`). Same token shape `rankSkillsForRequest` treats as a plugin
+ * mention when it surfaces that plugin's skills.
+ */
+const BARE_MENTION_TOKEN = /^[a-z0-9][a-z0-9:_-]*$/iu;
+
+const NO_KNOWN_MENTION_NAMES: ReadonlySet<string> = new Set();
+
+type KnownMentionNamesLoader = () => Promise<ReadonlySet<string>>;
+
+/**
+ * Installed plugin ids plus loaded skill names and aliases, lowercased.
+ *
+ * Read through the session's skills manager with the same config snapshot
+ * `run-turn.ts` hands the skill listing (the source of `rankSkillsForRequest`),
+ * so this hits the snapshot the turn loads anyway. A failing lookup keeps the
+ * plain file-mention behavior rather than blocking the prompt.
+ */
+async function loadKnownMentionNames(params: {
+  readonly session: Session;
+  readonly configStore: Pick<ConfigStore, "current">;
+}): Promise<ReadonlySet<string>> {
+  try {
+    const outcome = await params.session.services.skillsManager.skillsForConfig(
+      params.configStore.current(),
+      null,
+    );
+    const names = new Set<string>();
+    for (const skill of outcome.availableSkills ?? []) {
+      names.add(skill.name.toLowerCase());
+      for (const alias of skill.aliases ?? []) names.add(alias.toLowerCase());
+      if (skill.pluginId !== undefined) names.add(skill.pluginId.toLowerCase());
+    }
+    return names;
+  } catch {
+    return NO_KNOWN_MENTION_NAMES;
+  }
+}
+
+/** Loads the known names at most once per prepared prompt, and only on demand. */
+function createKnownMentionNamesLoader(params: {
+  readonly session: Session;
+  readonly configStore: Pick<ConfigStore, "current">;
+}): KnownMentionNamesLoader {
+  let pending: Promise<ReadonlySet<string>> | undefined;
+  return () => (pending ??= loadKnownMentionNames(params));
+}
+
+/**
+ * A bare token with no regular file behind it. `unreadable` covers a missing
+ * path (and the rare existing file that cannot be read), `not_file` a
+ * directory. Every other reason means a real file was found, so its warning
+ * is about that file and stays.
+ */
+function isBareMentionWithoutFile(rejection: FileMentionRejection): boolean {
+  return (
+    (rejection.reason === "unreadable" || rejection.reason === "not_file") &&
+    BARE_MENTION_TOKEN.test(rejection.raw)
+  );
+}
+
+/**
+ * Drop the "could not be read" warning for `@plugin-id` and `@skill-name`
+ * mentions. Those are first-class mentions: `rankSkillsForRequest` surfaces
+ * the plugin's skills and the model calls the Skill tool, so the file warning
+ * is noise in the transcript and the errors log.
+ *
+ * The file lookup always runs first. A readable regular file named like a
+ * plugin id is attached as usual and never reaches `rejected`, so the file
+ * wins; only the "no such file" outcome is reinterpreted, and only for a
+ * bare token that matches a known plugin id, skill name, or skill alias.
+ */
+async function selectFileMentionWarnings(
+  rejected: readonly FileMentionRejection[],
+  loadKnownNames: KnownMentionNamesLoader,
+): Promise<readonly FileMentionRejection[]> {
+  if (!rejected.some(isBareMentionWithoutFile)) return rejected;
+  const knownNames = await loadKnownNames();
+  return rejected.filter(
+    (rejection) =>
+      !(
+        isBareMentionWithoutFile(rejection) &&
+        knownNames.has(rejection.raw.toLowerCase())
+      ),
+  );
+}
+
 function emitFileMentionWarnings(
   session: Session,
-  expansion: FileMentionExpansion,
+  rejections: readonly FileMentionRejection[],
 ): void {
-  for (const rejection of expansion.rejected) {
+  for (const rejection of rejections) {
     session.emit({
       id: session.nextInternalSubId(),
       msg: {
@@ -64,13 +153,20 @@ async function expandTextFileMentions(params: {
   readonly session: Session;
   readonly configStore: Pick<ConfigStore, "current">;
   readonly input: string;
+  readonly loadKnownMentionNames: KnownMentionNamesLoader;
 }): Promise<{ readonly input: string; readonly expanded: boolean }> {
   const cwd = params.session.sessionConfiguration.cwd ?? process.cwd();
   const expansion = await expandFileMentions(params.input, {
     cwd,
     allowedRoots: extractMentionAllowedRoots(params.configStore.current()),
   });
-  emitFileMentionWarnings(params.session, expansion);
+  emitFileMentionWarnings(
+    params.session,
+    await selectFileMentionWarnings(
+      expansion.rejected,
+      params.loadKnownMentionNames,
+    ),
+  );
   if (expansion.attachments.length === 0) {
     return { input: params.input, expanded: false };
   }
@@ -93,11 +189,16 @@ async function expandPromptFileMentions(params: {
   if (params.configStore === undefined) {
     return { input: params.input, displayInput };
   }
+  const loadKnownMentionNames = createKnownMentionNamesLoader({
+    session: params.session,
+    configStore: params.configStore,
+  });
   if (typeof params.input === "string") {
     const expanded = await expandTextFileMentions({
       session: params.session,
       configStore: params.configStore,
       input: params.input,
+      loadKnownMentionNames,
     });
     return { input: expanded.input, displayInput };
   }
@@ -113,6 +214,7 @@ async function expandPromptFileMentions(params: {
       session: params.session,
       configStore: params.configStore,
       input: part.text,
+      loadKnownMentionNames,
     });
     changed ||= expanded.expanded;
     parts.push(expanded.expanded ? { ...part, text: expanded.input } : part);

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -238,6 +238,8 @@ export interface SkillLoadOutcome {
     readonly allowedTools?: readonly string[];
     readonly argumentHint?: string;
     readonly argNames?: readonly string[];
+    /** Id of the owning plugin when the skill ships inside one. */
+    readonly pluginId?: string;
     readonly whenToUse?: string;
     readonly version?: string;
     readonly model?: string;

--- a/runtime/tests/hooks/user-prompt-ingress.test.ts
+++ b/runtime/tests/hooks/user-prompt-ingress.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,6 +17,7 @@ function promptSession(
   cwd: string,
   hooks: Array<(input: { readonly prompt: string }) => unknown>,
   simpleMode = false,
+  skillsForConfig?: (...args: unknown[]) => unknown,
 ) {
   const events: unknown[] = [];
   const session = {
@@ -30,10 +31,49 @@ function promptSession(
     services: {
       hooks: { userPromptSubmitHooks: hooks },
       runtimeOptions: resolveAgentRuntimeOptions({}, { simpleMode }),
+      ...(skillsForConfig !== undefined
+        ? { skillsManager: { skillsForConfig } }
+        : {}),
     },
     sessionConfiguration: { cwd },
   };
   return { session, events };
+}
+
+/** Paths of every `file_mention_attachment_dropped` warning, in emit order. */
+function droppedMentionPaths(events: readonly unknown[]): string[] {
+  const paths: string[] = [];
+  for (const event of events) {
+    const msg = (event as {
+      msg?: { type?: string; payload?: { cause?: string; path?: string } };
+    }).msg;
+    if (
+      msg?.type === "warning" &&
+      msg.payload?.cause === "file_mention_attachment_dropped"
+    ) {
+      paths.push(msg.payload.path ?? "");
+    }
+  }
+  return paths;
+}
+
+/** A `skillsForConfig` mock shaped like the local loader's outcome. */
+function skillsForConfigWith(
+  skills: ReadonlyArray<{
+    readonly name: string;
+    readonly aliases?: readonly string[];
+    readonly pluginId?: string;
+  }>,
+) {
+  return vi.fn(async () => ({
+    invokedSkills: [],
+    availableSkills: skills.map((skill) => ({
+      ...skill,
+      path: `/skills/${skill.name}/SKILL.md`,
+      root: "/skills",
+      scope: "plugin",
+    })),
+  }));
 }
 
 describe("canonical user prompt ingress", () => {
@@ -137,5 +177,145 @@ describe("canonical user prompt ingress", () => {
       displayInput: "unchanged prompt",
     });
     expect(events).toEqual([]);
+  });
+});
+
+describe("plugin and skill mentions in prompt ingress", () => {
+  it("does not warn for a bare mention that names an installed plugin, missing or a directory", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-prompt-plugin-"));
+    // A plugin checked out under its own name in cwd is the usual layout
+    // while developing it; a directory is still not an attachable file.
+    await mkdir(join(cwd, "motor3d"));
+    const skillsForConfig = skillsForConfigWith([
+      { name: "motor3d-build", pluginId: "motor3d" },
+      { name: "roarm-drive", pluginId: "RoArm" },
+    ]);
+    const { session, events } = promptSession(cwd, [], false, skillsForConfig);
+    const input = "use @motor3d then @roarm to move the part";
+
+    try {
+      const result = await prepareUserPromptForTurn({
+        session: session as never,
+        configStore: { current: () => defaultConfig },
+        input,
+      });
+
+      expect(result).toEqual({ blocked: false, input, displayInput: input });
+      expect(droppedMentionPaths(events)).toEqual([]);
+      // Same call and config snapshot run-turn.ts hands the skill listing
+      // that feeds rankSkillsForRequest, so the lookup shares its cache.
+      expect(skillsForConfig).toHaveBeenCalledTimes(1);
+      expect(skillsForConfig).toHaveBeenCalledWith(defaultConfig, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn for a bare mention that names a loaded skill or one of its aliases", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-prompt-skill-"));
+    const skillsForConfig = skillsForConfigWith([
+      { name: "motor3d" },
+      { name: ".hidden:reflect", aliases: ["reflect"] },
+    ]);
+    const { session, events } = promptSession(cwd, [], false, skillsForConfig);
+    const input = [
+      { type: "image_url" as const, image_url: { url: "data:image/png;base64,AA==" } },
+      { type: "text" as const, text: "run @motor3d" },
+      { type: "text" as const, text: "then @reflect on the result" },
+    ];
+
+    try {
+      const result = await prepareUserPromptForTurn({
+        session: session as never,
+        configStore: { current: () => defaultConfig },
+        input,
+      });
+
+      expect(result.blocked).toBe(false);
+      expect(result.input).toEqual(input);
+      expect(droppedMentionPaths(events)).toEqual([]);
+      // One lookup per prepared prompt, shared by every text part.
+      expect(skillsForConfig).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still attaches a readable file named like a plugin and never loads the skills for it", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-prompt-file-wins-"));
+    await writeFile(join(cwd, "motor3d"), "gcode header\n", "utf8");
+    const skillsForConfig = skillsForConfigWith([
+      { name: "motor3d-build", pluginId: "motor3d" },
+    ]);
+    const { session, events } = promptSession(cwd, [], false, skillsForConfig);
+
+    try {
+      const result = await prepareUserPromptForTurn({
+        session: session as never,
+        configStore: { current: () => defaultConfig },
+        input: "read @motor3d",
+      });
+
+      expect(result.blocked).toBe(false);
+      expect(JSON.stringify(result.input)).toContain("gcode header");
+      expect(droppedMentionPaths(events)).toEqual([]);
+      // The file won, so no bare mention failed and nothing was looked up.
+      expect(skillsForConfig).not.toHaveBeenCalled();
+    } finally {
+      clearSessionReadState(session.conversationId, tmpdir());
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the warning for unknown bare tokens and for path or dotted mentions", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-prompt-unknown-"));
+    const skillsForConfig = skillsForConfigWith([
+      { name: "motor3d-build", pluginId: "motor3d" },
+    ]);
+    const { session, events } = promptSession(cwd, [], false, skillsForConfig);
+
+    try {
+      const result = await prepareUserPromptForTurn({
+        session: session as never,
+        configStore: { current: () => defaultConfig },
+        input: "see @nothere, @motor3d.md and @src/motor3d",
+      });
+
+      expect(result.blocked).toBe(false);
+      // A dot or a separator makes it a file path even when the stem is a
+      // plugin id; an unknown bare token is still a broken mention.
+      expect(droppedMentionPaths(events)).toEqual([
+        "nothere",
+        "motor3d.md",
+        "src/motor3d",
+      ]);
+      expect(skillsForConfig).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the file warning when the skill lookup fails or is absent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-prompt-lookup-fail-"));
+    const failing = promptSession(cwd, [], false, () =>
+      Promise.reject(new Error("skills unavailable")),
+    );
+    const absent = promptSession(cwd, []);
+
+    try {
+      for (const { session, events } of [failing, absent]) {
+        const result = await prepareUserPromptForTurn({
+          session: session as never,
+          configStore: { current: () => defaultConfig },
+          input: "use @motor3d",
+        });
+
+        expect(result.blocked).toBe(false);
+        expect(result.input).toBe("use @motor3d");
+        expect(droppedMentionPaths(events)).toEqual(["motor3d"]);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Why

Since 575f7b9bf ("Resolve plugin mentions to their skills") a bare `@plugin-id` mention is a first-class plugin mention: `rankSkillsForRequest` surfaces that plugin's skills and the model calls the Skill tool. The prompt ingress (`prepareUserPromptForTurn`) still ran every `@token` through `expandFileMentions` and emitted a `file_mention_attachment_dropped` warning ("@motor3d could not be read", reason `unreadable`) for each such mention. The warning landed in the transcript and in `<home>/projects/<project>/errors/<date>.jsonl` on every turn that mentioned a plugin.

## What

- `runtime/src/hooks/user-prompt-ingress.ts`: after `expandFileMentions`, filter the rejections before emitting warnings. A rejection is dropped when it is a bare token (no path separator, no dot, same token shape as the plugin-mention regex in `rankSkillsForRequest`), its reason is `unreadable` or `not_file` (no regular file behind it), and the lowercased token matches an installed plugin id, a loaded skill name, or a skill alias. The known names come from `session.services.skillsManager.skillsForConfig(configStore.current(), null)`, the same call and config snapshot `run-turn.ts` hands the skill listing that feeds `rankSkillsForRequest`, so the lookup shares the cached snapshot the turn loads anyway. The lookup is created once per prepared prompt, shared across multimodal text parts, and only runs when a bare mention actually failed. A throwing or absent skills lookup falls back to the previous warning instead of blocking the prompt. Comment documents that the file lookup always runs first, so a readable regular file named like a plugin id still wins and is attached.
- `runtime/src/session/turn-context.ts`: `SkillLoadOutcome.availableSkills` gains the optional `pluginId` field that 575f7b9bf already set on `LocalSkillMetadata` (the runtime objects assigned here). Type-only.
- `runtime/tests/hooks/user-prompt-ingress.test.ts`: `promptSession` accepts an optional `skillsForConfig` mock; new describe block covers plugin id (missing path and directory, case-insensitive), skill name and alias across multimodal parts with a single lookup, file wins with no lookup, unknown bare tokens plus dotted and path-like mentions keeping the warning, and lookup failure or absence falling back to the warning.

## Evidence

- Reproduced on 2026-09-11 with the motor3d plugin installed in a test home: session rollouts show the `file_mention_attachment_dropped` warning for `@motor3d` immediately before a successful `Skill("motor3d")` call.
- `MENTION_REGEX` in `runtime/src/prompts/file-mentions.ts` matches any `@token`, and `expandFileMentions` records `unreadable` when `fs.stat` fails, so every plugin mention without a same-named file produced the warning.
- `MENTION_REGEX` excludes `:`, so `@figma:figma-use` scans as the token `figma`; that is the plugin id, which the plugin-id match covers.
- Falsification: with the two source files reverted to main and only the new tests applied, 3 of the 8 ingress tests fail (the two "does not warn" cases and the lookup-count assertion); the "file wins" and "fallback" cases pass on main because they pin behavior that must not change.

## Tests

Run from `runtime/` on macOS (the full `npm test` needs the Linux Docker host and was not run):

- `npm run typecheck`: passes (`tsc --noEmit` and `typecheck:test-support`).
- `npx vitest run tests/hooks/user-prompt-ingress.test.ts tests/prompts/file-mentions.test.ts tests/skills/local-loader.test.ts tests/prompts/attachments/skill-listing.test.ts tests/tui/parity/session-transcript.test.ts tests/hooks/hook-authority-regression.test.ts`: 6 files, 163 tests passed.
- `npx vitest run tests/hooks/user-prompt-ingress.test.ts`: 8 passed (3 existing + 5 new).

## Not changed

- `runtime/src/prompts/file-mentions.ts`: `MENTION_REGEX`, `scanMentions`, `expandFileMentions` and the rejection reasons are untouched, so real file mentions resolve exactly as before and the TUI composer's mention validation is unaffected.
- Rejections that found a real file (`too_large`, `binary`, `too_many_files`, `total_too_large`, `outside_workspace`) keep their warning even for a bare token that matches a plugin id.
- An existing regular file that exists but cannot be read (`readFile` failure) also reports `unreadable` and is therefore treated as a plugin mention when the bare token matches; documented in the code comment, not distinguished further to keep `file-mentions.ts` unchanged.
- Bundled registry skills (`bundledRegistrySkills`) are not consulted; only the loader's `availableSkills` (plugin ids, skill names, aliases).
- `rankSkillsForRequest`, the skill listing, and the Skill tool are unchanged.

## Counterpart PRs

None
