### PR TITLE
openrouter: request-level zero data retention via [providers.openrouter] zero_data_retention

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -583,6 +583,7 @@ optional `headers`), `github` (`repo`, optional `ref`, `path`, `sparsePaths`),
 | `providers.<provider>.web_search`, `providers.<provider>.x_search`, `providers.<provider>.code_execution` | Grok-only native web, X, and code capabilities; rejected on every other provider. |
 | `providers.<provider>.enable_image_search`, `providers.<provider>.enable_image_understanding`, `providers.<provider>.enable_video_understanding` | Grok-only native media capabilities; rejected on every other provider. |
 | `providers.<provider>.incremental_continuation` | Grok-only boolean opt-in (`AGENC_XAI_INCREMENTAL`) for Responses `previous_response_id` continuation on streaming turns; default off. |
+| `providers.<provider>.zero_data_retention` | OpenRouter-only boolean. Every request carries `provider.zdr = true`, so OpenRouter routes only to endpoints with a zero-data-retention policy and refuses a model that has none instead of serving it elsewhere. Rejected under every other provider table: those providers control retention per account, project or team on their own console (see [providers.md](providers.md#zero-data-retention)). |
 | `providers.<provider>.collections` | Grok-only native collection-search block. |
 | `providers.<provider>.collections.enabled`, `providers.<provider>.collections.max_num_results`, `providers.<provider>.collections.vector_store_ids` | Collection enablement, positive result cap, and vector-store ID list. |
 | `providers.<provider>.remote_mcp` | Grok-only server-side MCP block. |

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -776,6 +776,38 @@ single "Fast" dial. What it does depends on the provider:
 `flex` is OpenAI's lower-priority tier and is only sent to providers that
 document `service_tier`.
 
+## Zero data retention
+
+Only one built-in provider takes a request-level zero-data-retention control:
+`[providers.openrouter] zero_data_retention = true` adds `provider.zdr = true`
+to every request (OR-ed with the account setting on OpenRouter's side), so
+routing is restricted to endpoints with a zero-data-retention policy and a
+model without one is refused. The desktop shows this as a switch on the
+OpenRouter card. Everywhere else retention is an account, project or team
+setting, so the config field is rejected and the desktop card states the
+provider's policy instead. Verified 2026-09-12 against each provider's
+documentation:
+
+| Provider | Default retention | Zero data retention | AgenC |
+| --- | --- | --- | --- |
+| OpenRouter | Depends on the upstream endpoint | Per request (`provider.zdr`) and per account (privacy settings) | `zero_data_retention` switch |
+| OpenAI | 30 days for abuse monitoring; Responses state 30 days when `store` is true | Per organization or project, on request and approval; `store` is then forced false | Requests already send `store: false`; ZDR itself is granted by OpenAI |
+| Anthropic | Per the commercial retention policy | Organization-level agreement | Account level |
+| xAI Grok | 30 days encrypted, no training | Team-level in the xAI Console (enterprise); every response carries `x-zero-data-retention: true/false` and ZDR disables the stateful Responses, Files, Collections and Batch APIs | Account level |
+| Google Gemini | Prompts logged for abuse monitoring (paid: 55 days) | Per project, on request | Account level |
+| Groq | No retention of inputs and outputs by default; temporary logs up to 30 days for troubleshooting or abuse | Self-serve in the console Data Controls, globally or per feature | Account level |
+| Mistral | 30-day abuse monitoring window | Organization setting on paid plans, after approval; stateless endpoints only | Account level |
+| Cerebras | Does not retain prompts, requests or responses | Standard policy, nothing to enable | Always on |
+| Ollama Cloud | "Prompt or response data is never logged or trained on"; partners must run zero-data-retention policies | Standard policy, nothing to enable | Always on |
+| DeepSeek | Retained on servers in China while the account exists | None offered | Not available |
+| MiniMax | Purpose- and law-based retention | None documented | Not available |
+| AgenC managed | Requests are routed through the gateway to zero-data-retention endpoints only (`zdr: true`, `data_collection: "deny"`) | Built in | Always on |
+| Local servers (Ollama, LM Studio, OpenAI-compatible) | Nothing leaves the machine unless the endpoint is remote | Not applicable | Local |
+
+Kimi, Qwen, Z.AI, Meta, NVIDIA NIM and GitHub Copilot publish no
+zero-data-retention control for their APIs; treat them as retaining data per
+their terms.
+
 ## Ollama Cloud
 
 Select `ollama-cloud` and provide `OLLAMA_API_KEY` for direct hosted inference at

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -612,6 +612,15 @@ export interface ProviderFallbackConfig {
 export interface ProviderConfig {
   readonly base_url?: string;
   readonly default_model?: string;
+  /**
+   * Request-level zero data retention. Accepted only under
+   * `providers.openrouter`: every request carries `provider.zdr = true`, so
+   * OpenRouter routes only to endpoints with a zero-data-retention policy
+   * and a model without one is refused instead of silently falling back.
+   * Other providers control retention per account, project or team on their
+   * own console and reject this field (see docs/reference/providers.md).
+   */
+  readonly zero_data_retention?: boolean;
   readonly context_window_tokens?: number;
   readonly max_output_tokens?: number;
   /**
@@ -1573,6 +1582,12 @@ const PROVIDER_KEYS: ReadonlySet<string> = new Set([
   "collections",
   "remote_mcp",
   "incremental_continuation",
+  "zero_data_retention",
+]);
+
+/** Providers whose API takes a per-request zero-data-retention control. */
+const REQUEST_LEVEL_ZERO_DATA_RETENTION_PROVIDERS: ReadonlySet<string> = new Set([
+  "openrouter",
 ]);
 
 const GROK_CAPABILITY_BOOLEAN_KEYS = Object.freeze([
@@ -1967,6 +1982,20 @@ function validateSingleProviderConfig(
   );
   if (fallback !== undefined) out.fallback = fallback;
   Object.assign(out, validateGrokCapabilities(record, providerId));
+  const zeroDataRetention = optionalBoolean(
+    record.zero_data_retention,
+    fieldPath(providerId, "zero_data_retention"),
+    (field, detail) => new InvalidProviderConfigError(field, detail),
+  );
+  if (zeroDataRetention !== undefined) {
+    if (!REQUEST_LEVEL_ZERO_DATA_RETENTION_PROVIDERS.has(providerId)) {
+      throw new InvalidProviderConfigError(
+        fieldPath(providerId, "zero_data_retention"),
+        "request-level zero data retention is supported only under providers.openrouter; this provider controls retention at the account, project or team level",
+      );
+    }
+    out.zero_data_retention = zeroDataRetention;
+  }
   return Object.freeze(out as ProviderConfig);
 }
 

--- a/runtime/src/llm/provider-request.ts
+++ b/runtime/src/llm/provider-request.ts
@@ -230,6 +230,10 @@ export function resolveProviderRuntimeRequest(params: {
     params.config.providers?.grok?.incremental_continuation === true
       ? { incrementalContinuation: true }
       : {}),
+    ...(params.provider === "openrouter" &&
+    params.config.providers?.openrouter?.zero_data_retention === true
+      ? { zeroDataRetention: true }
+      : {}),
   };
   return Object.freeze({
     settings,

--- a/runtime/src/llm/provider.ts
+++ b/runtime/src/llm/provider.ts
@@ -146,6 +146,8 @@ export type ProviderRuntimeExtra = Partial<
   readonly gemini?: GeminiRuntimeOptions;
   /** Grok-only opt-in for streaming previous_response_id continuation. */
   readonly incrementalContinuation?: boolean;
+  /** OpenRouter: route only to zero-data-retention endpoints (`provider.zdr`). */
+  readonly zeroDataRetention?: boolean;
   readonly grokAcp?: {
     readonly binaryPath?: string;
     readonly allowPermissions?: boolean;
@@ -1167,6 +1169,9 @@ function readRuntimeExtra(
     ...(readBoolean(extra, "incrementalContinuation") !== undefined
       ? { incrementalContinuation: readBoolean(extra, "incrementalContinuation") }
       : {}),
+    ...(readBoolean(extra, "zeroDataRetention") !== undefined
+      ? { zeroDataRetention: readBoolean(extra, "zeroDataRetention") }
+      : {}),
     ...(readString(extra, "visionModel") !== undefined
       ? { visionModel: readString(extra, "visionModel") }
       : {}),
@@ -1387,6 +1392,9 @@ function buildOpenAICompatibleProvider(
     ...(extra.store !== undefined ? { store: extra.store } : {}),
     ...(extra.contextWindowTokens !== undefined
       ? { contextWindowTokens: extra.contextWindowTokens }
+      : {}),
+    ...(extra.zeroDataRetention !== undefined
+      ? { zeroDataRetention: extra.zeroDataRetention }
       : {}),
     ...(extra.authMode ? { authMode: extra.authMode } : {}),
     ...(oauthConfig ? { oauth: oauthConfig } : {}),

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -1036,6 +1036,9 @@ export class OpenAIProvider implements LLMProvider {
       maxTokenField: this.resolveChatCompletionsMaxTokenField(),
       providerCapabilityHints,
     });
+    for (const [key, value] of Object.entries(this.config.extraBody ?? {})) {
+      request[key] = value;
+    }
     let metadata = collectChatCompletionsRequestMetadata(request);
     const accountedInputTokens = normalizePositiveInteger(
       args.options?.accountedInputTokens,

--- a/runtime/src/llm/providers/openai/types.ts
+++ b/runtime/src/llm/providers/openai/types.ts
@@ -37,4 +37,16 @@ export interface OpenAIProviderConfig extends LLMProviderConfig {
   readonly basePath?: string;
   /** Internal managed transport marker; direct provider credentials omit it. */
   readonly managedRequestId?: boolean;
+  /**
+   * Zero data retention as a request-level routing preference. Only
+   * subclasses whose API has such a control act on it (OpenRouter sends
+   * `provider.zdr = true`); the base adapter ignores it.
+   */
+  readonly zeroDataRetention?: boolean;
+  /**
+   * Fields merged verbatim into every chat-completions request body after
+   * shaping, for provider-specific routing preferences the shared wire
+   * layer does not model. Never carries user-controlled input.
+   */
+  readonly extraBody?: Readonly<Record<string, unknown>>;
 }

--- a/runtime/src/llm/providers/openrouter/index.ts
+++ b/runtime/src/llm/providers/openrouter/index.ts
@@ -16,13 +16,36 @@ function buildOpenRouterHeaders(
   };
 }
 
+/**
+ * Request-level zero data retention: `provider.zdr = true` restricts routing
+ * to endpoints with a zero-data-retention policy (OR-ed with the account
+ * setting on OpenRouter's side). A model with no such endpoint is refused by
+ * OpenRouter rather than silently served elsewhere.
+ * https://openrouter.ai/docs/features/provider-routing
+ */
+export function openRouterExtraBody(
+  config: Pick<OpenRouterProviderConfig, "zeroDataRetention" | "extraBody">,
+): Readonly<Record<string, unknown>> | undefined {
+  if (config.zeroDataRetention !== true) return config.extraBody;
+  const existingProvider = config.extraBody?.provider;
+  const provider =
+    existingProvider !== null &&
+    typeof existingProvider === "object" &&
+    !Array.isArray(existingProvider)
+      ? { ...(existingProvider as Record<string, unknown>), zdr: true }
+      : { zdr: true };
+  return { ...(config.extraBody ?? {}), provider };
+}
+
 export class OpenRouterProvider extends OpenAIProvider {
   constructor(config: OpenRouterProviderConfig) {
+    const extraBody = openRouterExtraBody(config);
     super({
       ...config,
       providerName: "openrouter",
       useResponsesApi: false,
       defaultHeaders: buildOpenRouterHeaders(config.defaultHeaders),
+      ...(extraBody !== undefined ? { extraBody } : {}),
     });
   }
 }

--- a/runtime/tests/config/config.test.ts
+++ b/runtime/tests/config/config.test.ts
@@ -883,6 +883,25 @@ describe("schema: closed config block validators (CF-13)", () => {
     expect(Object.isFrozen(out?.grok?.fallback?.statuses)).toBe(true);
   });
 
+  test("validateProviderConfig accepts zero_data_retention only where the API takes it per request", () => {
+    expect(validateProviderConfig({ openrouter: { zero_data_retention: true } })).toEqual({
+      openrouter: { zero_data_retention: true },
+    });
+    expect(validateProviderConfig({ openrouter: { zero_data_retention: false } })).toEqual({
+      openrouter: { zero_data_retention: false },
+    });
+    expect(() =>
+      validateProviderConfig({ openrouter: { zero_data_retention: "yes" } }),
+    ).toThrow(InvalidProviderConfigError);
+    // Every other provider controls retention on its own console; the field
+    // must not pretend otherwise.
+    for (const provider of ["openai", "anthropic", "grok", "deepseek", "groq"]) {
+      expect(() =>
+        validateProviderConfig({ [provider]: { zero_data_retention: true } }),
+      ).toThrow(/supported only under providers\.openrouter/u);
+    }
+  });
+
   test("validateProviderConfig rejects unknown nested provider fields", () => {
     expect(() =>
       validateProviderConfig({

--- a/runtime/tests/llm/provider-request.test.ts
+++ b/runtime/tests/llm/provider-request.test.ts
@@ -8,6 +8,32 @@ import { createProvider } from '../../src/llm/provider.ts'
 import { bindingFromProvider } from '../../src/session/provider-service.ts'
 
 describe('provider runtime request', () => {
+  test('forwards OpenRouter zero data retention as a runtime extra and nowhere else', () => {
+    const openrouter = resolveProviderRuntimeRequest({
+      provider: 'openrouter',
+      model: 'x-ai/grok-4.5',
+      config: { providers: { openrouter: { zero_data_retention: true } } },
+      environment: {},
+    })
+    expect(openrouter.requested.extra).toMatchObject({ zeroDataRetention: true })
+
+    const off = resolveProviderRuntimeRequest({
+      provider: 'openrouter',
+      model: 'x-ai/grok-4.5',
+      config: { providers: { openrouter: { zero_data_retention: false } } },
+      environment: {},
+    })
+    expect(off.requested.extra?.zeroDataRetention).toBeUndefined()
+
+    const openai = resolveProviderRuntimeRequest({
+      provider: 'openai',
+      model: 'gpt-5',
+      config: { providers: { openrouter: { zero_data_retention: true } } },
+      environment: {},
+    })
+    expect(openai.requested.extra?.zeroDataRetention).toBeUndefined()
+  })
+
   test('prepares compatibility transport inputs at provider ingress', () => {
     const result = resolveProviderRuntimeRequest({
       provider: 'openai-compatible',

--- a/runtime/tests/llm/providers/openrouter/provider.test.ts
+++ b/runtime/tests/llm/providers/openrouter/provider.test.ts
@@ -4,6 +4,7 @@ import {
   OPENROUTER_DEFAULT_REFERER,
   OPENROUTER_DEFAULT_TITLE,
   OpenRouterProvider,
+  openRouterExtraBody,
 } from "./index.js";
 import {
   BUILT_IN_PROVIDER_BASE_URLS,
@@ -61,6 +62,42 @@ describe("OpenRouterProvider", () => {
     const requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
     expect(requestBody.model).toBe(model);
     expect(requestBody.stream).toBe(false);
+  });
+
+  test("routes only to zero-data-retention endpoints when configured, and sends no routing block otherwise", async () => {
+    const reply = () =>
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl_zdr",
+          model: BUILT_IN_PROVIDER_DEFAULT_MODELS.openrouter,
+          choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 4, completion_tokens: 1, total_tokens: 5 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => reply());
+    const model = BUILT_IN_PROVIDER_DEFAULT_MODELS.openrouter;
+
+    await new OpenRouterProvider({ apiKey: "or-test", model, fetchImpl, zeroDataRetention: true })
+      .chat([{ role: "user", content: "hello" }]);
+    await new OpenRouterProvider({ apiKey: "or-test", model, fetchImpl })
+      .chat([{ role: "user", content: "hello" }]);
+    await new OpenRouterProvider({
+      apiKey: "or-test",
+      model,
+      fetchImpl,
+      zeroDataRetention: true,
+      extraBody: { provider: { data_collection: "deny" } },
+    }).chat([{ role: "user", content: "hello" }]);
+
+    const bodies = fetchImpl.mock.calls.map(([, init]) =>
+      JSON.parse(String(init?.body)) as Record<string, unknown>,
+    );
+    expect(bodies[0]?.provider).toEqual({ zdr: true });
+    expect(bodies[1]).not.toHaveProperty("provider");
+    // An existing routing block keeps its other preferences.
+    expect(bodies[2]?.provider).toEqual({ data_collection: "deny", zdr: true });
+    expect(openRouterExtraBody({})).toBeUndefined();
   });
 
   test.each(


### PR DESCRIPTION
## Why

The desktop provider cards are getting a zero-data-retention control, and the honest version of that control depends on what each provider's API offers. Checked against each provider's documentation on 2026-09-12: only OpenRouter takes zero data retention per request (`provider.zdr = true`, OR-ed with the account setting; routing is restricted to endpoints with a zero-data-retention policy and a model without one is refused). OpenAI, Anthropic, xAI, Gemini, Groq and Mistral grant it per organization, project or team on their own console; Cerebras, Ollama Cloud and the AgenC managed route are always zero-retention; DeepSeek and MiniMax offer nothing. So there is exactly one config field that can be a switch, and it has to be OpenRouter-only.

## What

- `runtime/src/config/schema.ts`: `ProviderConfig.zero_data_retention?: boolean`, listed in `PROVIDER_KEYS`, validated as a boolean and accepted only under `providers.openrouter`; any other provider table rejects it with "request-level zero data retention is supported only under providers.openrouter; this provider controls retention at the account, project or team level".
- `runtime/src/llm/provider-request.ts`: the field becomes the `zeroDataRetention` runtime extra for `openrouter` only.
- `runtime/src/llm/provider.ts`: `ProviderRuntimeExtra.zeroDataRetention`, parsed by `readRuntimeExtra` and carried into the OpenAI-compatible provider config.
- `runtime/src/llm/providers/openai/types.ts`: `zeroDataRetention` and `extraBody` on `OpenAIProviderConfig`. `runtime/src/llm/providers/openai/adapter.ts`: `extraBody` is merged into every chat-completions body after shaping (Responses requests are untouched; OpenRouter uses chat completions only).
- `runtime/src/llm/providers/openrouter/index.ts`: `openRouterExtraBody` turns `zeroDataRetention` into `extraBody.provider.zdr = true`, preserving other routing preferences in an existing `provider` block; the constructor passes it through.
- `docs/reference/config.md`: the `providers.<provider>.zero_data_retention` row. `docs/reference/providers.md`: new "Zero data retention" section with the per-provider table (default retention, how ZDR is obtained, what AgenC does).
- Tests: `tests/config/config.test.ts` (accepted true/false for openrouter, non-boolean rejected, rejected under openai/anthropic/grok/deepseek/groq with the message), `tests/llm/provider-request.test.ts` (extra present only for openrouter and only when true), `tests/llm/providers/openrouter/provider.test.ts` (body carries `provider: { zdr: true }` when configured, no `provider` block otherwise, merges with an existing routing block).

## Evidence

Provider documentation fetched 2026-09-12:

- OpenRouter provider routing: `zdr` (boolean) "Restrict routing to only ZDR (Zero Data Retention) endpoints"; "The per-request zdr parameter operates as an OR with your account-wide and guardrail ZDR settings".
- OpenAI data controls: ZDR is selected per organization or project after approval; with ZDR the `store` parameter is always treated as false. AgenC already sends `store: false` on Responses requests.
- Anthropic API and data retention: ZDR is an organization-level arrangement; no request parameter.
- xAI security FAQ: 30-day encrypted retention by default; ZDR is enabled per team in the console; every response carries `x-zero-data-retention: true/false`; ZDR disables the stateful Responses, Files, Collections and Batch APIs.
- Gemini API ZDR: per project, on request; prompts are otherwise logged for abuse monitoring.
- Groq "Your data": no retention of inputs and outputs by default; ZDR is a self-serve Data Controls setting, globally or per feature; no request parameter.
- Mistral ZDR: organization setting on paid plans after approval, stateless endpoints only.
- Cerebras support: does not retain prompt content, API requests or responses. Ollama cloud page: "Prompt or response data is never logged or trained on."
- The AgenC managed gateway pins `zdr: true, data_collection: "deny"` on its OpenRouter dispatch (see the gateway findings from the DeepSeek incident).

## Tests

From `runtime/` with `TMPDIR=/private/tmp/tt/vt`:

- `npm run typecheck`: exit 0.
- `npx vitest run tests/config/config.test.ts tests/llm/provider-request.test.ts tests/llm/providers/openrouter tests/llm/providers/openai/adapter.test.ts`: 4 files, 271 tests passed.
- `npx vitest run tests/llm/provider.test.ts tests/llm/provider-options.test.ts tests/config tests/llm/providers/openai tests/llm/providers/openrouter`: every file passes except `tests/config/direct-environment-documentation.architecture.test.ts` (1 test), `tests/config/session-home-authority.architecture.test.ts` and `tests/config/session-home-authority.test.ts` (6 tests), which fail identically on `origin/main` (37de831d3) on this Mac and are unrelated to this change.

## Not changed

- No provider other than OpenRouter changes its requests. OpenAI keeps `store: false` on Responses as before.
- No response-header inspection (xAI's `x-zero-data-retention`) yet; a later change can surface it in the provider status.
- The daemon protocol and `providers --json` are unchanged; the desktop reads the field with `config get providers.openrouter.zero_data_retention`.

## Counterpart PRs

Desktop: "Zero data retention" row on every provider card (switch on OpenRouter, provider policy elsewhere), to be opened.
