### PR TITLE
cli: print mode writes each assistant message once

### DIFF
--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -1543,7 +1543,19 @@ function daemonNestedTranscriptEvent(event: unknown): JsonObject | null {
   return params;
 }
 
-function daemonOneShotMessageChunk(event: unknown): string | null {
+/**
+ * Assistant text carried by one daemon event: a streamed delta, or the
+ * complete message the daemon emits once the deltas are done. The daemon
+ * sends both for the same message, so the caller must reconcile them
+ * (see oneShotFinalMessageRemainder) or print mode writes the answer twice.
+ */
+type OneShotMessageChunk =
+  | { readonly kind: "delta"; readonly text: string }
+  | { readonly kind: "final"; readonly text: string };
+
+function daemonOneShotMessageChunk(
+  event: unknown,
+): OneShotMessageChunk | null {
   if (!isJsonRecord(event)) return null;
   const params = daemonEventParams(event);
   if (
@@ -1551,7 +1563,7 @@ function daemonOneShotMessageChunk(event: unknown): string | null {
     params !== null &&
     typeof params.delta === "string"
   ) {
-    return params.delta;
+    return { kind: "delta", text: params.delta };
   }
   const transcriptEvent = daemonNestedTranscriptEvent(event);
   if (transcriptEvent === null) return null;
@@ -1563,16 +1575,31 @@ function daemonOneShotMessageChunk(event: unknown): string | null {
     payload !== null &&
     typeof payload.delta === "string"
   ) {
-    return payload.delta;
+    return { kind: "delta", text: payload.delta };
   }
   if (
     transcriptEvent.type === "agent_message" &&
     payload !== null &&
     typeof payload.message === "string"
   ) {
-    return `${payload.message}\n`;
+    return { kind: "final", text: payload.message };
   }
   return null;
+}
+
+/**
+ * What the complete message adds beyond the deltas already written, plus
+ * the newline that ends it. With no deltas the whole message is new; when
+ * the message extends the deltas only the tail is; when the two disagree
+ * both are kept on separate lines, since dropping text is the worse fault.
+ */
+export function oneShotFinalMessageRemainder(
+  streamed: string,
+  message: string,
+): string {
+  if (streamed.length === 0) return `${message}\n`;
+  if (message.startsWith(streamed)) return `${message.slice(streamed.length)}\n`;
+  return `\n${message}\n`;
 }
 
 function writeOneShotJsonLine(value: unknown): void {
@@ -1752,6 +1779,9 @@ async function awaitDaemonOneShotRun(params: {
   let printedAssistantOutput = false;
   let assistantOutput = "";
   let lastPrintedChar = "";
+  // Deltas of the assistant message currently streaming; reset by its
+  // complete message so the two are never written twice.
+  let streamedMessage = "";
   const collectedEvents: unknown[] = [];
   // In continue mode the stream id we choose is the daemon's turn id, so
   // terminal events of any other turn (a replayed history item, an unrelated
@@ -1924,13 +1954,24 @@ async function awaitDaemonOneShotRun(params: {
           }
 
           const chunk = daemonOneShotMessageChunk(event);
-          if (chunk !== null && chunk.length > 0) {
-            assistantOutput += chunk;
-            if (outputFormat === "text") {
-              process.stdout.write(chunk);
+          if (chunk !== null) {
+            // Deltas stream as they arrive; the complete message that
+            // follows them contributes only what was not streamed, so the
+            // answer is written once whichever events the daemon sends.
+            const text =
+              chunk.kind === "delta"
+                ? chunk.text
+                : oneShotFinalMessageRemainder(streamedMessage, chunk.text);
+            streamedMessage =
+              chunk.kind === "delta" ? streamedMessage + chunk.text : "";
+            if (text.length > 0) {
+              assistantOutput += text;
+              if (outputFormat === "text") {
+                process.stdout.write(text);
+              }
+              printedAssistantOutput = true;
+              lastPrintedChar = text.at(-1) ?? lastPrintedChar;
             }
-            printedAssistantOutput = true;
-            lastPrintedChar = chunk.at(-1) ?? lastPrintedChar;
           }
 
           activeTurnId ??= daemonOneShotStartedTurnId(event);

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1930,64 +1930,34 @@ describe("main() smoke", () => {
   });
 
   it("oneShotCLI writes the answer once when the daemon streams deltas and then the complete message", async () => {
-    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-once-home-"));
-    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-once-cwd-"));
-    const prevEnv = { ...process.env };
-
-    process.env.AGENC_HOME = tmpHome;
-    process.env.AGENC_WORKSPACE = tmpCwd;
-    process.env.AGENC_PROVIDER = "openai";
-    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
-    process.env.AGENC_ALLOW_UNTRUSTED_HOOKS = "true";
-    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
-    const agentId = "agent_once";
-    const sessionId = "session_once";
     // The daemon path emits every assistant message twice: as streamed
     // deltas (event.message_chunk / agent_message_delta) and then as one
     // complete agent_message transcript event. Print mode used to write
     // both, so `agenc -p` answered "pongpong".
-    installDaemonCliDepsForTest({
-      agentId,
-      sessionId,
-      cwd: tmpCwd,
-      oneShotEvents: [
-        { method: "event.message_chunk", params: { sessionId, eventId: "once_delta_1", agentId, delta: "po" } },
-        {
-          method: "event.session_event",
-          params: { sessionId, eventId: "once_delta_2", agentId, msg: { type: "agent_message_delta", payload: { delta: "ng" } } },
-        },
-        {
-          method: "event.session_event",
-          params: { sessionId, eventId: "once_final_1", agentId, msg: { type: "agent_message", payload: { message: "pong" } } },
-        },
-        // A second message with no deltas at all is still written whole.
-        {
-          method: "event.session_event",
-          params: { sessionId, eventId: "once_final_2", agentId, msg: { type: "agent_message", payload: { message: "and done" } } },
-        },
-        { method: "event.agent_status", params: { sessionId, eventId: "once_complete", agentId, status: "idle", runStatus: "completed" } },
-      ],
-    });
-    const stdoutSpy = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(() => true);
-
-    try {
-      trustWorkspaceForTest(tmpHome, tmpCwd);
-      const code = await oneShotCLI("Reply with exactly the word pong");
+    await withOneShotTestEnvironment("agenc-once-", async ({ cwd, run, stdout }) => {
+      const agentId = "agent_once";
+      const sessionId = "session_once";
+      const transcript = (eventId: string, type: string, payload: Record<string, string>) => ({
+        method: "event.session_event",
+        params: { sessionId, eventId, agentId, msg: { type, payload } },
+      });
+      installDaemonCliDepsForTest({
+        agentId,
+        sessionId,
+        cwd,
+        oneShotEvents: [
+          { method: "event.message_chunk", params: { sessionId, eventId: "once_delta_1", agentId, delta: "po" } },
+          transcript("once_delta_2", "agent_message_delta", { delta: "ng" }),
+          transcript("once_final_1", "agent_message", { message: "pong" }),
+          // A second message with no deltas at all is still written whole.
+          transcript("once_final_2", "agent_message", { message: "and done" }),
+          { method: "event.agent_status", params: { sessionId, eventId: "once_complete", agentId, status: "idle", runStatus: "completed" } },
+        ],
+      });
+      const code = await run(() => oneShotCLI("Reply with exactly the word pong"), 10_000);
       expect(code).toBe(0);
-      expect(
-        stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join(""),
-      ).toBe("pong\nand done\n");
-    } finally {
-      stdoutSpy.mockRestore();
-      for (const key of Object.keys(process.env)) {
-        if (!(key in prevEnv)) delete process.env[key];
-      }
-      Object.assign(process.env, prevEnv);
-      await rm(tmpHome, { recursive: true, force: true });
-      await rm(tmpCwd, { recursive: true, force: true });
-    }
+      expect(stdout()).toBe("pong\nand done\n");
+    });
   });
 
   it("oneShotFinalMessageRemainder adds only what the deltas did not carry", () => {

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -36,6 +36,7 @@ import {
   main,
   maybeReloadConfigBetweenTurns,
   oneShotCLI,
+  oneShotFinalMessageRemainder,
   parseStreamJsonPrompt,
   prepareTurnRuntimeInputs,
   resolveCliCwdForStartup,
@@ -1926,6 +1927,75 @@ describe("main() smoke", () => {
       await rm(tmpHome, { recursive: true, force: true });
       await rm(tmpCwd, { recursive: true, force: true });
     }
+  });
+
+  it("oneShotCLI writes the answer once when the daemon streams deltas and then the complete message", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-once-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-once-cwd-"));
+    const prevEnv = { ...process.env };
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.AGENC_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
+    process.env.AGENC_ALLOW_UNTRUSTED_HOOKS = "true";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+    const agentId = "agent_once";
+    const sessionId = "session_once";
+    // The daemon path emits every assistant message twice: as streamed
+    // deltas (event.message_chunk / agent_message_delta) and then as one
+    // complete agent_message transcript event. Print mode used to write
+    // both, so `agenc -p` answered "pongpong".
+    installDaemonCliDepsForTest({
+      agentId,
+      sessionId,
+      cwd: tmpCwd,
+      oneShotEvents: [
+        { method: "event.message_chunk", params: { sessionId, eventId: "once_delta_1", agentId, delta: "po" } },
+        {
+          method: "event.session_event",
+          params: { sessionId, eventId: "once_delta_2", agentId, msg: { type: "agent_message_delta", payload: { delta: "ng" } } },
+        },
+        {
+          method: "event.session_event",
+          params: { sessionId, eventId: "once_final_1", agentId, msg: { type: "agent_message", payload: { message: "pong" } } },
+        },
+        // A second message with no deltas at all is still written whole.
+        {
+          method: "event.session_event",
+          params: { sessionId, eventId: "once_final_2", agentId, msg: { type: "agent_message", payload: { message: "and done" } } },
+        },
+        { method: "event.agent_status", params: { sessionId, eventId: "once_complete", agentId, status: "idle", runStatus: "completed" } },
+      ],
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      const code = await oneShotCLI("Reply with exactly the word pong");
+      expect(code).toBe(0);
+      expect(
+        stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join(""),
+      ).toBe("pong\nand done\n");
+    } finally {
+      stdoutSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("oneShotFinalMessageRemainder adds only what the deltas did not carry", () => {
+    expect(oneShotFinalMessageRemainder("", "pong")).toBe("pong\n");
+    expect(oneShotFinalMessageRemainder("pong", "pong")).toBe("\n");
+    expect(oneShotFinalMessageRemainder("po", "pong")).toBe("ng\n");
+    // Disagreement keeps both texts rather than dropping either.
+    expect(oneShotFinalMessageRemainder("draft", "final answer")).toBe("\nfinal answer\n");
   });
 
   it.each([


### PR DESCRIPTION
## Why

`agenc -p "Reply with exactly the word pong"` printed `pongpong`. The daemon path emits every assistant message twice, first as streamed deltas (`event.message_chunk` / `agent_message_delta`) and then as one complete `agent_message` transcript event, and the one-shot runner wrote both. Seen today on Ollama Cloud and DeepSeek alike, in text mode and in the `--output-format json` text, on main 8e023250e. Anything that consumes print-mode output (scripts, the benchmark runner, the SDK examples in docs) received the answer doubled.

## What, per file

- `runtime/src/bin/agenc-main.ts`: `daemonOneShotMessageChunk` now returns a tagged chunk (`delta` or `final`) instead of a string. The one-shot event handler keeps the deltas of the message in flight in `streamedMessage`; when the complete message arrives it writes `oneShotFinalMessageRemainder(streamed, message)`: the whole message plus newline when nothing was streamed, only the tail plus newline when the message extends the deltas (normally just `\n`), and both on separate lines if they disagree, since dropping text is the worse fault. The complete message resets the buffer so a second message in the same turn starts clean.
- `runtime/tests/bin/agenc.test.ts`: a fake-daemon one-shot test that streams `po` + `ng`, then the complete `pong`, then a second message with no deltas, and expects stdout to be exactly `pong\nand done\n` (the old code produced `pongpong\nand done\n`); plus unit cases for `oneShotFinalMessageRemainder`.

## Evidence

Live, from a build of this branch, Ollama Cloud `deepseek-v4.1-flash`, fresh `AGENC_HOME`, `--bypass-approvals -p "Reply with exactly the word pong and nothing else."`:

- before (main 8e023250e): stdout bytes `p o n g p o n g \n`; the same on DeepSeek `deepseek-v4-flash`.
- after: stdout bytes `p o n g \n`; `--output-format json` exits 0 with `finalMessage: "pong"`.

## Tests

- `npx vitest run tests/bin/agenc.test.ts tests/bin/agenc.deferred-input.test.ts`: 135 passed (includes the two new cases).
- `npx tsc --noEmit` on the runtime: clean.
- `npm run build` in the runtime: pass (the build used for the live check).

## Not changed

- `stream-json` output still forwards every daemon event untouched, deltas and complete messages included; consumers of that format already see both and decide themselves.
- The TUI transcript is not involved; it renders from the session transcript, not from this printer.
- The daemon keeps emitting both event kinds; other clients rely on the complete message.

## Counterpart PRs

None. Found while verifying the Ollama Cloud provider end to end after agenc-desktop #269.
