### PR TITLE
Keep uncapped agent work running and expose child session ownership

### DIFF
--- a/docs/design/execution-admission-kernel.md
+++ b/docs/design/execution-admission-kernel.md
@@ -137,7 +137,13 @@ Common fail-closed reasons include:
 | Budget exhausted, allocation blocked, parent cancelled, or deadline expired                     | deny/cancel with a journal reason                                                  |
 | Policy requests approval                                                                        | persist `approval_required`; the current client does not auto-approve or bypass it |
 | Usage is missing or invalid after dispatch                                                      | consume the full reservation as `held_unknown`                                     |
-| Provider exceeds the reservation                                                                | persist `provider_overrun`, block the allocation, and cancel the run subtree       |
+| Provider exceeds a reservation backed by an explicit hard budget cap                            | persist `provider_overrun`, block the allocation, and cancel the run subtree       |
+
+Without an explicit token or cost cap, reservation estimates do not impose a
+budget limit. Reported usage above an estimate is recorded and the run continues.
+The reconciliation check uses the reservation's durable allocation links, so
+inherited and retained period caps remain enforced. Explicit provider-overrun
+reports remain terminal independently of whether a budget was configured.
 
 Provider-side automatic fallback is not used to make a cap appear satisfied.
 Every deliberate model/provider fallback is a visible `fallback` journal

--- a/runtime/src/app-server/session-lifecycle.ts
+++ b/runtime/src/app-server/session-lifecycle.ts
@@ -849,6 +849,7 @@ function storedThreadToSessionSummary(
 ): SessionSummary {
   const roleWorkspace = roleWorkspaceFromThreadSource(thread.source);
   const metadata: JsonObject = {
+    ...(thread.parentThreadId !== undefined ? { parentThreadId: thread.parentThreadId } : {}),
     source:
       thread.source === undefined
         ? undefined

--- a/runtime/src/state/execution-admission.ts
+++ b/runtime/src/state/execution-admission.ts
@@ -2094,11 +2094,26 @@ export class ExecutionAdmissionRepository {
       actualCostNanos =
         usage.costUsd === null ? null : usdToNanos(usage.costUsd);
       providerRequestId = requestedProviderRequestId;
+      // Reservations estimate provider usage even when budgets are disabled.
+      // Only an explicitly capped allocation makes that estimate a hard limit.
+      // Read the durable links, including inherited and retained period caps.
+      const hasHardBudgetCap = this.#driver
+        .prepareState<[string], { readonly capped: number }>(
+          `SELECT 1 AS capped
+           FROM execution_admission_reservation_allocations AS link
+           JOIN execution_admission_allocations AS allocation
+             ON allocation.scope_key = link.scope_key
+           WHERE link.reservation_id = ?
+             AND (allocation.max_tokens IS NOT NULL OR allocation.max_cost_nanos IS NOT NULL)
+           LIMIT 1`,
+        )
+        .get(reservationId) !== undefined;
       overrun =
         input.kind === "provider_overrun" ||
-        actualTokens > reservation.reserved_tokens ||
-        (actualCostNanos !== null &&
-          actualCostNanos > reservation.reserved_cost_nanos);
+        (hasHardBudgetCap &&
+          (actualTokens > reservation.reserved_tokens ||
+            (actualCostNanos !== null &&
+              actualCostNanos > reservation.reserved_cost_nanos)));
       if (actualCostNanos === null && !overrun) {
         finalStatus = "held_unknown";
         event = "held_unknown";

--- a/runtime/src/state/threads.ts
+++ b/runtime/src/state/threads.ts
@@ -4,6 +4,8 @@ import type { StateSqliteDriver } from "./sqlite-driver.js";
 
 export interface IndexedThreadRecord {
   readonly threadId: ThreadId;
+  /** Derived from the canonical spawn edge; distinct from a user-created fork. */
+  readonly parentThreadId?: ThreadId;
   readonly name?: string;
   readonly model?: string;
   readonly modelProvider?: string;
@@ -25,6 +27,7 @@ export interface IndexedThreadPage {
 
 interface ThreadRow {
   readonly thread_id: string;
+  readonly parent_thread_id: string | null;
   readonly name: string | null;
   readonly created_at: string;
   readonly updated_at: string;
@@ -193,7 +196,9 @@ export class StateThreadRepository {
       .prepareState<[ThreadId], ThreadRow>(
         `SELECT thread_id, name, created_at, updated_at, archived_at, cwd, originator,
           source_json, forked_from_id, model, model_provider, memory_mode,
-          rollout_path, archived_rollout_path
+          rollout_path, archived_rollout_path,
+          (SELECT edge.parent_thread_id FROM thread_spawn_edges AS edge
+           WHERE edge.child_thread_id = threads.thread_id) AS parent_thread_id
          FROM threads
          WHERE thread_id = ?`,
       )
@@ -206,7 +211,9 @@ export class StateThreadRepository {
       .prepareState<[], ThreadRow>(
         `SELECT thread_id, name, created_at, updated_at, archived_at, cwd, originator,
           source_json, forked_from_id, model, model_provider, memory_mode,
-          rollout_path, archived_rollout_path
+          rollout_path, archived_rollout_path,
+          (SELECT edge.parent_thread_id FROM thread_spawn_edges AS edge
+           WHERE edge.child_thread_id = threads.thread_id) AS parent_thread_id
          FROM threads`,
       )
       .all()
@@ -256,7 +263,9 @@ export class StateThreadRepository {
     const statement = this.driver.prepareState(
       `SELECT thread_id, name, created_at, updated_at, archived_at, cwd, originator,
           source_json, forked_from_id, model, model_provider, memory_mode,
-          rollout_path, archived_rollout_path
+          rollout_path, archived_rollout_path,
+          (SELECT edge.parent_thread_id FROM thread_spawn_edges AS edge
+           WHERE edge.child_thread_id = threads.thread_id) AS parent_thread_id
          FROM threads
          WHERE ${archivePredicate}${pagePredicate}
          ORDER BY ${sortColumn} ${direction}, thread_id ${direction}
@@ -590,6 +599,7 @@ export interface RolloutItemRow {
 function rowToThread(row: ThreadRow): IndexedThreadRecord {
   const record: IndexedThreadRecord = {
     threadId: row.thread_id,
+    ...(row.parent_thread_id != null ? { parentThreadId: row.parent_thread_id } : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(row.name !== null ? { name: row.name } : {}),

--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -1724,6 +1724,7 @@ function normalizeRegistryEntry(value: unknown): RegistryEntry | undefined {
   const source = normalizeThreadSource(value.source);
   return {
     threadId: value.threadId,
+    ...(typeof value.parentThreadId === "string" ? { parentThreadId: value.parentThreadId } : {}),
     createdAt:
       typeof value.createdAt === "string"
         ? value.createdAt

--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -168,6 +168,7 @@ export interface ListThreadsParams {
  *  policy, git info, full preview, and cli version are not populated. */
 export interface StoredThread {
   readonly threadId: ThreadId;
+  readonly parentThreadId?: ThreadId;
   readonly rolloutPath?: string;
   readonly forkedFromId?: ThreadId;
   readonly name?: string;
@@ -290,6 +291,7 @@ export interface ThreadStore {
 // ─────────────────────────────────────────────────────────────────────
 
 interface RegistryEntry {
+  readonly parentThreadId?: ThreadId;
   readonly threadId: ThreadId;
   readonly name?: string;
   readonly modelProvider?: string;
@@ -1491,6 +1493,7 @@ function toStoredThread(
       : (entry.rolloutPath ?? entry.archivedRolloutPath);
   return {
     threadId: entry.threadId,
+    ...(entry.parentThreadId !== undefined ? { parentThreadId: entry.parentThreadId } : {}),
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
     modelProvider: entry.modelProvider ?? defaultModelProviderId,

--- a/runtime/tests/app-server/session-subagent-lineage.test.ts
+++ b/runtime/tests/app-server/session-subagent-lineage.test.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { StateThreadRepository } from "../../src/state/threads.js";
+import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
+import { openStateDatabases } from "../../src/state/sqlite-driver.js";
+import { FileThreadStore } from "../../src/thread-store/store.js";
+
+it("lists canonical child ownership after restart without classifying user forks as subagents", async () => {
+  const home = mkdtempSync(join(tmpdir(), "agenc-session-lineage-"));
+  const cwd = join(home, "project");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+  const driver = openStateDatabases({ cwd, agencHome: home });
+  try {
+    const index = new StateThreadRepository(driver);
+    for (const threadId of ["parent", "child", "user-fork"]) {
+      index.upsertThread({
+        threadId, createdAt: "2026-09-12T12:00:00Z", updatedAt: "2026-09-12T12:00:00Z", cwd,
+        ...(threadId === "user-fork" ? { forkedFromId: "parent" } : {}),
+      });
+    }
+    // Restore a historical, already-admitted child with missing rollout source metadata.
+    new ThreadSpawnEdgeRepository(driver).create({
+      childThreadId: "child", parentThreadId: "parent", parentPath: "/root",
+      metadata: { agentId: "child", agentPath: "/root/research", depth: 1 }, status: "closed",
+    }, { admissionGate: "import" });
+    for (let restart = 0; restart < 2; restart++) {
+      const store = new FileThreadStore({ cwd, agencHome: home });
+      try {
+        const manager = new AgenCDaemonSessionManager({ threadStore: store });
+        const result = await manager.listSessions({ limit: 100 });
+        expect(result.sessions).toHaveLength(3);
+        expect(result.sessions.find(s => s.sessionId === "child")?.metadata?.parentThreadId).toBe("parent");
+        expect(result.sessions.find(s => s.sessionId === "parent")?.metadata?.parentThreadId).toBeUndefined();
+        expect(result.sessions.find(s => s.sessionId === "user-fork")?.metadata?.parentThreadId).toBeUndefined();
+      } finally { store.close(); }
+    }
+  } finally {
+    driver.close();
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/runtime/tests/app-server/session-subagent-lineage.test.ts
+++ b/runtime/tests/app-server/session-subagent-lineage.test.ts
@@ -29,6 +29,7 @@ it("lists canonical child ownership after restart without classifying user forks
     for (let restart = 0; restart < 2; restart++) {
       const store = new FileThreadStore({ cwd, agencHome: home });
       try {
+        expect(store.readThread({ threadId: "child", includeTurns: false }).parentThreadId).toBe("parent");
         const manager = new AgenCDaemonSessionManager({ threadStore: store });
         const result = await manager.listSessions({ limit: 100 });
         expect(result.sessions).toHaveLength(3);

--- a/runtime/tests/budget/execution-admission-kernel.test.ts
+++ b/runtime/tests/budget/execution-admission-kernel.test.ts
@@ -722,6 +722,25 @@ describe("ExecutionAdmissionKernel recovery", () => {
 });
 
 describe("ExecutionAdmissionKernel active cancellation", () => {
+  it("keeps an uncapped run and its children usable after an underestimated response", async () => {
+    const value = kernel("uncapped-estimate");
+    const client = bind(value, "uncapped-root");
+    const lease = await client.acquire({
+      stepId: "web-extraction", kind: "model_turn", model: "deepseek-flash", provider: "deepseek",
+      maxInputTokens: 12450, maxOutputTokens: 2000, maxCostUsd: 0.006135,
+    });
+    client.markDispatched(lease.reservation.reservationId, { boundary: "provider_wire" });
+    expect(client.reconcile(lease.reservation.reservationId, {
+      inputTokens: 13735, outputTokens: 965, costUsd: 0.0052785,
+    })).toMatchObject({ outcome: "reconciled" });
+    expect(lease.signal.aborted).toBe(false);
+    client.acknowledgeCompletion(lease.reservation.reservationId);
+    const child = client.forSession({ runId: "uncapped-child", sessionId: "uncapped-child" });
+    const next = await acquire(child, "continue");
+    expect(next.signal.aborted).toBe(false);
+    expect(client.getUsageSummary?.()).toMatchObject({ totalTokens: 14700, costUsd: 0.0052785 });
+  });
+
   it("enforces a direct scope hard cap across sibling reservations", async () => {
     const siblingLimits = {
       global: 2,
@@ -887,7 +906,11 @@ describe("ExecutionAdmissionKernel active cancellation", () => {
     }
 
     const value = kernel("atomic-provider-overrun");
-    const client = bind(value, "atomic_overrun_root");
+    const client = value.bindClient({
+      cwd,
+      scope: { runId: "atomic_overrun_root", sessionId: "atomic_overrun_root", autonomous: false },
+      budget: { runMaxTokens: 100 },
+    });
     const lease = await acquire(client);
     client.markDispatched(lease.reservation.reservationId, {
       boundary: "provider_wire",

--- a/runtime/tests/state/execution-admission.test.ts
+++ b/runtime/tests/state/execution-admission.test.ts
@@ -510,6 +510,53 @@ describe("ExecutionAdmissionRepository", () => {
     ).toEqual(["queued", "allowed", "dispatched", "held_unknown", "cancelled"]);
   });
 
+  it.each([
+    { name: "input estimate", input: 13735, output: 965, cost: 0.0052785 },
+    { name: "cost estimate", input: 12000, output: 965, cost: 0.01 },
+  ])("records actual $name overruns without cancelling an uncapped run", ({ input, output, cost }) => {
+    const root = request("uncapped", "web-fetch", {
+      input: 12450, output: 2000, cost: 0.006135,
+      scopes: [{ key: "uncapped-root" }],
+    });
+    admissions.enqueue(root);
+    const reservation = claimReservation(admissionRecordKey(root.step));
+    admissions.markDispatched(reservation.reservationId);
+    expect(admissions.reconcile(reservation.reservationId, {
+      kind: "reported", usage: { inputTokens: input, outputTokens: output, costUsd: cost },
+    })).toMatchObject({ applied: true, outcome: "reconciled" });
+    expect(admissions.listAllocations()[0]).toMatchObject({
+      usedTokens: input + output, usedCostUsd: cost, blockedByProviderOverrun: false,
+    });
+    now = new Date(T1);
+    admissions.recover({ now: T1 });
+    expect(admissions.listAllocations()[0]?.blockedByProviderOverrun).toBe(false);
+    const child = request("uncapped-child", "next", {
+      parentRunId: "uncapped",
+      scopes: [{ key: "uncapped-child", parentKey: "uncapped-root" }],
+    });
+    admissions.enqueue(child);
+    expect(claimReservation(admissionRecordKey(child.step)).reservationId).toBeTruthy();
+  });
+
+  it("honors a durable parent cap even when the child request omits the limit", () => {
+    const parent = request("capped-parent", "first", {
+      scopes: [{ key: "parent-cap", maxTokens: 1000 }],
+    });
+    admissions.enqueue(parent);
+    const first = claimReservation(admissionRecordKey(parent.step));
+    admissions.void(first.reservationId, "fixture_complete");
+    const child = request("capped-child", "next", {
+      parentRunId: "capped-parent", input: 5, output: 5,
+      scopes: [{ key: "child-cap", parentKey: "parent-cap" }],
+    });
+    admissions.enqueue(child);
+    const lease = claimReservation(admissionRecordKey(child.step));
+    admissions.markDispatched(lease.reservationId);
+    expect(admissions.reconcile(lease.reservationId, {
+      kind: "reported", usage: { inputTokens: 7, outputTokens: 4, costUsd: 0.001 },
+    })).toMatchObject({ outcome: "provider_overrun" });
+  });
+
   it("makes provider overrun explicit, blocks the allocation, and cancels descendants", () => {
     const root = request("root-run", "turn-1", {
       input: 5,


### PR DESCRIPTION
Interactive DeepSeek work could stop with `provider_overrun` despite having no configured budget. A real web extraction reserved 14,450 tokens and reported 14,700; the uncapped root allocation was then permanently cancelled. Reconciliation now records actual usage without enforcing estimate overruns unless a durable allocation has an explicit hard cap. Explicit provider-overrun reports and inherited/retained caps keep their existing enforcement.

Desktop also needs canonical child ownership to keep delegated agents out of ordinary conversation history. Thread reads and bounded session listings now expose the spawn parent's thread ID, including older children whose rollout source metadata is missing. User-created forks remain independent conversations.

Validation:
- Core typecheck passed.
- 149 admission, accounting, cancellation and provider-wrapper tests passed, including the observed DeepSeek usage and continued child admission without a cap.
- 49 session lifecycle/thread-store tests passed, including canonical parent recovery across restart and preservation of ordinary forks.
- The paired Desktop renderer was checked in Electron: four children hidden and three independent conversations retained with all-history enabled, including after reload.

Hosted Actions are skipped; validation is local. The paired Desktop change consumes the additive session metadata.
