### PR TITLE
eval: Harbor adapter and recipe for Terminal-Bench 2.0, with the first pilot results

### DIFF
--- a/docs/eval/terminal-bench.md
+++ b/docs/eval/terminal-bench.md
@@ -93,4 +93,40 @@ harbor run ... -a agenc_agent:Agenc --ak runtime_url=http://host.docker.internal
 
 ## Results
 
-RESULTS_PLACEHOLDER
+Pilot, 2026-09-12: 11 tasks, one trial each, DeepSeek V4 Pro direct at
+medium effort for every agent, run on a Mac through colima with Rosetta (so
+timings are indicative and the 900 second task budget is tight). AgenC
+0.17.0 is the public installer; AgenC main is commit 4c3afd221 (with #2424
+and #2427) as a tarball; the `+adddir` column reruns AgenC main's four
+failed tasks with `add_dirs=/`.
+
+```
+task                         agenc-0.17.0 agenc-main agenc+adddir     hermes   opencode
+---------------------------------------------------------------------------------------
+chess-best-move                       0          0          1          1          0
+configure-git-webserver               0          0          0          0          0
+count-dataset-tokens                  1          1          -          1          1
+extract-elf                           1          1          -          1          1
+fix-git                               1          1          -          1          1
+git-multibranch                       0          0          0          1          1
+log-summary-date-ranges               1          1          -          1          1
+nginx-request-logging                 0          0          0          1          1
+openssl-selfsigned-cert               -          1          -          1          1
+regex-log                             1          1          -          1          1
+sqlite-db-truncate                    1          1          -          1          1
+---------------------------------------------------------------------------------------
+pass                               6/10       7/11        1/4      10/11       9/11
+agent time (s), sum                3703       4080       1780       3232       2896
+input tokens, sum              10805626    9248524    4929672          0       3330
+output tokens, sum               288694     297244     116402          0       1607
+```
+
+Hermes 10/11, OpenCode 9/11, AgenC main 7/11 (8/11 counting the chess pass in
+the rerun; that task sits at the timeout under emulation). Every agent failed
+configure-git-webserver. The two tasks AgenC fails and the others pass,
+nginx-request-logging and git-multibranch, need a service to keep running
+after the agent's last command; see the containment finding above. Token
+columns: only AgenC's adapter reports usage from its rollouts; Harbor's
+Hermes adapter reports none and the OpenCode adapter only the last message.
+Raw job directories with per-trial rollouts and grader output are kept
+outside the repo (`~/claude-agenc/bench-harbor/jobs` on the run host).

--- a/docs/eval/terminal-bench.md
+++ b/docs/eval/terminal-bench.md
@@ -33,7 +33,11 @@ name follows Harbor's `provider/model` form. The provider's key is read from
 the runner's environment and forwarded only into the agent process.
 
 Options (`--ak key=value`): `version` (pin a release), `manifest_url`,
-`runtime_url`, `effort` (default `medium`).
+`runtime_url`, `effort` (default `medium`), `add_dirs` (extra workspace
+roots passed as `--add-dir`, default `/`: the tasks configure the whole
+container and AgenC's shell write policy otherwise refuses writes outside
+the task directory, a boundary the other harnesses do not have), and
+`stop_daemon` (default false).
 
 The same file carries `HermesCurrent`, Harbor's Hermes adapter with its
 install check fixed (the current Hermes CLI has no `version` subcommand) and
@@ -74,11 +78,18 @@ harbor run ... -a agenc_agent:Agenc --ak runtime_url=http://host.docker.internal
   ("Native secure storage read failed"); release 0.17.0 did not. Fixed in
   core #2424, which is the first commit a benchmark build of main must carry.
 - `exec_command` containment kills every process the agent started when the
-  command returns, so a server or daemon the agent set up is gone by the
-  time the grader runs. Three of the four failures in the 0.17.0 pilot were
-  tasks of that shape (nginx, a git server with a deploy hook, an sshd-based
-  multi-branch server). Other harnesses leave such processes alive. This is
-  a product decision still open: an opt-in way to leave a service running.
+  command returns, and a managed background process (`run_in_background`)
+  dies when the one-shot session ends, daemon running or not (checked by
+  hand in the nginx task image). A server or daemon the agent set up is gone
+  by the time the grader runs. Three of the four failures in every AgenC
+  run were tasks of that shape (nginx, a git server with a deploy hook, an
+  sshd-based multi-branch server); Hermes and OpenCode passed them on the
+  same model. Other harnesses leave such processes alive. This is a product
+  decision still open: an opt-in way to leave a service running.
+- Even with `--dangerously-bypass-approvals-and-sandbox`, shell commands
+  that write or delete under `/etc`, `/var/www` or `/git` are refused by the
+  workspace write policy, and `workdir: /tmp` is refused as outside the
+  workspace. `--add-dir /` lifts that for the benchmark; see `add_dirs`.
 
 ## Results
 

--- a/docs/eval/terminal-bench.md
+++ b/docs/eval/terminal-bench.md
@@ -1,0 +1,85 @@
+# Terminal-Bench 2.0 through Harbor
+
+A public, reproducible way to measure AgenC against other agent harnesses on
+the same tasks and the same model. Terminal-Bench 2.0 is 89 verified terminal
+tasks (Laude Institute); Harbor is its runner. Every trial installs the agent
+inside the task container, runs one instruction, and grades the container
+state with the task's own tests. The score is pass@1 over the tasks.
+
+## What is measured
+
+- The agent harness, at a fixed model. Harbor reports rows as `agent +
+  model`, so AgenC on DeepSeek V4 Pro sits next to OpenCode or Hermes on the
+  same model. Model choice moves scores far more than the harness does, so a
+  comparison only means something at equal model.
+- Time and tokens per task, from AgenC's own rollout (`token_count` events),
+  so the run also answers "how much does a solved task cost".
+
+## The adapter
+
+`runtime/eval/harbor/agenc_agent.py` is a Harbor installed-agent adapter
+(`--agent agenc_agent:Agenc` with the file's directory on `PYTHONPATH`). It
+installs AgenC with the public installer (`https://get.agenc.ag/install.sh
+--no-daemon`), or from a tarball built by
+`packages/agenc/scripts/build-runtime-tarball.mjs` when `runtime_url` is set,
+which is how an unreleased commit of main is measured. It then runs
+
+```
+agenc --dangerously-bypass-approvals-and-sandbox --provider <p> --model <m> -p "<instruction>"
+```
+
+in the task's working directory, trusting that directory first. The model
+name follows Harbor's `provider/model` form. The provider's key is read from
+the runner's environment and forwarded only into the agent process.
+
+Options (`--ak key=value`): `version` (pin a release), `manifest_url`,
+`runtime_url`, `effort` (default `medium`).
+
+The same file carries `HermesCurrent`, Harbor's Hermes adapter with its
+install check fixed (the current Hermes CLI has no `version` subcommand) and
+DeepSeek registered as a native Hermes provider, so Hermes reaches DeepSeek
+directly instead of through OpenRouter. OpenCode runs through Harbor's own
+ACP adapter (`-a acp:opencode`).
+
+## Running
+
+```bash
+uv tool install harbor
+harbor datasets download terminal-bench@2.0 -o ./tb2
+export PYTHONPATH=/path/to/agenc-core/runtime/eval/harbor
+DEEPSEEK_API_KEY=... harbor run -p ./tb2/terminal-bench -a agenc_agent:Agenc \
+  -m deepseek/deepseek-v4-pro -o ./jobs/agenc -n 4 -k 1
+```
+
+Task images are `linux/amd64`. On Apple silicon, run Docker in a VM with
+Rosetta (colima: `--vz-rosetta`) and share the working directory with the VM
+(colima: `--mount <dir>:w`), or Harbor's bind mounts come back empty and no
+reward file is found. Slim images lack `libatomic.so.1`; the adapter installs
+it before the bundled Node runs.
+
+For an unreleased build of main:
+
+```bash
+AGENC_ARTIFACT_PROFILE=container-local AGENC_RELEASE_OUT_DIR=./dist \
+  node packages/agenc/scripts/build-runtime-tarball.mjs      # on linux-x64
+python3 -m http.server 8765 --directory ./dist &
+harbor run ... -a agenc_agent:Agenc --ak runtime_url=http://host.docker.internal:8765/<tarball>
+```
+
+## What the first runs found in AgenC itself
+
+- Slim Debian and Ubuntu images lack `libatomic.so.1`; the bundled Node dies
+  at daemon spawn. The adapter installs it.
+- Main aborted every headless run on a host without a Secret Service
+  ("Native secure storage read failed"); release 0.17.0 did not. Fixed in
+  core #2424, which is the first commit a benchmark build of main must carry.
+- `exec_command` containment kills every process the agent started when the
+  command returns, so a server or daemon the agent set up is gone by the
+  time the grader runs. Three of the four failures in the 0.17.0 pilot were
+  tasks of that shape (nginx, a git server with a deploy hook, an sshd-based
+  multi-branch server). Other harnesses leave such processes alive. This is
+  a product decision still open: an opt-in way to leave a service running.
+
+## Results
+
+RESULTS_PLACEHOLDER

--- a/runtime/eval/harbor/agenc_agent.py
+++ b/runtime/eval/harbor/agenc_agent.py
@@ -1,0 +1,288 @@
+"""Harbor installed-agent adapter for AgenC.
+
+Installs the public AgenC release inside the task container with the same
+one-line installer a user runs (https://get.agenc.ag/install.sh), then runs
+one headless turn: ``agenc --dangerously-bypass-approvals-and-sandbox
+--provider <p> --model <m> -p "<instruction>"`` in the task's working
+directory. Model names follow Harbor's ``provider/model`` convention, e.g.
+``deepseek/deepseek-v4-pro``. The provider's API key is read from the host
+environment and forwarded only into the agent process.
+
+Options (``--ak key=value``):
+  version       release to pin (default: latest public release)
+  manifest_url  explicit release manifest (a release candidate mirror)
+  effort        reasoning effort written to config (default: medium)
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shlex
+from pathlib import Path
+
+from pydantic import Field
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.agents.options import InstalledAgentOptions
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+# Provider id (as AgenC names it) -> environment variables that carry its key,
+# first match wins. Mirrors runtime/src/llm/registry/provider-info.ts.
+PROVIDER_KEY_ENV: dict[str, tuple[str, ...]] = {
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "grok": ("XAI_API_KEY", "GROK_API_KEY"),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "ollama-cloud": ("OLLAMA_API_KEY",),
+    "cerebras": ("CEREBRAS_API_KEY",),
+    "mistral": ("MISTRAL_API_KEY",),
+    "groq": ("GROQ_API_KEY",),
+    "minimax": ("MINIMAX_API_KEY",),
+    "kimi": ("MOONSHOT_API_KEY", "KIMI_API_KEY"),
+    "zai": ("ZAI_API_KEY",),
+    "qwen": ("QWEN_API_KEY", "DASHSCOPE_API_KEY"),
+    "nvidia-nim": ("NVIDIA_API_KEY",),
+    "meta": ("LLAMA_API_KEY",),
+}
+
+INSTALLER_URL = "https://get.agenc.ag/install.sh"
+AGENT_LOG = "/logs/agent/agenc.txt"
+
+
+class AgencOptions(InstalledAgentOptions):
+    manifest_url: str | None = Field(
+        default=None,
+        description="Explicit release manifest URL, for a release candidate mirror.",
+    )
+    runtime_url: str | None = Field(
+        default=None,
+        description=(
+            "URL of a runtime tarball built with packages/agenc/scripts/"
+            "build-runtime-tarball.mjs (release layout, embedded Node). When set, "
+            "the public installer is skipped and this exact build is installed, "
+            "which is how an unreleased commit of main is measured."
+        ),
+    )
+    effort: str = Field(
+        default="medium",
+        description="reasoning_effort written to the AgenC config before the run.",
+    )
+
+
+class Agenc(BaseInstalledAgent):
+    """AgenC (https://agenc.ag) running headless inside the task container."""
+
+    options_model = AgencOptions
+
+    @staticmethod
+    def name() -> str:
+        return "agenc"
+
+    def version(self) -> str | None:
+        return self.options.version or super().version()
+
+    def get_version_command(self) -> str | None:
+        return 'export PATH="$HOME/.local/bin:$PATH"; agenc --version'
+
+    def parse_version(self, stdout: str) -> str:
+        return stdout.strip().split()[-1] if stdout.strip() else ""
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        await self.ensure_system_dependencies(environment, ("curl",))
+        await self._install_libatomic(environment)
+        if self.options.runtime_url:
+            await self._install_from_tarball(environment, str(self.options.runtime_url))
+            return
+        await self._install_from_public_installer(environment)
+
+    async def _install_libatomic(self, environment: BaseEnvironment) -> None:
+        """The bundled Node links libatomic, which slim Debian and Ubuntu images
+        leave out; the daemon then dies at spawn with "libatomic.so.1: cannot
+        open shared object file". Install it the way the image's package
+        manager knows it (a no-op where it is already present)."""
+        await self.exec_as_root(
+            environment,
+            command=(
+                "if ldconfig -p 2>/dev/null | grep -q 'libatomic.so.1'; then exit 0; fi; "
+                "if command -v apt-get >/dev/null 2>&1; then "
+                "apt-get update -qq && apt-get install -y -qq libatomic1; "
+                "elif command -v dnf >/dev/null 2>&1; then dnf install -y libatomic; "
+                "elif command -v yum >/dev/null 2>&1; then yum install -y libatomic; "
+                "elif command -v apk >/dev/null 2>&1; then apk add --no-cache libatomic; fi"
+            ),
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+            timeout_sec=600,
+        )
+
+    async def _install_from_tarball(self, environment: BaseEnvironment, url: str) -> None:
+        """Unpack a build-runtime-tarball.mjs artifact and wire an `agenc` wrapper.
+
+        The tarball already carries its own Node under node_modules/.agenc-node,
+        so nothing else is downloaded; the wrapper mirrors what the installer
+        writes for a release.
+        """
+        root = "$HOME/.agenc-runtime"
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                f'mkdir -p {root} "$HOME/.local/bin" && '
+                f"curl -fsSL {shlex.quote(url)} | tar -xz -C {root} && "
+                f'NODE="$(cd {root} && pwd)/node_modules/.agenc-node/bin/node" && '
+                f'ENTRY="$(cd {root} && pwd)/node_modules/@tetsuo-ai/runtime/bin/agenc" && '
+                '[ -x "$NODE" ] && [ -f "$ENTRY" ] && '
+                'printf \'#!/bin/sh\\nexec "%s" "%s" "$@"\\n\' "$NODE" "$ENTRY" > "$HOME/.local/bin/agenc" && '
+                'chmod +x "$HOME/.local/bin/agenc" && '
+                'export PATH="$HOME/.local/bin:$PATH" && agenc --version'
+            ),
+            timeout_sec=900,
+        )
+
+    async def _install_from_public_installer(self, environment: BaseEnvironment) -> None:
+        flags = ["--no-daemon", "--verbose"]
+        if self.options.version:
+            flags += ["--version", shlex.quote(str(self.options.version))]
+        if self.options.manifest_url:
+            flags += ["--manifest-url", shlex.quote(str(self.options.manifest_url))]
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                f"curl -fsSL {INSTALLER_URL} -o /tmp/agenc-install.sh && "
+                f"sh /tmp/agenc-install.sh {' '.join(flags)} && "
+                'export PATH="$HOME/.local/bin:$PATH" && agenc --version'
+            ),
+            timeout_sec=900,
+        )
+
+    def _provider_and_model(self) -> tuple[str, str]:
+        if not self.model_name or "/" not in self.model_name:
+            raise ValueError(
+                "Model name must be provider/model, e.g. deepseek/deepseek-v4-pro"
+            )
+        provider, model = self.model_name.split("/", 1)
+        return provider.strip().lower(), model.strip()
+
+    def _key_env(self, provider: str) -> dict[str, str]:
+        names = PROVIDER_KEY_ENV.get(provider)
+        if names is None:
+            raise ValueError(f"No API key mapping for provider {provider!r}")
+        for name in names:
+            value = os.environ.get(name)
+            if value:
+                return {name: value}
+        raise ValueError(f"No API key found for {provider}: set {' or '.join(names)}")
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        provider, model = self._provider_and_model()
+        env = self._key_env(provider)
+        env["HARBOR_INSTRUCTION"] = instruction
+        effort = shlex.quote(str(self.options.effort))
+        trust = (
+            '{"version":1,"trustedProjects":[{"path":"\'"$PWD"\'",'
+            '"trustedAt":"1970-01-01T00:00:00Z"}]}'
+        )
+        run_cmd = (
+            'export PATH="$HOME/.local/bin:$PATH"; '
+            'AH="${AGENC_HOME:-$HOME/.agenc}"; mkdir -p "$AH" /logs/agent; '
+            f"printf '%s' '{trust}' > \"$AH/trusted-projects.json\"; "
+            f"agenc config set reasoning_effort {effort} >/dev/null; "
+            "agenc --dangerously-bypass-approvals-and-sandbox "
+            f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
+            f'-p "$HARBOR_INSTRUCTION" 2>&1 | stdbuf -oL tee {AGENT_LOG}'
+        )
+        try:
+            await self.exec_as_agent(environment, command=run_cmd, env=env)
+        finally:
+            # The rollout is the trajectory: copy it out for token accounting,
+            # then stop the daemon the one-shot started.
+            await self.exec_as_agent(
+                environment,
+                command=(
+                    'export PATH="$HOME/.local/bin:$PATH"; '
+                    'AH="${AGENC_HOME:-$HOME/.agenc}"; '
+                    'for f in "$AH"/projects/*/sessions/*/rollout-*.jsonl; do '
+                    '[ -f "$f" ] && cp "$f" /logs/agent/ || true; done; '
+                    "agenc daemon stop >/dev/null 2>&1 || true"
+                ),
+                timeout_sec=60,
+            )
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        prompt = completion = cached = 0
+        cost = 0.0
+        seen_cost = False
+        for path in glob.glob(str(self.logs_dir / "rollout-*.jsonl")):
+            for line in Path(path).read_text(errors="replace").splitlines():
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                payload = event.get("payload") if isinstance(event, dict) else None
+                msg = payload.get("msg") if isinstance(payload, dict) else None
+                if not isinstance(msg, dict):
+                    continue
+                body = msg.get("payload") or {}
+                if msg.get("type") == "token_count":
+                    prompt += int(body.get("promptTokens") or 0)
+                    completion += int(body.get("completionTokens") or 0)
+                    cached += int(body.get("cachedInputTokens") or 0)
+                elif msg.get("type") == "session_usage":
+                    seen_cost = True
+                    cost = max(cost, float(body.get("costUsd") or 0.0))
+        if prompt or completion:
+            context.n_input_tokens = prompt
+            context.n_output_tokens = completion
+            context.n_cache_tokens = cached
+        if seen_cost and cost > 0:
+            context.cost_usd = cost
+
+
+# --- Comparison agents -------------------------------------------------------
+# Harbor 0.23.0's Hermes adapter ends its install with `hermes version`, a
+# subcommand the current Hermes CLI no longer has (argparse lists status,
+# doctor, config, ... but no version), so every trial died at setup. Same
+# install, same run; only the final check differs.
+from harbor.agents.installed.hermes import Hermes as _Hermes  # noqa: E402
+
+
+class HermesCurrent(_Hermes):
+    @staticmethod
+    def name() -> str:
+        return "hermes"
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        await self.ensure_system_dependencies(
+            environment, ("curl", "git", "ripgrep", "xz")
+        )
+        branch_flag = f" --branch {self._version}" if self._version else ""
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                f"curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup{branch_flag} && "
+                'export PATH="$HOME/.local/bin:$PATH" && '
+                'export HERMES_HOME="${HERMES_HOME:-/tmp/hermes}" && '
+                'mkdir -p "$HERMES_HOME" "$HERMES_HOME/sessions" "$HERMES_HOME/skills" "$HERMES_HOME/memories" && '
+                "command -v hermes && (hermes --version 2>/dev/null || hermes --help >/dev/null 2>&1 || true)"
+            ),
+            timeout_sec=2400,
+        )
+
+
+# Hermes has a native `deepseek` provider (DEEPSEEK_API_KEY), which Harbor's
+# adapter table does not list; without it the run falls back to OpenRouter.
+import harbor.agents.installed.hermes as _hermes_mod  # noqa: E402
+
+_hermes_mod._NATIVE_PROVIDERS.setdefault("deepseek", ("deepseek", ["DEEPSEEK_API_KEY"]))

--- a/runtime/eval/harbor/agenc_agent.py
+++ b/runtime/eval/harbor/agenc_agent.py
@@ -72,6 +72,24 @@ class AgencOptions(InstalledAgentOptions):
         default="medium",
         description="reasoning_effort written to the AgenC config before the run.",
     )
+    add_dirs: str = Field(
+        default="/",
+        description=(
+            "Comma-separated extra workspace roots passed as --add-dir. AgenC's "
+            "shell write policy only lets commands write inside the workspace; "
+            "Terminal-Bench tasks configure the whole container, so the default "
+            "widens the workspace to the filesystem root, which is what the "
+            "other harnesses have implicitly."
+        ),
+    )
+    stop_daemon: bool = Field(
+        default=False,
+        description=(
+            "Stop the AgenC daemon after the turn. Off by default so background "
+            "processes the agent started as managed sessions can outlive the turn "
+            "until the container is torn down."
+        ),
+    )
 
 
 class Agenc(BaseInstalledAgent):
@@ -189,6 +207,11 @@ class Agenc(BaseInstalledAgent):
         env = self._key_env(provider)
         env["HARBOR_INSTRUCTION"] = instruction
         effort = shlex.quote(str(self.options.effort))
+        add_dir_flags = " ".join(
+            f"--add-dir {shlex.quote(path.strip())}"
+            for path in str(self.options.add_dirs).split(",")
+            if path.strip()
+        )
         trust = (
             '{"version":1,"trustedProjects":[{"path":"\'"$PWD"\'",'
             '"trustedAt":"1970-01-01T00:00:00Z"}]}'
@@ -199,6 +222,7 @@ class Agenc(BaseInstalledAgent):
             f"printf '%s' '{trust}' > \"$AH/trusted-projects.json\"; "
             f"agenc config set reasoning_effort {effort} >/dev/null; "
             "agenc --dangerously-bypass-approvals-and-sandbox "
+            f"{add_dir_flags + ' ' if add_dir_flags else ''}"
             f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
             f'-p "$HARBOR_INSTRUCTION" 2>&1 | stdbuf -oL tee {AGENT_LOG}'
         )
@@ -213,8 +237,8 @@ class Agenc(BaseInstalledAgent):
                     'export PATH="$HOME/.local/bin:$PATH"; '
                     'AH="${AGENC_HOME:-$HOME/.agenc}"; '
                     'for f in "$AH"/projects/*/sessions/*/rollout-*.jsonl; do '
-                    '[ -f "$f" ] && cp "$f" /logs/agent/ || true; done; '
-                    "agenc daemon stop >/dev/null 2>&1 || true"
+                    '[ -f "$f" ] && cp "$f" /logs/agent/ || true; done'
+                    + ("; agenc daemon stop >/dev/null 2>&1 || true" if self.options.stop_daemon else "")
                 ),
                 timeout_sec=60,
             )


### PR DESCRIPTION
## Why

A public, reproducible way to measure AgenC against other harnesses on the same tasks and the same model, for the launch. Terminal-Bench 2.0 through Harbor was chosen because its leaderboard compares agent plus model pairs and Harbor runs any installed agent inside the task container. The first pilot (11 tasks, DeepSeek V4 Pro, one trial, four harnesses) is in the docs page, with the three AgenC problems it surfaced.

## What, per file

- `runtime/eval/harbor/agenc_agent.py` (new): a Harbor installed-agent adapter. `Agenc` installs AgenC with the public installer (`--no-daemon`, optional `version` or `manifest_url`) or from a tarball built by `packages/agenc/scripts/build-runtime-tarball.mjs` (`runtime_url`, how an unreleased commit of main is measured), installs `libatomic1` where slim images lack it, trusts the task directory, writes `reasoning_effort`, runs `agenc --dangerously-bypass-approvals-and-sandbox --add-dir <roots> --provider P --model M -p "<instruction>"`, copies the rollout out and reports prompt, cached and completion tokens to Harbor. Options: `version`, `manifest_url`, `runtime_url`, `effort`, `add_dirs` (default `/`), `stop_daemon` (default false). `HermesCurrent` is Harbor's Hermes adapter with two fixes needed against the current Hermes CLI (no `version` subcommand; DeepSeek as a native provider so it is not routed through OpenRouter).
- `docs/eval/terminal-bench.md` (new): what the benchmark measures, the adapter, the exact run commands (including the Apple silicon caveats: Rosetta, the shared directory, libatomic), the findings in AgenC, and the pilot table.

## Evidence

The pilot table in the docs page: Hermes 10/11, OpenCode 9/11, AgenC main 7/11 (8/11 with the rerun), all on DeepSeek V4 Pro. Two main-only regressions found by these runs are already fixed and merged (#2424, #2427). Two harness behaviours that cost the server tasks are documented as open decisions.

## Tests

- The adapter imports and its schema renders under Harbor 0.23.0 (`harbor agent schema agenc_agent:Agenc`); it ran 36 Terminal-Bench trials today across three AgenC builds.
- No runtime code changes in this PR, so no runtime test suites are affected; `docs` only otherwise.

## Not changed

- Nothing in the runtime. The adapter lives under `runtime/eval/harbor/` as a Python file Harbor imports; it is not part of the npm package.
- The pilot numbers come from a Mac under Rosetta with one trial per task; the launch number needs an x86 Linux host and repeated trials, as the page says.

## Counterpart PRs

- agenc-core #2424 and #2427 (merged): the regressions these runs found.
