### PR TITLE
cli: add --bypass-approvals, the approvals-only bypass that keeps the OS sandbox

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,7 +60,8 @@ From `formatCliHelpText()`:
 | `--model <id\|provider:id>` | Override model for this session |
 | `--permission-mode <mode>` | Override startup mode: `default`, `acceptEdits`, `plan`, `dontAsk`, or `auto`. `bypassPermissions` is an explicit session-only opt-in bound to the current workspace. Internal `unattended` / `bubble` modes are not CLI addressable. |
 | `--autonomous` | Enable autonomous tick mode |
-| `--dangerously-bypass-approvals-and-sandbox` | Bypass approvals and sandbox checks |
+| `--bypass-approvals` | Skip approval prompts but keep the OS sandbox (same session-only `bypassPermissions` opt-in as `--permission-mode bypassPermissions`). On a host that cannot sandbox at all the run continues without kernel confinement and prints one stderr notice naming the reason. Conflicts with a different `--permission-mode`. |
+| `--dangerously-bypass-approvals-and-sandbox` | Bypass approvals and sandbox checks everywhere (the explicit no-sandbox opt-out) |
 | `--image <file\|url\|data-url>` | Attach a startup image |
 
 ### Print-mode notes

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -391,9 +391,23 @@ the RPC is refused with "requires explicit consent for this exact cwd"
 unless stored accept-bypass consent already matches.
 
 `--permission-mode bypassPermissions` is an explicit startup opt-in for the
-current session and workspace; it does not write durable consent. The
+current session and workspace; it does not write durable consent.
+`--bypass-approvals` is the same opt-in as a dedicated flag: approval prompts
+off, the configured OS sandbox kept (Seatbelt on macOS, bubblewrap or Landlock
+on Linux). It is the right default for unattended runs. When the host cannot
+sandbox at all (`probeSandboxExecutionStatus` reports `unavailable`, for
+example Windows or a Linux box without user namespaces and Landlock) the run
+would otherwise fail closed on its first tool call, so the flag degrades that
+session to `danger-full-access` and prints one stderr line naming the reason
+(`runtime/src/bin/bypass-approvals.ts`). The
 `--dangerously-bypass-approvals-and-sandbox` flag is the separate combined
-escape hatch for bypassed prompts and `danger-full-access`.
+escape hatch for bypassed prompts and `danger-full-access` on every host.
+Passing `--bypass-approvals` together with a different `--permission-mode` is
+an error.
+
+The SDK mirrors the split: `createSession({ bypassApprovals: true })` sends
+`permissionMode: "bypassPermissions"` and leaves the sandbox on, while
+`dangerouslyBypassApprovalsAndSandbox: true` remains the no-sandbox option.
 
 Neither bypass setting removes a planning worker's permanent read-only
 constraint. See [read-only planning workers](agents.md#read-only-planning-workers).

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -264,6 +264,19 @@ export interface AgencCreateSessionParams extends SessionCreateParams {
    * Existing sessions retain the authority captured when they were created.
    */
   readonly dangerouslyBypassApprovalsAndSandbox?: boolean;
+  /**
+   * Disable approval prompts but keep the OS sandbox: the session starts in
+   * `bypassPermissions` mode with the daemon's configured sandbox policy.
+   * Mirrors the CLI `--bypass-approvals` flag. Conflicts with a different
+   * explicit `permissionMode`.
+   */
+  readonly bypassApprovals?: boolean;
+  /** Session-wide permission mode for the spawned agent (`agent.create`). */
+  readonly permissionMode?: AgentCreateParams["permissionMode"];
+  /** Model override for the spawned agent (`agent.create`). */
+  readonly model?: string;
+  /** Provider override for the spawned agent (`agent.create`). */
+  readonly provider?: string;
 }
 
 export interface AgencPromptOptions {
@@ -980,10 +993,26 @@ export class AgencClient {
     const {
       pluginStorageRoot: requestedPluginStorageRoot,
       dangerouslyBypassApprovalsAndSandbox = false,
+      bypassApprovals = false,
+      permissionMode: explicitPermissionMode,
+      model,
+      provider,
       initialPrompt,
       metadata,
       ...sessionParams
     } = params;
+    if (
+      bypassApprovals &&
+      explicitPermissionMode !== undefined &&
+      explicitPermissionMode !== "bypassPermissions"
+    ) {
+      throw new Error(
+        `AgencClient.createSession: bypassApprovals conflicts with permissionMode "${explicitPermissionMode}"; pass one of them`,
+      );
+    }
+    const permissionMode = bypassApprovals
+      ? ("bypassPermissions" as const)
+      : explicitPermissionMode;
     const pluginStorageRoot = normalizePluginStorageRoot(
       requestedPluginStorageRoot,
     );
@@ -1020,6 +1049,9 @@ export class AgencClient {
       cwd,
       initialContent: initialPrompt === undefined ? [] : initialPrompt,
       ...(metadata !== undefined ? { metadata } : {}),
+      ...(permissionMode !== undefined ? { permissionMode } : {}),
+      ...(model !== undefined && model.length > 0 ? { model } : {}),
+      ...(provider !== undefined && provider.length > 0 ? { provider } : {}),
       runtimeOptions: safeSdkRuntimeOptions(
         pluginStorageRoot,
         dangerouslyBypassApprovalsAndSandbox,

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -289,6 +289,10 @@ import {
   type StartupCliFlags,
 } from "./startup-selection.js";
 import {
+  resolveStartupSandboxBypass,
+  writeStartupSandboxBypassNotice,
+} from "./bypass-approvals.js";
+import {
   isProjectTrustedSync,
   trustProject,
 } from "../permissions/trust/project-trust.js";
@@ -436,6 +440,7 @@ export function formatCliHelpText(): string {
     "  --model <id|provider:id>                 Override model for this session",
     "  --permission-mode <mode>                 Override the startup permission mode",
     "  --autonomous                             Enable autonomous tick mode",
+    "  --bypass-approvals                       Skip approval prompts but keep the OS sandbox",
     "  --dangerously-bypass-approvals-and-sandbox",
     "                                           Bypass approvals and sandbox checks",
     "  --image <file|url|data-url>              Attach a startup image",
@@ -2063,10 +2068,15 @@ export async function oneShotCLI(
     const startupCliFlags =
       parsedStartupCliFlags ?? readStartupCliFlags(process.argv);
     const sessionEnv = process.env;
+    const sandboxBypass = resolveStartupSandboxBypass(startupCliFlags, {
+      cwd: process.cwd(),
+      env: sessionEnv,
+    });
+    writeStartupSandboxBypassNotice(sandboxBypass);
     const runtimeOptions = resolveAgentRuntimeOptions(sessionEnv, {
       simpleMode: startupCliFlags.simpleMode === true,
       dangerouslyBypassApprovalsAndSandbox:
-        startupCliFlags.dangerouslyBypassApprovalsAndSandbox === true,
+        sandboxBypass.dangerouslyBypassApprovalsAndSandbox,
     });
     validateAgencHome();
     throwIfAborted("validateAgencHome");
@@ -4558,10 +4568,15 @@ async function resumeColdDaemonSession(params: {
 }): Promise<AgentSummary> {
   const startupFlags = params.startupCliFlags;
   const sessionEnv = process.env;
+  const sandboxBypass = resolveStartupSandboxBypass(startupFlags, {
+    cwd: params.descriptor.cwd,
+    env: sessionEnv,
+  });
+  writeStartupSandboxBypassNotice(sandboxBypass);
   const runtimeOptions = resolveAgentRuntimeOptions(sessionEnv, {
     simpleMode: startupFlags.simpleMode === true,
     dangerouslyBypassApprovalsAndSandbox:
-      startupFlags.dangerouslyBypassApprovalsAndSandbox === true,
+      sandboxBypass.dangerouslyBypassApprovalsAndSandbox,
   });
   const startupLayers = startupConfigLayerOptions({
     cli: startupFlags,
@@ -4621,10 +4636,15 @@ export async function bootTUIEntry(
   const startupCliFlags =
     parsedStartupCliFlags ?? readStartupCliFlags(process.argv);
   const sessionEnv = process.env;
+  const sandboxBypass = resolveStartupSandboxBypass(startupCliFlags, {
+    cwd: process.cwd(),
+    env: sessionEnv,
+  });
+  writeStartupSandboxBypassNotice(sandboxBypass);
   const runtimeOptions = resolveAgentRuntimeOptions(sessionEnv, {
     simpleMode: startupCliFlags.simpleMode === true,
     dangerouslyBypassApprovalsAndSandbox:
-      startupCliFlags.dangerouslyBypassApprovalsAndSandbox === true,
+      sandboxBypass.dangerouslyBypassApprovalsAndSandbox,
   });
   return runWithAgentRuntimeOptions(runtimeOptions, async () => {
     setIsRemoteMode(runtimeOptions.remoteMode);

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -143,6 +143,10 @@ import {
   startupConfigLayerOptions,
   type StartupCliFlags,
 } from "./startup-selection.js";
+import {
+  resolveStartupSandboxBypass,
+  writeStartupSandboxBypassNotice,
+} from "./bypass-approvals.js";
 import { resolveProjectTrustStateSync } from "../permissions/trust/project-trust.js";
 import { findSuitableShell } from "../utils/Shell.js";
 import { subprocessEnv } from "../utils/subprocessEnv.js";
@@ -804,8 +808,14 @@ export async function bootstrapLocalRuntimeSession(
     options.runtimeOptions ??
     resolveAgentRuntimeOptions(env, {
       simpleMode: cli.simpleMode === true,
-      dangerouslyBypassApprovalsAndSandbox:
-        cli.dangerouslyBypassApprovalsAndSandbox === true,
+      dangerouslyBypassApprovalsAndSandbox: (() => {
+        const sandboxBypass = resolveStartupSandboxBypass(cli, {
+          cwd: process.cwd(),
+          env,
+        });
+        writeStartupSandboxBypassNotice(sandboxBypass);
+        return sandboxBypass.dangerouslyBypassApprovalsAndSandbox;
+      })(),
     });
   const commandShellPath = await findSuitableShell(parsedRuntimeOptions, env);
   options.signal?.throwIfAborted();

--- a/runtime/src/bin/bypass-approvals.ts
+++ b/runtime/src/bin/bypass-approvals.ts
@@ -1,0 +1,103 @@
+import { probeSandboxExecutionStatus } from "../sandbox/execution-broker.js";
+import type { SandboxExecutionStatus } from "../sandbox/execution-broker.js";
+import { BYPASS_APPROVALS_FLAG, DANGEROUS_BYPASS_FLAG } from "./startup-flags.js";
+import type { StartupCliFlags } from "./startup-selection.js";
+
+/**
+ * How `--bypass-approvals` resolves on this host.
+ *
+ * The flag skips approval prompts (permission mode `bypassPermissions`) and
+ * keeps the OS sandbox: Seatbelt on macOS, bubblewrap or Landlock on Linux.
+ * On a host that cannot sandbox at all (Windows, a Linux box without user
+ * namespaces or Landlock, a broken sandbox-exec) the configured
+ * `workspace-write` policy would fail closed on the first tool call, which is
+ * useless for an unattended run. The flag therefore degrades to full access
+ * there, once, with a stderr notice naming the reason. Callers that want "no
+ * sandbox anywhere" keep using `--dangerously-bypass-approvals-and-sandbox`.
+ */
+export interface StartupSandboxBypass {
+  /** Value for `AgentRuntimeOptions.dangerouslyBypassApprovalsAndSandbox`. */
+  readonly dangerouslyBypassApprovalsAndSandbox: boolean;
+  /** One operator-facing line to write to stderr, when the sandbox was dropped. */
+  readonly notice?: string;
+}
+
+export interface StartupSandboxBypassOptions {
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  /** Injectable probe for tests; defaults to the real platform probe. */
+  readonly probe?: (options: {
+    readonly cwd: string;
+    readonly env: NodeJS.ProcessEnv;
+    readonly platform: NodeJS.Platform;
+  }) => SandboxExecutionStatus;
+}
+
+function defaultProbe(options: {
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform: NodeJS.Platform;
+}): SandboxExecutionStatus {
+  // `workspace_write` is the most demanding configured mode; if the host can
+  // run it, it can run `read_only` too, and `danger-full-access` never probes.
+  return probeSandboxExecutionStatus({ mode: "workspace_write", ...options });
+}
+
+export function sandboxUnavailableNotice(status: SandboxExecutionStatus): string {
+  const reason = status.reason ?? "the platform sandbox is unavailable";
+  return (
+    `agenc: ${BYPASS_APPROVALS_FLAG}: the OS sandbox is unavailable on this host (${reason}); ` +
+    `tools run without kernel confinement for this session. ` +
+    `Run \`agenc doctor\` to repair the sandbox, or pass ${DANGEROUS_BYPASS_FLAG} to make the unsandboxed run explicit.`
+  );
+}
+
+/**
+ * Resolve the runtime sandbox flag for this startup from the parsed CLI flags.
+ *
+ * - `--dangerously-bypass-approvals-and-sandbox`: full access, no probe.
+ * - `--bypass-approvals`: probe the host; keep the sandbox when it is ready
+ *   (or not required), drop it with a notice when it is unavailable.
+ * - neither: the configured sandbox policy applies unchanged.
+ */
+export function resolveStartupSandboxBypass(
+  flags: Pick<StartupCliFlags, "bypassApprovals" | "dangerouslyBypassApprovalsAndSandbox">,
+  options: StartupSandboxBypassOptions,
+): StartupSandboxBypass {
+  if (flags.dangerouslyBypassApprovalsAndSandbox === true) {
+    return { dangerouslyBypassApprovalsAndSandbox: true };
+  }
+  if (flags.bypassApprovals !== true) {
+    return { dangerouslyBypassApprovalsAndSandbox: false };
+  }
+  const probe = options.probe ?? defaultProbe;
+  const status = probe({
+    cwd: options.cwd,
+    env: options.env,
+    platform: options.platform ?? process.platform,
+  });
+  if (status.kind === "unavailable") {
+    return {
+      dangerouslyBypassApprovalsAndSandbox: true,
+      notice: sandboxUnavailableNotice(status),
+    };
+  }
+  return { dangerouslyBypassApprovalsAndSandbox: false };
+}
+
+/** Write the notice, if any, exactly once per process. */
+let noticeWritten = false;
+export function writeStartupSandboxBypassNotice(
+  resolution: StartupSandboxBypass,
+  stderr: { write(chunk: string): unknown } = process.stderr,
+): void {
+  if (resolution.notice === undefined || noticeWritten) return;
+  noticeWritten = true;
+  stderr.write(`${resolution.notice}\n`);
+}
+
+/** Test-only reset for the once-per-process notice latch. */
+export function resetStartupSandboxBypassNoticeForTests(): void {
+  noticeWritten = false;
+}

--- a/runtime/src/bin/route.ts
+++ b/runtime/src/bin/route.ts
@@ -25,6 +25,7 @@ import {
 } from "./cli-option-region.js";
 import {
   AUTONOMOUS_FLAG,
+  BYPASS_APPROVALS_FLAG,
   DANGEROUS_BYPASS_FLAG,
   findRetiredStartupFlag,
   retiredStartupFlagError,
@@ -102,6 +103,7 @@ const STARTUP_BOOLEAN_FLAGS = Object.freeze([
   "--debug-to-stderr",
   "-d2e",
   AUTONOMOUS_FLAG,
+  BYPASS_APPROVALS_FLAG,
   DANGEROUS_BYPASS_FLAG,
 ] as const);
 

--- a/runtime/src/bin/startup-flags.ts
+++ b/runtime/src/bin/startup-flags.ts
@@ -5,6 +5,15 @@ export const DANGEROUS_BYPASS_FLAG =
 
 export const AUTONOMOUS_FLAG = "--autonomous" as const;
 
+/**
+ * Skip approval prompts but keep the OS sandbox. Equivalent to
+ * `--permission-mode bypassPermissions`; when the host cannot sandbox at all
+ * the CLI falls back to full access with a stderr notice (see
+ * `bin/bypass-approvals.ts`). `--dangerously-bypass-approvals-and-sandbox`
+ * stays the explicit "no sandbox anywhere" opt-out.
+ */
+export const BYPASS_APPROVALS_FLAG = "--bypass-approvals" as const;
+
 const RETIRED_STARTUP_FLAG_REPLACEMENTS = Object.freeze({
   "--yolo": DANGEROUS_BYPASS_FLAG,
   "--allow-dangerously-skip-permissions": DANGEROUS_BYPASS_FLAG,

--- a/runtime/src/bin/startup-selection.ts
+++ b/runtime/src/bin/startup-selection.ts
@@ -17,6 +17,7 @@ import { extractFlagValue, extractFlagValues } from "./route.js";
 import {
   assertNoRetiredStartupFlags,
   AUTONOMOUS_FLAG,
+  BYPASS_APPROVALS_FLAG,
   DANGEROUS_BYPASS_FLAG,
 } from "./startup-flags.js";
 import {
@@ -35,6 +36,12 @@ export interface StartupCliFlags {
   readonly addDirs?: readonly string[];
   readonly permissionMode?: PermissionMode;
   readonly dangerouslyBypassApprovalsAndSandbox?: boolean;
+  /**
+   * `--bypass-approvals`: approvals off, sandbox kept. Also sets
+   * `permissionMode` to `bypassPermissions` so every consumer of the startup
+   * mode sees the same thing `--permission-mode bypassPermissions` would give.
+   */
+  readonly bypassApprovals?: boolean;
   readonly autonomousMode?: boolean;
   readonly simpleMode?: boolean;
 }
@@ -67,9 +74,26 @@ export function readStartupCliFlags(
   // DEFAULT mode — a silent failure toward a LESS restrictive session). Throw
   // a helpful error mirroring provider validation and `/permissions mode`,
   // surfacing as a clean error + non-zero exit at the CLI entrypoint.
-  const permissionMode = resolvePermissionModeOrThrow(rawPermissionMode);
+  const explicitPermissionMode = resolvePermissionModeOrThrow(rawPermissionMode);
   const dangerouslyBypassApprovalsAndSandbox =
     optionArgs.includes(DANGEROUS_BYPASS_FLAG);
+  const bypassApprovals = optionArgs.includes(BYPASS_APPROVALS_FLAG);
+  // `--bypass-approvals` is the approvals-only half of the dangerous flag. It
+  // resolves to the bypassPermissions mode; a different explicit
+  // `--permission-mode` alongside it is a contradiction, not a tie to break
+  // silently toward a less restrictive session.
+  if (
+    bypassApprovals &&
+    explicitPermissionMode !== undefined &&
+    explicitPermissionMode !== "bypassPermissions"
+  ) {
+    throw new Error(
+      `${BYPASS_APPROVALS_FLAG} conflicts with --permission-mode ${explicitPermissionMode}. Pass one of them.`,
+    );
+  }
+  const permissionMode = bypassApprovals
+    ? ("bypassPermissions" as const)
+    : explicitPermissionMode;
   const autonomousMode = optionArgs.includes(AUTONOMOUS_FLAG);
   const simpleMode = optionArgs.includes("--bare");
   return Object.freeze({
@@ -82,6 +106,7 @@ export function readStartupCliFlags(
     ...(dangerouslyBypassApprovalsAndSandbox
       ? { dangerouslyBypassApprovalsAndSandbox: true }
       : {}),
+    ...(bypassApprovals ? { bypassApprovals: true } : {}),
     ...(autonomousMode ? { autonomousMode: true } : {}),
     ...(simpleMode ? { simpleMode: true } : {}),
   });

--- a/runtime/tests/bin/bypass-approvals.test.ts
+++ b/runtime/tests/bin/bypass-approvals.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  resetStartupSandboxBypassNoticeForTests,
+  resolveStartupSandboxBypass,
+  sandboxUnavailableNotice,
+  writeStartupSandboxBypassNotice,
+} from "../../src/bin/bypass-approvals.js";
+import { classifyCLI, stripRoutingFlags } from "../../src/bin/route.js";
+import type { SandboxExecutionStatus } from "../../src/sandbox/execution-broker.js";
+
+const executable = ["/usr/bin/node", "/opt/agenc/agenc.js"];
+
+function status(
+  kind: SandboxExecutionStatus["kind"],
+  reason?: string,
+): SandboxExecutionStatus {
+  return {
+    kind,
+    mode: "workspace_write",
+    platform: "darwin",
+    ...(reason !== undefined ? { reason } : {}),
+  };
+}
+
+describe("--bypass-approvals routing", () => {
+  it("is a startup flag, not prompt text, in print mode", () => {
+    expect(
+      classifyCLI({
+        argv: [...executable, "--bypass-approvals", "-p", "explain the repo"],
+        isTTY: false,
+        isStdoutTTY: false,
+      }),
+    ).toMatchObject({ kind: "oneShotCLI", userMessage: "explain the repo" });
+    expect(
+      stripRoutingFlags(["--bypass-approvals", "-p", "explain the repo"]),
+    ).toEqual(["explain the repo"]);
+  });
+
+  it("boots the TUI when no prompt is given", () => {
+    expect(
+      classifyCLI({
+        argv: [...executable, "--bypass-approvals"],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toMatchObject({ kind: "bootTUI" });
+  });
+});
+
+describe("resolveStartupSandboxBypass", () => {
+  afterEach(() => {
+    resetStartupSandboxBypassNoticeForTests();
+  });
+
+  it("keeps the configured sandbox when neither bypass flag is set", () => {
+    const probe = vi.fn(() => status("ready"));
+    expect(
+      resolveStartupSandboxBypass({}, { cwd: "/tmp", env: {}, probe }),
+    ).toEqual({ dangerouslyBypassApprovalsAndSandbox: false });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("drops the sandbox without probing for the dangerous flag", () => {
+    const probe = vi.fn(() => status("ready"));
+    expect(
+      resolveStartupSandboxBypass(
+        { dangerouslyBypassApprovalsAndSandbox: true, bypassApprovals: true },
+        { cwd: "/tmp", env: {}, probe },
+      ),
+    ).toEqual({ dangerouslyBypassApprovalsAndSandbox: true });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it.each(["ready", "not_required", "external"] as const)(
+    "keeps the sandbox for --bypass-approvals when the host reports %s",
+    (kind) => {
+      const probe = vi.fn(() => status(kind));
+      const resolution = resolveStartupSandboxBypass(
+        { bypassApprovals: true },
+        { cwd: "/repo", env: { PATH: "/usr/bin" }, platform: "linux", probe },
+      );
+      expect(resolution).toEqual({ dangerouslyBypassApprovalsAndSandbox: false });
+      expect(probe).toHaveBeenCalledWith({
+        cwd: "/repo",
+        env: { PATH: "/usr/bin" },
+        platform: "linux",
+      });
+    },
+  );
+
+  it("falls back to full access with a notice when the host cannot sandbox", () => {
+    const unavailable = status(
+      "unavailable",
+      "Windows restricted-token sandbox is not implemented",
+    );
+    const resolution = resolveStartupSandboxBypass(
+      { bypassApprovals: true },
+      { cwd: "/repo", env: {}, platform: "win32", probe: () => unavailable },
+    );
+    expect(resolution.dangerouslyBypassApprovalsAndSandbox).toBe(true);
+    expect(resolution.notice).toBe(sandboxUnavailableNotice(unavailable));
+    expect(resolution.notice).toContain("--bypass-approvals");
+    expect(resolution.notice).toContain(
+      "Windows restricted-token sandbox is not implemented",
+    );
+    expect(resolution.notice).toContain("--dangerously-bypass-approvals-and-sandbox");
+    expect(resolution.notice).not.toContain("\u2014");
+  });
+
+  it("writes the notice once per process and nothing when there is none", () => {
+    const writes: string[] = [];
+    const stderr = { write: (chunk: string) => writes.push(chunk) };
+    writeStartupSandboxBypassNotice(
+      { dangerouslyBypassApprovalsAndSandbox: false },
+      stderr,
+    );
+    expect(writes).toEqual([]);
+    const resolution = {
+      dangerouslyBypassApprovalsAndSandbox: true,
+      notice: "agenc: --bypass-approvals: the OS sandbox is unavailable on this host (x)",
+    };
+    writeStartupSandboxBypassNotice(resolution, stderr);
+    writeStartupSandboxBypassNotice(resolution, stderr);
+    expect(writes).toEqual([`${resolution.notice}\n`]);
+  });
+});

--- a/runtime/tests/bin/startup-selection.test.ts
+++ b/runtime/tests/bin/startup-selection.test.ts
@@ -132,6 +132,65 @@ describe("readStartupCliFlags --permission-mode validation", () => {
     expect(flags.permissionMode).toBe("plan");
   });
 
+  it("maps --bypass-approvals to the bypassPermissions mode with the sandbox kept", () => {
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "--bypass-approvals",
+      "-p",
+      "explain",
+    ]);
+    expect(flags.permissionMode).toBe("bypassPermissions");
+    expect(flags.bypassApprovals).toBe(true);
+    // Only the dangerous flag drops the sandbox.
+    expect(flags).not.toHaveProperty("dangerouslyBypassApprovalsAndSandbox");
+  });
+
+  it("accepts --bypass-approvals alongside --permission-mode bypassPermissions", () => {
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "--bypass-approvals",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+    expect(flags.permissionMode).toBe("bypassPermissions");
+    expect(flags.bypassApprovals).toBe(true);
+  });
+
+  it("rejects --bypass-approvals combined with a different --permission-mode", () => {
+    expect(() =>
+      readStartupCliFlags([
+        "node",
+        "agenc",
+        "--bypass-approvals",
+        "--permission-mode",
+        "plan",
+      ]),
+    ).toThrow(/--bypass-approvals conflicts with --permission-mode plan/u);
+  });
+
+  it("keeps both bypass flags when the dangerous one is also present", () => {
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "--bypass-approvals",
+      "--dangerously-bypass-approvals-and-sandbox",
+    ]);
+    expect(flags.permissionMode).toBe("bypassPermissions");
+    expect(flags.bypassApprovals).toBe(true);
+    expect(flags.dangerouslyBypassApprovalsAndSandbox).toBe(true);
+  });
+
+  it("parses --bypass-approvals only in the startup option region", () => {
+    expect(
+      readStartupCliFlags(["node", "agenc", "explain", "--bypass-approvals"]),
+    ).not.toHaveProperty("bypassApprovals");
+    expect(
+      readStartupCliFlags(["node", "agenc", "--", "--bypass-approvals"]),
+    ).not.toHaveProperty("bypassApprovals");
+  });
+
   it("defaults (undefined) when --permission-mode is absent", () => {
     const flags = readStartupCliFlags(["node", "agenc"]);
     expect(flags.permissionMode).toBeUndefined();

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -475,6 +475,45 @@ describe("agenc-sdk client over the in-process transport", () => {
     await daemon.close();
   });
 
+  it("createSession bypassApprovals keeps the sandbox and forwards permissionMode, model and provider", async () => {
+    const cwd = await workspaces.create();
+    const daemon = await createFakeDaemon({});
+    try {
+      await daemon.client.initialize();
+      const session = await daemon.client.createSession({
+        cwd,
+        pluginStorageRoot: daemon.pluginStorageRoot,
+        bypassApprovals: true,
+        model: "grok-4.6",
+        provider: "grok",
+      });
+      expect(session.sessionId).toBe("session_1");
+      const created = daemon.calls.created.at(-1);
+      expect(created).toMatchObject({
+        permissionMode: "bypassPermissions",
+        model: "grok-4.6",
+        provider: "grok",
+      });
+      // Approvals off, sandbox on: only the dangerous option drops the sandbox.
+      expect(created?.runtimeOptions).toMatchObject({
+        dangerouslyBypassApprovalsAndSandbox: false,
+      });
+
+      await expect(
+        daemon.client.createSession({
+          cwd,
+          pluginStorageRoot: daemon.pluginStorageRoot,
+          bypassApprovals: true,
+          permissionMode: "plan",
+        }),
+      ).rejects.toThrow(/bypassApprovals conflicts with permissionMode "plan"/u);
+      // The conflict is refused before anything reaches the daemon.
+      expect(daemon.calls.created).toHaveLength(1);
+    } finally {
+      await daemon.close();
+    }
+  });
+
   it("routes a permission request through the callback and back over tool.approve", async () => {
     const seen: AgencPermissionRequest[] = [];
     const daemon = await createFakeDaemon({


### PR DESCRIPTION
## Why

The only headless way to skip approval prompts was `--dangerously-bypass-approvals-and-sandbox`, which also drops the OS sandbox (`danger-full-access`). `--permission-mode bypassPermissions` already means "approvals off, sandbox kept", but it is not discoverable as the unattended-run flag, and on a host that cannot sandbox at all (Windows, a Linux box without user namespaces and Landlock, a broken sandbox-exec) it fails closed on the first tool call, which is useless for an unattended run. For autonomous and benchmark runs the right default is approvals off with the sandbox kept wherever the platform has one.

## What

- `runtime/src/bin/startup-flags.ts`: `BYPASS_APPROVALS_FLAG = "--bypass-approvals"` with its contract in the doc comment.
- `runtime/src/bin/startup-selection.ts`: parses the flag into `bypassApprovals: true` and `permissionMode: "bypassPermissions"`, so every existing consumer of the startup mode (trust prompt, `startupPermissionMode`, bootstrap permission init, daemon `agent.create`) behaves as with `--permission-mode bypassPermissions`. A different explicit `--permission-mode` alongside it throws instead of silently picking one.
- `runtime/src/bin/route.ts`: the flag is a startup boolean flag, so it is stripped from the prompt region and never becomes prompt text.
- `runtime/src/bin/bypass-approvals.ts` (new): `resolveStartupSandboxBypass` decides the runtime `dangerouslyBypassApprovalsAndSandbox` value: dangerous flag means full access with no probe; `--bypass-approvals` probes the host with `probeSandboxExecutionStatus({ mode: "workspace_write" })` and keeps the sandbox on `ready`, `not_required` or `external`, falls back to full access on `unavailable` with a notice; neither flag leaves the configured policy alone. `writeStartupSandboxBypassNotice` prints the notice once per process.
- `runtime/src/bin/agenc-main.ts`: the one-shot, TUI boot and cold-resume startup paths resolve their runtime options through the helper; help text lists the flag.
- `runtime/src/bin/bootstrap.ts`: the CLI-driven bootstrap path does the same.
- `packages/agenc-sdk/src/client.ts`: `AgencCreateSessionParams` gains `bypassApprovals`, `permissionMode`, `model`, `provider`. `bypassApprovals` sends `permissionMode: "bypassPermissions"` with `dangerouslyBypassApprovalsAndSandbox: false`; a conflicting explicit `permissionMode` throws before anything reaches the daemon. `permissionMode`, `model` and `provider` are now forwarded to `agent.create` instead of being dropped (the desktop worked around that drop by calling `agent.create` directly).
- `docs/reference/cli.md`, `docs/reference/tools-permissions-sandbox.md`: the flag, the fallback rule and the SDK mirror are documented.
- `runtime/tests/bin/startup-selection.test.ts`: flag parsing, mode mapping, conflict, coexistence with the dangerous flag, option-region boundary.
- `runtime/tests/bin/bypass-approvals.test.ts` (new): routing (`--bypass-approvals -p "…"` stays a one-shot with the prompt intact, TUI boot without a prompt), resolver decisions for every probe outcome with an injected probe, notice text, once-per-process notice.
- `runtime/tests/sdk-package/client-inprocess.contract.test.ts`: `createSession({ bypassApprovals: true, model, provider })` reaches the fake daemon as `permissionMode: "bypassPermissions"` plus the forwarded selection with the sandbox kept; the conflict is refused client-side.

## Evidence

- `bypassPermissions` is an approval mode and does not by itself remove kernel confinement (`docs/reference/tools-permissions-sandbox.md`, "Permission modes"); only `runtimeOptions.dangerouslyBypassApprovalsAndSandbox` selects `danger_full_access` (`app-server-client/index.ts` sandbox policy projection, `SandboxExecutionBroker` mode). The new flag therefore changes nothing in the daemon or the sandbox engine; it only chooses the existing mode and, when the probe says the host has no sandbox, the existing full-access option.
- `probeSandboxExecutionStatus` is the same probe `agenc doctor` runs; on macOS it checks `/usr/bin/sandbox-exec` with a restricted-process smoke test, on Linux bubblewrap then Landlock, and reports `unavailable` on Windows.
- The desktop today maps its bypass setting to the dangerous option (`src/main/daemon.ts`: `dangerouslyBypassApprovalsAndSandbox: options.permissionMode === "bypassPermissions"`), so a desktop bypass session runs with no sandbox even on macOS where Seatbelt works.

## Tests

From `runtime/` with `TMPDIR=/private/tmp/tt/vt`:

- `npm run typecheck`: exit 0.
- `npm run typecheck` in `packages/agenc-sdk`: exit 0 (generated types verified).
- `npx vitest run tests/bin/startup-selection.test.ts tests/bin/bypass-approvals.test.ts tests/bin/unknown-startup-options.test.ts tests/sdk-package/client-inprocess.contract.test.ts`: 4 files, 54 tests passed.

## Not changed

- `--dangerously-bypass-approvals-and-sandbox` keeps its meaning (approvals off, no sandbox on every host) and stays the explicit opt-out.
- `--permission-mode bypassPermissions` is unchanged; the new flag is its discoverable spelling plus the unavailable-host fallback.
- The fail-closed sandbox invariant is unchanged for every other startup: only a session that asked for `--bypass-approvals` degrades, and it says so on stderr.
- No protocol or generated SDK type changes; `permissionMode`, `model` and `provider` already existed on `AgentCreateParams`.

## Counterpart PRs

Desktop (tetsuo-ai/agenc-desktop), to be opened: in `src/main/daemon.ts` the bypass setting should send `permissionMode: "bypassPermissions"` with `dangerouslyBypassApprovalsAndSandbox: false` and only set the dangerous option when the daemon reports the sandbox unavailable (or through a separate explicit "disable sandbox" setting); `src/renderer/src/settings.ts` keeps the mode list. Until then desktop bypass sessions keep running without a sandbox.
