### PR TITLE
session: drop a reasoning replay that redaction would alter instead of failing the turn

### DIFF
--- a/runtime/src/session/message-history-conversion.ts
+++ b/runtime/src/session/message-history-conversion.ts
@@ -263,7 +263,7 @@ function redactResponseItemForPersistence(
   bodyMode: "authenticate" | "preserve",
 ): ResponseItem {
   const { toolResultIntegrity: _omittedIntegrity, ...unsealedItem } = item;
-  const redacted =
+  let redacted =
     unsealedItem.agentInvocation === undefined
       ? (redactSecretsInValue(unsealedItem) as ResponseItem)
       : (() => {
@@ -291,9 +291,16 @@ function redactResponseItemForPersistence(
             item.providerReasoning.provider ||
           redacted.providerReasoning.model !== item.providerReasoning.model)))
   ) {
-    throw new Error(
-      "cannot persist provider reasoning replay because secret redaction would change its opaque content",
-    );
+    // The replay is opaque provider state: redacting it would corrupt what
+    // the provider gets back, and persisting it unredacted would write the
+    // matched secret into the rollout. Neither is acceptable, so the replay
+    // is dropped from the durable record and the message itself is kept.
+    // The cost is one lost replay on resume. Failing the turn here cost the
+    // whole task: DeepSeek V4 Pro reasoning that quoted a generated password
+    // or a long token-shaped string ended every such run with
+    // turn_execution_failed.
+    const { providerReasoning: _droppedReplay, ...withoutReplay } = redacted;
+    redacted = withoutReplay as ResponseItem;
   }
   assertResponseAgentInvocationItem(redacted);
   if (integrity === undefined) return redacted;

--- a/runtime/tests/session/provider-reasoning-durability.test.ts
+++ b/runtime/tests/session/provider-reasoning-durability.test.ts
@@ -137,7 +137,7 @@ describe("provider reasoning durability", () => {
       .toThrow(/invalid provider reasoning replay/u);
   });
 
-  test("fails closed instead of mutating replay state during secret redaction", () => {
+  test("drops a replay that redaction would alter and keeps the message, while the sink still refuses such a replay", () => {
     const qwenCredential = [
       "sk-ws-H",
       "WORK123",
@@ -145,13 +145,25 @@ describe("provider reasoning durability", () => {
       "a".repeat(64),
     ].join(".");
     const secretLikeReasoning = `provider state ${qwenCredential}`;
-    expect(() =>
-      llmMessageToDurableResponseItem({
-        role: "assistant",
-        content: "",
-        providerReasoningContent: secretLikeReasoning,
-      }))
-      .toThrow(/secret redaction would change its opaque content/u);
+    // Redacting opaque replay state would corrupt it and persisting it raw
+    // would leak the match, so the durable record carries the message
+    // without its replay instead of failing the turn.
+    const durable = llmMessageToDurableResponseItem({
+      role: "assistant",
+      content: "Setting the password now.",
+      providerReasoningContent: secretLikeReasoning,
+      toolCalls: [{ id: "call-9", name: "exec_command", arguments: "{}" }],
+    });
+    expect(durable.providerReasoning).toBeUndefined();
+    expect(durable.content).toBe("Setting the password now.");
+    expect(durable.toolCalls).toEqual([
+      { id: "call-9", name: "exec_command", arguments: "{}" },
+    ]);
+    expect(llmMessageToCheckpointResponseItem({
+      role: "assistant",
+      content: "Setting the password now.",
+      providerReasoningContent: secretLikeReasoning,
+    }).providerReasoning).toBeUndefined();
     expect(() =>
       serializeRolloutItem({
         type: "response_item",


### PR DESCRIPTION
## Why

Two Terminal-Bench 2.0 tasks run with a build of main on DeepSeek V4 Pro ended with

```
turn_failed: turn_execution_failed: cannot persist provider reasoning replay because secret redaction would change its opaque content
```

The model's reasoning had quoted a generated password (a git server task) and a long token-shaped string (a chess task). The durable projection refuses to persist a provider reasoning replay whose redaction would alter it, and it did so by throwing, which turns one unpersistable replay into a dead turn. Release 0.17.0 predates the check (it arrived with the QwenCloud providers), so these tasks completed there.

## What, per file

- `runtime/src/session/message-history-conversion.ts`: when secret redaction would change `providerReasoning` (content, version, provider or model), the durable and checkpoint projections drop the replay from the persisted item and keep everything else. Redacting opaque provider state would corrupt it and persisting it raw would leak the match, so dropping it is the only safe outcome that keeps the turn alive; the cost is one lost replay on resume.
- `runtime/tests/session/provider-reasoning-durability.test.ts`: the pin changes from "throws" to "drops the replay and keeps content and tool calls", and asserts the checkpoint projection agrees. The rollout sink's own refusal (`serializeRolloutItem`) is still asserted, as a second line for items built elsewhere.

## Evidence

Rollouts of the two failed trials (`chess-best-move`, `git-multibranch`, Harbor jobs on 2026-09-12) end with the `turn_failed` event above; the same tasks completed on the 0.17.0 installer build.

## Tests

- `npx vitest run tests/session/`: 93 files passed, 1608 tests passed; the one failing file, `tests/session/cost.test.ts` ("built-in provider defaults with authoritative pricing resolve as known costs"), fails identically on an untouched main checkout ("ollama-cloud:deepseek-v4.1-flash should use a known registry entry"), so it is not from this branch.
- `npx tsc --noEmit` on the runtime: clean.

## Not changed

- The redaction of every other field, the tool-result integrity checks and the rollout sink's refusal of a redactable replay are unchanged.
- Live turns keep the in-memory reasoning; only the durable record loses the replay when it cannot be stored safely.

## Counterpart PRs

- agenc-core #2424 (merged): the other main-only blocker found in the same Terminal-Bench runs (Secret Service unavailable on hosts without one).
