### PR TITLE
tools: hand file tools their root at dispatch under add-dir and the full bypass; adapter passes the prompt after --

### DIFF
--- a/docs/eval/terminal-bench.md
+++ b/docs/eval/terminal-bench.md
@@ -114,6 +114,20 @@ harbor run ... -a agenc_agent:Agenc --ak runtime_url=http://host.docker.internal
   refused by the Editor workspace fence, which the dispatcher keeps around
   every tool call; a detached service is now outside that fence. `tty: true`
   is still refused by the same fence in one-shot runs (pre-existing, open).
+  The full run then showed the file-tool refusal again on FileRead of
+  `/build/gcc-13.2.0/...` (custom-memory-heap-crash): under the full bypass
+  the permission evaluator does not run, so the permission-layer fix never
+  executed; the dispatcher now widens the root itself (2026-09-13).
+- A task whose instruction starts with `-` (pytorch-model-recovery) made the
+  CLI reject the prompt as an unknown option. The adapter now passes the
+  instruction after `--`.
+- Harbor pulls each task image when the trial starts, with a 600 s limit.
+  On a slow line the multi-GB images time out (`EnvironmentStartTimeoutError`,
+  21 of the first 71 trials of the full run on a 4 Mbit/s Wi-Fi link) and
+  concurrent pulls starve the tasks that download data. Pull all 89 images
+  first (`docker pull alexgshaw/<task>:20251031`) and only then run.
+- `qemu-startup` is Debian 11 (glibc 2.31); the runtime build needs glibc
+  2.34, so the daemon cannot start there. Counted as a failure.
 
 ## Results
 

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -469,8 +469,12 @@ signs onto their input. When the layer allows a path outside the cwd on its
 own, through `--add-dir`, an allow rule, or `bypassPermissions`, it hands the
 tool that path's directory the same way it does after an approval; before,
 such an allow ended in the tool's own `Path is outside allowed directories`
-(the half-bypass seen with Edit on `/etc/nginx/nginx.conf`). The safety gates
-(`.git`, `.agenc`, `.agents`, dangerous removals) are not widened.
+(the half-bypass seen with Edit on `/etc/nginx/nginx.conf`). Under the full
+bypass the evaluator does not run at all, so the dispatcher does the same at
+dispatch time (`filesystemRootsForDispatch`): a `file_path` inside a directory
+the user added, or any `file_path` when the mode is `bypassPermissions` and
+the sandbox is `danger_full_access`, carries its signed directory. The safety
+gates (`.git`, `.agenc`, `.agents`, dangerous removals) are not widened.
 
 Neither bypass setting removes a planning worker's permanent read-only
 constraint. See [read-only planning workers](agents.md#read-only-planning-workers).

--- a/runtime/eval/harbor/agenc_agent.py
+++ b/runtime/eval/harbor/agenc_agent.py
@@ -224,7 +224,7 @@ class Agenc(BaseInstalledAgent):
             "agenc --dangerously-bypass-approvals-and-sandbox "
             f"{add_dir_flags + ' ' if add_dir_flags else ''}"
             f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
-            f'-p "$HARBOR_INSTRUCTION" 2>&1 | stdbuf -oL tee {AGENT_LOG}'
+            f'-p -- "$HARBOR_INSTRUCTION" 2>&1 | stdbuf -oL tee {AGENT_LOG}'
         )
         try:
             await self.exec_as_agent(environment, command=run_cmd, env=env)

--- a/runtime/src/phases/_deps/tool-runtime.ts
+++ b/runtime/src/phases/_deps/tool-runtime.ts
@@ -32,7 +32,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
 
 import { isWorkflowApprovalSession } from "../../permissions/approval-failure.js";
-import { dirname, isAbsolute, resolve } from "node:path";
+import {
+  filesystemRootsForDispatch,
+  type FilesystemRootSessionLike,
+} from "../../tools/filesystem-dispatch-roots.js";
 import type { LLMToolCall } from "../../llm/types.js";
 import { signedSessionPlanFileArgs } from "../../agents/_deps/filesystem-args.js";
 import { sessionPlanFileAuthority } from "../../planning/session-plan-authority.js";
@@ -85,7 +88,6 @@ import {
   SESSION_AGENC_HOME_ARG,
   SESSION_ID_SIG_ARG,
   signSessionId,
-  withSignedAllowedRoots,
 } from "../../tools/system/filesystem.js";
 import {
   routerFromRegistry as realRouterFromRegistry,
@@ -114,42 +116,6 @@ interface ToolRegistryLike {
   dispatch(toolCall: LLMToolCall): Promise<ToolDispatchResultLike>;
 }
 
-const APPROVED_FILE_PATH_TOOLS = new Set([
-  "FileRead",
-  "Write",
-  "Edit",
-  "MultiEdit",
-  "NotebookEdit",
-]);
-
-function approvedFilePathForTool(
-  toolName: string,
-  args: Record<string, unknown>,
-): string | null {
-  if (!APPROVED_FILE_PATH_TOOLS.has(toolName)) return null;
-  const filePath = args["file_path"];
-  return typeof filePath === "string" && filePath.trim().length > 0
-    ? filePath
-    : null;
-}
-
-function withApprovedFilesystemRoot(
-  toolName: string,
-  args: Record<string, unknown>,
-): Record<string, unknown> {
-  const filePath = approvedFilePathForTool(toolName, args);
-  if (filePath === null) return args;
-
-  const cwd =
-    typeof args["cwd"] === "string" && args["cwd"].trim().length > 0
-      ? args["cwd"]
-      : process.cwd();
-  const resolvedPath = isAbsolute(filePath)
-    ? filePath
-    : resolve(cwd, filePath);
-  const approvedRoot = dirname(resolvedPath);
-  return withSignedAllowedRoots(args, [approvedRoot]);
-}
 
 // ─────────────────────────────────────────────────────────────────────
 // Re-exports (back-compat with previous stub surface)
@@ -952,7 +918,7 @@ export class StreamingToolExecutor {
                 message: `approval required for ${ctx.toolName} but no resolver is wired`,
               });
             },
-            dispatch: async (_sandbox, dispatchContext) => {
+            dispatch: async (sandbox, dispatchContext) => {
               if (tool.cancelBeforeDispatch) {
                 return buildTerminalToolResult({
                   toolCall: tool.toolCall,
@@ -978,9 +944,15 @@ export class StreamingToolExecutor {
                 sessionWithId.conversationId.length > 0
                   ? sessionWithId.conversationId
                   : null;
-              const dispatchArgs = dispatchContext.approvalResolved
-                ? withApprovedFilesystemRoot(tool.toolCall.name, effectiveArgs)
-                : effectiveArgs;
+              const dispatchArgs = filesystemRootsForDispatch(
+                tool.toolCall.name,
+                effectiveArgs,
+                {
+                  approvalResolved: dispatchContext.approvalResolved,
+                  sandboxMode: sandbox,
+                  session: session as FilesystemRootSessionLike | undefined,
+                },
+              );
               const dispatchCall: LLMToolCall = {
                 ...tool.toolCall,
                 // Re-stringify so the registry sees the (possibly)

--- a/runtime/src/tools/filesystem-dispatch-roots.ts
+++ b/runtime/src/tools/filesystem-dispatch-roots.ts
@@ -1,0 +1,128 @@
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+
+import { withSignedAllowedRoots } from "./system/filesystem.js";
+
+/** The file tools whose `file_path` the dispatcher may widen a root for. */
+const APPROVED_FILE_PATH_TOOLS: ReadonlySet<string> = new Set([
+  "FileRead",
+  "Write",
+  "Edit",
+  "MultiEdit",
+  "NotebookEdit",
+]);
+
+export function approvedFilePathForTool(
+  toolName: string,
+  args: Record<string, unknown>,
+): string | null {
+  if (!APPROVED_FILE_PATH_TOOLS.has(toolName)) return null;
+  const filePath = args["file_path"];
+  return typeof filePath === "string" && filePath.trim().length > 0
+    ? filePath
+    : null;
+}
+
+type PermissionModeRegistryLike = {
+  readonly current?: () => unknown;
+};
+
+/** The session shape the dispatcher can read a permission mode from. */
+export type FilesystemRootSessionLike = {
+  readonly permissionModeRegistry?: PermissionModeRegistryLike;
+  readonly services?: {
+    readonly permissionModeRegistry?: PermissionModeRegistryLike;
+  };
+};
+
+export interface FilesystemRootDispatchParams {
+  /** The approval resolver accepted this exact call. */
+  readonly approvalResolved: boolean;
+  /** The sandbox mode this dispatch runs under (`danger_full_access` means none). */
+  readonly sandboxMode?: string;
+  readonly session?: FilesystemRootSessionLike | undefined;
+}
+
+function resolveFilePath(
+  filePath: string,
+  args: Record<string, unknown>,
+): string {
+  const cwd =
+    typeof args["cwd"] === "string" && args["cwd"].trim().length > 0
+      ? args["cwd"]
+      : process.cwd();
+  return isAbsolute(filePath) ? filePath : resolve(cwd, filePath);
+}
+
+function isInside(candidate: string, root: string): boolean {
+  const rel = relative(resolve(root), candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * The permission context the session publishes (mode plus the directories the
+ * user added), read the way the arbiter reads it; unreadable means unknown.
+ */
+function publishedPermissionContext(
+  session: FilesystemRootSessionLike | undefined,
+): { readonly mode?: unknown; readonly additionalWorkingDirectories?: unknown } | undefined {
+  const registry =
+    session?.permissionModeRegistry ?? session?.services?.permissionModeRegistry;
+  if (registry === undefined || typeof registry.current !== "function") {
+    return undefined;
+  }
+  try {
+    const current = registry.current();
+    return typeof current === "object" && current !== null
+      ? (current as { readonly mode?: unknown; readonly additionalWorkingDirectories?: unknown })
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function addedDirectories(context: ReturnType<typeof publishedPermissionContext>): string[] {
+  const directories = context?.additionalWorkingDirectories;
+  if (!(directories instanceof Map)) return [];
+  const roots: string[] = [];
+  for (const entry of directories.values()) {
+    const path = (entry as { readonly path?: unknown } | null)?.path;
+    if (typeof path === "string" && path.trim().length > 0) roots.push(path.trim());
+  }
+  return roots;
+}
+
+/**
+ * Hand a file tool the directory of the file it is about to touch, signed, so
+ * its own confinement (the workspace root plus signed roots) accepts a path
+ * the session has already allowed. An approval always did this. The same is
+ * owed when no prompt ran: the path lies in a directory the user added
+ * (`--add-dir`, or approved during the session), or the session bypasses
+ * approvals and runs without a sandbox, where the evaluator is skipped and
+ * the tool's confinement was the only thing left saying no (observed:
+ * "Path is outside allowed directories" on FileRead /build/... under
+ * --dangerously-bypass-approvals-and-sandbox with --add-dir /). Anything else
+ * leaves the args untouched, and tools without a `file_path` are never widened.
+ */
+export function filesystemRootsForDispatch(
+  toolName: string,
+  args: Record<string, unknown>,
+  params: FilesystemRootDispatchParams,
+): Record<string, unknown> {
+  const filePath = approvedFilePathForTool(toolName, args);
+  if (filePath === null) return args;
+  const resolvedPath = resolveFilePath(filePath, args);
+  const widen = (): Record<string, unknown> =>
+    withSignedAllowedRoots(args, [dirname(resolvedPath)]);
+  if (params.approvalResolved) return widen();
+  const context = publishedPermissionContext(params.session);
+  if (
+    context?.mode === "bypassPermissions" &&
+    params.sandboxMode === "danger_full_access"
+  ) {
+    return widen();
+  }
+  if (addedDirectories(context).some((root) => isInside(resolvedPath, root))) {
+    return widen();
+  }
+  return args;
+}

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -31,7 +31,6 @@
  * @module
  */
 
-import { dirname, isAbsolute, resolve } from "node:path";
 import type { LLMTool, LLMToolCall } from "../llm/types.js";
 import type { ToolDispatchResult, ToolRegistry } from "../tool-registry.js";
 import {
@@ -108,7 +107,7 @@ import {
   readToolRuntimeContext,
   type ToolRuntimeAttemptContext,
 } from "./runtimes/context.js";
-import { withSignedAllowedRoots } from "./system/filesystem.js";
+import { filesystemRootsForDispatch } from "./filesystem-dispatch-roots.js";
 import {
   hasExactLedgerMention,
   REQUEST_LEDGER_TRANSFER_TOOL_NAME,
@@ -560,7 +559,7 @@ export class ToolRouter {
       // boundary (e.g. code_mode js_repl helper calls). These are a
       // TRUSTED INTERNAL channel for runtime-injected filesystem scoping
       // and must never be supplied by the model; runtime values are
-      // merged in later (execution.ts / withApprovedFilesystemRoot).
+      // merged in later (execution.ts / filesystemRootsForDispatch).
       let executionArgs = stripModelSuppliedAgenCInternalArgs(args);
       const initialPreflight = preflightToolCall(spec.tool, executionArgs, invocation);
       if (initialPreflight !== null) return initialPreflight;
@@ -679,12 +678,15 @@ export class ToolRouter {
           directDispatchAttempt += 1;
           const executionPreflight = preflightToolCall(spec.tool, executionArgs, invocation);
           if (executionPreflight !== null) return executionPreflight;
-          const dispatchArgs = dispatchContext.approvalResolved
-            ? withApprovedFilesystemRoot(
-                nameDisplay(invocation.toolName),
-                executionArgs,
-              )
-            : executionArgs;
+          const dispatchArgs = filesystemRootsForDispatch(
+            nameDisplay(invocation.toolName),
+            executionArgs,
+            {
+              approvalResolved: dispatchContext.approvalResolved,
+              sandboxMode: sandbox,
+              session: invocation.session,
+            },
+          );
           const dispatchPayload =
             dispatchArgs === executionArgs
               ? executionPayload
@@ -1287,9 +1289,15 @@ export class ToolRouter {
           orchestrateDispatchAttempt += 1;
           const executionPreflight = preflightToolCall(spec.tool, executionArgs, invocation, opts);
           if (executionPreflight !== null) return executionPreflight;
-          const dispatchArgs = dispatchContext.approvalResolved
-            ? withApprovedFilesystemRoot(toolCall.name, executionArgs)
-            : executionArgs;
+          const dispatchArgs = filesystemRootsForDispatch(
+            toolCall.name,
+            executionArgs,
+            {
+              approvalResolved: dispatchContext.approvalResolved,
+              sandboxMode: sandbox,
+              session: opts.session,
+            },
+          );
           const dispatchPayload =
             dispatchArgs === executionArgs
               ? executionPayload
@@ -1657,41 +1665,6 @@ function stripModelSuppliedAgenCInternalArgs(
     out[key] = value;
   }
   return out;
-}
-
-const APPROVED_FILE_PATH_TOOLS = new Set([
-  "FileRead",
-  "Write",
-  "Edit",
-  "MultiEdit",
-  "NotebookEdit",
-]);
-
-function approvedFilePathForTool(
-  toolName: string,
-  args: Record<string, unknown>,
-): string | null {
-  if (!APPROVED_FILE_PATH_TOOLS.has(toolName)) return null;
-  const filePath = args["file_path"];
-  return typeof filePath === "string" && filePath.trim().length > 0
-    ? filePath
-    : null;
-}
-
-function withApprovedFilesystemRoot(
-  toolName: string,
-  args: Record<string, unknown>,
-): Record<string, unknown> {
-  const filePath = approvedFilePathForTool(toolName, args);
-  if (filePath === null) return args;
-
-  const cwd =
-    typeof args["cwd"] === "string" && args["cwd"].trim().length > 0
-      ? args["cwd"]
-      : process.cwd();
-  const resolvedPath = isAbsolute(filePath) ? filePath : resolve(cwd, filePath);
-  const approvedRoot = dirname(resolvedPath);
-  return withSignedAllowedRoots(args, [approvedRoot]);
 }
 
 function planFileContextForApproval(

--- a/runtime/tests/tools/filesystem-dispatch-roots.test.ts
+++ b/runtime/tests/tools/filesystem-dispatch-roots.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ALLOWED_ROOTS_SIG_ARG,
+  verifyAllowedRoots,
+} from "../../src/agents/_deps/filesystem-args.js";
+import { filesystemRootsForDispatch } from "../../src/tools/filesystem-dispatch-roots.js";
+
+function signedRoots(args: Record<string, unknown>): string[] {
+  return verifyAllowedRoots(args[SESSION_ALLOWED_ROOTS_ARG], args[SESSION_ALLOWED_ROOTS_SIG_ARG]);
+}
+
+function session(mode: string, added: readonly string[] = []) {
+  return {
+    permissionModeRegistry: {
+      current: () => ({
+        mode,
+        additionalWorkingDirectories: new Map(
+          added.map((path) => [path, { path, source: "cliArg" }]),
+        ),
+      }),
+    },
+  };
+}
+
+describe("filesystemRootsForDispatch", () => {
+  let outside = "";
+
+  beforeEach(async () => {
+    outside = await mkdtemp(join(tmpdir(), "agenc-dispatch-roots-"));
+  });
+
+  afterEach(async () => {
+    if (outside) await rm(outside, { recursive: true, force: true });
+    outside = "";
+  });
+
+  test("an approval hands the tool the file's directory, as before", () => {
+    const target = join(outside, "nginx.conf");
+    const args = filesystemRootsForDispatch("Edit", { file_path: target }, {
+      approvalResolved: true,
+      sandboxMode: "workspace_write",
+      session: session("default"),
+    });
+    expect(signedRoots(args)).toContain(dirname(target));
+  });
+
+  test("the full bypass hands it out without a prompt", () => {
+    // Under --dangerously-bypass-approvals-and-sandbox the evaluator never
+    // runs, so no approval ever resolved; FileRead /build/... was refused by
+    // the tool's own confinement in the Terminal-Bench runs.
+    const target = join(outside, "locale_init.cc");
+    const args = filesystemRootsForDispatch("FileRead", { file_path: target }, {
+      approvalResolved: false,
+      sandboxMode: "danger_full_access",
+      session: session("bypassPermissions"),
+    });
+    expect(signedRoots(args)).toContain(dirname(target));
+  });
+
+  test("bypassPermissions with a sandbox still on does not widen", () => {
+    const target = join(outside, "locale_init.cc");
+    const input = { file_path: target };
+    const args = filesystemRootsForDispatch("FileRead", input, {
+      approvalResolved: false,
+      sandboxMode: "workspace_write",
+      session: session("bypassPermissions"),
+    });
+    expect(args).toBe(input);
+  });
+
+  test("a path inside a directory the user added is widened in any mode", () => {
+    const target = join(outside, "deploy", "hook.sh");
+    const args = filesystemRootsForDispatch("Write", { file_path: target }, {
+      approvalResolved: false,
+      sandboxMode: "workspace_write",
+      session: session("default", [outside]),
+    });
+    expect(signedRoots(args)).toContain(dirname(target));
+  });
+
+  test("a prompting session without an added directory leaves the args alone", () => {
+    const input = { file_path: join(outside, "x.txt") };
+    const args = filesystemRootsForDispatch("Edit", input, {
+      approvalResolved: false,
+      sandboxMode: "danger_full_access",
+      session: session("default"),
+    });
+    expect(args).toBe(input);
+  });
+
+  test("tools without a file_path and unknown sessions are never widened", () => {
+    const shell = { cmd: "ls /etc" };
+    expect(
+      filesystemRootsForDispatch("exec_command", shell, {
+        approvalResolved: false,
+        sandboxMode: "danger_full_access",
+        session: session("bypassPermissions"),
+      }),
+    ).toBe(shell);
+    const noSession = { file_path: join(outside, "x.txt") };
+    expect(
+      filesystemRootsForDispatch("Edit", noSession, {
+        approvalResolved: false,
+        sandboxMode: "danger_full_access",
+      }),
+    ).toBe(noSession);
+  });
+});


### PR DESCRIPTION
## Why

The full Terminal-Bench 2.0 run on main 618d2e0db still showed `Access denied: Path is outside allowed directories` on `FileRead` of `/build/gcc-13.2.0/...` under `--dangerously-bypass-approvals-and-sandbox` with `--add-dir /` (custom-memory-heap-crash, two refusals). #2429 widened the root in `checkToolPathPermission`, but under that flag the permission evaluator never runs, so the widening never executed: the only place the file tools' confinement was ever widened was the dispatcher, and only after a resolved approval. A second, unrelated failure came from the Harbor adapter: one task's instruction (pytorch-model-recovery) starts with `-`, and `agenc ... -p "$HARBOR_INSTRUCTION"` refused it as an unknown option (`Use '--' before literal prompt text that starts with '-'`), so the trial died in one second.

## What, per file

- `runtime/src/tools/filesystem-dispatch-roots.ts` (new): `approvedFilePathForTool` and `filesystemRootsForDispatch(toolName, args, { approvalResolved, sandboxMode, session })`. For `FileRead`, `Write`, `Edit`, `MultiEdit`, `NotebookEdit` it signs the file's directory onto the args (`withSignedAllowedRoots`, the same root an approval adds) when the approval resolved, when the path lies inside a directory the user added (`--add-dir` or approved during the session, read from the permission context the session publishes), or when the mode is `bypassPermissions` and the sandbox is `danger_full_access`. Otherwise the args are returned untouched; tools without a `file_path` are never widened.
- `runtime/src/tools/router.ts`: both dispatch closures call the shared helper with the effective sandbox and the session; the private `APPROVED_FILE_PATH_TOOLS` / `approvedFilePathForTool` / `withApprovedFilesystemRoot` copies and the now unused `node:path` import are removed.
- `runtime/src/phases/_deps/tool-runtime.ts`: the phases dispatch site (the main-session turn loop) uses the same helper; its private copies and unused imports are removed.
- `runtime/eval/harbor/agenc_agent.py`: the run command passes the instruction after `--` (`-p -- "$HARBOR_INSTRUCTION"`).
- `docs/reference/tools-permissions-sandbox.md`: the file-tool paragraph now says the dispatcher widens the root when the evaluator does not run.
- `docs/eval/terminal-bench.md`: three new findings from the full run (the dispatch-time widening, the dash-prefixed instruction, and the image-pull timeouts plus the Debian 11 glibc limit of `qemu-startup`).
- `runtime/tests/tools/filesystem-dispatch-roots.test.ts` (new): approval widens as before; full bypass widens without a prompt; bypassPermissions with a sandbox on does not; a path inside an added directory widens in any mode; a prompting session without one leaves the args alone; a tool without `file_path` and a missing session are never widened.

## Evidence

- Live rollout of the custom-memory-heap-crash trial in the full run (job `full-agenc-618d2e0db` on the run host): `FileRead` on `/build/gcc-13.2.0/libstdc++-v3/src/c++98/locale_init.cc` refused twice with `Path is outside allowed directories`, mode bypassPermissions, sandbox danger_full_access, `--add-dir /`.
- pytorch-model-recovery trial: `NonZeroAgentExitCodeError` after 1 s with `agenc: unknown option '- You are given a PyTorch state dictionary ...'. Use '--' before literal prompt text that starts with '-'.`
- `runtime/src/bin/cli-option-region.ts`: `--` ends the option region and everything after it is prompt text.

## Tests

- `npm run typecheck` in `runtime/`: exit 0.
- `npx vitest run` on `tests/tools/filesystem-dispatch-roots.test.ts tests/tools/router.test.ts tests/tools/router-preflight-context.test.ts tests/phases/tool-runtime-deps.test.ts tests/session/run-turn.test.ts tests/permissions/session-plan-mutation.test.ts tests/permissions/path-validation.test.ts`: 7 files, 271 tests passed.
- Linux (node:26.5.0-bookworm on x86, in Docker on the run host): `tests/tools/filesystem-dispatch-roots.test.ts`, `router*.test.ts`, `phases/tool-runtime-deps`, `session/run-turn`, `tests/permissions`, `tests/tools/system`: 103 files, 2255 of 2258 passed (1 skipped). The two failures (`donor-stack-import-boundary > gains no new importers`, `sandbox > exclude_slash_tmp keeps /tmp out of the list`) fail identically on main 618d2e0db in that container.

## Not changed

- The safety gates (`.git`, `.agenc`, `.agents`, dangerous removals) are not widened; they are enforced by the tools and the evaluator regardless of the roots on the input.
- Prompting sessions without an added directory behave as before: only a resolved approval widens the root.
- `checkToolPathPermission` keeps the widening added in #2429 for the sessions where the evaluator does run.

## Counterpart PRs

- agenc-core #2429 (merged): the shell write policy, detach, the residue note and the evaluator-side widening this completes. No desktop change.
