### PR TITLE
test(cli): pin print-mode exit after a failed one-shot turn

### DIFF
--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1705,6 +1705,58 @@ describe("runSingleTurn seam (R1 multi-turn future-proofing)", () => {
 // T10 A+ Fix-alpha - main() smoke test
 // ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Isolated home + trusted cwd + captured stdio for a one-shot run. The env is
+ * restored and the temp dirs removed however the body ends; `run` races the
+ * body against a bounded timeout so a hang fails instead of stalling the suite.
+ */
+async function withOneShotTestEnvironment<T>(
+  prefix: string,
+  body: (env: {
+    readonly cwd: string;
+    readonly run: <R>(start: () => Promise<R>, timeoutMs: number) => Promise<R | "timeout">;
+    readonly stdout: () => string;
+    readonly stderr: () => string;
+  }) => Promise<T>,
+): Promise<T> {
+  const tmpHome = await mkdtemp(join(tmpdir(), `${prefix}home-`));
+  const tmpCwd = await mkdtemp(join(tmpdir(), `${prefix}cwd-`));
+  const prevEnv = { ...process.env };
+  Object.assign(process.env, {
+    AGENC_HOME: tmpHome,
+    AGENC_WORKSPACE: tmpCwd,
+    AGENC_PROVIDER: "openai",
+    OPENAI_API_KEY: "stub-openai-key-for-test",
+    AGENC_CLI_ENTRY_DISABLE: "1",
+  });
+  const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  const captured = (spy: typeof stdoutSpy) => () =>
+    spy.mock.calls.map(([chunk]) => String(chunk)).join("");
+  try {
+    trustWorkspaceForTest(tmpHome, tmpCwd);
+    return await body({
+      cwd: tmpCwd,
+      run: (start, timeoutMs) =>
+        Promise.race([
+          start(),
+          new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), timeoutMs)),
+        ]),
+      stdout: captured(stdoutSpy),
+      stderr: captured(stderrSpy),
+    });
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in prevEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, prevEnv);
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(tmpCwd, { recursive: true, force: true });
+  }
+}
+
 describe("main() smoke", () => {
   it("loads mcp serve config only when the route needs configured defaults", () => {
     expect(shouldLoadMcpCliConfig(["mcp"])).toBe(false);
@@ -1926,6 +1978,76 @@ describe("main() smoke", () => {
       await rm(tmpHome, { recursive: true, force: true });
       await rm(tmpCwd, { recursive: true, force: true });
     }
+  });
+
+  it("oneShotCLI exits non-zero promptly with the provider error on stderr when its only turn fails", async () => {
+    // Pins the print-mode contract for a provider failure on the only turn,
+    // using the notification shapes the daemon really emits (taken from the
+    // 2026-09-11 grok HTTP 403 rollout): turn_started reaches the client as an
+    // event.agent_status running projection, diagnostics travel as
+    // event.session_event records, and turn_failed is delivered as an
+    // event.session_event, never as an agent_status. The client must classify
+    // that session event, write the message to stderr, settle with code 1
+    // within a bounded time, and stop the daemon agent with one_shot_complete.
+    const agentId = "agent_auth_failed";
+    const sessionId = "session_auth_failed";
+    const turnId = "sub-conv-auth-3";
+    const failureMessage = "grok authentication failed (HTTP 403)";
+    const sessionEvent = (
+      id: string,
+      type: string,
+      payload: Record<string, unknown>,
+    ) => ({
+      method: "event.session_event",
+      params: {
+        sessionId,
+        agentId,
+        eventId: id,
+        turnId,
+        event: { id, type, payload },
+      },
+    });
+    const admission = (id: string, event: string, extra: Record<string, unknown>) =>
+      sessionEvent(id, "execution_admission", {
+        sequence: id === "admission-dispatched" ? 1 : 2,
+        runId: "conv-auth",
+        stepId: `model:${turnId}:1:0:primary`,
+        kind: "model_turn",
+        event,
+        ...extra,
+      });
+    const failedTurnEvents = (cwd: string) =>
+      installDaemonCliDepsForTest({
+        agentId,
+        sessionId,
+        cwd,
+        oneShotEvents: [
+          {
+            method: "event.agent_status",
+            params: { sessionId, agentId, eventId: "turn-started", turnId, status: "running", runStatus: "running" },
+          },
+          sessionEvent("warning", "warning", { cause: "skill_listing_truncated", message: "listed 83 of 1801 invocable skills" }),
+          admission("admission-dispatched", "dispatched", { provider: "grok", model: "grok-4.6" }),
+          admission("admission-held", "held_unknown", { reason: "provider_call_failed_after_dispatch" }),
+          sessionEvent("failed", "turn_failed", { turnId, code: "turn_execution_failed", message: failureMessage, completedAt: 1789161618399, durationMs: 1506 }),
+        ],
+      });
+
+    const outcome = await withOneShotTestEnvironment("agenc-turn-failed-", async ({ cwd, run, stdout, stderr }) => {
+      const daemon = failedTurnEvents(cwd);
+      // A regression that leaves the run waiting for a status the daemon never
+      // sends must fail here as a timeout instead of stalling the suite.
+      const result = await run(() => oneShotCLI("Reply pong"), 4000);
+      return { daemon, result, stdout: stdout(), stderr: stderr() };
+    });
+
+    expect(outcome.result).toBe(1);
+    expect(outcome.stderr).toContain(failureMessage);
+    expect(outcome.stdout).toBe("");
+    const stop = outcome.daemon.requests.find((request) => request.method === "agent.stop");
+    expect(stop?.params).toEqual({ agentId, reason: "one_shot_complete" });
+    expect(outcome.daemon.stopPromptAgent).not.toHaveBeenCalled();
+    expect(outcome.daemon.client.close).toHaveBeenCalled();
   });
 
   it("oneShotCLI DENIES an unanswerable permission request and terminates instead of hanging", async () => {


### PR DESCRIPTION
## Why

The 2026-09-11 grok benchmark (`bench/reports/agenc-commands.json`, task `add-clamp`) recorded exit 124 after 120173 ms, and the hypothesis was that print mode (`agenc --dangerously-bypass-approvals-and-sandbox -p ...`) did not exit after its only turn failed with `grok authentication failed (HTTP 403)`.

The investigation does not support that. The exit 124 belongs to a different attempt than the 403 rollout: an active slow turn that the eval runner killed at its 120 s task timeout, after which the client aborted, stopped the agent, and exited within 173 ms. The 403 attempt settled and stopped its agent 21 ms after `turn_failed`, and a real HTTP 403 against main exits 1 in about a second with the message on stderr. The code path is already correct: the daemon delivers `turn_failed` as an `event.session_event`, `daemonOneShotFinalStatus` classifies it through `classifyTurnTerminal` as code 1 with the message, the client writes the message to stderr, settles, and the `finally` block stops the agent with `one_shot_complete`.

What was missing is a test that pins this contract with the notification shapes the daemon really emits (the existing terminal test feeds `turn_started` as a session event, while production projects it as `event.agent_status running`) and that fails fast, as a bounded timeout, if the client ever stops honouring the session-event form of `turn_failed`. This PR adds that test and records the corrected diagnosis. No production code changes.

## What

- `runtime/tests/bin/agenc.test.ts`: new test "oneShotCLI exits non-zero promptly with the provider error on stderr when its only turn fails". It drives the fake daemon through `event.agent_status running` (turn_started projection), `warning` and `execution_admission` session events, and an `event.session_event turn_failed` with code `turn_execution_failed` and the grok HTTP 403 message, then asserts exit 1 within a 4 s race, the message on stderr only, empty stdout, `agent.stop` requested with `{ agentId, reason: "one_shot_complete" }`, no fallback `stopPromptAgent`, and the client closed.

## Evidence

Rollouts under `bench/agenc-home/projects/*add-clamp*/sessions/`:

- `conv-mtxgcrm5`, `rollout-2026-09-11T21-12-31-307Z`: the attempt that produced exit 124. Three grok-4.6 model calls dispatched at 21:12:31, 21:13:26, and 21:14:17 (roughly 50 s each), 37588 input tokens, thinking deltas and tool calls throughout; the third call was still in flight when the runner's SIGTERM arrived at 21:14:30. The rollout ends with `turn_aborted` reason `session_shutdown` and `run_terminal` status `cancelled`, stopReason `one_shot_cancelled`, finishedAt 21:14:30.272Z. The report shows the process closed at 120173 ms, 173 ms after the 120 s timer.
- `conv-mtxgmqqm`, `rollout-2026-09-11T21-20-16-807Z`: the 403 attempt. `turn_failed` code `turn_execution_failed`, message `grok authentication failed (HTTP 403)`, durationMs 1506, followed 21 ms later by `run_terminal` with stopReason `one_shot_complete`. That stop reason is only sent by the one-shot client's `finally` block after the run promise settled with `completed = true`. No agenc report covers 21:20Z (the commands run finished at 21:19:53Z and the next agenc run started at 21:24:59Z), so this attempt was not the one recorded as exit 124.
- The report's `commandReport` keeps only `command`, `exitCode`, and `durationMs`; every command in every report shows empty stdout and stderr, so the empty stderr in the report is not evidence of a missing message.
- The bench binary was built from 0245ef4fe. The one-shot client code in `runtime/src/bin/agenc-main.ts` is unchanged between that commit and main (3154897be); the diff touches unrelated TUI and resume paths.

Real reproduction on main (built with `npm run build` in `runtime/`), isolated `AGENC_HOME=/private/tmp/tt/oneshot-home` with `model = "grok-4.6"`, `model_provider = "grok"`, a fresh trusted cwd under `/private/tmp/tt`, `XAI_API_KEY=sk-invalid-test`, wrapped in `perl -e 'alarm 100; exec @ARGV'`:

- Invalid key against api.x.ai returns HTTP 400: exit 1 in 3 s, stderr `grok error: 400 "Incorrect API key provided. ..."`.
- `XAI_BASE_URL=http://127.0.0.1:18403/v1` pointing at a local server that answers 403 to every request, fresh daemon: exit 1 in 2 s, stderr `grok authentication failed (HTTP 403)`.
- Same, against the already running daemon: exit 1 in 3 s, same stderr.
- Same, launched the way the eval runner does (`spawn` with `shell: true`, `stdio: ["ignore", "pipe", "pipe"]`, 100 s kill timer): `{"exitCode":1,"durationMs":1248,"stdout":"","stderr":"grok authentication failed (HTTP 403)\n"}`.

Falsification of the new test: with `daemonOneShotFinalStatus` temporarily returning null for `turn_failed` session events, the test fails as `expected 'timeout' to be 1` after 4016 ms; with the source restored it passes in 19 ms.

## Tests

From `runtime/`:

- `npx vitest run tests/bin/agenc.test.ts -t "only turn fails"`: 1 passed, 96 skipped.
- `npx vitest run tests/bin/agenc.test.ts`: 97 passed.
- `npm run typecheck`: exit 0 (both `tsc --noEmit` and `typecheck:test-support`).

## Not changed

- No production code. `daemonOneShotFinalStatus`, `classifyTurnTerminal`, the one-shot `finally` block, and the daemon event projection are untouched.
- TUI behaviour, the daemon `agent.stop` path, and the eval runner (`runtime/scripts/run-agent-eval.mjs`) are untouched. Its 120 s default task timeout is what ended the benchmark attempt; raising it is a harness decision, not a runtime fix.
- One latent observation, left alone for lack of a producer: `daemonOneShotFinalStatus` checks `status === "idle"` before `runStatus === "errored"`, so an `event.agent_status` carrying both would settle print mode with exit 0. Every current producer keeps `status` and `runStatus` consistent (`run_error` sends `error`/`errored`, `run_terminal failed` maps to `error`/`errored`), so this is not reachable today.

## Counterpart PRs

None
