### PR TITLE
Keep failed background commands from locking the conversation

### DIFF
--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -18,6 +18,7 @@ import {
   SANDBOX_PERMISSION_INPUT_PROPERTIES,
 } from "./exec-command.js";
 import { SandboxExecutionError } from "../../sandbox/execution-broker.js";
+import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 
 export interface WriteStdinToolConfig {
   readonly cwd?: string;
@@ -232,8 +233,29 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
           content: formatUnifiedExecToolContent(output),
           isError: isError || undefined,
           codeModeResult: unifiedExecCodeModeResult(output),
+          // The manager returned an authoritative process observation. A
+          // non-zero exit or timeout is a command failure, not an unknown
+          // stdin delivery. This receipt settles this call only; it does not
+          // claim that the command succeeded or left the workspace unchanged.
+          effectDisposition: createToolEffectDispositionEvidence({
+            disposition: "confirmed_committed",
+            evidenceKind: "provider_receipt",
+            evidenceRef: stillAlive
+              ? "tool:system.write-stdin:process-yield"
+              : "tool:system.write-stdin:process-exit",
+            evidenceMaterial: JSON.stringify({
+              sessionId,
+              chars,
+              exitCode: output.exitCode,
+              processId: output.process_id ?? null,
+              timedOut: output.timedOut,
+              durationMs: output.durationMs,
+            }),
+          }),
           metadata: {
             sessionId,
+            exitCode: output.exitCode,
+            timedOut: output.timedOut,
             ...(output.process_id !== undefined
               ? { processId: output.process_id }
               : {}),

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -330,6 +330,7 @@ interface ProcessEntry {
   stopPromise?: Promise<void>;
   cleanupFailure?: Error;
   hardTimeout?: NodeJS.Timeout;
+  hardTimeoutExpired?: boolean;
   // gaphunt3 #44: removes the upstream-abort listener attached to the (long-lived,
   // session-scoped) source signal so it is cleaned up on normal exit, not only on abort.
   detachUpstreamAbort?: () => void;
@@ -664,6 +665,8 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
         : null;
     if (explicitTimeoutMs !== null) {
       entry.hardTimeout = setTimeout(() => {
+        if (entry.exitState !== null) return;
+        entry.hardTimeoutExpired = true;
         this.forceTerminate(entry);
       }, explicitTimeoutMs);
       entry.hardTimeout.unref?.();
@@ -1354,7 +1357,7 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       exitCode: entry.exitState?.exitCode ?? null,
       processId: entry.exitState === null ? entry.processId : undefined,
       durationMs: (entry.endedAt ?? Date.now()) - entry.startedAt,
-      timedOut,
+      timedOut: entry.hardTimeoutExpired === true || timedOut,
       maxOutputTokens: options.maxOutputTokens,
     });
   }

--- a/runtime/tests/budget/admitted-tool-call.test.ts
+++ b/runtime/tests/budget/admitted-tool-call.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -21,6 +21,10 @@ import type { Session } from "../../src/session/session.js";
 import type { Tool } from "../../src/tools/types.js";
 import { attachPendingPhysicalSettlement } from "../../src/tools/physical-settlement.js";
 import { createFileEditTool } from "../../src/tools/system/file-edit.js";
+import { createExecCommandTool } from "../../src/tools/system/exec-command.js";
+import { createWriteStdinTool } from "../../src/tools/system/write-stdin.js";
+import { UnifiedExecProcessManager } from "../../src/unified-exec/process-manager.js";
+import { bindExplicitDangerBoundary } from "../helpers/explicit-danger-boundary.js";
 
 const zeroAdmissionEstimate = () => ({
   maxInputTokens: 0,
@@ -106,6 +110,51 @@ function toolHarness() {
 }
 
 describe("runAdmittedToolCall", () => {
+  it.each(["timeout", "nonzero", "signal"] as const)(
+    "a real background process %s stays an error without locking subsequent commands",
+    async (termination) => {
+      const root = await mkdtemp(join(tmpdir(), "agenc-process-settlement-"));
+      const manager = new UnifiedExecProcessManager({ cwd: root });
+      const state = toolHarness();
+      const exec = bindExplicitDangerBoundary(createExecCommandTool({ cwd: root, unifiedExecManager: manager }));
+      const poll = bindExplicitDangerBoundary(createWriteStdinTool({ cwd: root, unifiedExecManager: manager }));
+      const invoke = (tool: Tool, callId: string, args: Record<string, unknown>) => runAdmittedToolCall({
+        session: state.session, turnId: "turn-1", callId, tool, args,
+        invoke: async ({ crossEffectBoundary }) => {
+          crossEffectBoundary();
+          return tool.execute(args);
+        },
+      });
+      try {
+        await mkdir(join(root, "tmp"));
+        // A failed command can already have made changes. The poll receipt
+        // confirms observation, never that the workspace is unchanged.
+        const started = await invoke(exec, "start-background", {
+          cmd: termination === "nonzero"
+            ? "printf partial > tmp/partial.txt; sleep 0.6; exit 7"
+            : "printf partial > tmp/partial.txt; sleep 30",
+          yield_time_ms: 250,
+          ...(termination === "timeout" ? { timeoutMs: 600 } : {}),
+        });
+        const sessionId = started.metadata?.sessionId as number;
+        expect(sessionId, started.content).toEqual(expect.any(Number));
+        if (termination === "signal") manager.terminateProcess(sessionId);
+        const result = await invoke(poll, "poll-background", { session_id: sessionId, chars: "" });
+        expect(result.isError).toBe(true);
+        expect(result.effectDisposition).toMatchObject({ disposition: "confirmed_committed", evidenceKind: "provider_receipt" });
+        expect(result.content).toContain(termination === "timeout" ? "timed_out=true" : termination === "nonzero" ? "exit_code=7" : "signal_terminated=true");
+        expect(await readFile(join(root, "tmp/partial.txt"), "utf8")).toBe("partial");
+        const followUp = await invoke(exec, "follow-up", { cmd: "printf recovered > tmp/recovered.txt" });
+        expect(followUp.isError).not.toBe(true);
+        expect(await readFile(join(root, "tmp/recovered.txt"), "utf8")).toBe("recovered");
+        expect(state.effectEvents.some((event) => event.msg.type === "effect_unknown_outcome")).toBe(false);
+      } finally {
+        await manager.closeAll("test_cleanup");
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("fails closed before tool dispatch when the canonical effect journal is detached", async () => {
     const state = toolHarness();
     Object.assign(state.session, { rolloutStore: null });

--- a/runtime/tests/gaphunt3/tools-system-write-stdin.test.ts
+++ b/runtime/tests/gaphunt3/tools-system-write-stdin.test.ts
@@ -64,6 +64,10 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
 
     // Before the fix this was `undefined` (silent success); after, true.
     expect(result.isError).toBe(true);
+    expect(result.effectDisposition).toMatchObject({
+      disposition: "confirmed_committed",
+      evidenceRef: "tool:system.write-stdin:process-exit",
+    });
   });
 
   test("flags a timed-out kill (exitCode null, no process_id, timedOut) as isError", async () => {
@@ -81,6 +85,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
     const result = await tool.execute({ session_id: 1, chars: "" });
 
     expect(result.isError).toBe(true);
+    expect(result.effectDisposition?.disposition).toBe("confirmed_committed");
   });
 
   test("does NOT flag a still-alive yielded process (exitCode null, process_id set)", async () => {
@@ -99,6 +104,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
     const result = await tool.execute({ session_id: 7, chars: "" });
 
     expect(result.isError).toBeUndefined();
+    expect(result.effectDisposition?.evidenceRef).toBe("tool:system.write-stdin:process-yield");
   });
 
   test("does NOT flag a clean completion (exitCode 0)", async () => {
@@ -111,6 +117,7 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
     const result = await tool.execute({ session_id: 1, chars: "" });
 
     expect(result.isError).toBeUndefined();
+    expect(result.effectDisposition?.disposition).toBe("confirmed_committed");
   });
 
   test("flags a non-zero exit code as isError", async () => {
@@ -123,5 +130,6 @@ describe("write_stdin isError on signal kill (gaphunt3 #4)", () => {
     const result = await tool.execute({ session_id: 1, chars: "" });
 
     expect(result.isError).toBe(true);
+    expect(result.effectDisposition?.disposition).toBe("confirmed_committed");
   });
 });

--- a/runtime/tests/unified-exec/process-manager.test.ts
+++ b/runtime/tests/unified-exec/process-manager.test.ts
@@ -1010,6 +1010,7 @@ describe("UnifiedExecProcessManager", () => {
       });
       expect(polled.process_id).toBeUndefined();
       expect(polled.exit_code).toBeNull();
+      expect(polled.timedOut).toBe(true);
     } finally {
       await manager.closeAll("test_cleanup");
     }


### PR DESCRIPTION
A background Git clone was explicitly limited to 120 seconds. When it exited during an empty `write_stdin` poll, the tool returned an error without an effect receipt. Admission incorrectly classified the completed observation as unknown and blocked every later mutation behind `/resolve`.

`write_stdin` now records the process manager's authoritative observation, matching `exec_command`. Nonzero exits, signal termination and explicit timeouts remain visible errors. The receipt confirms the observation or accepted input; it makes no claim that the command succeeded or left the workspace unchanged. Writes that fail after bytes may have reached stdin remain unknown. Explicit deadline expiry is also retained across polling so it is reported as a timeout instead of an unexplained signal.

Validation: Core typecheck passed; 114 tests passed across tool adapters, admission, process management and restart recovery. Real subprocess regressions cover timeout, nonzero exit and signal termination, preserve partial filesystem changes, and successfully execute a subsequent admitted command. Commands without an explicit timeout remain alive across polls.

Hosted Actions are skipped; validation is local.
