### PR TITLE
secure storage: a host without a Secret Service reads as empty instead of aborting the run

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -194,6 +194,12 @@ no default home, relocated home, or colliding directory still owns the record;
 keep those processes stopped until apply completes.
 
 Linux uses its bundled Secret Service helper to enumerate every collection.
+On a Linux host with no Secret Service at all (a container, a server, CI:
+no `libsecret-1.so.0`, or no session bus), the native backend is
+unavailable rather than unreadable. Reads then answer empty, with one
+warning line on stderr, so credentials from the environment and from
+`config.toml` keep working; saving or clearing a credential still fails with
+a clear message, and the destructive migration preconditions stay strict.
 Read, update, and delete refuse multiple records for the exact service/account
 identity; a single existing item is updated or deleted in its own collection.
 This replaces the mismatched all-collection lookup, default-collection store,

--- a/runtime/src/utils/secureStorage/index.ts
+++ b/runtime/src/utils/secureStorage/index.ts
@@ -2,6 +2,12 @@ import type { HomeContext } from '../../config/home.js'
 import { createMacOsKeychainStorage } from './macOsKeychainStorage.js'
 import { createLinuxSecretStorage } from './linuxSecretStorage.js'
 import { createWindowsCredentialStorage } from './windowsCredentialStorage.js'
+import { SecureStorageUnavailableError } from './unavailable.js'
+
+export {
+  isSecureStorageUnavailableMessage,
+  SecureStorageUnavailableError,
+} from './unavailable.js'
 
 /** Account identity and role metadata associated with the stored OAuth tokens. */
 export interface OAuthAccountMetadata {
@@ -178,10 +184,14 @@ export interface SecureStorageMigrationIdentity {
 const unavailableSecureStorage: SecureStorage = {
   name: 'unavailable-secure-storage',
   read: () => {
-    throw new Error('Native secure storage is unavailable on this platform')
+    throw new SecureStorageUnavailableError(
+      'Native secure storage is unavailable on this platform',
+    )
   },
   readAsync: async () => {
-    throw new Error('Native secure storage is unavailable on this platform')
+    throw new SecureStorageUnavailableError(
+      'Native secure storage is unavailable on this platform',
+    )
   },
   update: () => ({
     success: false,

--- a/runtime/src/utils/secureStorage/linuxSecretStorage.ts
+++ b/runtime/src/utils/secureStorage/linuxSecretStorage.ts
@@ -6,6 +6,10 @@ import {
 } from './macOsKeychainHelpers.js'
 import type { HomeContext } from '../../config/home.js'
 import type { SecureStorage, SecureStorageData } from './index.js'
+import {
+  isSecureStorageUnavailableMessage,
+  SecureStorageUnavailableError,
+} from './unavailable.js'
 import { decodeSecureStorageData } from './decode.js'
 import {
   resolveBundledSecureStorageHelper,
@@ -70,10 +74,15 @@ export function createLinuxSecretStorage(
       return null
     }
     if (result.exitCode !== 0) {
-      throw new Error(
-        result.stderr?.trim() ||
-          `Secret Service lookup failed with exit code ${result.exitCode}`,
-      )
+      const detail = result.stderr?.trim() ||
+        `Secret Service lookup failed with exit code ${result.exitCode}`
+      // No libsecret, or no session bus to reach a Secret Service (containers,
+      // servers, CI): the backend is absent on this host rather than holding
+      // an unreadable record.
+      if (isSecureStorageUnavailableMessage(detail)) {
+        throw new SecureStorageUnavailableError(detail)
+      }
+      throw new Error(detail)
     }
     if (!result.stdout?.trim()) {
       throw new Error('Secret Service returned an empty credential record')

--- a/runtime/src/utils/secureStorage/native.ts
+++ b/runtime/src/utils/secureStorage/native.ts
@@ -7,11 +7,36 @@ import {
   getSecureStorage,
   type SecureStorageData,
 } from './index.js'
+import { SecureStorageUnavailableError } from './unavailable.js'
 
 const NATIVE_STORAGE_TRANSACTION_LOCK = '.secure-storage-transaction'
 
 export class NativeSecureStorageError extends Error {
   readonly name = 'NativeSecureStorageError'
+}
+
+/**
+ * A locked or fresh read found no native backend on this host. Plain reads
+ * never raise this: a backend that does not exist here holds no record, so
+ * they answer empty (once with a warning) and environment credentials keep
+ * working. Writes and the destructive-migration preconditions stay strict.
+ */
+export class NativeSecureStorageUnavailableError extends NativeSecureStorageError {}
+
+let warnedUnavailable = false
+
+function noteUnavailable(reason: string): void {
+  if (warnedUnavailable) return
+  warnedUnavailable = true
+  process.stderr.write(
+    `agenc: native secure storage is unavailable on this host (${reason}); ` +
+      'stored credentials cannot be read here, so only environment and config credentials apply\n',
+  )
+}
+
+/** Test seam: forget that the unavailability warning was already printed. */
+export function resetNativeSecureStorageUnavailableWarningForTest(): void {
+  warnedUnavailable = false
 }
 
 export interface NativeSecureStorageTransaction {
@@ -43,6 +68,15 @@ function readStorageOrThrow(
       : storage.read()
     return cloneSecureStorageData(data ?? {})
   } catch (error) {
+    if (error instanceof SecureStorageUnavailableError) {
+      if (!fresh) {
+        noteUnavailable(error.message)
+        return {}
+      }
+      throw new NativeSecureStorageUnavailableError(
+        `${failureMessage}: ${error.message}`,
+      )
+    }
     throw new NativeSecureStorageError(
       `${failureMessage}: ${error instanceof Error ? error.message : String(error)}`,
     )
@@ -102,6 +136,10 @@ export async function readNativeSecureStorageAsync(
       (await getSecureStorage(home).readAsync()) ?? {},
     )
   } catch (error) {
+    if (error instanceof SecureStorageUnavailableError) {
+      noteUnavailable(error.message)
+      return {}
+    }
     throw new NativeSecureStorageError(
       `Native secure storage read failed: ${error instanceof Error ? error.message : String(error)}`,
     )

--- a/runtime/src/utils/secureStorage/unavailable.ts
+++ b/runtime/src/utils/secureStorage/unavailable.ts
@@ -1,0 +1,32 @@
+/**
+ * Backend absence, kept in its own module so the platform backends and the
+ * native adapter can share it without importing the (test-mocked) index.
+ */
+
+/**
+ * The native backend cannot be used on this host at all: the library or
+ * helper is missing, or (Linux) there is no Secret Service session bus.
+ * Distinct from a record that exists but cannot be read: nothing can have
+ * been stored in a backend that does not exist here, so read-only callers
+ * may treat it as empty while every write stays fail-closed.
+ */
+export class SecureStorageUnavailableError extends Error {
+  readonly name = 'SecureStorageUnavailableError'
+}
+
+const SECURE_STORAGE_UNAVAILABLE_MARKERS: readonly RegExp[] = [
+  /^Secret Service is unavailable:/u,
+  /^Secret Service helper could not load /u,
+  /session initialization failed/iu,
+  /message bus/iu,
+  /D-?Bus/iu,
+  /org\.freedesktop\.secrets/u,
+  /Failed to connect to socket/iu,
+  /Native secure storage is unavailable on this platform/u,
+]
+
+/** True when a backend failure message means the backend is absent, not that a record is unreadable. */
+export function isSecureStorageUnavailableMessage(message: string): boolean {
+  const text = message.trim()
+  return SECURE_STORAGE_UNAVAILABLE_MARKERS.some((marker) => marker.test(text))
+}

--- a/runtime/tests/utils/secureStorage/native-unavailable.test.ts
+++ b/runtime/tests/utils/secureStorage/native-unavailable.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { resolveHomeContext } from '../../../src/config/home.js'
+import {
+  getSecureStorage,
+  type SecureStorage,
+} from '../../../src/utils/secureStorage/index.js'
+import { SecureStorageUnavailableError } from '../../../src/utils/secureStorage/unavailable.js'
+import {
+  NativeSecureStorageError,
+  NativeSecureStorageUnavailableError,
+  readNativeSecureStorage,
+  readNativeSecureStorageAsync,
+  readNativeSecureStorageFresh,
+  resetNativeSecureStorageUnavailableWarningForTest,
+  updateNativeSecureStorage,
+} from '../../../src/utils/secureStorage/native.js'
+import { createTempWorkspaceFixture } from '../../helpers/temp-workspace.js'
+
+const fixture = createTempWorkspaceFixture('agenc-native-unavailable-')
+const getSecureStorageMock = vi.mocked(getSecureStorage)
+const hermeticStorageFactory = getSecureStorageMock.getMockImplementation()
+
+/** A host with no Secret Service at all: every backend call reports absence. */
+const absentBackend: SecureStorage = {
+  name: 'absent-libsecret',
+  read: () => {
+    throw new SecureStorageUnavailableError(
+      'Secret Service is unavailable: libsecret-1.so.0: cannot open shared object file',
+    )
+  },
+  readFresh: () => {
+    throw new SecureStorageUnavailableError(
+      'Secret Service is unavailable: libsecret-1.so.0: cannot open shared object file',
+    )
+  },
+  readAsync: async () => {
+    throw new SecureStorageUnavailableError(
+      'Secret Service is unavailable: libsecret-1.so.0: cannot open shared object file',
+    )
+  },
+  update: () => ({ success: false, warning: 'no backend' }),
+  delete: () => true,
+}
+
+describe('native secure storage on a host without a backend', () => {
+  beforeEach(() => {
+    if (!hermeticStorageFactory) throw new Error('Expected the hermetic secure-storage mock')
+    getSecureStorageMock.mockReturnValue(absentBackend)
+    resetNativeSecureStorageUnavailableWarningForTest()
+  })
+
+  afterEach(async () => {
+    if (hermeticStorageFactory) getSecureStorageMock.mockImplementation(hermeticStorageFactory)
+    await fixture.cleanup()
+  })
+
+  async function home() {
+    const path = await fixture.create()
+    return resolveHomeContext({ AGENC_HOME: path }, { platformHome: '/unused' })
+  }
+
+  test('plain reads answer empty and warn once, so environment credentials keep working', async () => {
+    const boundHome = await home()
+    const writes: string[] = []
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write)
+    try {
+      expect(readNativeSecureStorage(boundHome)).toEqual({})
+      expect(readNativeSecureStorage(boundHome)).toEqual({})
+      expect(await readNativeSecureStorageAsync(boundHome)).toEqual({})
+    } finally {
+      spy.mockRestore()
+    }
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toContain('native secure storage is unavailable on this host')
+    expect(writes[0]).toContain('libsecret-1.so.0')
+  })
+
+  test('fresh reads and writes stay fail-closed', async () => {
+    const boundHome = await home()
+    expect(() => readNativeSecureStorageFresh(boundHome)).toThrow(NativeSecureStorageUnavailableError)
+    expect(() => readNativeSecureStorageFresh(boundHome)).toThrow(NativeSecureStorageError)
+    expect(() =>
+      updateNativeSecureStorage(boundHome, (current) => ({ ...current, primaryApiKey: 'k' }), 'no storage'),
+    ).toThrow(NativeSecureStorageError)
+  })
+})

--- a/runtime/tests/utils/secureStorage/platformStorage.test.ts
+++ b/runtime/tests/utils/secureStorage/platformStorage.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { SecureStorageUnavailableError } from "../../../src/utils/secureStorage/unavailable.js";
 import {
   createLinuxSecretStorage,
 } from "../../../src/utils/secureStorage/linuxSecretStorage.ts";
@@ -642,6 +643,34 @@ describe("Secure Storage Platform Implementations", () => {
       })
       expect(getExecaCall(0)[0]).toBe("/usr/libexec/agenc-keychain-helper")
       expect(getExecaCall(0)[1][0]).toBe("read")
+    });
+  });
+
+  describe("Linux Secret Service unavailability", () => {
+    test("a missing libsecret or session bus is unavailable, not an unreadable record", () => {
+      const storage = createLinuxSecretStorage(defaultHome(), mockExecaSync);
+      for (const stderr of [
+        "Secret Service is unavailable: libsecret-1.so.0: cannot open shared object file: No such file or directory",
+        "Secret Service session initialization failed: Cannot spawn a message bus without a machine-id: Unable to load /var/lib/dbus/machine-id",
+        "Secret Service helper could not load secret_service_open_sync: symbol unavailable",
+      ]) {
+        mockExecaSync.mockReturnValueOnce({ exitCode: 1, stdout: "", stderr });
+        expect(() => storage.read()).toThrow(SecureStorageUnavailableError);
+      }
+    });
+
+    test("other helper failures stay ordinary read errors", () => {
+      const storage = createLinuxSecretStorage(defaultHome(), mockExecaSync);
+      mockExecaSync.mockReturnValueOnce({ exitCode: 1, stdout: "", stderr: "Access denied" });
+      let caught: unknown;
+      try {
+        storage.read();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(SecureStorageUnavailableError);
+      expect((caught as Error).message).toBe("Access denied");
     });
   });
 


### PR DESCRIPTION
## Why

Running current main headless on a Linux host without a Secret Service ends every run before the first turn:

```
agenc: Native secure storage read failed: Secret Service is unavailable: libsecret-1.so.0: cannot open shared object file: No such file or directory
```

With `libsecret-1-0` installed but no session bus the message becomes `Secret Service session initialization failed: Cannot spawn a message bus without a machine-id`. Seen while installing a build of main into Terminal-Bench task containers (`python:3.13-slim-bookworm`, `ubuntu:24.04`) with the provider key in the environment. Release 0.17.0 runs fine on the same images, so this is a regression for containers, servers and CI, the places where a key comes from the environment rather than from a keychain.

## What, per file

- `runtime/src/utils/secureStorage/unavailable.ts` (new): `SecureStorageUnavailableError` and `isSecureStorageUnavailableMessage`, which recognises the helper's "Secret Service is unavailable:", "could not load <symbol>", "session initialization failed", message-bus and D-Bus failures. Its own module so the platform backends and the native adapter share it without importing the index module the test suite mocks.
- `runtime/src/utils/secureStorage/linuxSecretStorage.ts`: a helper failure whose stderr matches those markers throws `SecureStorageUnavailableError`; every other failure stays an ordinary read error.
- `runtime/src/utils/secureStorage/index.ts`: re-exports the two symbols; the non-Linux/macOS/Windows stub throws the unavailable error too.
- `runtime/src/utils/secureStorage/native.ts`: `readNativeSecureStorage` and `readNativeSecureStorageAsync` answer `{}` on an unavailable backend and print one warning line per process ("native secure storage is unavailable on this host (...); stored credentials cannot be read here, so only environment and config credentials apply"). Fresh reads raise the new `NativeSecureStorageUnavailableError` (a `NativeSecureStorageError`), so `updateNativeSecureStorage`, rollback and the destructive migration preconditions stay fail-closed. A test seam resets the once-only warning.
- `runtime/tests/utils/secureStorage/platformStorage.test.ts`: the three unavailability messages classify as unavailable; "Access denied" does not.
- `runtime/tests/utils/secureStorage/native-unavailable.test.ts` (new): plain reads return empty and warn once; fresh reads and writes throw.
- `docs/reference/config.md`: one paragraph on hosts without a Secret Service.

## Evidence

Reproduced by hand in `alexgshaw/openssl-selfsigned-cert:20251031` (Debian slim) with a linux-x64 tarball of main 1705a41e0 built by `packages/agenc/scripts/build-runtime-tarball.mjs`: `agenc --dangerously-bypass-approvals-and-sandbox --provider deepseek --model deepseek-v4-pro -p "Reply pong"` exits 1 with the message above, both without libsecret and with libsecret but no machine-id. The same command with the public 0.17.0 installer answers.

## Tests

- `npx vitest run tests/utils/secureStorage/ tests/auth/native-credentials.test.ts tests/config/plaintext-credential-migration.test.ts`: 91 passed.
- `npx vitest run` on the migration, auth backend, OAuth credential and secure-storage architecture suites: 9 files, 147 passed (`native-secure-storage-authority.architecture`, `migration-lock-release`, `global-state-authority-migration`, `retired-config-surface-authority`, `migration-quarantine-race`, `auth/backends/local.contract`, `auth/backends/remote.contract`, `openAiOauthCredentials.authority`, `auth-primary-api-key-secure-storage`).
- `npx tsc --noEmit` on the runtime: clean.

## Not changed

- Nothing about how records are written or migrated. An unreadable record (backend present, read fails) still throws exactly as before; only a backend that is absent on the host reads as empty.
- macOS and Windows behaviour is untouched apart from the shared error class.

## Counterpart PRs

None. Found while preparing the Terminal-Bench runs of main for the launch (adapter and recipe in a follow-up PR).
