### PR TITLE
tools: move the spawn_agent delegation rules into the static prompt and defer the CSV job family

### DIFF
--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -25,13 +25,13 @@ in `runtime/src/bin/model-facing-tools.ts`, not inside `v2/index.ts`.
 | `assign_task` | Admit one new task to an idle reusable worker (**triggers a turn**). Argument, identity, and target-resolution refusals plus the four no-mutation admission rejections are confirmed no-effect: [agent validation refusals](#agent-validation-refusals). |
 | `send_message` | Queue passive context (**does not** trigger a turn). The same pre-delivery refusals as `assign_task` are confirmed no-effect: [agent validation refusals](#agent-validation-refusals). |
 | `list_agents` | Read the live agent tree and current statuses. Optional `path_prefix`. |
-| `spawn_agents_on_csv` | Fan out workers from CSV rows (job orchestrator) |
-| `report_agent_job_result` | Report a CSV/job worker result back to the orchestrator |
-| `inspect_csv_agent_job` | Read a bounded job summary and keyset item page |
-| `read_csv_agent_job_result` | Read one bounded base64 result chunk |
-| `list_csv_job_reviews` | List a bounded page of unknown-outcome reviews |
-| `show_csv_job_review` | Read one bounded review record |
-| `resolve_csv_job_review` | Approval-gated operator resolution with canonical evidence |
+| `spawn_agents_on_csv` | Fan out workers from CSV rows (job orchestrator). Deferred: load with `system.searchTools` (`select:spawn_agents_on_csv`). |
+| `report_agent_job_result` | Report a CSV/job worker result back to the orchestrator. Visible by default because row workers call it. |
+| `inspect_csv_agent_job` | Read a bounded job summary and keyset item page (deferred) |
+| `read_csv_agent_job_result` | Read one bounded base64 result chunk (deferred) |
+| `list_csv_job_reviews` | List a bounded page of unknown-outcome reviews (deferred) |
+| `show_csv_job_review` | Read one bounded review record (deferred) |
+| `resolve_csv_job_review` | Approval-gated operator resolution with canonical evidence (deferred) |
 
 ### Read-only planning workers
 

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -290,13 +290,27 @@ Canonical v2 surface (`runtime/src/agents/v2/`). Details:
 | `assign_task` | New task (triggers turn) |
 | `send_message` | Follow-up (no turn trigger) |
 | `list_agents` | Inspect agent tree |
-| `spawn_agents_on_csv` | Batch CSV agent jobs |
-| `report_agent_job_result` | Record CSV job item result |
-| `inspect_csv_agent_job` | Read a bounded summary and keyset-paginated item page |
-| `read_csv_agent_job_result` | Read one bounded base64 result chunk |
-| `list_csv_job_reviews` | Bounded page of unknown-outcome CSV reviews |
-| `show_csv_job_review` | One bounded review record |
-| `resolve_csv_job_review` | Approval-gated operator resolution with canonical evidence |
+| `spawn_agents_on_csv` | Batch CSV agent jobs (deferred) |
+| `report_agent_job_result` | Record CSV job item result (visible: row subagents call it) |
+| `inspect_csv_agent_job` | Read a bounded summary and keyset-paginated item page (deferred) |
+| `read_csv_agent_job_result` | Read one bounded base64 result chunk (deferred) |
+| `list_csv_job_reviews` | Bounded page of unknown-outcome CSV reviews (deferred) |
+| `show_csv_job_review` | One bounded review record (deferred) |
+| `resolve_csv_job_review` | Approval-gated operator resolution with canonical evidence (deferred) |
+
+The CSV job family is deferred (`metadata.deferred`) because a coding turn
+almost never touches it and its six schemas cost about 4 KB of every request.
+`system.searchTools` lists and loads them (`select:spawn_agents_on_csv`), and
+the loaded `spawn_agents_on_csv` description names its companion tools.
+`report_agent_job_result` stays visible because the row subagents a job spawns
+must call it without a discovery step.
+
+The `spawn_agent` description states only what its schema needs. The
+delegation rules (foreground vs background, parallel launches, how to brief an
+agent, never predicting a result) live in the static `# Subagents` system
+prompt section (`getAgentToolSection` in `runtime/src/prompts/system-prompt.ts`),
+which is emitted only when `spawn_agent` is in the catalog and rides the cached
+prefix once instead of the tool catalog of every request.
 
 ### MCP helpers (built-in) + bridge
 
@@ -323,11 +337,12 @@ Exact visibility is request-scoped and config-dependent. As coded in
   `FileRead`, `Edit`, `MultiEdit`, `Write`, `Glob`, `Grep`, `Orient`,
   `AskUserQuestion`, `TodoWrite`, `EnterPlanMode`, `ExitPlanMode`,
   `system.searchTools`, plus non-deferred model-facing tools (web, multi-agent
-  v2, Skill, CSV jobs, Imagine when registered). Task* / Cron* / `WorkflowTool`
-  are **deferred**.
+  v2, Skill, `report_agent_job_result`, Imagine when registered). Task* /
+  Cron* / `WorkflowTool` are **deferred**.
 - **Deferred / discoverable examples:** `system.bash`, git/symbol `system.*`
-  intel tools, MCP tools when `deferMcpTools` is on, MCP resource helpers,
-  passthrough `StructuredOutput`, and other tools marked
+  intel tools, the CSV job family (`spawn_agents_on_csv` and its five
+  inspection/review tools), MCP tools when `deferMcpTools` is on, MCP resource
+  helpers, passthrough `StructuredOutput`, and other tools marked
   `metadata.deferred`.
 
 Coordinator mode further **allowlists** orchestration tools only — see

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -53,40 +53,6 @@ import {
 const SPAWN_AGENT_INHERITED_MODEL_GUIDANCE =
   "Spawned agents inherit your current model by default. Omit `model` to use that preferred default; set `model` only when an explicit override is needed.";
 
-const SPAWN_AGENT_DELEGATION_DISCIPLINE = `
-### When to delegate vs. do the subtask yourself
-- First, quickly analyze the overall user task and form a succinct high-level plan. Identify which tasks are immediate blockers on the critical path, and which tasks are sidecar tasks that are needed but can run in parallel without blocking the next local step. As part of that plan, explicitly decide what immediate task you should do locally right now. Do this planning step before delegating to agents so you do not hand off the immediate blocking task to a submodel and then waste time waiting on it.
-- Use a subagent when a subtask is easy enough for it to handle and can run in parallel with your local work. Prefer delegating concrete, bounded sidecar tasks that materially advance the main task without blocking your immediate next local step.
-- Do not delegate urgent blocking work when your immediate next step depends on that result. If the very next action is blocked on that task, the main rollout should usually do it locally to keep the critical path moving.
-- Keep work local when the subtask is too difficult to delegate well and when it is tightly coupled, urgent, or likely to block your immediate next step.
-- For reviewer, tester, or verifier agents, first create the artifact they are supposed to inspect and do the smallest local check that it exists. Agents asked to review missing files waste the user's time and produce confusing output.
-
-### Designing delegated subtasks
-- Subtasks must be concrete, well-defined, and self-contained.
-- Delegated subtasks must materially advance the main task.
-- Do not duplicate work between the main rollout and delegated subtasks.
-- Avoid issuing multiple delegate calls on the same unresolved thread unless the new delegated task is genuinely different and necessary.
-- Narrow the delegated ask to the concrete output you need next.
-- For coding tasks, prefer delegating concrete code-change runner subtasks over read-only scanner analysis when the subagent can make a bounded patch in a clear write scope.
-- When delegating coding work, instruct the submodel to edit files directly in its forked workspace and list the file paths it changed in the final answer.
-- For code-edit subtasks, decompose work so each delegated task has a disjoint write set.
-- For parallel code-edit subtasks, use \`isolation: "worktree"\`. Require the worker to commit its changes and report the commit, changed files, and verification it ran. Review and integrate one exact verified \`base_commit..integration_ref\` range at a time; never infer an integration target from a mutable worker branch or treat completion as merge approval. An intended deliverable under an ignored path must be explicitly unignored or force-added and committed.
-- The spawned agent inherits its working directory from the parent session and receives the same Environment section. Do NOT embed absolute filesystem paths from memory in the \`message\` body and do NOT invent project root paths. Refer to files relative to the cwd the spawned agent will already know.
-- Omit \`fork_turns\` for a clean fork: the spawned agent starts fresh with ONLY your task as its context, so make the \`message\` fully self-contained (background, goal, constraints, relevant file paths/snippets) — it has NOT seen this conversation. This is the default and the cheap path for an N-agent fan-out. Use \`fork_turns: "all"\` only when the subtask genuinely needs the full parent conversation, or a positive integer string such as \`"3"\` for just the most recent turns. Full-history forks inherit the parent role/model/effort and cannot be combined with \`agent_type\`, \`model\`, or \`reasoning_effort\` overrides.
-
-### After you delegate
-- Call wait_agent very sparingly. Only call wait_agent when you need the result immediately for the next critical-path step and you are blocked until it returns.
-- Do not redo delegated subagent tasks yourself; focus on integrating results or tackling non-overlapping work.
-- While the subagent is running in the background, do meaningful non-overlapping work immediately.
-- Do not repeatedly wait by reflex.
-- When a delegated coding task returns, quickly review the uploaded changes, then integrate or refine them.
-
-### Parallel delegation patterns
-- Run multiple independent information-seeking subtasks in parallel when you have distinct questions that can be answered independently.
-- Split implementation into disjoint codebase slices and spawn multiple agents for them in parallel when the write scopes do not overlap.
-- Delegate verification only when it can run in parallel with ongoing implementation and is likely to catch a concrete risk before final integration.
-- The key is to find opportunities to spawn multiple independent subtasks in parallel within the same round, while ensuring each subtask is well-defined, self-contained, and materially advances the main task.`;
-
 function buildSpawnAgentDescription(session: Session | null): string {
   const base = `Spawns an agent to work on the specified task.
 
@@ -104,7 +70,12 @@ The new agent's canonical task name will be provided to it along with the messag
   if (sessionIsPlanning(session) || sessionReadOnlyDelegation(session) !== undefined) {
     return `${base}\n\n${READ_ONLY_DELEGATION_PROMPT}\nDelegate bounded independent inspection tasks in parallel. Use isolation none, list_agents, wait_agent, and close_agent for your constrained workers.`;
   }
-  let result = `${base}${SPAWN_AGENT_DELEGATION_DISCIPLINE}`;
+  // The delegation rules (when to delegate, how to design subtasks, what to
+  // do after delegating, parallel patterns) live in the static `# Subagents`
+  // system prompt section (prompts/system-prompt.ts getAgentToolSection),
+  // emitted whenever this tool is in the catalog. Keeping them out of the
+  // description takes about 4.8 KB out of the tool catalog of every request.
+  let result = `${base}\nThe delegation rules are in the Subagents section of your instructions.`;
   if (cfg?.usageHintEnabled && cfg.usageHintText) {
     result = `${result}\n${cfg.usageHintText}`;
   }

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2320,12 +2320,18 @@ function createMultiAgentV2RuntimeTools(
 
   return [
     ...multiAgentV2Tools,
+    // The CSV job family is deferred (metadata.deferred): a coding turn almost
+    // never touches it, and its six schemas cost about 4 KB of every request.
+    // system.searchTools still lists and loads them; report_agent_job_result
+    // stays visible because the row subagents spawned by the job must call it
+    // without a discovery step.
     {
       name: "spawn_agents_on_csv",
       description:
-        "Spawn one subagent per CSV row. The approved instruction is kept separate from an inert structured row payload; subagents must call `report_agent_job_result` exactly once. Optionally writes an output CSV with each row's status and result.",
+        "Spawn one subagent per CSV row. The approved instruction is kept separate from an inert structured row payload; subagents must call `report_agent_job_result` exactly once. Optionally writes an output CSV with each row's status and result. Companion tools for the job it starts load through system.searchTools (select:<name>): inspect_csv_agent_job, read_csv_agent_job_result, list_csv_job_reviews, show_csv_job_review, resolve_csv_job_review.",
       metadata: toolMetadata("agent", {
         mutating: true,
+        deferred: true,
         keywords: ["agent", "spawn", "batch", "csv", "job"],
       }),
       requiresApproval: true,
@@ -2416,6 +2422,7 @@ function createMultiAgentV2RuntimeTools(
         "Read a bounded summary and keyset-paginated item page for a CSV agent job. Result bodies are not embedded.",
       metadata: toolMetadata("agent", {
         mutating: false,
+        deferred: true,
         keywords: ["agent", "job", "csv", "inspect", "status"],
       }),
       isReadOnly: true,
@@ -2447,6 +2454,7 @@ function createMultiAgentV2RuntimeTools(
         "Read one bounded base64 chunk of an available CSV job item result blob.",
       metadata: toolMetadata("agent", {
         mutating: false,
+        deferred: true,
         keywords: ["agent", "job", "csv", "result", "read"],
       }),
       isReadOnly: true,
@@ -2474,6 +2482,7 @@ function createMultiAgentV2RuntimeTools(
         "List a bounded cursor page of CSV job items with unknown outcomes.",
       metadata: toolMetadata("agent", {
         mutating: false,
+        deferred: true,
         keywords: ["agent", "job", "csv", "review", "list"],
       }),
       isReadOnly: true,
@@ -2499,6 +2508,7 @@ function createMultiAgentV2RuntimeTools(
       description: "Read one bounded CSV unknown-outcome review record.",
       metadata: toolMetadata("agent", {
         mutating: false,
+        deferred: true,
         keywords: ["agent", "job", "csv", "review", "show"],
       }),
       isReadOnly: true,
@@ -2520,6 +2530,7 @@ function createMultiAgentV2RuntimeTools(
         "Resolve one CSV unknown outcome from operator evidence. This requires explicit approval and fails closed on a conflicting replay.",
       metadata: toolMetadata("agent", {
         mutating: true,
+        deferred: true,
         keywords: ["agent", "job", "csv", "review", "resolve"],
       }),
       requiresApproval: true,

--- a/runtime/src/prompts/system-prompt.ts
+++ b/runtime/src/prompts/system-prompt.ts
@@ -291,16 +291,34 @@ export function getUsingYourToolsSection(enabledTools: ReadonlySet<string>): str
 /**
  * 6. agent_tool — guidance for the multi-agent delegation surface.
  *
- * The host exposes delegation through the primary agent tool spec.
+ * Emitted only when the primary `spawn_agent` tool (agents/v2/spawn.ts) is
+ * in the catalog. This is the home of the delegation discipline that used to
+ * ride inside the spawn_agent tool description on every request: when to
+ * delegate, how to design subtasks, what to do after delegating, parallel
+ * patterns. The description now states only what the schema needs and points
+ * here; the rules live in the cacheable static head so they are sent once per
+ * prefix, not once per tool catalog, and in fewer words.
+ *
  * Do not add separate prompt guidance for AgenC's compatibility
- * `system.agent.delegate` compatibility shim; surfacing that tool here
- * causes the model to bypass the supported task-name/background semantics.
+ * `system.agent.delegate` shim; surfacing that tool here causes the model to
+ * bypass the supported task-name/background semantics.
  */
 export function getAgentToolSection(
   enabledTools: ReadonlySet<string>,
 ): string | null {
-  void enabledTools;
-  return null;
+  if (!enabledTools.has("spawn_agent")) return null;
+  const items: Array<string | string[]> = [
+    `Plan first: identify the critical-path step you must do locally right now and the bounded sidecar tasks that can run in parallel without blocking it. Never hand the immediate blocking step to a subagent and then wait on it.`,
+    `Delegate concrete, self-contained subtasks that materially advance the task and can run beside your own work. Keep work local when it is tightly coupled, urgent, likely to block your next step, or too hard to specify well.`,
+    `Before spawning a reviewer, tester, or verifier, create the artifact it must inspect and do the smallest local check that it exists.`,
+    `Do not duplicate work between yourself and subagents, and do not issue another delegate call on the same unresolved thread unless the new task is genuinely different and necessary. Narrow each ask to the concrete output you need next.`,
+    `For coding work, prefer bounded runner subtasks with a clear write scope over read-only scanner analysis. Tell the worker to edit files directly in its workspace and to list the paths it changed in its final answer. Give parallel code-edit subtasks disjoint write sets and isolation: "worktree"; require each worker to commit and report the commit, the changed files, and the verification it ran; integrate one exact verified base_commit..integration_ref range at a time, and never infer an integration target from a mutable worker branch or treat completion as merge approval. A deliverable under an ignored path must be explicitly unignored or force-added and committed.`,
+    `The spawned agent inherits your working directory and receives the same Environment section. Refer to files relative to that cwd; do not embed absolute paths from memory or invent a project root in the message.`,
+    `Omit fork_turns for the default clean fork and make the message fully self-contained (background, goal, constraints, relevant paths and snippets): the agent has not seen this conversation. Use fork_turns "all" only when the subtask genuinely needs the whole conversation; it then inherits your role, model, and effort and cannot be combined with agent_type, model, or reasoning_effort overrides. A positive integer string such as "3" forks only the most recent turns.`,
+    `After delegating, call wait_agent only when the next critical-path step is blocked on the result; otherwise do meaningful non-overlapping work and never wait by reflex. Do not redo delegated work. When a coding task returns, review the changes, then integrate or refine them.`,
+    `Run independent information-seeking subtasks in parallel, split implementation into disjoint slices for parallel agents when write scopes do not overlap, and delegate verification only when it can run beside implementation and is likely to catch a concrete risk before integration.`,
+  ];
+  return joinSection("# Subagents", items);
 }
 
 /**

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -730,6 +730,62 @@ describe("model-facing tools", () => {
     expect(visibleNames).not.toContain("StructuredOutput");
   });
 
+  it("defers the CSV job family until system.searchTools loads it, keeping the worker-side report tool visible", async () => {
+    const session = fakeSession(process.cwd());
+    const registry = buildBootstrapToolRegistry({
+      workspaceRoot: process.cwd(),
+      agencHome: join(tmpdir(), "agenc-tools-test"),
+      mcpManager: fakeMcpManager() as never,
+      csvAgentJobsRepositories: UNUSED_CSV_AGENT_JOBS_REPOSITORIES,
+      getSession: () => session,
+      emitWarning: () => {},
+    });
+    const deferredCsvTools = [
+      "spawn_agents_on_csv",
+      "inspect_csv_agent_job",
+      "read_csv_agent_job_result",
+      "list_csv_job_reviews",
+      "show_csv_job_review",
+      "resolve_csv_job_review",
+    ];
+    const allNames = registry.tools.map((tool) => tool.name);
+    const visibleBefore = registry
+      .toLLMTools()
+      .map((tool) => tool.function.name);
+    for (const name of deferredCsvTools) {
+      expect(allNames).toContain(name);
+      expect(visibleBefore).not.toContain(name);
+      expect(
+        registry.tools.find((tool) => tool.name === name)?.metadata?.deferred,
+      ).toBe(true);
+    }
+    // Row subagents spawned by a CSV job must call this without a discovery
+    // step, so it stays in the default catalog.
+    expect(visibleBefore).toContain("report_agent_job_result");
+    // The orchestration tools a coding turn does use stay visible.
+    for (const name of ["spawn_agent", "wait_agent", "close_agent", "list_agents"]) {
+      expect(visibleBefore).toContain(name);
+    }
+
+    const result = await registry.dispatch({
+      id: "search-select-csv",
+      name: "system.searchTools",
+      arguments: JSON.stringify({ select: "spawn_agents_on_csv" }),
+    });
+    const body = JSON.parse(result.content) as { loaded?: string[] };
+    expect(body.loaded, result.content).toContain("spawn_agents_on_csv");
+    const visibleAfter = registry
+      .toLLMTools()
+      .map((tool) => tool.function.name);
+    expect(visibleAfter).toContain("spawn_agents_on_csv");
+    // The loaded description tells the model where the companion tools are.
+    const loaded = registry
+      .toLLMTools()
+      .find((tool) => tool.function.name === "spawn_agents_on_csv");
+    expect(loaded?.function.description).toContain("system.searchTools");
+    expect(loaded?.function.description).toContain("inspect_csv_agent_job");
+  });
+
   it("exposes only max_concurrency for CSV worker limits", async () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),

--- a/runtime/tests/prompts/system-prompt.test.ts
+++ b/runtime/tests/prompts/system-prompt.test.ts
@@ -328,11 +328,32 @@ describe("static section emitters", () => {
     expect(s).toBeNull();
   });
 
-  test("agent_tool returns null when system.agent.delegate is not enabled (gated)", () => {
+  test("agent_tool returns null when spawn_agent is not enabled (gated)", () => {
     expect(getAgentToolSection(new Set())).toBeNull();
     expect(
       getAgentToolSection(new Set(["exec_command", "Edit", "Write"])),
     ).toBeNull();
+  });
+
+  test("agent_tool states the delegation rules that left the spawn_agent description", () => {
+    const s = getAgentToolSection(new Set(["spawn_agent", "FileRead"]));
+    expect(s).not.toBeNull();
+    expect(s!.startsWith("# Subagents")).toBe(true);
+    // The four groups of the delegation discipline that the spawn_agent
+    // description used to carry on every request (when to delegate, designing
+    // subtasks, after delegating, parallel patterns) must all be stated here.
+    expect(s).toContain("critical-path");
+    expect(s).toContain("reviewer, tester, or verifier");
+    expect(s).toContain("disjoint write sets");
+    expect(s).toContain('isolation: "worktree"');
+    expect(s).toContain("base_commit..integration_ref");
+    expect(s).toContain("fork_turns");
+    expect(s).toContain("wait_agent");
+    expect(s).toContain("never wait by reflex");
+    expect(s).toContain("in parallel");
+    expect(s).not.toContain("system.agent.delegate");
+    // No em dashes in user-visible prompt text.
+    expect(s).not.toContain("\u2014");
   });
 
   test("tone_and_style bans emojis + colons before tool calls", () => {
@@ -902,6 +923,31 @@ describe("assembleSystemPrompt", () => {
         .slice(boundaryIdx + 1)
         .some((s) => s.includes("token target")),
     ).toBe(true);
+  });
+
+  test("spawn_agent puts the Subagents section in the static head next to the tool guidance", async () => {
+    const { sections, staticPrefix, dynamicSuffix } = await assembleSystemPrompt({
+      session: fakeSession,
+      ctx: fakeCtx(),
+      enabledToolNames: new Set([
+        "exec_command",
+        "FileRead",
+        "Edit",
+        "Grep",
+        "spawn_agent",
+      ]),
+      simpleMode: false,
+    });
+    const headings = sections
+      .slice(0, sections.indexOf(SYSTEM_PROMPT_DYNAMIC_BOUNDARY))
+      .map((s) => s.split("\n")[0]);
+    const usingIdx = headings.indexOf("# Using your tools");
+    const subagentsIdx = headings.indexOf("# Subagents");
+    const guidanceIdx = headings.indexOf("# Session-specific guidance");
+    expect(subagentsIdx).toBe(usingIdx + 1);
+    expect(guidanceIdx).toBe(subagentsIdx + 1);
+    expect(staticPrefix).toContain("# Subagents");
+    expect(dynamicSuffix).not.toContain("# Subagents");
   });
 
   test("legacy system.agent.delegate does not add subagent prompt prose", async () => {


### PR DESCRIPTION
## Why

The per-request tool catalog measured 46,430 bytes for 38 tools on a plain DeepSeek turn (logging proxy, 2026-09-11, see `docs/eval/harness-review-2026-09-11.md`). `spawn_agent` alone was 10,139 bytes because its description carried the whole delegation discipline (when to delegate, designing subtasks, after delegating, parallel patterns) on every request. The six CSV job tools cost about 4 KB although a coding turn never touches them: across the 82 benchmark rollouts the tool calls were FileRead 144, Edit 106, Glob 43, exec_command 29, Grep 29, Write 26, Orient 2, kill_process 1, and none for the CSV family.

## What

- `runtime/src/agents/v2/spawn.ts`: the description no longer embeds `SPAWN_AGENT_DELEGATION_DISCIPLINE` (constant removed). It keeps the base text, the inherited-model note, the read-only delegation prompt for planning sessions and the config usage hint, and points to the Subagents section.
- `runtime/src/prompts/system-prompt.ts`: `getAgentToolSection` now emits a `# Subagents` section whenever `spawn_agent` is in the catalog, stating the same rules in fewer words: plan first and keep the critical-path step local, delegate bounded self-contained sidecar tasks, create the artifact before spawning a reviewer, no duplicate delegation, runner over scanner with disjoint write sets and `isolation: "worktree"`, cwd-relative paths, `fork_turns` semantics, `wait_agent` only when blocked, parallel patterns. It sits between `# Using your tools` and `# Session-specific guidance` in the cacheable static head.
- `runtime/src/bin/model-facing-tools.ts`: `metadata.deferred` on `spawn_agents_on_csv`, `inspect_csv_agent_job`, `read_csv_agent_job_result`, `list_csv_job_reviews`, `show_csv_job_review`, `resolve_csv_job_review`; the `spawn_agents_on_csv` description names its companion tools so the model can `select:` them after discovery. `report_agent_job_result` stays visible because the row subagents a job spawns must call it without a discovery step.
- `runtime/tests/bin/model-facing-tools.test.ts`: new test pinning that the six are cataloged but not advertised, that `report_agent_job_result`, `spawn_agent`, `wait_agent`, `close_agent`, `list_agents` stay visible, and that `system.searchTools select:spawn_agents_on_csv` loads the tool with a description naming the companions.
- `runtime/tests/prompts/system-prompt.test.ts`: the gate tests now name `spawn_agent`; new tests pin the section's content and its position in the static head (not in the dynamic tail).
- `docs/reference/tools-permissions-sandbox.md`, `docs/reference/agents.md`: the deferral and the prompt section are documented.

## Evidence

Wire measurement through the local logging proxy on `deepseek-v4-pro`, one plain `-p` turn ("Reply with the single word pong."), same isolated home, before = origin/main build, after = this branch:

| | before | after |
| --- | --- | --- |
| tools advertised | 38 | 32 |
| tool catalog bytes | 46,430 | 37,557 |
| system prompt bytes | 21,217 | 23,919 |
| prefix total (tools + system) | 67,647 | 61,476 |
| spawn_agent bytes / description bytes | 10,139 / 5,640 | 5,318 / 856 |

About 6.2 KB (roughly 1,500 tokens) less per request. The new `# Subagents` section is 2,764 bytes and rides the cached static head.

Deliberately not deferred: `write_stdin` (the `exec_command` description tells the model to poll background commands with it), `Orient` (the compact profile and the navigation guidance name it), `list_agents` and `close_agent` (the `wait_agent` timeout guidance and the coordinator flow use them; together 533 bytes).

## Tests

From `runtime/` with `TMPDIR=/private/tmp/tt/vt`:

- `npm run typecheck`: exit 0.
- `npx vitest run tests/prompts tests/bin/model-facing-tools.test.ts tests/agents/v2 tests/tool-registry.test.ts tests/app-server/csv-job-review.contract.test.ts tests/bin/bootstrap.test.ts tests/tools/system/tool-search.test.ts`: 43 files passed, 779 tests passed; the one failure is `tests/prompts/agenc-md.test.ts > invalidates when an AGENC.md mtime advances`, which fails identically on origin/main on macOS (the test shells out to `touch -d`, which BSD touch rejects).

## Not changed

- The `spawn_agent` input schema (about 4.4 KB, mostly the dynamic role list in `agent_type`) is unchanged.
- Visibility of `write_stdin`, `Orient`, `list_agents`, `close_agent`.
- The vendored `tools/AgentTool` (not part of the model-facing catalog) is untouched.
- Planning and read-only delegation sessions keep `READ_ONLY_DELEGATION_PROMPT` in the description as before.

## Counterpart PRs

None. The desktop does not render tool descriptions.
