### PR TITLE
exec_command: detach for services, a residue note, and the shell write policy under the full bypass

### DIFF
--- a/docs/eval/terminal-bench.md
+++ b/docs/eval/terminal-bench.md
@@ -78,18 +78,30 @@ harbor run ... -a agenc_agent:Agenc --ak runtime_url=http://host.docker.internal
   ("Native secure storage read failed"); release 0.17.0 did not. Fixed in
   core #2424, which is the first commit a benchmark build of main must carry.
 - `exec_command` containment kills every process the agent started when the
-  command returns, and a managed background process (`run_in_background`)
-  dies when the one-shot session ends, daemon running or not (checked by
-  hand in the nginx task image). A server or daemon the agent set up is gone
-  by the time the grader runs. Three of the four failures in every AgenC
-  run were tasks of that shape (nginx, a git server with a deploy hook, an
-  sshd-based multi-branch server); Hermes and OpenCode passed them on the
-  same model. Other harnesses leave such processes alive. This is a product
-  decision still open: an opt-in way to leave a service running.
-- Even with `--dangerously-bypass-approvals-and-sandbox`, shell commands
-  that write or delete under `/etc`, `/var/www` or `/git` are refused by the
-  workspace write policy, and `workdir: /tmp` is refused as outside the
-  workspace. `--add-dir /` lifts that for the benchmark; see `add_dirs`.
+  command returns, and a managed background process (`yield_time_ms`) dies
+  when the one-shot session ends, daemon running or not (checked by hand in
+  the nginx task image). A server or daemon the agent set up was gone by the
+  time the grader ran, and the tool result never said so: the pilot
+  rollouts show the model running `nginx`, `setsid nginx`, `setsid -f ...`
+  and finally `nginx -g 'daemon off;'` under `yield_time_ms`, each time
+  finding nothing listening afterwards. Three of the four failures in every
+  AgenC run were tasks of that shape (nginx, a git server with a deploy
+  hook, an sshd-based multi-branch server); Hermes and OpenCode passed them
+  on the same model. Fixed 2026-09-12: the result now carries a note when
+  leftover processes were stopped, and `exec_command` takes `detach: true`
+  to start a service that outlives the command and the session (under the
+  `danger-full-access` sandbox only). See
+  [tools-permissions-sandbox](../reference/tools-permissions-sandbox.md#shell--process).
+- Even with `--dangerously-bypass-approvals-and-sandbox`, the shell write
+  policy refused removals outside the workspace (`unlink
+  /etc/nginx/sites-enabled/default`, `rm -rf /git/project`) and every
+  command it could not analyse, which was any command containing `$(...)`:
+  51 of 459 shell calls in the git-multibranch run, most an `echo "$(...)"`
+  beside a harmless write. Fixed 2026-09-12: with approvals bypassed and no
+  sandbox, those two guards are lifted (protected paths and the Edit/Write
+  routing for workspace files stay), and removals under `--add-dir` roots
+  count as workspace removals in every mode. `workdir` outside the workspace
+  still needs `--add-dir`; the adapter passes `add_dirs` (default `/`).
 
 ## Results
 

--- a/docs/eval/terminal-bench.md
+++ b/docs/eval/terminal-bench.md
@@ -100,8 +100,20 @@ harbor run ... -a agenc_agent:Agenc --ak runtime_url=http://host.docker.internal
   beside a harmless write. Fixed 2026-09-12: with approvals bypassed and no
   sandbox, those two guards are lifted (protected paths and the Edit/Write
   routing for workspace files stay), and removals under `--add-dir` roots
-  count as workspace removals in every mode. `workdir` outside the workspace
-  still needs `--add-dir`; the adapter passes `add_dirs` (default `/`).
+  count as workspace removals in every mode, and `workdir` may point at an
+  added directory or, under the full bypass, anywhere. The first rerun with
+  that build still showed the refusals: the dispatcher ran a tool's
+  preflight before it attached the runtime context, so the policy decided
+  with no session at all; a provisional context is now attached first.
+- Under the same flag, and even with `--add-dir /`, `Edit`, `Write` and
+  `FileRead` refused every path outside the workspace (`Access denied: Path
+  is outside allowed directories`, 8 times in one nginx trial): the
+  permission layer allowed the path but never handed the tool the widened
+  root it hands out after an approval. Fixed 2026-09-12 in
+  `checkToolPathPermission`. The first rerun also showed `detach: true`
+  refused by the Editor workspace fence, which the dispatcher keeps around
+  every tool call; a detached service is now outside that fence. `tty: true`
+  is still refused by the same fence in one-shot runs (pre-existing, open).
 
 ## Results
 

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -456,7 +456,21 @@ so the two guards that only route a mutation to a prompt or the sandbox are
 lifted: undeterminable targets run, and removals outside the workspace are
 allowed. Workspace content writes still belong to Edit and Write, and the
 protected paths stay refused. `--bypass-approvals` alone keeps every guard;
-the sandbox is the boundary there.
+the sandbox is the boundary there. `exec_command`'s `workdir` follows the
+same rule: the workspace, a directory added with `--add-dir`, or anywhere
+under the full bypass. The policy is evaluated with the session's mode and
+sandbox at preflight as well as at execution (the dispatcher attaches a
+provisional runtime context before a tool's `preflight`), so the two phases
+decide alike.
+
+The file tools (`FileRead`, `Edit`, `Write`, `MultiEdit`, `NotebookEdit`)
+confine themselves to the workspace root plus the roots the permission layer
+signs onto their input. When the layer allows a path outside the cwd on its
+own, through `--add-dir`, an allow rule, or `bypassPermissions`, it hands the
+tool that path's directory the same way it does after an approval; before,
+such an allow ended in the tool's own `Path is outside allowed directories`
+(the half-bypass seen with Edit on `/etc/nginx/nginx.conf`). The safety gates
+(`.git`, `.agenc`, `.agents`, dangerous removals) are not widened.
 
 Neither bypass setting removes a planning worker's permanent read-only
 constraint. See [read-only planning workers](agents.md#read-only-planning-workers).

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -153,6 +153,22 @@ Legacy `system.*` utilities (not the primary edit surface):
 | `system.bash` | Direct/shell fallback — **deferred** by default; prefer `exec_command` |
 | `PowerShell` | Registered only when `pwsh`/`powershell` is on `PATH` **and** a unified-exec manager is available; **deferred** |
 
+Background processes and services. `exec_command` stops every process a
+command leaves behind when the command returns (a trailing `&`, `nohup`,
+`setsid`, a daemon that forks) and says so in the result, on a line after the
+footer: `[note: this command left processes running ... detach: true]`. A
+process kept alive with `yield_time_ms` has a `session_id`, lives for the
+session, and is stopped by `closeAll` when the session ends. `detach: true`
+starts a service AgenC never stops: its own session, stdout and stderr in a
+log file under the session temp root, an early-exit wait of `yield_time_ms`
+(default 2 s) so a daemon that rejects its config still reports the error,
+then `running=true pid=<pid> detached=true log=<path>` in the footer. It needs
+the `danger-full-access` sandbox (`--dangerously-bypass-approvals-and-sandbox`
+or `sandbox_mode = "danger-full-access"`): a detached process escapes every
+containment a sandbox lease relies on, so under a sandbox the tool refuses it
+and points at `yield_time_ms`. It cannot be combined with `tty`, and
+`kill_process` does not know detached processes; stop one with `kill <pid>`.
+
 ### Search / discovery / code intel
 
 | Name | Notes |
@@ -423,6 +439,24 @@ an error.
 The SDK mirrors the split: `createSession({ bypassApprovals: true })` sends
 `permissionMode: "bypassPermissions"` and leaves the sandbox on, while
 `dangerouslyBypassApprovalsAndSandbox: true` remains the no-sandbox option.
+
+The shell write policy follows the same split. It refuses shell commands that
+write workspace files outside the generated roots (`build`, `dist`, `logs`,
+`.cache`, `tmp`, `coverage`; use Edit or Write), that remove or move files
+outside the workspace, the system temp directory, or a directory added with
+`--add-dir`, that remove protected paths (the workspace root, `/`, the home,
+`.git`, `.agenc`, `.agents`, the AgenC home, shell and git config files), and
+commands whose write targets it cannot determine (variables, globs, command
+substitution). Removals inside the workspace or an added directory run
+without a prompt in `bypassPermissions`, `acceptEdits` and `auto`, and after
+approval otherwise. When approvals are bypassed **and** no sandbox applies
+(`--dangerously-bypass-approvals-and-sandbox`, or `bypassPermissions` on a
+host that cannot sandbox) nothing but this policy would gate a shell mutation,
+so the two guards that only route a mutation to a prompt or the sandbox are
+lifted: undeterminable targets run, and removals outside the workspace are
+allowed. Workspace content writes still belong to Edit and Write, and the
+protected paths stay refused. `--bypass-approvals` alone keeps every guard;
+the sandbox is the boundary there.
 
 Neither bypass setting removes a planning worker's permanent read-only
 constraint. See [read-only planning workers](agents.md#read-only-planning-workers).

--- a/runtime/src/llm/shell-write-policy.ts
+++ b/runtime/src/llm/shell-write-policy.ts
@@ -123,6 +123,26 @@ export interface ShellWorkspaceWritePolicyInput {
   readonly allowWorkspaceDeletions?: boolean;
   /** Extra roots (the AgenC home) that a shell command may never remove. */
   readonly protectedRoots?: readonly string[];
+  /**
+   * Directories the user added with `--add-dir` or approved during the
+   * session. A shell command may remove or move files under them the way it
+   * may inside the workspace: without a prompt when `allowWorkspaceDeletions`
+   * is set, otherwise after approval. Content writes there were never
+   * refused, since they are outside the workspace.
+   */
+  readonly additionalRoots?: readonly string[];
+  /**
+   * The session bypasses approvals and runs without a sandbox
+   * (`--dangerously-bypass-approvals-and-sandbox`, or bypassPermissions on a
+   * host that cannot sandbox). Nothing but this policy would gate a shell
+   * mutation, and the user chose that, so the guards that exist only to route
+   * a mutation through a prompt or the sandbox are lifted: a command whose
+   * write targets cannot be determined runs, and removals outside the
+   * workspace are allowed. Workspace content writes still belong to Edit and
+   * Write, and the protected roots (`/`, the home, `.git`, `.agenc`, the
+   * AgenC home, shell and git config files) stay refused.
+   */
+  readonly bypassesApprovalsAndSandbox?: boolean;
 }
 
 interface ShellMove {
@@ -633,21 +653,42 @@ function isProtectedDeletionPath(
   return PROTECTED_DELETION_FILES.has(basename(absolutePath));
 }
 
+interface DeletionPolicyScope {
+  readonly workspaceRoot: string;
+  readonly protectedRoots: readonly string[];
+  readonly additionalRoots: readonly string[];
+  readonly allowWorkspaceDeletions: boolean;
+  readonly bypassesApprovalsAndSandbox: boolean;
+}
+
 function classifyDeletionTarget(
   absolutePath: string,
-  workspaceRoot: string,
-  protectedRoots: readonly string[],
-  allowWorkspaceDeletions: boolean,
+  scope: DeletionPolicyScope,
 ):
   | { readonly kind: "allowed"; readonly inWorkspace: boolean }
   | { readonly kind: "blocked"; readonly reason: DeletionBlockReason } {
+  const { workspaceRoot, protectedRoots, allowWorkspaceDeletions } = scope;
   if (isProtectedDeletionPath(absolutePath, workspaceRoot, protectedRoots)) {
     return { kind: "blocked", reason: "protected" };
   }
   if (workspaceRelation(workspaceRoot, absolutePath) === "outside") {
-    return isUnderTempRoot(absolutePath)
-      ? { kind: "allowed", inWorkspace: false }
-      : { kind: "blocked", reason: "outside" };
+    if (isUnderTempRoot(absolutePath) || scope.bypassesApprovalsAndSandbox) {
+      return { kind: "allowed", inWorkspace: false };
+    }
+    // An added directory is a root the user granted, so a removal there is
+    // the workspace class of mutation (prompt-free or approved), never the
+    // "ask the user to remove it themselves" refusal. It is still not a
+    // workspace path: the file-history sidecar does not back it up.
+    if (
+      scope.additionalRoots.some(
+        (root) => workspaceRelation(root, absolutePath) === "inside",
+      )
+    ) {
+      return allowWorkspaceDeletions
+        ? { kind: "allowed", inWorkspace: false }
+        : { kind: "blocked", reason: "needs_approval" };
+    }
+    return { kind: "blocked", reason: "outside" };
   }
   if (isWorkspaceGeneratedOutputPath(workspaceRoot, absolutePath)) {
     return { kind: "allowed", inWorkspace: true };
@@ -781,13 +822,16 @@ export function classifyShellWorkspaceWritePolicy(
   const deletionTargets: string[] = [];
   const blockedDeletions: string[] = [];
   const deletionReasons = new Set<DeletionBlockReason>();
+  const bypassesApprovalsAndSandbox = params.bypassesApprovalsAndSandbox === true;
+  const deletionScope: DeletionPolicyScope = {
+    workspaceRoot,
+    protectedRoots: params.protectedRoots ?? [],
+    additionalRoots: (params.additionalRoots ?? []).map((root) => resolvePath(root)),
+    allowWorkspaceDeletions: params.allowWorkspaceDeletions === true,
+    bypassesApprovalsAndSandbox,
+  };
   for (const target of removals) {
-    const verdict = classifyDeletionTarget(
-      target,
-      workspaceRoot,
-      params.protectedRoots ?? [],
-      params.allowWorkspaceDeletions === true,
-    );
+    const verdict = classifyDeletionTarget(target, deletionScope);
     if (verdict.kind === "allowed") {
       if (verdict.inWorkspace) deletionTargets.push(target);
     } else {
@@ -806,7 +850,11 @@ export function classifyShellWorkspaceWritePolicy(
   if (blockedDeletions.length > 0) {
     messages.push(buildDeletionPolicyMessage(deletionReasons, blockedDeletions));
   }
-  if (collected.indeterminate) {
+  // With approvals bypassed and no sandbox, an unresolvable target no longer
+  // has a prompt or a kernel boundary to be routed to; refusing it only made
+  // the model rewrite `echo "$(id)"` and `for f in *; do ... done` until they
+  // parsed. The decision still reports `indeterminate` for callers.
+  if (collected.indeterminate && !bypassesApprovalsAndSandbox) {
     messages.push(buildIndeterminatePolicyMessage(observedTargets));
   }
 

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -130,7 +130,8 @@ export interface LLMMessage {
       readonly kind:
         | "input_validation"
         | "mcp_tool_not_shell_command"
-        | "shell_workspace_write_policy";
+        | "shell_workspace_write_policy"
+        | "exec_detach_unavailable";
     };
     /**
      * Durable tool-result identity. This is runtime-only state: provider wire

--- a/runtime/src/permissions/path-validation.ts
+++ b/runtime/src/permissions/path-validation.ts
@@ -698,10 +698,22 @@ export function checkToolPathPermission(
       ) ? opts.planFileAuthority : null,
     },
   );
+  // A file tool confines itself to the workspace root plus the signed roots
+  // on its input; the permission layer widens that only when the user
+  // approves a prompt (see the `ask` result below). An allow the layer
+  // reaches on its own for a path outside the cwd, through `--add-dir`, an
+  // allow rule, or bypassPermissions, therefore used to end in the tool's
+  // own "Path is outside allowed directories" (observed: Edit on
+  // /etc/nginx/nginx.conf under --dangerously-bypass-approvals-and-sandbox
+  // with --add-dir /). Hand the tool the same directory an approval would.
+  const inputForAllow = (): Record<string, unknown> =>
+    isPathInside(result.resolvedPath, resolve(opts.cwd))
+      ? opts.input
+      : withTransientAllowedRoot(opts.input, result.resolvedPath);
   if (result.allowed) {
     return {
       behavior: "allow",
-      updatedInput: opts.input,
+      updatedInput: inputForAllow(),
       decisionReason: result.decisionReason,
     };
   }
@@ -743,7 +755,7 @@ export function checkToolPathPermission(
   ) {
     return {
       behavior: "allow",
-      updatedInput: opts.input,
+      updatedInput: inputForAllow(),
       decisionReason: { type: "mode", mode: "bypassPermissions" },
     };
   }

--- a/runtime/src/tools/result-metadata.ts
+++ b/runtime/src/tools/result-metadata.ts
@@ -24,7 +24,8 @@ export interface FileMutationMetadataInput {
 export type RecoverableToolFailureKind =
   | "input_validation"
   | "mcp_tool_not_shell_command"
-  | "shell_workspace_write_policy";
+  | "shell_workspace_write_policy"
+  | "exec_detach_unavailable";
 
 export function buildRecoverableToolFailureMetadata(
   kind: RecoverableToolFailureKind,
@@ -46,7 +47,8 @@ export function recoverableFailureKind(
   if (metadata.hiddenFromTranscript !== true) return null;
   return metadata.kind === "input_validation" ||
     metadata.kind === "mcp_tool_not_shell_command" ||
-    metadata.kind === "shell_workspace_write_policy"
+    metadata.kind === "shell_workspace_write_policy" ||
+    metadata.kind === "exec_detach_unavailable"
     ? metadata.kind
     : null;
 }

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -102,8 +102,10 @@ import {
 } from "../planning/plan-files.js";
 import { markLoadedToolNamesDiscovered } from "./deferred-discovery.js";
 import {
+  attachToolRuntimeContext,
   buildToolRuntimeAttemptContext,
   buildToolRuntimeCallContext,
+  readToolRuntimeContext,
   type ToolRuntimeAttemptContext,
 } from "./runtimes/context.js";
 import { withSignedAllowedRoots } from "./system/filesystem.js";
@@ -1915,12 +1917,64 @@ function readSessionId(session: Session): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+/**
+ * Give a tool's preflight the facts the dispatcher already knows about the
+ * call. Preflight runs before approval and before the attempt context is
+ * built, so a preflight that depends on the session's permission mode or
+ * sandbox (the shell write policy in exec_command, write_stdin and
+ * system.bash) used to decide with no context at all and refused under
+ * `--dangerously-bypass-approvals-and-sandbox` what its execution would then
+ * have allowed. The context carries the session (for the permission mode),
+ * the session's approval policy and requested sandbox mode, and
+ * `approvalResolved: false`; the dispatcher attaches its own context at
+ * execution, which replaces this one. Args that already carry a context keep
+ * it.
+ */
+export function attachPreflightRuntimeContext(
+  tool: Tool,
+  args: Record<string, unknown>,
+  invocation: ToolInvocation,
+  params: {
+    readonly approvalPolicy: ApprovalPolicy;
+    readonly sandboxMode: SandboxMode;
+  },
+): void {
+  if (readToolRuntimeContext(args) !== undefined) return;
+  const call = buildToolRuntimeCallContext({
+    toolCall: { id: invocation.callId, name: nameDisplay(invocation.toolName) },
+    payload: invocation.payload,
+    tool,
+    args,
+    source: invocation.source,
+  });
+  attachToolRuntimeContext(
+    args,
+    buildToolRuntimeAttemptContext(call, {
+      approvalPolicy: params.approvalPolicy,
+      requestedSandboxMode: params.sandboxMode,
+      sandboxMode: params.sandboxMode,
+      approvalResolved: false,
+      rawArgs: stringifyToolArgsWithBigInt(args),
+      invocation,
+    }),
+  );
+}
+
 function preflightToolCall(
   tool: Tool,
   args: Record<string, unknown>,
   invocation: ToolInvocation,
-  options: { readonly discoveredToolNames?: ReadonlySet<string> } = {},
+  options: {
+    readonly discoveredToolNames?: ReadonlySet<string>;
+    readonly approvalPolicy?: ApprovalPolicy;
+    readonly sandboxMode?: SandboxMode;
+  } = {},
 ): ToolDispatchResult | null {
+  attachPreflightRuntimeContext(tool, args, invocation, {
+    approvalPolicy:
+      options.approvalPolicy ?? directDispatchApprovalPolicy(invocation),
+    sandboxMode: options.sandboxMode ?? directDispatchSandboxMode(invocation),
+  });
   const result = validateToolPreflight(tool, args, options);
   if (result !== null) {
     emitErrorEvent(invocation.session.eventLog, invocation.callId, {

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -4,7 +4,11 @@ import { resolve } from "node:path";
 import type { Tool, ToolExecutionInjectedArgs, ToolPreflightFailure, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
-import { shellWorkspaceMutationPermission } from "./shell-mutation-permission.js";
+import {
+  shellAdditionalWriteRoots,
+  shellBypassesApprovalsAndSandbox,
+  shellWorkspaceMutationPermission,
+} from "./shell-mutation-permission.js";
 import { preflightShellWorkspaceWritePolicy } from "./shell-preflight.js";
 import type { BashToolConfig } from "./types.js";
 import { UnifiedExecError } from "../../unified-exec/types.js";
@@ -442,7 +446,16 @@ function validateExecCommandInput(
     return { code: "invalid-input", message: "detach cannot be combined with tty; a detached service has no terminal" };
   }
   const workdir = asString(args.workdir);
-  if (workdir !== undefined && workdir.trim().length > 0) {
+  // The working directory may be the workspace, a directory the user added
+  // with --add-dir, or anywhere when approvals are bypassed and no sandbox
+  // applies (the command could `cd` there anyway; refusing only cost the
+  // model a turn: `workdir: /tmp` was refused in every Terminal-Bench run).
+  const context = readToolRuntimeContext(args as Record<string, unknown>);
+  if (
+    workdir !== undefined &&
+    workdir.trim().length > 0 &&
+    !shellBypassesApprovalsAndSandbox(context)
+  ) {
     const canonicalPath = (candidate: string): string => {
       try {
         return existsSync(candidate) ? realpathSync(candidate) : candidate;
@@ -451,7 +464,10 @@ function validateExecCommandInput(
       }
     };
     const resolvedWorkdir = canonicalPath(resolve(config?.cwd ?? process.cwd(), workdir));
-    const roots = (config?.allowedPaths ?? (config?.cwd !== undefined ? [config.cwd] : [])).map(canonicalPath);
+    const roots = [
+      ...(config?.allowedPaths ?? (config?.cwd !== undefined ? [config.cwd] : [])),
+      ...shellAdditionalWriteRoots(context),
+    ].map(canonicalPath);
     if (roots.length > 0 && !roots.some((root) =>
       resolvedWorkdir === root ||
       resolvedWorkdir.startsWith(root.endsWith("/") || root.endsWith("\\") ? root : `${root}/`) ||

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -9,7 +9,11 @@ import { preflightShellWorkspaceWritePolicy } from "./shell-preflight.js";
 import type { BashToolConfig } from "./types.js";
 import { UnifiedExecError } from "../../unified-exec/types.js";
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
-import type { UnifiedExecProcessManagerLike, UnifiedExecRuntimeSandbox } from "../../unified-exec/types.js";
+import type {
+  ExecCommandToolOutput,
+  UnifiedExecProcessManagerLike,
+  UnifiedExecRuntimeSandbox,
+} from "../../unified-exec/types.js";
 import { processOwnerIdFromToolArgs } from "../../unified-exec/process-ownership.js";
 import type {
   NetworkSandboxPolicy,
@@ -341,30 +345,76 @@ export function confirmedNoEffectDisposition(
   });
 }
 
+/** A detached service that was still running when its yield window closed. */
+function isDetachedAndRunning(output: ExecCommandToolOutput): boolean {
+  return output.detached === true && output.exitCode === null;
+}
+
+/**
+ * Whether the command's process is alive after the tool returned: yielded to
+ * the caller with a session_id, or started detached and still running.
+ */
+function processStillAlive(output: ExecCommandToolOutput): boolean {
+  return (
+    isDetachedAndRunning(output) ||
+    (output.exitCode === null && output.process_id !== undefined)
+  );
+}
+
 function processObservationDisposition(
   cmd: string,
   cwd: string,
-  output: Awaited<
-    ReturnType<UnifiedExecProcessManagerLike["execCommand"]>
-  >,
+  output: ExecCommandToolOutput,
 ) {
-  const stillAlive =
-    output.exitCode === null && output.process_id !== undefined;
+  const evidenceRef = isDetachedAndRunning(output)
+    ? "tool:system.exec-command:process-detached"
+    : processStillAlive(output)
+      ? "tool:system.exec-command:process-yield"
+      : "tool:system.exec-command:process-exit";
   return createToolEffectDispositionEvidence({
     disposition: "confirmed_committed",
     evidenceKind: "provider_receipt",
-    evidenceRef: stillAlive
-      ? "tool:system.exec-command:process-yield"
-      : "tool:system.exec-command:process-exit",
+    evidenceRef,
     evidenceMaterial: JSON.stringify({
       cmd,
       cwd,
       exitCode: output.exitCode,
       processId: output.process_id ?? null,
+      ...(output.detached === true
+        ? { detached: true, pid: output.pid ?? null }
+        : {}),
       timedOut: output.timedOut,
       durationMs: output.durationMs,
     }),
   });
+}
+
+/**
+ * Why `detach: true` cannot run here, or null when it can. A detached process
+ * escapes every containment the sandbox lease relies on, so it exists only
+ * where no sandbox applies; the message names the flag that gets there and
+ * the sandboxed alternative.
+ */
+function detachRefusal(
+  runtimeSandbox: UnifiedExecRuntimeSandbox | undefined,
+  manager: UnifiedExecProcessManagerLike,
+): ToolResult | null {
+  const message =
+    runtimeSandbox !== undefined
+      ? "detach: true needs the danger-full-access sandbox: start AgenC with --dangerously-bypass-approvals-and-sandbox (or sandbox_mode = \"danger-full-access\"). In a sandboxed session keep the process alive with yield_time_ms instead; it stops when the session ends."
+      : manager.startDetachedProcess === undefined
+        ? "detach: true is not supported by this exec manager."
+        : null;
+  if (message === null) return null;
+  return {
+    content: safeStringify({ error: message }),
+    isError: true,
+    metadata: buildRecoverableToolFailureMetadata("exec_detach_unavailable"),
+    effectDisposition: confirmedNoEffectDisposition(
+      "tool:system.exec-command:detach-unavailable",
+      message,
+    ),
+  };
 }
 
 const REMOVED_ALIAS_HINTS = {
@@ -385,6 +435,12 @@ function validateExecCommandInput(
   if (permissions.kind === "invalid") return { code: "invalid-input", message: permissions.reason };
   const cmd = asString(args.cmd);
   if (cmd === undefined) return { code: "invalid-input", message: "cmd must be a non-empty string" };
+  if (args.detach !== undefined && typeof args.detach !== "boolean") {
+    return { code: "invalid-input", message: "detach must be a boolean" };
+  }
+  if (args.detach === true && args.tty === true) {
+    return { code: "invalid-input", message: "detach cannot be combined with tty; a detached service has no terminal" };
+  }
   const workdir = asString(args.workdir);
   if (workdir !== undefined && workdir.trim().length > 0) {
     const canonicalPath = (candidate: string): string => {
@@ -424,7 +480,7 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
   return {
     name: "exec_command",
     description:
-      "Run a shell command in the current AgenC workspace and return captured stdout/stderr. Use this for inspection, tests, builds, and other terminal work. Use Edit or Write for source-file edits; delete or rename workspace files here with rm or mv. Never use this to print commentary, placeholders, or reminders to yourself; call the relevant tool directly instead.\n\nLong-running commands: set a short yield_time_ms to run in the BACKGROUND — when the command outlives the yield window the result carries a session_id and the process keeps running. Poll for more output with write_stdin(session_id, chars='') and stop it with kill_process(session_id). Prefer this over trailing '&' (a shell-backgrounded child has no session_id, so its output is unrecoverable).",
+      "Run a shell command in the current AgenC workspace and return captured stdout/stderr. Use this for inspection, tests, builds, and other terminal work. Use Edit or Write for source-file edits; delete or rename workspace files here with rm or mv. Never use this to print commentary, placeholders, or reminders to yourself; call the relevant tool directly instead.\n\nLong-running commands: set a short yield_time_ms to run in the BACKGROUND — when the command outlives the yield window the result carries a session_id and the process keeps running. Poll for more output with write_stdin(session_id, chars='') and stop it with kill_process(session_id). Prefer this over trailing '&' (a shell-backgrounded child has no session_id, so its output is unrecoverable).\n\nServices: every process a command leaves behind (a trailing '&', nohup, setsid, a daemon that forks) is stopped when the command returns, and a process kept alive with yield_time_ms is stopped when the session ends. To start a web server, database, sshd, or other daemon that must keep running afterwards, set detach: true (needs the danger-full-access sandbox); the result carries its pid and log file.",
     metadata: {
       family: "terminal",
       source: "builtin",
@@ -508,6 +564,11 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
           description:
             "Shell executable to run the command through. Defaults to the user's shell.",
         },
+        detach: {
+          type: "boolean",
+          description:
+            "Start the command as a detached service: its own session, stdout/stderr to a log file, never stopped by AgenC, so it survives this command returning and the session ending. Waits yield_time_ms (default 2000) for an early exit, then returns pid and log path. Only under the danger-full-access sandbox (--dangerously-bypass-approvals-and-sandbox); not with tty.",
+        },
         ...SANDBOX_PERMISSION_INPUT_PROPERTIES,
         prefix_rule: {
           type: "array",
@@ -536,6 +597,7 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
       const workdir = asString(args.workdir);
       const timeoutMs = asNumber(args.timeoutMs);
       const tty = asBoolean(args.tty);
+      const detach = asBoolean(args.detach) === true;
 
       if (!(tty === true && isPlainInteractiveShellCommand(cmd))) {
         const workspaceWriteDecision = classifyShellWorkspaceWritePolicy({
@@ -571,46 +633,57 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
           args,
           config?.cwd ?? process.cwd(),
         );
+        if (detach) {
+          const refusal = detachRefusal(runtimeSandbox, manager);
+          if (refusal !== null) return refusal;
+        }
         const ownerId = processOwnerIdFromToolArgs(
           args as Record<string, unknown>,
         );
-        const output = await manager.execCommand({
+        const shellRequest = {
+          ...(workdir !== undefined ? { workdir } : {}),
+          ...(asString(args.shell) !== undefined ? { shell: asString(args.shell) } : {}),
+          ...(asBoolean(args.login) !== undefined ? { login: asBoolean(args.login) } : {}),
+        };
+        const commonRequest = {
           cmd,
           callId: asString(args.__callId),
-          ...(inspection !== undefined
-            ? { directInvocation: inspection, workdir: inspection.cwd }
-            : {
-                ...(workdir !== undefined ? { workdir } : {}),
-                ...(asString(args.shell) !== undefined ? { shell: asString(args.shell) } : {}),
-                ...(asBoolean(args.login) !== undefined ? { login: asBoolean(args.login) } : {}),
-                ...(tty !== undefined ? { tty } : {}),
-              }),
           ...(asNumber(args.yield_time_ms) !== undefined
             ? { yield_time_ms: asNumber(args.yield_time_ms) }
             : {}),
           ...(asNumber(args.max_output_tokens) !== undefined
             ? { max_output_tokens: asNumber(args.max_output_tokens) }
             : {}),
-          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           ...(args.__abortSignal !== undefined
             ? { __abortSignal: args.__abortSignal }
-            : {}),
-          ...(args.__onProgress !== undefined
-            ? { __onProgress: args.__onProgress }
             : {}),
           ...(config?.execObserver !== undefined
             ? { observer: config.execObserver }
             : {}),
-          ...(runtimeSandbox !== undefined ? { runtimeSandbox } : {}),
-          ...(ownerId !== undefined ? { ownerId } : {}),
-        });
-        // exitCode === null has three meaningful sub-cases. The
-        // reliable discriminator is `process_id !== undefined`:
+        };
+        const output = detach
+          ? await manager.startDetachedProcess!({ ...commonRequest, ...shellRequest })
+          : await manager.execCommand({
+              ...commonRequest,
+              ...(inspection !== undefined
+                ? { directInvocation: inspection, workdir: inspection.cwd }
+                : { ...shellRequest, ...(tty !== undefined ? { tty } : {}) }),
+              ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+              ...(args.__onProgress !== undefined
+                ? { __onProgress: args.__onProgress }
+                : {}),
+              ...(runtimeSandbox !== undefined ? { runtimeSandbox } : {}),
+              ...(ownerId !== undefined ? { ownerId } : {}),
+            });
+        // exitCode === null has these sub-cases. The reliable discriminator
+        // is `process_id !== undefined` (or `detached` with a pid):
         //   - process_id set    → process is still alive (YIELDED to
         //                         caller; can resume via write_stdin).
         //                         `timedOut` is NOT a kill marker here —
         //                         it just means the yield window
         //                         elapsed. Not an error.
+        //   - detached + pid    → a detached service still running when
+        //                         its yield window closed. Not an error.
         //   - process_id absent + timedOut    → configured timeout
         //                                       fired AND process was
         //                                       killed. Error.
@@ -620,8 +693,7 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
         // Previously isError was `exitCode !== null && exitCode !== 0`,
         // which evaluated to false for ALL null-exitCode cases and
         // produced a silent success on signal kill.
-        const stillAlive =
-          output.exitCode === null && output.process_id !== undefined;
+        const stillAlive = processStillAlive(output);
         const isError =
           (output.exitCode !== null && output.exitCode !== 0) ||
           (output.exitCode === null && !stillAlive);
@@ -661,6 +733,16 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
             durationMs: output.durationMs,
             ...(output.process_id !== undefined
               ? { processId: output.process_id, sessionId: output.process_id }
+              : {}),
+            ...(output.detached === true
+              ? {
+                  detached: true,
+                  ...(output.pid !== undefined ? { pid: output.pid } : {}),
+                  ...(output.log_path !== undefined ? { logPath: output.log_path } : {}),
+                }
+              : {}),
+            ...(output.residual_processes_terminated === true
+              ? { residualProcessesTerminated: true }
               : {}),
           },
         };

--- a/runtime/src/tools/system/exec-result-format.ts
+++ b/runtime/src/tools/system/exec-result-format.ts
@@ -1,5 +1,14 @@
 import type { ExecCommandToolOutput } from "../../unified-exec/types.js";
 
+/**
+ * Shown after the footer when the supervisor had to stop processes the
+ * command left behind. Without it the model saw exit 0 for `nginx` or
+ * `nohup server &`, then found nothing listening, and could not learn why:
+ * the containment that stops a command's residue never said so.
+ */
+export const RESIDUAL_PROCESSES_NOTE =
+  "[note: this command left processes running (a trailing '&', nohup, setsid, or a daemon that forked) and AgenC stopped them when the command returned. To start a service that must keep running after the command returns and after this session ends, call exec_command again with detach: true.]";
+
 export function formatUnifiedExecToolContent(
   output: ExecCommandToolOutput,
 ): string {
@@ -20,6 +29,11 @@ export function formatUnifiedExecToolContent(
   const footerLines: string[] = [];
   if (output.exitCode !== null) {
     footerLines.push(`exit_code=${output.exitCode}`);
+  } else if (output.detached === true && output.pid !== undefined) {
+    // A detached service that was still running when the yield window
+    // closed. AgenC does not track it, so there is no session_id: the pid
+    // and the log file are the handles the model has.
+    footerLines.push(`running=true pid=${output.pid}`);
   } else if (output.process_id !== undefined) {
     // exitCode is null AND a process_id is exposed → process is still
     // alive (yielded to caller, can be resumed via write_stdin / the
@@ -42,10 +56,17 @@ export function formatUnifiedExecToolContent(
   if (sessionId !== undefined) {
     footerLines.push(`session_id=${sessionId}`);
   }
+  if (output.detached === true) {
+    footerLines.push("detached=true");
+    if (output.log_path !== undefined) footerLines.push(`log=${output.log_path}`);
+  }
   // Compact one-line footer separated from output by a blank line so the
   // model sees the two sections distinctly.
   sections.push("");
   sections.push(`[exec ${footerLines.join(" ")}]`);
+  if (output.residual_processes_terminated === true) {
+    sections.push(RESIDUAL_PROCESSES_NOTE);
+  }
   return sections.join("\n");
 }
 
@@ -60,6 +81,8 @@ export function unifiedExecCodeModeResult(
 
   if (output.exitCode !== null) {
     result.exit_code = output.exitCode;
+  } else if (output.detached === true && output.pid !== undefined) {
+    result.running = true;
   } else if (output.process_id !== undefined) {
     // Process yielded and is still alive — see formatUnifiedExecToolContent
     // for the matching content-side decision. timedOut is irrelevant
@@ -74,6 +97,14 @@ export function unifiedExecCodeModeResult(
   const sessionId = output.process_id ?? output.session_id;
   if (sessionId !== undefined) {
     result.session_id = sessionId;
+  }
+  if (output.detached === true) {
+    result.detached = true;
+    if (output.pid !== undefined) result.pid = output.pid;
+    if (output.log_path !== undefined) result.log_path = output.log_path;
+  }
+  if (output.residual_processes_terminated === true) {
+    result.residual_processes_terminated = true;
   }
 
   return result;

--- a/runtime/src/tools/system/shell-mutation-permission.ts
+++ b/runtime/src/tools/system/shell-mutation-permission.ts
@@ -28,6 +28,10 @@ const PROMPT_FREE_APPROVAL_POLICIES: ReadonlySet<
 export interface ShellWorkspaceMutationPermission {
   readonly allowWorkspaceDeletions: boolean;
   readonly protectedRoots: readonly string[];
+  /** Directories the user added with `--add-dir` or approved during the session. */
+  readonly additionalRoots: readonly string[];
+  /** Approvals bypassed and no sandbox: see ShellWorkspaceWritePolicyInput. */
+  readonly bypassesApprovalsAndSandbox: boolean;
 }
 
 type SessionLike = {
@@ -45,9 +49,9 @@ function sessionOf(
   return typeof session === "object" && session !== null ? session : undefined;
 }
 
-function sessionPermissionMode(
+function sessionPermissionContext(
   context: ToolRuntimeAttemptContext | undefined,
-): string | undefined {
+): Record<string, unknown> | undefined {
   const session = sessionOf(context);
   const registry =
     session?.permissionModeRegistry ?? session?.services?.permissionModeRegistry;
@@ -55,13 +59,62 @@ function sessionPermissionMode(
     return undefined;
   }
   try {
-    const mode = (registry.current() as { readonly mode?: unknown } | null)?.mode;
-    return typeof mode === "string" ? mode : undefined;
+    const current = registry.current();
+    return typeof current === "object" && current !== null
+      ? (current as Record<string, unknown>)
+      : undefined;
   } catch {
     // The registry fences reads while an external authority publishes a new
-    // context; an unreadable mode is treated as one that prompts.
+    // context; an unreadable context is treated as one that prompts.
     return undefined;
   }
+}
+
+function sessionPermissionMode(
+  context: ToolRuntimeAttemptContext | undefined,
+): string | undefined {
+  const mode = sessionPermissionContext(context)?.mode;
+  return typeof mode === "string" ? mode : undefined;
+}
+
+/**
+ * Directories the user granted beyond the workspace: `--add-dir` on the
+ * command line, or a directory approved during the session. Read from the
+ * permission context the session publishes, the same source the file tools
+ * consult, so the shell policy and Edit/Write agree on what the user added.
+ */
+export function shellAdditionalWriteRoots(
+  context: ToolRuntimeAttemptContext | undefined,
+): readonly string[] {
+  const directories = sessionPermissionContext(context)?.additionalWorkingDirectories;
+  if (!(directories instanceof Map)) return [];
+  const roots = new Set<string>();
+  for (const entry of directories.values()) {
+    const path = (entry as { readonly path?: unknown } | null)?.path;
+    if (typeof path === "string" && path.trim().length > 0) {
+      roots.add(resolve(path.trim()));
+    }
+  }
+  return [...roots];
+}
+
+/**
+ * Whether nothing but the shell write policy would gate a mutation: the
+ * session never asks (`approvalPolicy: never`, or the bypassPermissions mode
+ * the `--dangerously-bypass-approvals-and-sandbox` flag selects) AND it runs
+ * without a kernel sandbox. Either alone keeps the guards: `--bypass-approvals`
+ * leaves the sandbox as the boundary, and a prompting session in
+ * danger-full-access still routes each command past the user.
+ */
+export function shellBypassesApprovalsAndSandbox(
+  context: ToolRuntimeAttemptContext | undefined,
+): boolean {
+  if (context === undefined) return false;
+  if (context.sandboxMode !== "danger_full_access") return false;
+  return (
+    context.approvalPolicy === "never" ||
+    sessionPermissionMode(context) === "bypassPermissions"
+  );
 }
 
 /**
@@ -123,5 +176,7 @@ export function shellWorkspaceMutationPermission(
   return {
     allowWorkspaceDeletions: shellWorkspaceDeletionsAllowed(context),
     protectedRoots: shellDeletionProtectedRoots(context),
+    additionalRoots: shellAdditionalWriteRoots(context),
+    bypassesApprovalsAndSandbox: shellBypassesApprovalsAndSandbox(context),
   };
 }

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -1,7 +1,12 @@
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { closeSync, mkdirSync, openSync, readSync, statSync } from "node:fs";
 import { assertReadOnlyInspectionInvocation } from "../permissions/readonly-inspection.js";
-import { basename, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import treeKill from "tree-kill";
 
@@ -12,6 +17,7 @@ import {
   truncateHeadTail,
 } from "./head-tail-buffer.js";
 import {
+  type DetachedProcessRequest,
   type ExecCommandRequest,
   type ExecCommandToolOutput,
   type TerminateProcessRequest,
@@ -39,7 +45,7 @@ import {
 import {
   signalProcessTree,
   spawnContainedProcess,
-  terminateProcessTreeAndWait,
+  terminateProcessTreeAndReport,
 } from "../utils/supervisedProcess.js";
 import {
   commandShellArgs,
@@ -49,6 +55,14 @@ import { withChildTempAuthority } from "../utils/subprocessEnv.js";
 import { resolveSessionTempRoot } from "../session/runtime-options.js";
 
 const DEFAULT_EXEC_YIELD_TIME_MS = 10_000;
+/**
+ * How long a detached service gets to fail before the tool returns with it
+ * running. Long enough for a daemon to bind its port or reject its config,
+ * short enough that a service which simply runs does not hold the turn.
+ */
+const DEFAULT_DETACHED_YIELD_TIME_MS = 2_000;
+/** How much of a detached service's log the early result may carry. */
+const DETACHED_LOG_READ_LIMIT_BYTES = 256 * 1024;
 const DEFAULT_WRITE_STDIN_YIELD_TIME_MS = 250;
 const MIN_YIELD_TIME_MS = 250;
 const MIN_EMPTY_YIELD_TIME_MS = 5_000;
@@ -331,6 +345,12 @@ interface ProcessEntry {
   cleanupFailure?: Error;
   hardTimeout?: NodeJS.Timeout;
   hardTimeoutExpired?: boolean;
+  /**
+   * Set when the tree still had live members after the leader exited and the
+   * supervisor stopped them; surfaced to the model so a `nginx` or `nohup
+   * server &` that vanished is explained and pointed at `detach: true`.
+   */
+  residualProcessesTerminated?: boolean;
   // gaphunt3 #44: removes the upstream-abort listener attached to the (long-lived,
   // session-scoped) source signal so it is cleaned up on normal exit, not only on abort.
   detachUpstreamAbort?: () => void;
@@ -427,6 +447,11 @@ function createResult(params: {
   readonly durationMs: number;
   readonly timedOut: boolean;
   readonly maxOutputTokens?: number;
+  readonly residualProcessesTerminated?: boolean;
+  readonly detached?: {
+    readonly pid?: number;
+    readonly logPath: string;
+  };
 }): ExecCommandToolOutput {
   const maxChars = maxCharsForTokens(params.maxOutputTokens);
   const stdout = truncateHeadTail(params.stdout, maxChars);
@@ -449,7 +474,35 @@ function createResult(params: {
     timedOut: params.timedOut,
     truncated: stdout.truncated || stderr.truncated,
     original_token_count: approximateTokenCount(originalText),
+    ...(params.residualProcessesTerminated === true
+      ? { residual_processes_terminated: true }
+      : {}),
+    ...(params.detached !== undefined
+      ? {
+          detached: true,
+          log_path: params.detached.logPath,
+          ...(params.detached.pid !== undefined ? { pid: params.detached.pid } : {}),
+        }
+      : {}),
   };
+}
+
+/** The first bytes of a file, bounded; what a detached service wrote so far. */
+function readFileHead(path: string, limitBytes: number): string {
+  let fd: number | undefined;
+  try {
+    const size = statSync(path).size;
+    if (size === 0) return "";
+    fd = openSync(path, "r");
+    const buffer = Buffer.alloc(Math.min(size, limitBytes));
+    const read = readSync(fd, buffer, 0, buffer.length, 0);
+    const text = buffer.subarray(0, read).toString("utf8");
+    return size > limitBytes ? `${text}\n[log truncated; see ${path}]` : text;
+  } catch {
+    return "";
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }
 
 export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike {
@@ -698,6 +751,129 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       process_id: processId,
       session_id: processId,
     };
+  }
+
+  /**
+   * Start a service the model asked to keep running (`detach: true`). The
+   * child gets its own session and a log file for stdout/stderr, so nothing
+   * AgenC does later (command settlement, `closeAll` at session end) reaches
+   * it, and a closed pipe cannot kill it with SIGPIPE. The manager waits at
+   * most `yield_time_ms` for an early exit so a daemon that rejects its config
+   * still reports its error, then returns pid and log path. It never tracks
+   * the process: there is no session_id, `kill_process` does not know it, and
+   * the caller must have established that no sandbox applies.
+   */
+  async startDetachedProcess(
+    request: DetachedProcessRequest,
+  ): Promise<ExecCommandToolOutput> {
+    this.assertSandboxAuthorityAdmission();
+    if (request.cmd.trim().length === 0) {
+      throw new UnifiedExecError(
+        "missing_command",
+        "missing command line for unified exec request",
+      );
+    }
+    if (hasCurrentWorkspaceOperationLifetime()) {
+      throw new UnifiedExecError(
+        "create_process",
+        "detach=true is blocked while an Editor workspace fence is active because a detached process cannot be contained",
+      );
+    }
+    const cwd = resolve(request.workdir ?? this.cwd);
+    const shell = resolveShell(request.shell, this.shellPath);
+    const command = wrapCommandForShell(
+      shell,
+      this.commandWrapperArgv,
+      request.cmd,
+    );
+    const args = commandShellArgs(shell, command, request.login === true);
+    // No session temp authority here: the service outlives the session and
+    // the temp root that would be handed to it.
+    const env = buildEnv(this.baseEnv, this.env);
+    const logDir = join(this.sessionTempRoot, "detached");
+    mkdirSync(logDir, { recursive: true, mode: 0o700 });
+    const logPath = join(logDir, `${randomUUID()}.log`);
+    const logFd = openSync(logPath, "a", 0o600);
+    const startedAt = Date.now();
+    const processId = this.allocateProcessId();
+    const callId = request.callId ?? `exec-detached-${processId}`;
+    let child: ChildProcess;
+    try {
+      child = spawn(shell, args, {
+        cwd,
+        env,
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+        windowsHide: true,
+      });
+    } catch (error) {
+      this.releaseProcessId(processId);
+      throw new UnifiedExecError(
+        "create_process",
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      // The child holds its own copies of the log descriptor.
+      closeSync(logFd);
+    }
+    request.observer?.onBegin?.({
+      callId,
+      command: request.cmd,
+      cwd,
+      processId,
+      tty: false,
+    });
+    let settled: (ExitState & { readonly error?: Error }) | null = null;
+    const exit = new Promise<void>((resolveExit) => {
+      child.once("exit", (code, signal) => {
+        settled = { exitCode: code, signal };
+        resolveExit();
+      });
+      child.once("error", (error) => {
+        settled = { exitCode: 1, signal: null, error };
+        resolveExit();
+      });
+    });
+    const yieldMs = clampExecYield(
+      request.yield_time_ms ?? DEFAULT_DETACHED_YIELD_TIME_MS,
+    );
+    try {
+      await Promise.race([
+        delay(yieldMs, undefined, { signal: request.__abortSignal }),
+        exit,
+      ]);
+    } catch (error) {
+      // An aborted turn stops waiting; the service was asked for and stays.
+      if (!isAbortError(error)) throw error;
+    }
+    child.unref();
+    const outcome = settled as (ExitState & { readonly error?: Error }) | null;
+    const output = readFileHead(logPath, DETACHED_LOG_READ_LIMIT_BYTES);
+    const durationMs = Date.now() - startedAt;
+    const result = createResult({
+      stdout: output,
+      stderr: outcome?.error === undefined ? "" : outcome.error.message,
+      exitCode: outcome?.exitCode ?? null,
+      durationMs,
+      timedOut: false,
+      maxOutputTokens: request.max_output_tokens,
+      detached: {
+        logPath,
+        ...(outcome === null && child.pid !== undefined ? { pid: child.pid } : {}),
+      },
+    });
+    request.observer?.onEnd?.({
+      callId,
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      durationMs,
+      processId,
+      sessionId: processId,
+      tty: false,
+    });
+    this.releaseProcessId(processId);
+    return result;
   }
 
   async writeStdin(request: WriteStdinRequest): Promise<ExecCommandToolOutput> {
@@ -1150,10 +1326,14 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       if (settlementStarted) return;
       settlementStarted = true;
       setTimeout(() => {
-        void terminateProcessTreeAndWait(child, {
+        void terminateProcessTreeAndReport(child, {
           label: `exec_command process ${params.processId}`,
         }).then(
-          () => {
+          (outcome) => {
+            // Optional chaining: test doubles of the supervisor resolve void.
+            if (outcome?.residualProcessesTerminated === true) {
+              entry.residualProcessesTerminated = true;
+            }
             if (spawnError !== undefined) {
               notifyData("stderr", spawnError.message);
             }
@@ -1359,6 +1539,9 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       durationMs: (entry.endedAt ?? Date.now()) - entry.startedAt,
       timedOut: entry.hardTimeoutExpired === true || timedOut,
       maxOutputTokens: options.maxOutputTokens,
+      ...(entry.residualProcessesTerminated === true
+        ? { residualProcessesTerminated: true }
+        : {}),
     });
   }
 

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -773,12 +773,13 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
         "missing command line for unified exec request",
       );
     }
-    if (hasCurrentWorkspaceOperationLifetime()) {
-      throw new UnifiedExecError(
-        "create_process",
-        "detach=true is blocked while an Editor workspace fence is active because a detached process cannot be contained",
-      );
-    }
+    // The workspace fence (`retainCurrentWorkspaceOperation`) exists so the
+    // Editor can wait for every contained process to settle before it
+    // acquires the workspace. A detached service never settles and is, by
+    // the user's choice of the full-access sandbox, outside containment, so
+    // it neither retains the fence nor is refused by it: the dispatcher runs
+    // every tool call inside a fence, and refusing here would refuse detach
+    // everywhere (observed in the first Terminal-Bench rerun).
     const cwd = resolve(request.workdir ?? this.cwd);
     const shell = resolveShell(request.shell, this.shellPath);
     const command = wrapCommandForShell(

--- a/runtime/src/unified-exec/types.ts
+++ b/runtime/src/unified-exec/types.ts
@@ -96,6 +96,25 @@ export interface ExecCommandRequest extends ToolExecutionInjectedArgs {
   readonly ownerId?: string;
 }
 
+/**
+ * A command started with `detach: true`: a service the model wants to keep
+ * running after the command returns and after the session ends. The manager
+ * starts it in its own session with stdout/stderr going to a log file, waits
+ * at most `yield_time_ms` for an early exit, and then neither tracks nor
+ * stops it.
+ */
+export interface DetachedProcessRequest extends ToolExecutionInjectedArgs {
+  readonly callId?: string;
+  readonly cmd: string;
+  readonly workdir?: string;
+  readonly shell?: string;
+  readonly login?: boolean;
+  /** How long to wait for an early exit before returning with the process still running. */
+  readonly yield_time_ms?: number;
+  readonly max_output_tokens?: number;
+  readonly observer?: UnifiedExecObserver;
+}
+
 export interface WriteStdinRequest extends ToolExecutionInjectedArgs {
   readonly callId?: string;
   readonly session_id: number;
@@ -140,12 +159,28 @@ export interface ExecCommandToolOutput {
   readonly timedOut: boolean;
   readonly truncated: boolean;
   readonly original_token_count: number;
+  /** True when the command ran with `detach: true`; AgenC neither tracks nor stops it. */
+  readonly detached?: boolean;
+  /** OS pid of a detached process that was still running when the yield window closed. */
+  readonly pid?: number;
+  /** File a detached process keeps writing its stdout and stderr to. */
+  readonly log_path?: string;
+  /**
+   * True when processes the command left behind (a shell `&` job, nohup,
+   * setsid, a daemon that forked) were still alive after the command returned
+   * and the supervisor stopped them.
+   */
+  readonly residual_processes_terminated?: boolean;
 }
 
 export interface UnifiedExecProcessManagerLike {
   /** Explicit-timeout cap; Infinity means no configured cap. */
   readonly maxTimeoutMs: number;
   execCommand(request: ExecCommandRequest): Promise<ExecCommandToolOutput>;
+  /** Start a service that outlives the command and the session; see DetachedProcessRequest. */
+  startDetachedProcess?(
+    request: DetachedProcessRequest,
+  ): Promise<ExecCommandToolOutput>;
   writeStdin(request: WriteStdinRequest): Promise<ExecCommandToolOutput>;
   /**
    * Terminate one live background process by its session/process id.

--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -551,6 +551,25 @@ export interface ContainedProcessSpawnOptions {
   readonly linuxContainment?: "auto" | "subreaper";
 }
 
+/** What `terminateProcessTreeAndWait` found when it went to stop a tree. */
+export interface TerminateProcessTreeOutcome {
+  /**
+   * True when the tree still had a live member when cleanup began, so the
+   * supervisor stopped processes the command had left behind (a shell `&`
+   * job, nohup, setsid, or a daemon that forked away from its leader). False
+   * when the tree was already gone. The Windows `taskkill` path cannot tell
+   * the two apart and reports false.
+   */
+  readonly residualProcessesTerminated: boolean;
+}
+
+const TREE_ALREADY_GONE: TerminateProcessTreeOutcome = Object.freeze({
+  residualProcessesTerminated: false,
+});
+const RESIDUE_TERMINATED: TerminateProcessTreeOutcome = Object.freeze({
+  residualProcessesTerminated: true,
+});
+
 export interface TerminateProcessTreeOptions {
   readonly terminateGraceMs?: number;
   readonly killGraceMs?: number;
@@ -2066,10 +2085,22 @@ export async function terminateProcessTreeAndWait(
   child: ProcessTreeChild,
   options: TerminateProcessTreeOptions = {},
 ): Promise<void> {
+  await terminateProcessTreeAndReport(child, options);
+}
+
+/**
+ * `terminateProcessTreeAndWait` that also says whether it found anything to
+ * stop. The unified exec manager uses it to tell the model when a command
+ * left processes behind that the containment then ended.
+ */
+export async function terminateProcessTreeAndReport(
+  child: ProcessTreeChild,
+  options: TerminateProcessTreeOptions = {},
+): Promise<TerminateProcessTreeOutcome> {
   // Never pass an invalid synthetic root to taskkill, a Job Object, a cgroup,
   // process-table discovery, or POSIX negative-PID signalling.
   if (child.pid !== undefined && child.pid <= 1) {
-    if (!isProcessTreeAlive(child)) return;
+    if (!isProcessTreeAlive(child)) return TREE_ALREADY_GONE;
     safeKill(child, "SIGTERM");
     if (
       await waitForProcessTreeExit(
@@ -2077,7 +2108,7 @@ export async function terminateProcessTreeAndWait(
         options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS,
       )
     ) {
-      return;
+      return RESIDUE_TERMINATED;
     }
     safeKill(child, "SIGKILL");
     if (
@@ -2086,14 +2117,14 @@ export async function terminateProcessTreeAndWait(
         options.killGraceMs ?? DEFAULT_SETTLE_BACKSTOP_MS,
       )
     ) {
-      return;
+      return RESIDUE_TERMINATED;
     }
     throw new Error(
       `${options.label ?? "process"} invalid process root survived forced shutdown`,
     );
   }
   if (windowsJobBoundaries.has(child)) {
-    if (!isProcessTreeAlive(child)) return;
+    if (!isProcessTreeAlive(child)) return TREE_ALREADY_GONE;
     safeKill(child, "SIGTERM");
     if (
       await waitForProcessTreeExit(
@@ -2101,7 +2132,7 @@ export async function terminateProcessTreeAndWait(
         options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS,
       )
     ) {
-      return;
+      return RESIDUE_TERMINATED;
     }
     safeKill(child, "SIGKILL");
     if (
@@ -2110,7 +2141,7 @@ export async function terminateProcessTreeAndWait(
         options.killGraceMs ?? DEFAULT_SETTLE_BACKSTOP_MS,
       )
     ) {
-      return;
+      return RESIDUE_TERMINATED;
     }
     throw new Error(
       `${options.label ?? "process"} Windows Job Object broker survived forced shutdown`,
@@ -2123,7 +2154,7 @@ export async function terminateProcessTreeAndWait(
   // infer tree cleanup from the leader alone.
   if (process.platform === "win32" && child.pid !== undefined) {
     await terminateWindowsProcessTree(child.pid, options);
-    return;
+    return TREE_ALREADY_GONE;
   }
   if (!linuxCgroupBoundaries.has(child)) {
     captureProcessTreeDescendants(child);
@@ -2131,7 +2162,7 @@ export async function terminateProcessTreeAndWait(
   if (!isProcessTreeAlive(child)) {
     assertObservedBoundarySnapshotUsable(child, options.label ?? "process");
     await releaseLinuxCgroupBoundary(child);
-    return;
+    return TREE_ALREADY_GONE;
   }
   signalProcessTree(child, "SIGTERM");
   if (
@@ -2142,7 +2173,7 @@ export async function terminateProcessTreeAndWait(
   ) {
     assertObservedBoundarySnapshotUsable(child, options.label ?? "process");
     await releaseLinuxCgroupBoundary(child);
-    return;
+    return RESIDUE_TERMINATED;
   }
   signalProcessTree(child, "SIGKILL");
   if (
@@ -2153,7 +2184,7 @@ export async function terminateProcessTreeAndWait(
   ) {
     assertObservedBoundarySnapshotUsable(child, options.label ?? "process");
     await releaseLinuxCgroupBoundary(child);
-    return;
+    return RESIDUE_TERMINATED;
   }
   const survivors = liveOwnedBoundaryPids(child)
     .filter((pid) => pid !== child.pid)

--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -554,11 +554,13 @@ export interface ContainedProcessSpawnOptions {
 /** What `terminateProcessTreeAndWait` found when it went to stop a tree. */
 export interface TerminateProcessTreeOutcome {
   /**
-   * True when the tree still had a live member when cleanup began, so the
-   * supervisor stopped processes the command had left behind (a shell `&`
-   * job, nohup, setsid, or a daemon that forked away from its leader). False
-   * when the tree was already gone. The Windows `taskkill` path cannot tell
-   * the two apart and reports false.
+   * True when processes the command had left behind (a shell `&` job, nohup,
+   * setsid, or a daemon that forked away from its leader) were stopped:
+   * either the tree still had a live member when cleanup began, or the
+   * Linux subreaper broker reports that it stopped residual descendants
+   * itself when the leader exited. False when the tree was already gone on
+   * its own. The Windows `taskkill` path cannot tell the two apart and
+   * reports false.
    */
   readonly residualProcessesTerminated: boolean;
 }
@@ -2162,7 +2164,12 @@ export async function terminateProcessTreeAndReport(
   if (!isProcessTreeAlive(child)) {
     assertObservedBoundarySnapshotUsable(child, options.label ?? "process");
     await releaseLinuxCgroupBoundary(child);
-    return TREE_ALREADY_GONE;
+    // The subreaper broker stops orphaned descendants on its own when the
+    // leader exits and has closed by the time settlement looks, so the tree
+    // reads as gone here; its residual flag is the record that it did.
+    return linuxSubreaperBoundaries.get(child)?.residual === true
+      ? RESIDUE_TERMINATED
+      : TREE_ALREADY_GONE;
   }
   signalProcessTree(child, "SIGTERM");
   if (

--- a/runtime/tests/llm/shell-write-policy.test.ts
+++ b/runtime/tests/llm/shell-write-policy.test.ts
@@ -299,3 +299,88 @@ describe("classifyShellWorkspaceWritePolicy", () => {
     });
   });
 });
+
+describe("classifyShellWorkspaceWritePolicy under the full bypass", () => {
+  /** Approvals bypassed and no sandbox: `--dangerously-bypass-approvals-and-sandbox`. */
+  function classifyBypassed(command: string) {
+    return classifyShellWorkspaceWritePolicy({
+      toolName: "exec_command",
+      args: { command },
+      workspaceRoot: WORKSPACE_ROOT,
+      allowWorkspaceDeletions: true,
+      bypassesApprovalsAndSandbox: true,
+    });
+  }
+
+  it("lets a command with an unresolvable target run and still reports it indeterminate", () => {
+    // The Terminal-Bench git-multibranch run lost 51 of 459 shell calls to
+    // this refusal, most of them an `echo "$(...)"` next to a harmless write.
+    const decision = classifyBypassed(
+      'for f in refs/heads/*; do echo "$f: $(cat $f)"; done > /tmp/agenc-bypass/refs.txt',
+    );
+    expect(decision.indeterminate).toBe(true);
+    expect(decision.blocked).toBe(false);
+    expect(decision.message).toBeUndefined();
+  });
+
+  it("allows removals outside the workspace", () => {
+    const decision = classifyBypassed("rm -f /etc/nginx/sites-enabled/default");
+    expect(decision.blocked).toBe(false);
+    expect(decision.blockedDeletions).toEqual([]);
+    // Outside the workspace, so nothing for the file-history sidecar to back up.
+    expect(decision.deletionTargets).toEqual([]);
+  });
+
+  it.each(["rm -rf /", "rm .git/config", `rm -rf ${WORKSPACE_ROOT}`])(
+    "keeps refusing the protected roots: %s",
+    (command) => {
+      const decision = classifyBypassed(command);
+      expect(decision.blocked).toBe(true);
+      expect(decision.message).toContain("protected paths");
+    },
+  );
+
+  it("still routes workspace content writes to Edit and Write", () => {
+    const decision = classifyBypassed("cat > src/output.txt");
+    expect(decision.blocked).toBe(true);
+    expect(decision.blockedTargets).toContain("/repo/src/output.txt");
+  });
+
+  it("changes nothing while a prompt or a sandbox still gates the command", () => {
+    const decision = classify('echo "$(id)" > /tmp/agenc-bypass/out.txt', true);
+    expect(decision.blocked).toBe(true);
+    expect(decision.message).toContain("Unable to confirm workspace write targets");
+  });
+});
+
+describe("classifyShellWorkspaceWritePolicy with added directories", () => {
+  const ADDED_ROOT = "/srv/agenc-added-root";
+
+  function classifyWithAdded(command: string, allowWorkspaceDeletions: boolean) {
+    return classifyShellWorkspaceWritePolicy({
+      toolName: "exec_command",
+      args: { command },
+      workspaceRoot: WORKSPACE_ROOT,
+      allowWorkspaceDeletions,
+      additionalRoots: [ADDED_ROOT],
+    });
+  }
+
+  it("treats a removal under an added directory like a workspace removal", () => {
+    const promptFree = classifyWithAdded(`rm ${ADDED_ROOT}/stale.log`, true);
+    expect(promptFree.blocked).toBe(false);
+    // Granted by the user, but not a workspace path: no sidecar backup.
+    expect(promptFree.deletionTargets).toEqual([]);
+
+    const prompting = classifyWithAdded(`rm ${ADDED_ROOT}/stale.log`, false);
+    expect(prompting.blocked).toBe(true);
+    expect(prompting.message).toContain("shell_workspace_file_delete_requires_approval");
+    expect(prompting.message).not.toContain("only inside the workspace");
+  });
+
+  it("still refuses a removal outside every root", () => {
+    const decision = classifyWithAdded("rm /srv/agenc-elsewhere/file.txt", true);
+    expect(decision.blocked).toBe(true);
+    expect(decision.message).toContain("only inside the workspace");
+  });
+});

--- a/runtime/tests/permissions/path-validation.test.ts
+++ b/runtime/tests/permissions/path-validation.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
@@ -19,6 +19,11 @@ import {
   validatePath,
 } from "./path-validation.js";
 import { applyPermissionUpdate } from "./permission-updates.js";
+import {
+  SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ALLOWED_ROOTS_SIG_ARG,
+  verifyAllowedRoots,
+} from "../../src/agents/_deps/filesystem-args.js";
 import {
   createEmptyToolPermissionContext,
   type ToolPermissionContext,
@@ -405,6 +410,97 @@ describe("path-validation", () => {
         type: "mode",
         mode: "bypassPermissions",
       });
+    });
+  });
+
+  describe("an allow outside the cwd hands the tool the allowed directory", () => {
+    function signedRoots(input: Record<string, unknown>): string[] {
+      return verifyAllowedRoots(
+        input[SESSION_ALLOWED_ROOTS_ARG],
+        input[SESSION_ALLOWED_ROOTS_SIG_ARG],
+      );
+    }
+
+    test("through --add-dir in a prompting session", async () => {
+      // A read inside an added directory needs no prompt in default mode (a
+      // write there asks, like a write in the workspace), so it exercises
+      // the allow the layer reaches on its own.
+      const target = join(outside, "nginx.conf");
+      const input = { file_path: target };
+      const added = applyPermissionUpdate(ctx(), {
+        type: "addDirectories",
+        destination: "cliArg",
+        directories: [outside],
+      });
+
+      const result = checkToolPathPermission({
+        toolName: "FileRead",
+        input,
+        path: target,
+        cwd: root,
+        context: added,
+        operationType: "read",
+      });
+
+      expect(result.behavior).toBe("allow");
+      expect(signedRoots(result.updatedInput)).toContain(
+        dirname(join(await realpath(outside), "nginx.conf")),
+      );
+    });
+
+    test("through bypassPermissions, the way an approval would", async () => {
+      // Before: the mode allowed the edit and Edit then refused it with its
+      // own "Path is outside allowed directories" (the half-bypass seen with
+      // Edit on /etc/nginx/nginx.conf under --dangerously-bypass-approvals-and-sandbox).
+      const target = join(outside, "nginx.conf");
+      const input = { file_path: target };
+
+      const result = checkToolPathPermission({
+        toolName: "Edit",
+        input,
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "write",
+      });
+
+      expect(result.behavior).toBe("allow");
+      expect(result.decisionReason).toEqual({ type: "mode", mode: "bypassPermissions" });
+      expect(signedRoots(result.updatedInput)).toContain(
+        dirname(join(await realpath(outside), "nginx.conf")),
+      );
+    });
+
+    test("leaves the input alone for a path inside the cwd", () => {
+      const target = join(root, "src", "index.ts");
+      const input = { file_path: target };
+
+      const result = checkToolPathPermission({
+        toolName: "Edit",
+        input,
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "write",
+      });
+
+      expect(result.behavior).toBe("allow");
+      expect(result.updatedInput).toBe(input);
+    });
+
+    test("bypassPermissions still does not allow a protected path", () => {
+      const target = join(root, ".git", "config");
+
+      const result = checkToolPathPermission({
+        toolName: "Edit",
+        input: { file_path: target },
+        path: target,
+        cwd: root,
+        context: ctx({ mode: "bypassPermissions" }),
+        operationType: "write",
+      });
+
+      expect(result.behavior).not.toBe("allow");
     });
   });
 });

--- a/runtime/tests/tools/router-preflight-context.test.ts
+++ b/runtime/tests/tools/router-preflight-context.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { parseToolName } from "../../src/tools/context.js";
+import { attachPreflightRuntimeContext } from "../../src/tools/router.js";
+import { readToolRuntimeContext } from "../../src/tools/runtimes/context.js";
+import { createExecCommandTool } from "../../src/tools/system/exec-command.js";
+import type { ToolInvocation } from "../../src/tools/types.js";
+
+/** Chosen outside the workspace, the temp directory and the hermetic home. */
+const OUTSIDE_FILE = "/srv/agenc-outside-workspace/outside.txt";
+
+describe("attachPreflightRuntimeContext", () => {
+  let root = "";
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-preflight-context-"));
+  });
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+    root = "";
+  });
+
+  function invocationFor(mode: string): ToolInvocation {
+    return {
+      session: {
+        permissionModeRegistry: {
+          current: () => ({ mode, additionalWorkingDirectories: new Map() }),
+        },
+      },
+      turn: {
+        cwd: root,
+        approvalPolicy: { value: "on_request" },
+        sandboxPolicy: { value: "danger_full_access" },
+      },
+      callId: "call-preflight",
+      toolName: parseToolName("exec_command"),
+      payload: { kind: "function", arguments: "{}" },
+      source: "model",
+    } as unknown as ToolInvocation;
+  }
+
+  test("the exec_command preflight sees the session's mode and sandbox before approval", () => {
+    const tool = createExecCommandTool({ cwd: root, allowedPaths: [root] });
+    const args: Record<string, unknown> = { cmd: `rm ${OUTSIDE_FILE}` };
+
+    // Without a context the preflight decides as a prompting session would;
+    // this is what the live run under the full bypass saw.
+    expect(tool.preflight?.(args)).toMatchObject({ code: "shell_workspace_write_policy" });
+
+    attachPreflightRuntimeContext(tool, args, invocationFor("bypassPermissions"), {
+      approvalPolicy: "on_request",
+      sandboxMode: "danger_full_access",
+    });
+
+    expect(readToolRuntimeContext(args)).toMatchObject({
+      callId: "call-preflight",
+      toolName: "exec_command",
+      approvalPolicy: "on_request",
+      requestedSandboxMode: "danger_full_access",
+      sandboxMode: "danger_full_access",
+      approvalResolved: false,
+    });
+    expect(tool.preflight?.(args)).toBeNull();
+  });
+
+  test("a sandboxed bypass keeps the refusal at preflight", () => {
+    const tool = createExecCommandTool({ cwd: root, allowedPaths: [root] });
+    const args: Record<string, unknown> = { cmd: `rm ${OUTSIDE_FILE}` };
+
+    attachPreflightRuntimeContext(tool, args, invocationFor("bypassPermissions"), {
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    });
+
+    expect(tool.preflight?.(args)).toMatchObject({ code: "shell_workspace_write_policy" });
+  });
+
+  test("does not replace a context the args already carry", () => {
+    const tool = createExecCommandTool({ cwd: root, allowedPaths: [root] });
+    const args: Record<string, unknown> = { cmd: "ls" };
+
+    attachPreflightRuntimeContext(tool, args, invocationFor("default"), {
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    });
+    attachPreflightRuntimeContext(tool, args, invocationFor("bypassPermissions"), {
+      approvalPolicy: "never",
+      sandboxMode: "danger_full_access",
+    });
+
+    expect(readToolRuntimeContext(args)).toMatchObject({
+      approvalPolicy: "on_request",
+      sandboxMode: "workspace_write",
+    });
+  });
+});

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -94,6 +94,93 @@ describe("exec_command tool", () => {
     root = "";
   });
 
+  /**
+   * Args with a runtime context attached the way the dispatcher does. The
+   * defaults describe the full bypass (approvals never, no sandbox); the
+   * options narrow it: a sandboxed mode with a platform sandbox declared on
+   * the turn, a permission mode published by the session, directories the
+   * user added, an unresolved approval.
+   */
+  function contextArgs(
+    overrides: Record<string, unknown>,
+    options: {
+      readonly approvalPolicy?: string;
+      readonly sandboxMode?: string;
+      readonly mode?: string;
+      readonly added?: readonly string[];
+      readonly approvalResolved?: boolean;
+      readonly platformSandbox?: boolean;
+    } = {},
+  ): Record<string, unknown> {
+    const args: Record<string, unknown> = { ...overrides };
+    const sandboxMode = options.sandboxMode ?? "danger_full_access";
+    attachToolRuntimeContext(args, {
+      callId: "call-context",
+      toolName: "exec_command",
+      runtimeKind: "function",
+      classification: "exclusive",
+      supportsParallelToolCalls: false,
+      source: { type: "model" },
+      submittedAtMs: 0,
+      approvalPolicy: options.approvalPolicy ?? "never",
+      requestedSandboxMode: sandboxMode,
+      sandboxMode,
+      approvalResolved: options.approvalResolved ?? true,
+      rawArgs: "{}",
+      invocation: {
+        session: {
+          ...(options.mode !== undefined
+            ? {
+                permissionModeRegistry: {
+                  current: () => ({
+                    mode: options.mode,
+                    additionalWorkingDirectories: new Map(
+                      (options.added ?? []).map((path) => [path, { path, source: "cliArg" }]),
+                    ),
+                  }),
+                },
+              }
+            : {}),
+          services: { runtimeOptions: { sessionTempRoot: root } },
+        },
+        payload: { kind: "function", arguments: "{}" },
+        turn: {
+          subId: "turn-context",
+          cwd: root,
+          ...(options.platformSandbox === true ? { agencLinuxSandboxExe: "/bin/true" } : {}),
+        },
+      },
+    } as never);
+    return args;
+  }
+
+  /** The tool over a mock manager; the mocks it did not receive answer an empty success. */
+  function mockManagerTool(
+    mocks: {
+      readonly execCommand?: UnifiedExecProcessManagerLike["execCommand"];
+      readonly startDetachedProcess?: UnifiedExecProcessManagerLike["startDetachedProcess"];
+    } = {},
+  ) {
+    const execCommand =
+      mocks.execCommand ??
+      vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(async () => completedExecOutput("ran"));
+    const manager: UnifiedExecProcessManagerLike = {
+      maxTimeoutMs: 30_000,
+      execCommand,
+      ...(mocks.startDetachedProcess !== undefined
+        ? { startDetachedProcess: mocks.startDetachedProcess }
+        : {}),
+      writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
+        async () => completedExecOutput(""),
+      ),
+      closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
+    };
+    return {
+      execCommand,
+      tool: createExecCommandTool({ cwd: root, allowedPaths: [root], unifiedExecManager: manager }),
+    };
+  }
+
   // Live incident (session conv-mtjdmlfc, 2026-09-02): 21 `npm start` calls
   // over 412 s, each denied by the sandbox, each answered only by the child's
   // own errno text and an escalation request the parser silently discarded.
@@ -102,53 +189,17 @@ describe("exec_command tool", () => {
       overrides: Record<string, unknown>,
       approvalPolicy = "never",
     ): Record<string, unknown> {
-      const args: Record<string, unknown> = { ...overrides };
-      attachToolRuntimeContext(args, {
-        callId: "call-sandbox-denial",
-        toolName: "exec_command",
-        runtimeKind: "function",
-        classification: "exclusive",
-        supportsParallelToolCalls: false,
-        source: { type: "model" },
-        submittedAtMs: 0,
+      return contextArgs(overrides, {
         approvalPolicy,
-        requestedSandboxMode: "read_only",
         sandboxMode: "read_only",
-        approvalResolved: true,
-        rawArgs: "{}",
-        invocation: {
-          session: { services: { runtimeOptions: { sessionTempRoot: root } } },
-          payload: { kind: "function", arguments: "{}" },
-          turn: {
-            subId: "turn-sandbox-denial",
-            cwd: root,
-            agencLinuxSandboxExe: "/bin/true",
-          },
-        },
-      } as never);
-      return args;
+        platformSandbox: true,
+      });
     }
 
     function toolWith(output: ExecCommandToolOutput) {
-      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
-        async () => output,
-      );
-      const manager: UnifiedExecProcessManagerLike = {
-        maxTimeoutMs: 30_000,
-        execCommand,
-        writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
-          async () => completedExecOutput(""),
-        ),
-        closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
-      };
-      return {
-        execCommand,
-        tool: createExecCommandTool({
-          cwd: root,
-          allowedPaths: [root],
-          unifiedExecManager: manager,
-        }),
-      };
+      return mockManagerTool({
+        execCommand: vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(async () => output),
+      });
     }
 
     const BIND_DENIED = failedExecOutput(
@@ -581,50 +632,15 @@ describe("exec_command tool", () => {
         readonly sandboxMode?: "danger_full_access" | "workspace_write";
       },
     ): Record<string, unknown> {
-      const args: Record<string, unknown> = { cmd, workdir: root };
-      attachToolRuntimeContext(args, {
-        callId: "call-delete",
-        toolName: "exec_command",
-        runtimeKind: "function",
-        classification: "exclusive",
-        supportsParallelToolCalls: false,
-        source: { type: "model" },
-        submittedAtMs: 0,
+      return contextArgs({ cmd, workdir: root }, {
         approvalPolicy: permission.approvalPolicy ?? "on_request",
-        requestedSandboxMode: permission.sandboxMode ?? "danger_full_access",
         sandboxMode: permission.sandboxMode ?? "danger_full_access",
+        mode: permission.mode,
         approvalResolved: permission.approvalResolved ?? false,
-        rawArgs: "{}",
-        invocation: {
-          session: {
-            permissionModeRegistry: { current: () => ({ mode: permission.mode }) },
-            services: { runtimeOptions: { sessionTempRoot: root } },
-          },
-          payload: { kind: "function", arguments: "{}" },
-          turn: { subId: "turn-delete", cwd: root },
-        },
-      } as never);
-      return args;
+      });
     }
 
-    function deletionTool() {
-      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
-        async () => completedExecOutput("ran"),
-      );
-      const tool = createExecCommandTool({
-        cwd: root,
-        allowedPaths: [root],
-        unifiedExecManager: {
-          maxTimeoutMs: 30_000,
-          execCommand,
-          writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
-            async () => completedExecOutput(""),
-          ),
-          closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
-        },
-      });
-      return { tool, execCommand };
-    }
+    const deletionTool = () => mockManagerTool();
 
     test("runs rm on a workspace file under bypassPermissions", async () => {
       const { tool, execCommand } = deletionTool();
@@ -813,57 +829,9 @@ describe("exec_command tool", () => {
   );
 
   describe("detach", () => {
-    function fullAccessArgs(overrides: Record<string, unknown>): Record<string, unknown> {
-      const args: Record<string, unknown> = { ...overrides };
-      attachToolRuntimeContext(args, {
-        callId: "call-detach",
-        toolName: "exec_command",
-        runtimeKind: "function",
-        classification: "exclusive",
-        supportsParallelToolCalls: false,
-        source: { type: "model" },
-        submittedAtMs: 0,
-        approvalPolicy: "never",
-        requestedSandboxMode: "danger_full_access",
-        sandboxMode: "danger_full_access",
-        approvalResolved: true,
-        rawArgs: "{}",
-        invocation: {
-          session: { services: { runtimeOptions: { sessionTempRoot: root } } },
-          payload: { kind: "function", arguments: "{}" },
-          turn: { subId: "turn-detach", cwd: root },
-        },
-      } as never);
-      return args;
-    }
-
-    function sandboxedArgs(overrides: Record<string, unknown>): Record<string, unknown> {
-      const args: Record<string, unknown> = { ...overrides };
-      attachToolRuntimeContext(args, {
-        callId: "call-detach-sandboxed",
-        toolName: "exec_command",
-        runtimeKind: "function",
-        classification: "exclusive",
-        supportsParallelToolCalls: false,
-        source: { type: "model" },
-        submittedAtMs: 0,
-        approvalPolicy: "never",
-        requestedSandboxMode: "read_only",
-        sandboxMode: "read_only",
-        approvalResolved: true,
-        rawArgs: "{}",
-        invocation: {
-          session: { services: { runtimeOptions: { sessionTempRoot: root } } },
-          payload: { kind: "function", arguments: "{}" },
-          turn: {
-            subId: "turn-detach-sandboxed",
-            cwd: root,
-            agencLinuxSandboxExe: "/bin/true",
-          },
-        },
-      } as never);
-      return args;
-    }
+    const fullAccessArgs = (overrides: Record<string, unknown>) => contextArgs(overrides);
+    const sandboxedArgs = (overrides: Record<string, unknown>) =>
+      contextArgs(overrides, { sandboxMode: "read_only", platformSandbox: true });
 
     function detachedOutput(overrides: Partial<ExecCommandToolOutput>): ExecCommandToolOutput {
       return {
@@ -876,30 +844,12 @@ describe("exec_command tool", () => {
       };
     }
 
-    function toolWithManager(
+    const toolWithManager = (
       startDetachedProcess?: UnifiedExecProcessManagerLike["startDetachedProcess"],
-    ) {
-      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
-        async () => completedExecOutput("ran"),
+    ) =>
+      mockManagerTool(
+        startDetachedProcess !== undefined ? { startDetachedProcess } : {},
       );
-      const manager: UnifiedExecProcessManagerLike = {
-        maxTimeoutMs: 30_000,
-        execCommand,
-        ...(startDetachedProcess !== undefined ? { startDetachedProcess } : {}),
-        writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
-          async () => completedExecOutput(""),
-        ),
-        closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
-      };
-      return {
-        execCommand,
-        tool: createExecCommandTool({
-          cwd: root,
-          allowedPaths: [root],
-          unifiedExecManager: manager,
-        }),
-      };
-    }
 
     test("starts a detached service and reports its pid and log", async () => {
       const startDetachedProcess = vi.fn<
@@ -989,26 +939,12 @@ describe("exec_command tool", () => {
     test("the residue note follows the footer when leftover processes were stopped", async () => {
       // Before: `nginx` returned exit 0, the daemon was gone, and the model
       // had no way to learn why. Now the result says so and points at detach.
-      const { tool } = toolWithManager();
-      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
-        async () => ({
+      const { tool: noteTool } = mockManagerTool({
+        execCommand: vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(async () => ({
           ...completedExecOutput("nginx started"),
           residual_processes_terminated: true,
-        }),
-      );
-      const noteTool = createExecCommandTool({
-        cwd: root,
-        allowedPaths: [root],
-        unifiedExecManager: {
-          maxTimeoutMs: 30_000,
-          execCommand,
-          writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
-            async () => completedExecOutput(""),
-          ),
-          closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
-        },
+        })),
       });
-      void tool;
 
       const result = await noteTool.execute(fullAccessArgs({ cmd: "nginx" }));
 
@@ -1042,57 +978,16 @@ describe("exec_command tool", () => {
         readonly added?: readonly string[];
       },
     ): Record<string, unknown> {
-      const args: Record<string, unknown> = { cmd: "ls", workdir };
-      attachToolRuntimeContext(args, {
-        callId: "call-workdir",
-        toolName: "exec_command",
-        runtimeKind: "function",
-        classification: "exclusive",
-        supportsParallelToolCalls: false,
-        source: { type: "model" },
-        submittedAtMs: 0,
+      return contextArgs({ cmd: "ls", workdir }, {
         approvalPolicy: permission.approvalPolicy,
-        requestedSandboxMode: permission.sandboxMode,
         sandboxMode: permission.sandboxMode,
+        mode: permission.mode,
+        added: permission.added,
         approvalResolved: false,
-        rawArgs: "{}",
-        invocation: {
-          session: {
-            permissionModeRegistry: {
-              current: () => ({
-                mode: permission.mode,
-                additionalWorkingDirectories: new Map(
-                  (permission.added ?? []).map((path) => [path, { path, source: "cliArg" }]),
-                ),
-              }),
-            },
-            services: { runtimeOptions: { sessionTempRoot: root } },
-          },
-          payload: { kind: "function", arguments: "{}" },
-          turn: { subId: "turn-workdir", cwd: root },
-        },
-      } as never);
-      return args;
+      });
     }
 
-    function workdirTool() {
-      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
-        async () => completedExecOutput("listed"),
-      );
-      const tool = createExecCommandTool({
-        cwd: root,
-        allowedPaths: [root],
-        unifiedExecManager: {
-          maxTimeoutMs: 30_000,
-          execCommand,
-          writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
-            async () => completedExecOutput(""),
-          ),
-          closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
-        },
-      });
-      return { tool, execCommand };
-    }
+    const workdirTool = () => mockManagerTool();
 
     test("refuses a working directory outside the workspace in a prompting session", async () => {
       const { tool, execCommand } = workdirTool();

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -1020,4 +1020,128 @@ describe("exec_command tool", () => {
       expect(result.codeModeResult).toMatchObject({ residual_processes_terminated: true });
     });
   });
+
+  describe("workdir", () => {
+    let outsideDir = "";
+
+    beforeEach(async () => {
+      outsideDir = await mkdtemp(join(tmpdir(), "agenc-exec-outside-"));
+    });
+
+    afterEach(async () => {
+      if (outsideDir) await rm(outsideDir, { recursive: true, force: true });
+      outsideDir = "";
+    });
+
+    function workdirArgs(
+      workdir: string,
+      permission: {
+        readonly mode: string;
+        readonly approvalPolicy: "on_request" | "never";
+        readonly sandboxMode: "danger_full_access" | "workspace_write";
+        readonly added?: readonly string[];
+      },
+    ): Record<string, unknown> {
+      const args: Record<string, unknown> = { cmd: "ls", workdir };
+      attachToolRuntimeContext(args, {
+        callId: "call-workdir",
+        toolName: "exec_command",
+        runtimeKind: "function",
+        classification: "exclusive",
+        supportsParallelToolCalls: false,
+        source: { type: "model" },
+        submittedAtMs: 0,
+        approvalPolicy: permission.approvalPolicy,
+        requestedSandboxMode: permission.sandboxMode,
+        sandboxMode: permission.sandboxMode,
+        approvalResolved: false,
+        rawArgs: "{}",
+        invocation: {
+          session: {
+            permissionModeRegistry: {
+              current: () => ({
+                mode: permission.mode,
+                additionalWorkingDirectories: new Map(
+                  (permission.added ?? []).map((path) => [path, { path, source: "cliArg" }]),
+                ),
+              }),
+            },
+            services: { runtimeOptions: { sessionTempRoot: root } },
+          },
+          payload: { kind: "function", arguments: "{}" },
+          turn: { subId: "turn-workdir", cwd: root },
+        },
+      } as never);
+      return args;
+    }
+
+    function workdirTool() {
+      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
+        async () => completedExecOutput("listed"),
+      );
+      const tool = createExecCommandTool({
+        cwd: root,
+        allowedPaths: [root],
+        unifiedExecManager: {
+          maxTimeoutMs: 30_000,
+          execCommand,
+          writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
+            async () => completedExecOutput(""),
+          ),
+          closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
+        },
+      });
+      return { tool, execCommand };
+    }
+
+    test("refuses a working directory outside the workspace in a prompting session", async () => {
+      const { tool, execCommand } = workdirTool();
+
+      const result = await tool.execute(
+        workdirArgs(outsideDir, {
+          mode: "default",
+          approvalPolicy: "on_request",
+          sandboxMode: "workspace_write",
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("workdir is outside allowed workspace paths");
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("accepts a working directory the user added with --add-dir", async () => {
+      const { tool, execCommand } = workdirTool();
+
+      const result = await tool.execute(
+        workdirArgs(outsideDir, {
+          mode: "default",
+          approvalPolicy: "on_request",
+          sandboxMode: "workspace_write",
+          added: [outsideDir],
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(execCommand).toHaveBeenCalledTimes(1);
+      expect(execCommand.mock.calls[0]?.[0]).toMatchObject({ workdir: outsideDir });
+    });
+
+    test("accepts any working directory under the full bypass", async () => {
+      // `workdir: /tmp` was refused in every Terminal-Bench pilot run even
+      // though the command could have started with `cd /tmp`.
+      const { tool, execCommand } = workdirTool();
+
+      const result = await tool.execute(
+        workdirArgs(outsideDir, {
+          mode: "bypassPermissions",
+          approvalPolicy: "on_request",
+          sandboxMode: "danger_full_access",
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(execCommand).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -8,6 +8,7 @@ import {
   createExecCommandTool as createUnboundExecCommandTool,
   runtimeSandboxForExec,
 } from "./exec-command.js";
+import { RESIDUAL_PROCESSES_NOTE } from "./exec-result-format.js";
 import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
 import { createWriteStdinTool as createUnboundWriteStdinTool } from "./write-stdin.js";
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
@@ -577,6 +578,7 @@ describe("exec_command tool", () => {
         readonly mode: string;
         readonly approvalResolved?: boolean;
         readonly approvalPolicy?: "on_request" | "never";
+        readonly sandboxMode?: "danger_full_access" | "workspace_write";
       },
     ): Record<string, unknown> {
       const args: Record<string, unknown> = { cmd, workdir: root };
@@ -589,8 +591,8 @@ describe("exec_command tool", () => {
         source: { type: "model" },
         submittedAtMs: 0,
         approvalPolicy: permission.approvalPolicy ?? "on_request",
-        requestedSandboxMode: "danger_full_access",
-        sandboxMode: "danger_full_access",
+        requestedSandboxMode: permission.sandboxMode ?? "danger_full_access",
+        sandboxMode: permission.sandboxMode ?? "danger_full_access",
         approvalResolved: permission.approvalResolved ?? false,
         rawArgs: "{}",
         invocation: {
@@ -636,16 +638,22 @@ describe("exec_command tool", () => {
       expect(execCommand.mock.calls[0]?.[0]).toMatchObject({ cmd: REFACTOR_CLEANUP });
     });
 
-    test("refuses rm outside the workspace under bypassPermissions", async () => {
+    // Never touched by the refusal cases: the policy refuses before anything
+    // spawns. Chosen outside the workspace, the temp directory and the
+    // hermetic home the test harness points HOME and AGENC_HOME at (the home
+    // is a protected path with its own message).
+    const outside = "/srv/agenc-outside-workspace/outside.txt";
+
+    test("refuses rm outside the workspace under bypassPermissions while a sandbox is on", async () => {
+      // `--bypass-approvals`: prompts off, the OS sandbox stays the boundary,
+      // so the policy still keeps shell removals to the workspace.
       const { tool, execCommand } = deletionTool();
-      // Never touched: the policy refuses before anything spawns. Chosen
-      // outside the workspace, the temp directory and the hermetic home the
-      // test harness points HOME and AGENC_HOME at (the home is a protected
-      // path with its own message).
-      const outside = "/srv/agenc-outside-workspace/outside.txt";
 
       const result = await tool.execute(
-        permissionArgs(`rm ${outside}`, { mode: "bypassPermissions" }),
+        permissionArgs(`rm ${outside}`, {
+          mode: "bypassPermissions",
+          sandboxMode: "workspace_write",
+        }),
       );
 
       expect(result.isError).toBe(true);
@@ -655,6 +663,48 @@ describe("exec_command tool", () => {
         disposition: "confirmed_no_effect",
         evidenceRef: "tool:system.exec-command:workspace-write-policy",
       });
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("runs rm outside the workspace under the full bypass", async () => {
+      // `--dangerously-bypass-approvals-and-sandbox`: bypassPermissions and
+      // danger-full-access together. Nothing but this policy would gate the
+      // removal, and the user chose that.
+      const { tool, execCommand } = deletionTool();
+
+      const result = await tool.execute(
+        permissionArgs(`rm ${outside}`, { mode: "bypassPermissions" }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(execCommand).toHaveBeenCalledTimes(1);
+    });
+
+    test("runs a command with an unresolvable write target under the full bypass", async () => {
+      // 51 of 459 shell calls in one Terminal-Bench task were refused as
+      // indeterminate, most for an `echo "$(...)"` beside a harmless write.
+      const { tool, execCommand } = deletionTool();
+
+      const result = await tool.execute(
+        permissionArgs('for f in refs/heads/*; do echo "$f: $(cat $f)"; done > /tmp/agenc-refs.txt', {
+          mode: "bypassPermissions",
+          approvalPolicy: "never",
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(execCommand).toHaveBeenCalledTimes(1);
+    });
+
+    test("the full bypass keeps the protected paths refused", async () => {
+      const { tool, execCommand } = deletionTool();
+
+      const result = await tool.execute(
+        permissionArgs("rm -rf .git", { mode: "bypassPermissions", approvalPolicy: "never" }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("protected paths");
       expect(execCommand).not.toHaveBeenCalled();
     });
 
@@ -761,4 +811,213 @@ describe("exec_command tool", () => {
       }
     },
   );
+
+  describe("detach", () => {
+    function fullAccessArgs(overrides: Record<string, unknown>): Record<string, unknown> {
+      const args: Record<string, unknown> = { ...overrides };
+      attachToolRuntimeContext(args, {
+        callId: "call-detach",
+        toolName: "exec_command",
+        runtimeKind: "function",
+        classification: "exclusive",
+        supportsParallelToolCalls: false,
+        source: { type: "model" },
+        submittedAtMs: 0,
+        approvalPolicy: "never",
+        requestedSandboxMode: "danger_full_access",
+        sandboxMode: "danger_full_access",
+        approvalResolved: true,
+        rawArgs: "{}",
+        invocation: {
+          session: { services: { runtimeOptions: { sessionTempRoot: root } } },
+          payload: { kind: "function", arguments: "{}" },
+          turn: { subId: "turn-detach", cwd: root },
+        },
+      } as never);
+      return args;
+    }
+
+    function sandboxedArgs(overrides: Record<string, unknown>): Record<string, unknown> {
+      const args: Record<string, unknown> = { ...overrides };
+      attachToolRuntimeContext(args, {
+        callId: "call-detach-sandboxed",
+        toolName: "exec_command",
+        runtimeKind: "function",
+        classification: "exclusive",
+        supportsParallelToolCalls: false,
+        source: { type: "model" },
+        submittedAtMs: 0,
+        approvalPolicy: "never",
+        requestedSandboxMode: "read_only",
+        sandboxMode: "read_only",
+        approvalResolved: true,
+        rawArgs: "{}",
+        invocation: {
+          session: { services: { runtimeOptions: { sessionTempRoot: root } } },
+          payload: { kind: "function", arguments: "{}" },
+          turn: {
+            subId: "turn-detach-sandboxed",
+            cwd: root,
+            agencLinuxSandboxExe: "/bin/true",
+          },
+        },
+      } as never);
+      return args;
+    }
+
+    function detachedOutput(overrides: Partial<ExecCommandToolOutput>): ExecCommandToolOutput {
+      return {
+        ...completedExecOutput("starting"),
+        exitCode: null,
+        exit_code: null,
+        detached: true,
+        log_path: "/srv/agenc-session/detached/service.log",
+        ...overrides,
+      };
+    }
+
+    function toolWithManager(
+      startDetachedProcess?: UnifiedExecProcessManagerLike["startDetachedProcess"],
+    ) {
+      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
+        async () => completedExecOutput("ran"),
+      );
+      const manager: UnifiedExecProcessManagerLike = {
+        maxTimeoutMs: 30_000,
+        execCommand,
+        ...(startDetachedProcess !== undefined ? { startDetachedProcess } : {}),
+        writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
+          async () => completedExecOutput(""),
+        ),
+        closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
+      };
+      return {
+        execCommand,
+        tool: createExecCommandTool({
+          cwd: root,
+          allowedPaths: [root],
+          unifiedExecManager: manager,
+        }),
+      };
+    }
+
+    test("starts a detached service and reports its pid and log", async () => {
+      const startDetachedProcess = vi.fn<
+        NonNullable<UnifiedExecProcessManagerLike["startDetachedProcess"]>
+      >(async () => detachedOutput({ pid: 4242 }));
+      const { tool, execCommand } = toolWithManager(startDetachedProcess);
+
+      const result = await tool.execute(
+        fullAccessArgs({ cmd: "nginx", detach: true, yield_time_ms: 500 }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toContain("starting");
+      expect(result.content).toContain("running=true pid=4242");
+      expect(result.content).toContain("detached=true");
+      expect(result.content).toContain("log=/srv/agenc-session/detached/service.log");
+      expect(startDetachedProcess).toHaveBeenCalledWith(
+        expect.objectContaining({ cmd: "nginx", yield_time_ms: 500 }),
+      );
+      expect(execCommand).not.toHaveBeenCalled();
+      expect(result.metadata).toMatchObject({ detached: true, pid: 4242 });
+      expect(result.codeModeResult).toMatchObject({ running: true, detached: true, pid: 4242 });
+      expect(result.effectDisposition).toMatchObject({
+        disposition: "confirmed_committed",
+        evidenceRef: "tool:system.exec-command:process-detached",
+      });
+    });
+
+    test("a detached service that dies inside the window is an error with its exit code", async () => {
+      const { tool } = toolWithManager(async () =>
+        detachedOutput({ exitCode: 1, exit_code: 1, output: "bind() failed", stdout: "bind() failed" }),
+      );
+
+      const result = await tool.execute(fullAccessArgs({ cmd: "nginx", detach: true }));
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("bind() failed");
+      expect(result.content).toContain("exit_code=1");
+      expect(result.content).toContain("detached=true");
+    });
+
+    test("refuses detach under a sandbox and names the flag and the alternative", async () => {
+      const startDetachedProcess = vi.fn<
+        NonNullable<UnifiedExecProcessManagerLike["startDetachedProcess"]>
+      >(async () => detachedOutput({ pid: 1 }));
+      const { tool, execCommand } = toolWithManager(startDetachedProcess);
+
+      const result = await tool.execute(
+        sandboxedArgs({ cmd: "python3 -m http.server 8080", detach: true, workdir: root }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("danger-full-access");
+      expect(result.content).toContain("--dangerously-bypass-approvals-and-sandbox");
+      expect(result.content).toContain("yield_time_ms");
+      expect(result.metadata).toMatchObject({ kind: "exec_detach_unavailable", recoverable: true });
+      expect(result.effectDisposition).toMatchObject({
+        disposition: "confirmed_no_effect",
+        evidenceRef: "tool:system.exec-command:detach-unavailable",
+      });
+      expect(startDetachedProcess).not.toHaveBeenCalled();
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("refuses detach when the exec manager cannot detach", async () => {
+      const { tool, execCommand } = toolWithManager();
+
+      const result = await tool.execute(fullAccessArgs({ cmd: "nginx", detach: true }));
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not supported by this exec manager");
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("refuses detach together with tty", async () => {
+      const { tool, execCommand } = toolWithManager(async () => detachedOutput({ pid: 1 }));
+
+      const result = await tool.execute(
+        fullAccessArgs({ cmd: "nginx", detach: true, tty: true }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("detach cannot be combined with tty");
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("the residue note follows the footer when leftover processes were stopped", async () => {
+      // Before: `nginx` returned exit 0, the daemon was gone, and the model
+      // had no way to learn why. Now the result says so and points at detach.
+      const { tool } = toolWithManager();
+      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
+        async () => ({
+          ...completedExecOutput("nginx started"),
+          residual_processes_terminated: true,
+        }),
+      );
+      const noteTool = createExecCommandTool({
+        cwd: root,
+        allowedPaths: [root],
+        unifiedExecManager: {
+          maxTimeoutMs: 30_000,
+          execCommand,
+          writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
+            async () => completedExecOutput(""),
+          ),
+          closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
+        },
+      });
+      void tool;
+
+      const result = await noteTool.execute(fullAccessArgs({ cmd: "nginx" }));
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toContain("nginx started");
+      expect(result.content).toContain("[exec exit_code=0");
+      expect(result.content).toContain(RESIDUAL_PROCESSES_NOTE);
+      expect(result.metadata).toMatchObject({ residualProcessesTerminated: true });
+      expect(result.codeModeResult).toMatchObject({ residual_processes_terminated: true });
+    });
+  });
 });

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -1111,13 +1111,18 @@ describe("exec_command tool", () => {
     });
 
     test("accepts a working directory the user added with --add-dir", async () => {
+      // A prompting session (neither approval policy `never` nor
+      // bypassPermissions), so the added directory is what admits the
+      // workdir. danger_full_access keeps the platform sandbox out of the
+      // test: under workspace_write the call would fail on a host without
+      // one (the Linux container) before the workdir mattered.
       const { tool, execCommand } = workdirTool();
 
       const result = await tool.execute(
         workdirArgs(outsideDir, {
           mode: "default",
           approvalPolicy: "on_request",
-          sandboxMode: "workspace_write",
+          sandboxMode: "danger_full_access",
           added: [outsideDir],
         }),
       );

--- a/runtime/tests/tools/system/exec-result-format.test.ts
+++ b/runtime/tests/tools/system/exec-result-format.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  formatUnifiedExecToolContent,
+  RESIDUAL_PROCESSES_NOTE,
+  unifiedExecCodeModeResult,
+} from "../../../src/tools/system/exec-result-format.js";
+import type { ExecCommandToolOutput } from "../../../src/unified-exec/types.js";
+
+function output(overrides: Partial<ExecCommandToolOutput>): ExecCommandToolOutput {
+  return {
+    output: "hello",
+    stdout: "hello",
+    stderr: "",
+    exitCode: 0,
+    exit_code: 0,
+    durationMs: 12,
+    wall_time_seconds: 0.012,
+    timedOut: false,
+    truncated: false,
+    original_token_count: 1,
+    ...overrides,
+  };
+}
+
+describe("formatUnifiedExecToolContent", () => {
+  test("a detached service still running shows its pid and log instead of a session id", () => {
+    const content = formatUnifiedExecToolContent(
+      output({
+        exitCode: null,
+        exit_code: null,
+        detached: true,
+        pid: 4242,
+        log_path: "/srv/session/detached/service.log",
+      }),
+    );
+
+    expect(content).toContain("running=true pid=4242");
+    expect(content).toContain("detached=true log=/srv/session/detached/service.log");
+    expect(content).not.toContain("yielded");
+    expect(content).not.toContain("signal_terminated");
+    expect(content).not.toContain("session_id");
+  });
+
+  test("a detached command that exited keeps its exit code and the detached marker", () => {
+    const content = formatUnifiedExecToolContent(
+      output({ exitCode: 3, exit_code: 3, detached: true, log_path: "/srv/session/detached/x.log" }),
+    );
+
+    expect(content).toContain("exit_code=3");
+    expect(content).toContain("detached=true");
+    expect(content).not.toContain("running=true");
+  });
+
+  test("the residue note is appended after the footer and points at detach", () => {
+    const content = formatUnifiedExecToolContent(
+      output({ residual_processes_terminated: true }),
+    );
+
+    const lines = content.split("\n");
+    expect(lines.at(-2)).toMatch(/^\[exec exit_code=0 /);
+    expect(lines.at(-1)).toBe(RESIDUAL_PROCESSES_NOTE);
+    expect(RESIDUAL_PROCESSES_NOTE).toContain("detach: true");
+  });
+
+  test("an ordinary exit has neither marker", () => {
+    const content = formatUnifiedExecToolContent(output({}));
+
+    expect(content).not.toContain("detached");
+    expect(content).not.toContain("[note:");
+  });
+});
+
+describe("unifiedExecCodeModeResult", () => {
+  test("mirrors the detached and residue fields", () => {
+    expect(
+      unifiedExecCodeModeResult(
+        output({ exitCode: null, exit_code: null, detached: true, pid: 7, log_path: "/l.log" }),
+      ),
+    ).toMatchObject({ running: true, detached: true, pid: 7, log_path: "/l.log" });
+    expect(
+      unifiedExecCodeModeResult(output({ residual_processes_terminated: true })),
+    ).toMatchObject({ exit_code: 0, residual_processes_terminated: true });
+    expect(unifiedExecCodeModeResult(output({}))).not.toHaveProperty("detached");
+  });
+});

--- a/runtime/tests/tools/system/shell-mutation-permission.test.ts
+++ b/runtime/tests/tools/system/shell-mutation-permission.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
-import { shellDeletionProtectedRoots } from "src/tools/system/shell-mutation-permission.js";
+import {
+  shellAdditionalWriteRoots,
+  shellBypassesApprovalsAndSandbox,
+  shellDeletionProtectedRoots,
+} from "src/tools/system/shell-mutation-permission.js";
+import type { ToolRuntimeAttemptContext } from "src/tools/runtimes/context.js";
 
 describe("shell deletion protected roots", () => {
   afterEach(() => {
@@ -30,5 +35,86 @@ describe("shell deletion protected roots", () => {
     expect(shellDeletionProtectedRoots(undefined)).toContain(
       resolve(join(homedir(), ".agenc")),
     );
+  });
+});
+
+function runtimeContext(params: {
+  readonly sandboxMode: string;
+  readonly approvalPolicy: string;
+  readonly mode?: string;
+  readonly additionalWorkingDirectories?: ReadonlyMap<string, { readonly path: string; readonly source: string }>;
+}): ToolRuntimeAttemptContext {
+  return {
+    approvalPolicy: params.approvalPolicy,
+    sandboxMode: params.sandboxMode,
+    approvalResolved: false,
+    invocation: {
+      session: {
+        permissionModeRegistry: {
+          current: () => ({
+            mode: params.mode ?? "default",
+            additionalWorkingDirectories:
+              params.additionalWorkingDirectories ?? new Map(),
+          }),
+        },
+      },
+    },
+  } as unknown as ToolRuntimeAttemptContext;
+}
+
+describe("shellBypassesApprovalsAndSandbox", () => {
+  test("is true only when the session never asks and runs without a sandbox", () => {
+    expect(
+      shellBypassesApprovalsAndSandbox(
+        runtimeContext({ sandboxMode: "danger_full_access", approvalPolicy: "never" }),
+      ),
+    ).toBe(true);
+    // --dangerously-bypass-approvals-and-sandbox selects bypassPermissions; the
+    // arbiter short-circuits on the mode, so the policy must read it too.
+    expect(
+      shellBypassesApprovalsAndSandbox(
+        runtimeContext({
+          sandboxMode: "danger_full_access",
+          approvalPolicy: "on_request",
+          mode: "bypassPermissions",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("is false while either a prompt or a sandbox still gates the command", () => {
+    // --bypass-approvals: prompts off, sandbox on.
+    expect(
+      shellBypassesApprovalsAndSandbox(
+        runtimeContext({ sandboxMode: "workspace_write", approvalPolicy: "never" }),
+      ),
+    ).toBe(false);
+    // A prompting session that happens to run without a sandbox.
+    expect(
+      shellBypassesApprovalsAndSandbox(
+        runtimeContext({ sandboxMode: "danger_full_access", approvalPolicy: "on_request" }),
+      ),
+    ).toBe(false);
+    expect(shellBypassesApprovalsAndSandbox(undefined)).toBe(false);
+  });
+});
+
+describe("shellAdditionalWriteRoots", () => {
+  test("reads the directories the user added, from the command line or during the session", () => {
+    const roots = shellAdditionalWriteRoots(
+      runtimeContext({
+        sandboxMode: "workspace_write",
+        approvalPolicy: "on_request",
+        additionalWorkingDirectories: new Map([
+          ["/srv/added", { path: "/srv/added", source: "cliArg" }],
+          ["/srv/session", { path: "/srv/session/", source: "session" }],
+        ]),
+      }),
+    );
+    expect(roots).toEqual([resolve("/srv/added"), resolve("/srv/session")]);
+  });
+
+  test("is empty without a session", () => {
+    expect(shellAdditionalWriteRoots(undefined)).toEqual([]);
   });
 });

--- a/runtime/tests/unified-exec/detached-process.test.ts
+++ b/runtime/tests/unified-exec/detached-process.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { UnifiedExecProcessManager } from "../../src/unified-exec/process-manager.js";
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(process.platform === "win32")(
+  "UnifiedExecProcessManager.startDetachedProcess",
+  () => {
+    const pids: number[] = [];
+    let sessionTempRoot = "";
+
+    beforeEach(async () => {
+      sessionTempRoot = await mkdtemp(join(tmpdir(), "agenc-detached-"));
+    });
+
+    afterEach(async () => {
+      for (const pid of pids.splice(0)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+      await rm(sessionTempRoot, { recursive: true, force: true });
+    });
+
+    function manager(): UnifiedExecProcessManager {
+      return new UnifiedExecProcessManager({
+        cwd: process.cwd(),
+        sessionTempRoot,
+        shellPath: "/bin/sh",
+      });
+    }
+
+    test("a detached service survives the command returning and closeAll", async () => {
+      const exec = manager();
+      const result = await exec.startDetachedProcess({
+        cmd: "echo booting; sleep 30",
+        yield_time_ms: 400,
+      });
+
+      expect(result.detached).toBe(true);
+      expect(result.exitCode).toBeNull();
+      expect(result.pid).toBeTypeOf("number");
+      pids.push(result.pid!);
+      expect(result.stdout).toContain("booting");
+      expect(result.log_path).toContain(join(sessionTempRoot, "detached"));
+      // Not tracked: no session_id, nothing for kill_process or closeAll.
+      expect(result.process_id).toBeUndefined();
+      expect(exec.listBackgroundProcesses()).toEqual([]);
+
+      await exec.closeAll("session_shutdown");
+
+      expect(processIsRunning(result.pid!)).toBe(true);
+    });
+
+    test("a detached command that exits inside the window reports its exit code and both streams", async () => {
+      const result = await manager().startDetachedProcess({
+        cmd: "echo hello; echo oops >&2; exit 3",
+        yield_time_ms: 2_000,
+      });
+
+      expect(result.detached).toBe(true);
+      expect(result.exitCode).toBe(3);
+      expect(result.pid).toBeUndefined();
+      expect(result.stdout).toContain("hello");
+      expect(result.stdout).toContain("oops");
+    });
+
+    test("the service keeps writing to its log after the tool returned", async () => {
+      // A pipe the manager stopped reading would end the service with
+      // SIGPIPE on its next write; the log file must not.
+      const result = await manager().startDetachedProcess({
+        cmd: "sleep 0.7; echo later; sleep 30",
+        yield_time_ms: 300,
+      });
+      pids.push(result.pid!);
+
+      await delay(1_400);
+
+      expect(processIsRunning(result.pid!)).toBe(true);
+      expect(await readFile(result.log_path!, "utf8")).toContain("later");
+    });
+
+    test("an empty command is refused before anything spawns", async () => {
+      await expect(
+        manager().startDetachedProcess({ cmd: "   " }),
+      ).rejects.toMatchObject({ code: "missing_command" });
+    });
+  },
+);
+
+describe.skipIf(process.platform !== "linux")("residual process reporting", () => {
+  test("a command that leaves a background job behind is told so", async () => {
+    const sessionTempRoot = await mkdtemp(join(tmpdir(), "agenc-residue-"));
+    const exec = new UnifiedExecProcessManager({
+      cwd: process.cwd(),
+      sessionTempRoot,
+      shellPath: "/bin/sh",
+    });
+    try {
+      const result = await exec.execCommand({
+        cmd: "sleep 30 & echo started",
+        yield_time_ms: 10_000,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("started");
+      expect(result.residual_processes_terminated).toBe(true);
+
+      const clean = await exec.execCommand({ cmd: "echo alone", yield_time_ms: 10_000 });
+      expect(clean.residual_processes_terminated).toBeUndefined();
+    } finally {
+      await exec.closeAll("test_cleanup");
+      await rm(sessionTempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/runtime/tests/unified-exec/detached-process.test.ts
+++ b/runtime/tests/unified-exec/detached-process.test.ts
@@ -5,6 +5,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { UnifiedExecProcessManager } from "../../src/unified-exec/process-manager.js";
+import { runWithWorkspaceOperationLifetime } from "../../src/workspace/tool-operation-lifetime.js";
 
 function processIsRunning(pid: number): boolean {
   try {
@@ -92,6 +93,27 @@ describe.skipIf(process.platform === "win32")(
 
       expect(processIsRunning(result.pid!)).toBe(true);
       expect(await readFile(result.log_path!, "utf8")).toContain("later");
+    });
+
+    test("is neither refused by the workspace fence nor holds it", async () => {
+      // The dispatcher runs every tool call inside a workspace operation
+      // lifetime; the first Terminal-Bench rerun saw detach refused for it.
+      let retained = 0;
+      const exec = manager();
+      const result = await runWithWorkspaceOperationLifetime(
+        {
+          retain: () => {
+            retained += 1;
+            return () => {};
+          },
+        },
+        () => exec.startDetachedProcess({ cmd: "sleep 30", yield_time_ms: 300 }),
+      );
+      pids.push(result.pid!);
+
+      expect(result.detached).toBe(true);
+      expect(result.exitCode).toBeNull();
+      expect(retained).toBe(0);
     });
 
     test("an empty command is refused before anything spawns", async () => {

--- a/runtime/tests/utils/supervisedProcess.test.ts
+++ b/runtime/tests/utils/supervisedProcess.test.ts
@@ -35,6 +35,7 @@ import {
   runSupervisedProcess,
   signalProcessTree,
   spawnContainedProcess,
+  terminateProcessTreeAndReport,
   terminateProcessTreeAndWait,
   throwIfPreparedSpawnCleanupUnproven,
   POSIX_PROCESS_GATE_SCRIPT,
@@ -1959,4 +1960,53 @@ describe("posix process gate handoff", () => {
     expect(code).toBe(0);
     expect(stdout).toBe("legacy\n");
   });
+});
+
+describe("terminateProcessTreeAndReport", () => {
+  it.runIf(process.platform !== "win32")(
+    "reports whether it found anything left to stop",
+    async () => {
+      const gone = spawn("sh", ["-c", "exit 0"], { detached: true, stdio: "ignore" });
+      await waitForChildClose(gone, 5_000);
+
+      const afterExit = await terminateProcessTreeAndReport(gone, {
+        terminateGraceMs: 50,
+        killGraceMs: 1_000,
+        label: "test process",
+      });
+      expect(afterExit.residualProcessesTerminated).toBe(false);
+
+      const lingering = spawn("sh", ["-c", "sleep 30 & wait"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      await new Promise<void>((resolve, reject) => {
+        lingering.once("spawn", resolve);
+        lingering.once("error", reject);
+      });
+
+      const whileAlive = await terminateProcessTreeAndReport(lingering, {
+        terminateGraceMs: 50,
+        killGraceMs: 1_000,
+        label: "test process",
+      });
+      expect(whileAlive.residualProcessesTerminated).toBe(true);
+      // The leader is a zombie until Node reaps it on the next tick, and
+      // kill(pid, 0) still succeeds on a zombie; wait for the close event.
+      await waitForChildClose(lingering, 5_000);
+      expect(processIsRunning(lingering.pid!)).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "the void variant still resolves without a value",
+    async () => {
+      const gone = spawn("sh", ["-c", "exit 0"], { detached: true, stdio: "ignore" });
+      await waitForChildClose(gone, 5_000);
+
+      await expect(
+        terminateProcessTreeAndWait(gone, { label: "test process" }),
+      ).resolves.toBeUndefined();
+    },
+  );
 });

--- a/runtime/tests/utils/supervisedProcess.test.ts
+++ b/runtime/tests/utils/supervisedProcess.test.ts
@@ -1984,6 +1984,10 @@ describe("terminateProcessTreeAndReport", () => {
         lingering.once("spawn", resolve);
         lingering.once("error", reject);
       });
+      // Subscribe before terminating: the close event can fire while the
+      // supervisor awaits, and the leader stays a zombie (kill(pid, 0) still
+      // succeeds) until Node has reaped it.
+      const closed = waitForChildClose(lingering, 5_000);
 
       const whileAlive = await terminateProcessTreeAndReport(lingering, {
         terminateGraceMs: 50,
@@ -1991,9 +1995,7 @@ describe("terminateProcessTreeAndReport", () => {
         label: "test process",
       });
       expect(whileAlive.residualProcessesTerminated).toBe(true);
-      // The leader is a zombie until Node reaps it on the next tick, and
-      // kill(pid, 0) still succeeds on a zombie; wait for the close event.
-      await waitForChildClose(lingering, 5_000);
+      await closed;
       expect(processIsRunning(lingering.pid!)).toBe(false);
     },
   );


### PR DESCRIPTION
## Why

The Terminal-Bench 2.0 pilot (`docs/eval/terminal-bench.md`) put AgenC main at 7/11 against Hermes 10/11 and OpenCode 9/11 on the same model. The tasks only AgenC failed need a service to be running when the grader arrives. The pilot rollouts show the two causes.

Three further defects only showed up when the first build of this branch ran the four failed tasks again on an x86 host (run A, 0/4): the router runs a tool's `preflight` before it attaches the runtime context, so the shell write policy decided with no session and refused exactly as before; the file tools refused every path outside the workspace even with `--add-dir /` because the permission layer never handed them the widened root it hands out after a prompt; and `detach: true` was refused by the Editor workspace fence the dispatcher keeps around every tool call (the model did find `detach` on its own after four other attempts).

1. Every process a command left behind was stopped when the command returned, and the tool result never said so; a process kept alive with `yield_time_ms` died when the one-shot session ended. In nginx-request-logging the model ran `nginx` (exit 0, then "no nginx process"), `setsid nginx`, `setsid -f nginx </dev/null >/tmp/nginx.log 2>&1`, and finally `nginx -g 'daemon off;'` under `yield_time_ms`, and found nothing listening every time. Hermes and OpenCode leave such processes alive.
2. Under `--dangerously-bypass-approvals-and-sandbox` the shell write policy refused every command containing `$(...)` as an indeterminate write target and every removal outside the workspace (`unlink /etc/nginx/sites-enabled/default`, `rm -rf /git/project`, `mv /tmp/x /root/.ssh/authorized_keys`). In git-multibranch that was 51 of 459 shell calls, most an `echo "$(...)"` beside a harmless write.

## What, per file

- `runtime/src/unified-exec/types.ts`: `DetachedProcessRequest`; `ExecCommandToolOutput` gains `detached`, `pid`, `log_path`, `residual_processes_terminated`; `startDetachedProcess?` on `UnifiedExecProcessManagerLike`.
- `runtime/src/unified-exec/process-manager.ts`: `startDetachedProcess` does not consult the Editor workspace fence (a detached service never settles, so it neither retains nor is refused by it); it starts the shell command with `detached: true`, stdin ignored and stdout/stderr on a 0600 log file under `<sessionTempRoot>/detached/`, waits at most `yield_time_ms` (default 2000 ms) for an early exit, then `unref`s it and returns pid, log path and what the log holds so far. It is never entered in the process table, so `closeAll`, `kill_process` and settlement do not reach it, and a closed pipe cannot end it with SIGPIPE. No session temp authority is handed to it, since it outlives the session. Settlement of an ordinary command records `residualProcessesTerminated` from `terminateProcessTreeAndReport`.
- `runtime/src/utils/supervisedProcess.ts`: `terminateProcessTreeAndReport` returns `{ residualProcessesTerminated }` (true when the tree still had a live member when cleanup began, or when the Linux subreaper broker reports it stopped orphaned descendants itself; in a container without a writable cgroup leaf, which is what the benchmark runs in, the broker has already cleaned up and closed by the time settlement looks); `terminateProcessTreeAndWait` keeps its `Promise<void>` signature as a wrapper, so the TUI callers and the test doubles are untouched.
- `runtime/src/tools/router.ts`: `attachPreflightRuntimeContext` (exported) builds a provisional attempt context (session, the session's approval policy, requested sandbox mode, `approvalResolved: false`) and `preflightToolCall` attaches it before a tool's `preflight` when the args carry none; the dispatcher's own context replaces it at execution. Only the three shell tools have a `preflight`.
- `runtime/src/permissions/path-validation.ts`: `checkToolPathPermission` hands the tool the allowed path's directory (`withTransientAllowedRoot`, the same signed root an approval adds) when an allow for a path outside the cwd is reached on its own: `--add-dir`, an allow rule, or `bypassPermissions`. Paths inside the cwd keep the input untouched; the safety gates (`.git`, `.agenc`, `.agents`, dangerous removals) are not widened.
- `runtime/src/tools/system/exec-command.ts`: `workdir` may be the workspace, a directory the user added, or anywhere under the full bypass (`workdir: /tmp` was refused in every pilot run). New `detach` input (boolean; refused with `tty`; refused under a sandbox with a message that names `--dangerously-bypass-approvals-and-sandbox` and the `yield_time_ms` alternative; refused when the manager cannot detach). One shared result path for both manager calls, so the formatting, error classification, metadata and effect disposition stay in one place; a detached process still running is not an error and gets evidence ref `process-detached`. The description gains a Services paragraph.
- `runtime/src/tools/system/exec-result-format.ts`: footer `running=true pid=N ... detached=true log=<path>` for a detached service, `RESIDUAL_PROCESSES_NOTE` after the footer when leftover processes were stopped, and the same fields on the code-mode result.
- `runtime/src/tools/result-metadata.ts`, `runtime/src/llm/types.ts`: recoverable failure kind `exec_detach_unavailable`.
- `runtime/src/llm/shell-write-policy.ts`: inputs `additionalRoots` and `bypassesApprovalsAndSandbox`. Under the full bypass an indeterminate collection no longer produces a refusal (the decision still reports `indeterminate: true`) and removals outside the workspace are allowed; the protected roots (`/`, the home, the workspace root, `.git`, `.agenc`, `.agents`, the AgenC home, shell and git config files) and the Edit/Write routing for workspace content writes are unchanged. Removals under an added root are the workspace class of mutation: prompt-free when deletions are allowed, otherwise `needs_approval` instead of "ask the user to remove it themselves"; they are not sidecar-backed (not workspace paths).
- `runtime/src/tools/system/shell-mutation-permission.ts`: `shellBypassesApprovalsAndSandbox` is true only for `sandboxMode === "danger_full_access"` together with `approvalPolicy === "never"` or permission mode `bypassPermissions` (the arbiter already short-circuits on that mode); `shellAdditionalWriteRoots` reads `additionalWorkingDirectories` from the permission context the session publishes. Both flow into `exec_command`, `write_stdin` and `system.bash` through `shellWorkspaceMutationPermission`.
- `docs/reference/tools-permissions-sandbox.md`: a paragraph on background processes, the residue note and `detach` under Shell / process; a paragraph on what the shell write policy refuses and what the full bypass lifts, next to the `--bypass-approvals` split.
- `docs/eval/terminal-bench.md`: the two findings rewritten with the rollout evidence and the fix.
- Tests: `runtime/tests/tools/router-preflight-context.test.ts` (new: the exec_command preflight refuses an outside removal without a context and allows it once the provisional context carries bypassPermissions plus danger_full_access; a sandboxed bypass keeps the refusal; an attached context is not replaced), `runtime/tests/permissions/path-validation.test.ts` (an allow through `--add-dir` or `bypassPermissions` for a path outside the cwd carries the signed directory; a path inside the cwd leaves the input untouched; a protected path is still not allowed), `runtime/tests/unified-exec/detached-process.test.ts` (new: survives `closeAll`, early exit reports code and both streams, keeps logging after return, not refused by and not holding the workspace fence, empty command refused; Linux-only residue reporting), `runtime/tests/tools/system/exec-result-format.test.ts` (new), `runtime/tests/tools/system/exec-command.test.ts` (detach: pid and log, early death is an error, sandbox refusal, manager refusal, tty refusal, residue note; full bypass: outside removal runs, indeterminate runs, protected paths refused; the sandboxed bypass still refuses the outside removal; workdir: refused outside the workspace in a prompting session, accepted under `--add-dir` and under the full bypass), `runtime/tests/llm/shell-write-policy.test.ts` (full bypass and added roots), `runtime/tests/tools/system/shell-mutation-permission.test.ts` (predicate and roots), `runtime/tests/utils/supervisedProcess.test.ts` (report variant and the void wrapper).

## Evidence

- Pilot rollouts (`~/claude-agenc/bench-harbor/jobs/main-final11`): write-policy refusals per task: nginx-request-logging 31 of 221 shell calls, git-multibranch 51 of 459, configure-git-webserver 6 of 429 (28 of 293 in the `add_dirs=/` rerun). The service sequence quoted above is from nginx-request-logging; git-multibranch shows `/usr/sbin/sshd && nginx` succeeding and both listeners gone at the next call.
- Run A (first commit 66b067f92 only, x86 host, DeepSeek V4 Pro, one trial each): 0/4. nginx-request-logging 199 shell calls, 15 refusals, `detach: true` refused by the fence; git-multibranch 730 calls, 31 refusals; configure-git-webserver 335 calls, 31 refusals; chess-best-move failed on the position read from the image (a model error, not a harness one). The three defects above come from these rollouts.
- Run B with the full branch (13e39a5ef, same host, model and tasks): nginx-request-logging 1 (98 shell calls, 0 refusals), git-multibranch 1 (424 calls, 6 refusals, all the unchanged Edit/Write routing for workspace files), configure-git-webserver 0 (every harness failed this task in the pilot too; see the eval page), chess-best-move 0 (the model misread the board image). In the live containers the model chose `detach: true` for sshd and nginx after reading the tool description (4 and 6 uses) and the `running=true pid=` footers show the services alive. The residue note was confirmed separately in a task container with this build: `sleep 30 & echo started` returns the footer followed by the `[note: ... detach: true]` line.
- Linux (node:26.5.0-bookworm on x86) at 13e39a5ef: 58 files, 1113 of 1114 tests; the one failure was a test of this PR that depended on a platform sandbox and was made independent of it in 4a5cbfd16 (62 of 62 in the three affected files afterwards).

## Tests

- `npm run typecheck` in `runtime/`: exit 0.
- `npx vitest run` on the five directly affected suites: 104 passed, 1 skipped, 1 failed; the failure (`returns a session id for live PTY commands`) fails identically on the unmodified tree on this Mac (`posix_spawnp failed` from node-pty).
- Wider run (unified-exec, supervisedProcess, tools/system, code-mode, runtimes, streaming executor, escalation, permissions prompt, grok ACP, neovim contract, background-agent runner): 1401 passed, 14 failed. 13 of the 14 fail on the unmodified tree as well (PTY spawn, and darwin residue observation in `bash-workspace-fence` and `process-manager`); the fourteenth (`fails closed when taskkill cannot verify tree teardown`) passes 3 of 3 in isolation on both trees and is timing-sensitive under load.
- Linux (node:26.5.0-bookworm on x86, in Docker on the run host) at fb3aea875: 15 files, 356 tests passed, including the residue report and the PTY suites that cannot run on this Mac. At 13e39a5ef and 4a5cbfd16: see Evidence.

## Not changed

- Sandboxed and prompting sessions behave as before: residue is stopped, yielded processes end with the session, `detach` is refused, and the write policy refuses the same things. `--bypass-approvals` alone (sandbox on) keeps every guard.
- Shell content writes to workspace files still go to Edit and Write in every mode, including the full bypass.
- The write policy still resolves relative targets against the workspace root even after a `cd` inside the command (`cd /tmp/x; echo > index.html` is refused as `/app/index.html`); that false positive is a separate change.
- On macOS the residue note is best-effort: the POSIX gate settles its own process group before settlement looks, so the note fires only when the boundary still sees a member. Linux (cgroup or subreaper) is authoritative.

## Counterpart PRs

- agenc-core #2428 (adapter and recipe), #2424 and #2427 (the regressions the same runs found). No desktop change: the tool schema comes from the runtime and the desktop renders exec results generically.
